### PR TITLE
feat(testing): HttpFakeSource and one volatile-field set (FND-816, FND-819)

### DIFF
--- a/application_sdk/testing/__init__.py
+++ b/application_sdk/testing/__init__.py
@@ -7,12 +7,20 @@ Usage::
 
     from application_sdk.testing import MockStateStore, app_context, MockCredentialStore
 
+For an HTTP source with no container to pull, :class:`HttpFakeSource` fills the
+same fixture slot a testcontainer would::
+
+    from application_sdk.testing import HttpFakeSource
+
 Fixtures (import into conftest.py or test files)::
 
     from application_sdk.testing import (
+        reset_http_fake_sources,
         app_context,
         clean_app_registry,
+        clean_http_fake_sources,
         clean_task_registry,
+        http_fake_source_factory,
         mock_binding,
         mock_credential_store,
         mock_heartbeat,
@@ -23,16 +31,28 @@ Fixtures (import into conftest.py or test files)::
     )
 """
 
+from application_sdk.testing.fake_source import (
+    Authorizer,
+    FakeRequest,
+    FakeResponse,
+    Handler,
+    HandlerResult,
+    HttpFakeSource,
+    HttpFakeSourceFactory,
+)
 from application_sdk.testing.fixtures import (
     app_context,
     clean_app_registry,
+    clean_http_fake_sources,
     clean_task_registry,
+    http_fake_source_factory,
     mock_binding,
     mock_credential_store,
     mock_heartbeat,
     mock_pubsub,
     mock_secret_store,
     mock_state_store,
+    reset_http_fake_sources,
     restore_logger_init_flags,
 )
 from application_sdk.testing.mocks import (
@@ -43,24 +63,40 @@ from application_sdk.testing.mocks import (
     MockSecretStore,
     MockStateStore,
 )
+from application_sdk.testing.volatile_fields import (
+    ENVIRONMENT_SCOPED_FIELDS,
+    ENVIRONMENT_SCOPED_NESTED_FIELDS,
+    RUN_VOLATILE_FIELDS,
+)
 
 __all__ = [
-    # Mocks
+    "ENVIRONMENT_SCOPED_FIELDS",
+    "ENVIRONMENT_SCOPED_NESTED_FIELDS",
+    "RUN_VOLATILE_FIELDS",
+    "Authorizer",
+    "FakeRequest",
+    "FakeResponse",
+    "Handler",
+    "HandlerResult",
+    "HttpFakeSource",
+    "HttpFakeSourceFactory",
     "MockBinding",
     "MockCredentialStore",
     "MockHeartbeatController",
     "MockPubSub",
     "MockSecretStore",
     "MockStateStore",
-    # Fixtures
     "app_context",
     "clean_app_registry",
+    "clean_http_fake_sources",
     "clean_task_registry",
+    "http_fake_source_factory",
     "mock_binding",
     "mock_credential_store",
     "mock_heartbeat",
     "mock_pubsub",
     "mock_secret_store",
     "mock_state_store",
+    "reset_http_fake_sources",
     "restore_logger_init_flags",
 ]

--- a/application_sdk/testing/__init__.py
+++ b/application_sdk/testing/__init__.py
@@ -12,15 +12,17 @@ same fixture slot a testcontainer would::
 
     from application_sdk.testing import HttpFakeSource
 
+Its pytest fixtures are part of the integration kit rather than this module, so
+one star-import gives a connector the factory and its autouse reset together::
+
+    from application_sdk.testing.integration.fixtures import *  # noqa: F403
+
 Fixtures (import into conftest.py or test files)::
 
     from application_sdk.testing import (
-        reset_http_fake_sources,
         app_context,
         clean_app_registry,
-        clean_http_fake_sources,
         clean_task_registry,
-        http_fake_source_factory,
         mock_binding,
         mock_credential_store,
         mock_heartbeat,
@@ -43,16 +45,13 @@ from application_sdk.testing.fake_source import (
 from application_sdk.testing.fixtures import (
     app_context,
     clean_app_registry,
-    clean_http_fake_sources,
     clean_task_registry,
-    http_fake_source_factory,
     mock_binding,
     mock_credential_store,
     mock_heartbeat,
     mock_pubsub,
     mock_secret_store,
     mock_state_store,
-    reset_http_fake_sources,
     restore_logger_init_flags,
 )
 from application_sdk.testing.mocks import (
@@ -88,15 +87,12 @@ __all__ = [
     "MockStateStore",
     "app_context",
     "clean_app_registry",
-    "clean_http_fake_sources",
     "clean_task_registry",
-    "http_fake_source_factory",
     "mock_binding",
     "mock_credential_store",
     "mock_heartbeat",
     "mock_pubsub",
     "mock_secret_store",
     "mock_state_store",
-    "reset_http_fake_sources",
     "restore_logger_init_flags",
 ]

--- a/application_sdk/testing/_errors.py
+++ b/application_sdk/testing/_errors.py
@@ -1,0 +1,28 @@
+"""Typed error leaves for the top-level testing helpers.
+
+Sibling of :mod:`application_sdk.testing.integration._errors`, which holds the
+same thing for the integration-tier runner. Each module's leaves sit beside the
+module that raises them, so there is one place to look per import namespace.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from application_sdk.errors.leaves import InvalidInputError, PreconditionError
+
+
+@dataclass(kw_only=True)
+class FakeSourceRouteError(InvalidInputError):
+    """A route was registered with no HTTP methods."""
+
+    code: ClassVar[str] = "INVALID_INPUT_FAKE_SOURCE_ROUTE"
+    field: str | None = "methods"
+
+
+@dataclass(kw_only=True)
+class FakeSourceNotRunningError(PreconditionError):
+    """``base_url`` or ``port`` was read before the server was started."""
+
+    code: ClassVar[str] = "PRECONDITION_FAKE_SOURCE_NOT_RUNNING"

--- a/application_sdk/testing/fake_source.py
+++ b/application_sdk/testing/fake_source.py
@@ -10,20 +10,22 @@ an ephemeral loopback port, a hand-rolled path dispatch, a JSON writer, a
 silenced access log, and a thread they remember to join on teardown.
 
 :class:`HttpFakeSource` is that plumbing, once. It occupies exactly the slot a
-testcontainer occupies — a session-scoped fixture yielding a base URL — so a
+testcontainer occupies — the kit's session-scoped ``integration_source`` — so a
 connector's integration tier reads the same whether its source is a container or
 a fake::
 
     @pytest.fixture(scope="session")
-    def source_url(http_fake_source_factory) -> str:
+    def integration_source(http_fake_source_factory) -> HttpFakeSource:
         fake = http_fake_source_factory(name="my-source")
         fake.route(r"/api/v1/objects", list_objects)
         fake.route(r"/api/v1/objects/(?P<object_id>[^/]+)", get_object)
-        return fake.base_url
+        return fake
 
-``http_fake_source_factory`` in :mod:`application_sdk.testing.fixtures` owns the
-session lifecycle, and an autouse fixture alongside it resets every fake's
-recordings before each test, leaving the connector only its routes.
+``http_fake_source_factory`` in :mod:`application_sdk.testing.integration.fixtures`
+owns the session lifecycle, and the autouse ``reset_http_fake_sources`` alongside
+it clears every fake's per-test recordings, leaving the connector only its routes.
+Both arrive with the kit's star-import, so there is no second place to wire them
+up from.
 
 What stays with the connector is the part that is genuinely per-source: the
 endpoint map, the response envelope, and any auth-signature scheme. Those are
@@ -55,18 +57,22 @@ body that never arrives.
 
 from __future__ import annotations
 
-import json
 import re
 import threading
 import time
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any, ClassVar, Self
+from typing import Any, Self
 from urllib.parse import parse_qs, urlsplit
 
-from application_sdk.errors.leaves import InvalidInputError, PreconditionError
+import orjson
+
 from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.testing._errors import (
+    FakeSourceNotRunningError,
+    FakeSourceRouteError,
+)
 
 __all__ = [
     "Authorizer",
@@ -98,21 +104,6 @@ _BODY_REFUSALS = {
 }
 
 
-@dataclass(kw_only=True)
-class FakeSourceRouteError(InvalidInputError):
-    """A route was registered with no HTTP methods."""
-
-    code: ClassVar[str] = "INVALID_INPUT_FAKE_SOURCE_ROUTE"
-    field: str | None = "methods"
-
-
-@dataclass(kw_only=True)
-class FakeSourceNotRunningError(PreconditionError):
-    """``base_url`` or ``port`` was read before the server was started."""
-
-    code: ClassVar[str] = "PRECONDITION_FAKE_SOURCE_NOT_RUNNING"
-
-
 @dataclass(frozen=True)
 class FakeRequest:
     """One inbound request, parsed into the pieces a handler actually wants.
@@ -137,9 +128,9 @@ class FakeRequest:
         if not self.body:
             return default
         try:
-            return json.loads(self.body)
+            return orjson.loads(self.body)
         except (ValueError, UnicodeDecodeError):
-            return default
+            return default  # conformance: ignore[E007] a malformed body is the handler's call, not the fake's: it branches on ``default`` to pick a status code, and a log here would fire on every deliberate negative-path test
 
     def param(self, name: str, default: str | None = None) -> str | None:
         """Query parameter ``name``, or ``default`` when absent or empty."""
@@ -159,7 +150,7 @@ class FakeRequest:
         try:
             return int(raw)
         except ValueError:
-            return default
+            return default  # conformance: ignore[E007] documented above: a malformed query value falls back the way the real source would, and the handler sees only the default
 
     def header(self, name: str, default: str | None = None) -> str | None:
         """Header ``name``, matched case-insensitively."""
@@ -256,7 +247,10 @@ class FakeResponse:
         if body is None:
             return b"", content_type or default_content_type
         return (
-            json.dumps(body, default=str).encode(),
+            # OPT_NON_STR_KEYS keeps stdlib json's coercion of non-str dict keys:
+            # a handler replaying a captured payload keyed by int would otherwise
+            # raise where it previously serialised.
+            orjson.dumps(body, default=str, option=orjson.OPT_NON_STR_KEYS),
             content_type or default_content_type,
         )
 
@@ -380,6 +374,7 @@ class HttpFakeSource:
         self._requests: list[FakeRequest] = []
         self._unmatched: list[FakeRequest] = []
         self._hits: dict[int, int] = {}
+        self._lifetime_hits: dict[int, int] = {}
         for pattern, handler in routes:
             self.route(pattern, handler)
 
@@ -470,22 +465,32 @@ class HttpFakeSource:
             )
 
     def unused_routes(self) -> Sequence[str]:
-        """Patterns of routes no request ever matched.
+        """Patterns of routes no request has matched for the life of this fake.
 
         A route the extract never called is either dead fixture weight or a code
         path the test believes it covers and does not.
+
+        Deliberately reads a counter :meth:`reset` does not clear, because the two
+        counters answer questions at different scopes. :meth:`hits` is per-test —
+        "did *this* test call that endpoint?" — and must start at zero for every
+        test. "Is this route dead fixture weight?" is per-suite, and can only be
+        answered once every test has run. Reading the per-test counter here would
+        report every route the *other* tests exercised as unused, which is a
+        failure in any suite with more than one route-usage assertion.
         """
         with self._lock:
             return [
                 route.pattern.pattern
                 for index, route in enumerate(self._routes)
-                if not self._hits.get(index)
+                if not self._lifetime_hits.get(index)
             ]
 
     def reset(self) -> None:
-        """Forget all recorded requests and route hits, keeping the server up.
+        """Forget this test's recorded requests and route hits, keeping the server up.
 
         The move that lets one session-scoped fake serve per-test assertions.
+        :meth:`unused_routes` reads a separate lifetime counter and is unaffected;
+        see its docstring for why the two scopes cannot share one counter.
         """
         with self._lock:
             self._requests.clear()
@@ -576,6 +581,7 @@ class HttpFakeSource:
         index, route, match = selected
         with self._lock:
             self._hits[index] = self._hits.get(index, 0) + 1
+            self._lifetime_hits[index] = self._lifetime_hits.get(index, 0) + 1
         matched = FakeRequest(
             method=request.method,
             path=request.path,
@@ -680,7 +686,7 @@ def _make_handler_class(fake: HttpFakeSource) -> type[BaseHTTPRequestHandler]:
                 try:
                     size = int(line.split(b";", 1)[0].strip(), 16)
                 except ValueError:
-                    return None
+                    return None  # conformance: ignore[E007] a malformed chunk header is a protocol error the caller turns into a 400; the status code is the report
                 if size < 0 or len(decoded) + size > _MAX_BODY_BYTES:
                     return None
                 if size == 0:
@@ -708,6 +714,7 @@ def _make_handler_class(fake: HttpFakeSource) -> type[BaseHTTPRequestHandler]:
             try:
                 length = int(raw)
             except ValueError:
+                # conformance: ignore[E007] a malformed Content-Length is a protocol error reported to the client as the 400 returned here
                 return b"", 400
             if length < 0:
                 return b"", 400

--- a/application_sdk/testing/fake_source.py
+++ b/application_sdk/testing/fake_source.py
@@ -1,0 +1,848 @@
+"""The testcontainers equivalent for sources that cannot be containerized.
+
+Most connectors get their integration source from a container: a real Postgres,
+a real Kafka, started by testcontainers and torn down after the session. SaaS and
+on-prem HTTP sources — MicroStrategy, NetSuite, PowerCenter, SSRS — have no image
+to pull, so their suites instead stand up a local HTTP server that replays
+reconstructed responses. Four connectors wrote that server independently, and all
+four wrote the same thing: a stdlib :class:`~http.server.ThreadingHTTPServer` on
+an ephemeral loopback port, a hand-rolled path dispatch, a JSON writer, a
+silenced access log, and a thread they remember to join on teardown.
+
+:class:`HttpFakeSource` is that plumbing, once. It occupies exactly the slot a
+testcontainer occupies — a session-scoped fixture yielding a base URL — so a
+connector's integration tier reads the same whether its source is a container or
+a fake::
+
+    @pytest.fixture(scope="session")
+    def source_url(http_fake_source_factory) -> str:
+        fake = http_fake_source_factory(name="my-source")
+        fake.route(r"/api/v1/objects", list_objects)
+        fake.route(r"/api/v1/objects/(?P<object_id>[^/]+)", get_object)
+        return fake.base_url
+
+``http_fake_source_factory`` in :mod:`application_sdk.testing.fixtures` owns the
+session lifecycle, and an autouse fixture alongside it resets every fake's
+recordings before each test, leaving the connector only its routes.
+
+What stays with the connector is the part that is genuinely per-source: the
+endpoint map, the response envelope, and any auth-signature scheme. Those are
+irreducible — a NetSuite swagger fragment and a MicroStrategy folder listing have
+nothing in common — so the connector supplies handlers and this module supplies
+everything beneath them.
+
+Two behaviours here are load-bearing rather than cosmetic:
+
+*Catch-all fast 404.* Every method verb is bound, and any path no route matches
+gets an immediate 404 instead of falling through. A connector's client calling an
+endpoint the fake does not model then fails fast with a status code, rather than
+blocking on a socket until the suite's timeout — which is how this failure mode
+presents when the server only implements ``do_GET``.
+
+*Unmatched-request recording.* The 404s are kept, so a test can assert the extract
+called nothing the fake did not model. That assertion is what makes a
+reverse-engineered fake evidence rather than a tautology.
+
+Stdlib only, by constraint: ``pytest-httpserver`` and ``respx`` are not fleet
+dependencies, and adding one would make these suites unrunnable in normal CI.
+
+:data:`_RESERVED_RESPONSE_HEADERS` names the framing and hop-by-hop headers the
+server owns. A handler that replays a captured response verbatim will carry them,
+and emitting them alongside the server's own ``Content-Length`` puts two
+conflicting values on the wire: a client that honours the last one waits for a
+body that never arrives.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import threading
+import time
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, ClassVar, Self
+from urllib.parse import parse_qs, urlsplit
+
+from application_sdk.errors.leaves import InvalidInputError, PreconditionError
+from application_sdk.observability.logger_adaptor import get_logger
+
+__all__ = [
+    "Authorizer",
+    "FakeRequest",
+    "FakeResponse",
+    "FakeSourceNotRunningError",
+    "FakeSourceRouteError",
+    "Handler",
+    "HandlerResult",
+    "HttpFakeSource",
+    "HttpFakeSourceFactory",
+]
+
+logger = get_logger(__name__)
+
+_LOOPBACK = "127.0.0.1"
+_METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")
+_CONNECTION_TIMEOUT_SECONDS = 5.0
+_JOIN_GRACE_SECONDS = 5.0
+_MAX_BODY_BYTES = 64 * 1024 * 1024
+_MAX_CHUNK_LINE_BYTES = 8192
+_RESERVED_RESPONSE_HEADERS = frozenset(
+    {"content-length", "transfer-encoding", "connection"}
+)
+
+_BODY_REFUSALS = {
+    400: {"error": "malformed request body"},
+    413: {"error": "request body too large"},
+}
+
+
+@dataclass(kw_only=True)
+class FakeSourceRouteError(InvalidInputError):
+    """A route was registered with no HTTP methods."""
+
+    code: ClassVar[str] = "INVALID_INPUT_FAKE_SOURCE_ROUTE"
+    field: str | None = "methods"
+
+
+@dataclass(kw_only=True)
+class FakeSourceNotRunningError(PreconditionError):
+    """``base_url`` or ``port`` was read before the server was started."""
+
+    code: ClassVar[str] = "PRECONDITION_FAKE_SOURCE_NOT_RUNNING"
+
+
+@dataclass(frozen=True)
+class FakeRequest:
+    """One inbound request, parsed into the pieces a handler actually wants.
+
+    ``path_params`` holds the route pattern's named groups, so a handler reads
+    ``request.path_params["object_id"]`` rather than re-splitting the path.
+    ``params`` is the flattened query string (first value per key) because that is
+    what almost every handler needs; ``query`` keeps the full multi-value mapping
+    for the rare repeated parameter.
+    """
+
+    method: str
+    path: str
+    params: Mapping[str, str]
+    query: Mapping[str, Sequence[str]]
+    path_params: Mapping[str, str]
+    headers: Mapping[str, str]
+    body: bytes
+
+    def json(self, default: object = None) -> object:
+        """The request body decoded as JSON, or ``default`` if absent/undecodable."""
+        if not self.body:
+            return default
+        try:
+            return json.loads(self.body)
+        except (ValueError, UnicodeDecodeError):
+            return default
+
+    def param(self, name: str, default: str | None = None) -> str | None:
+        """Query parameter ``name``, or ``default`` when absent or empty."""
+        value = self.params.get(name)
+        return value if value else default
+
+    def int_param(self, name: str, default: int) -> int:
+        """Query parameter ``name`` as an int, falling back to ``default``.
+
+        A malformed value falls back rather than raising: a fake source that 500s
+        because a client sent ``limit=abc`` tells the connector's author nothing
+        about their extract, and the real source would coerce or ignore it too.
+        """
+        raw = self.params.get(name)
+        if raw is None or raw == "":
+            return default
+        try:
+            return int(raw)
+        except ValueError:
+            return default
+
+    def header(self, name: str, default: str | None = None) -> str | None:
+        """Header ``name``, matched case-insensitively."""
+        lowered = name.lower()
+        for key, value in self.headers.items():
+            if key.lower() == lowered:
+                return value
+        return default
+
+
+@dataclass(frozen=True)
+class FakeResponse:
+    """What a handler returns: a status, a body, and optional headers.
+
+    A handler may return this, or any of the shorthands
+    :meth:`HttpFakeSource.route` documents — ``dict``/``list`` for a 200 JSON
+    body, ``(status, body)`` for an explicit status, or ``None`` for a 404.
+
+    The primary constructor takes headers as a mapping only. The classmethod
+    constructors (:meth:`json_`, :meth:`text`, :meth:`raw`) take them two ways: a
+    ``headers`` mapping and keyword arguments. The mapping is the general form — a
+    real source's header names are routinely not Python identifiers, and
+    ``X-Some-Token`` cannot be spelled as a keyword at all — while the keyword form
+    stays the shorthand for the names that happen to be identifiers. Given the same
+    key both ways, the keyword wins.
+    """
+
+    status: int = 200
+    body: object = None
+    content_type: str | None = None
+    headers: Mapping[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def json_(
+        cls,
+        body: object,
+        status: int = 200,
+        *,
+        headers: Mapping[str, str] | None = None,
+        **header_kwargs: str,
+    ) -> FakeResponse:
+        """A JSON response; ``body`` is serialised with :func:`json.dumps`."""
+        return cls(
+            status=status,
+            body=body,
+            content_type="application/json",
+            headers=_merge_headers(headers, header_kwargs),
+        )
+
+    @classmethod
+    def text(
+        cls,
+        body: str,
+        status: int = 200,
+        content_type: str = "text/plain; charset=utf-8",
+        *,
+        headers: Mapping[str, str] | None = None,
+        **header_kwargs: str,
+    ) -> FakeResponse:
+        """A text response, for sources that answer in XML, CSV or SOAP."""
+        return cls(
+            status=status,
+            body=body,
+            content_type=content_type,
+            headers=_merge_headers(headers, header_kwargs),
+        )
+
+    @classmethod
+    def raw(
+        cls,
+        body: bytes,
+        status: int = 200,
+        content_type: str = "application/octet-stream",
+        *,
+        headers: Mapping[str, str] | None = None,
+        **header_kwargs: str,
+    ) -> FakeResponse:
+        """A byte-for-byte response, for a source whose payload must not be re-encoded."""
+        return cls(
+            status=status,
+            body=body,
+            content_type=content_type,
+            headers=_merge_headers(headers, header_kwargs),
+        )
+
+    def encode(self, default_content_type: str) -> tuple[bytes, str]:
+        """Serialise the body, returning the bytes and the content type to send."""
+        body = self.body
+        content_type = self.content_type
+        if isinstance(body, bytes):
+            return body, content_type or "application/octet-stream"
+        if isinstance(body, str):
+            return body.encode(), content_type or "text/plain; charset=utf-8"
+        if body is None:
+            return b"", content_type or default_content_type
+        return (
+            json.dumps(body, default=str).encode(),
+            content_type or default_content_type,
+        )
+
+
+HandlerResult = (
+    FakeResponse
+    | Mapping[str, object]
+    | Sequence[object]
+    | str
+    | bytes
+    | tuple[int, object]
+    | None
+)
+"""Everything :func:`_coerce` accepts from a handler or authorizer."""
+
+Handler = Callable[[FakeRequest], HandlerResult]
+Authorizer = Callable[[FakeRequest], HandlerResult]
+
+
+def _merge_headers(
+    headers: Mapping[str, str] | None, header_kwargs: Mapping[str, str]
+) -> Mapping[str, str]:
+    if not headers:
+        return dict(header_kwargs)
+    merged = dict(headers)
+    merged.update(header_kwargs)
+    return merged
+
+
+def _candidate_paths(path: str) -> tuple[str, ...]:
+    """The path as sent, then the same path without a single trailing slash."""
+    if len(path) > 1 and path.endswith("/") and not path.endswith("//"):
+        return (path, path[:-1])
+    return (path,)
+
+
+@dataclass(frozen=True)
+class _Route:
+    pattern: re.Pattern[str]
+    methods: frozenset[str]
+    handler: Handler
+
+    def matches_path(self, path: str) -> re.Match[str] | None:
+        return self.pattern.fullmatch(path)
+
+
+class _FakeSourceServer(ThreadingHTTPServer):
+    """Tracks the per-connection handler threads it starts, so they can be joined.
+
+    :class:`~socketserver.ThreadingMixIn` only remembers non-daemon threads, and
+    these are daemons on purpose — a wedged fake must never keep the interpreter
+    alive. Remembering them here is what lets :meth:`HttpFakeSource.stop` wait for
+    them and report the ones that outlive their budget.
+    """
+
+    daemon_threads = True
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self._handler_threads: set[threading.Thread] = set()
+        self._handler_lock = threading.Lock()
+        super().__init__(*args, **kwargs)
+
+    def process_request_thread(self, request: Any, client_address: Any) -> None:
+        current = threading.current_thread()
+        with self._handler_lock:
+            self._handler_threads.add(current)
+        try:
+            super().process_request_thread(request, client_address)
+        finally:
+            with self._handler_lock:
+                self._handler_threads.discard(current)
+
+    def handler_threads(self) -> list[threading.Thread]:
+        with self._handler_lock:
+            return list(self._handler_threads)
+
+
+class HttpFakeSource:
+    """A loopback HTTP server that replays a connector's reconstructed responses.
+
+    Register routes, enter as a context manager, hand :attr:`base_url` to the
+    connector's client. Routes are matched by :meth:`re.Pattern.fullmatch` against
+    the path (no query string), and named groups arrive as ``request.path_params``.
+    Ordering is precise: for each path candidate — the path exactly as sent, then
+    the same path with a single trailing slash removed — the first registered
+    route whose methods include the request's and whose pattern fullmatches wins.
+    Only if no route matches the exact path is the normalised path tried at all.
+
+    A handler may return a :class:`FakeResponse`, a ``dict``/``list`` (200 JSON),
+    a ``str``/``bytes`` (200, default content type), a ``(status, body)`` tuple,
+    or ``None`` for a 404 — so the common case stays a one-liner and the
+    uncommon one is still expressible.
+
+    Binding is always loopback: the server is reachable from the test process and
+    from nothing else on the network.
+    """
+
+    def __init__(
+        self,
+        *,
+        routes: Iterable[tuple[str, Handler]] = (),
+        default_content_type: str = "application/json",
+        not_found_body: object = None,
+        authorize: Authorizer | None = None,
+        warn_unmatched: bool = True,
+        name: str = "fake-source",
+        connection_timeout: float = _CONNECTION_TIMEOUT_SECONDS,
+    ) -> None:
+        self.name = name
+        self.default_content_type = default_content_type
+        self.not_found_body = (
+            {"error": "not found"} if not_found_body is None else not_found_body
+        )
+        self.authorize = authorize
+        self.warn_unmatched = warn_unmatched
+        self.connection_timeout = connection_timeout
+        self._routes: list[_Route] = []
+        self._server: _FakeSourceServer | None = None
+        self._thread: threading.Thread | None = None
+        self._lock = threading.Lock()
+        self._requests: list[FakeRequest] = []
+        self._unmatched: list[FakeRequest] = []
+        self._hits: dict[int, int] = {}
+        for pattern, handler in routes:
+            self.route(pattern, handler)
+
+    def route(
+        self,
+        pattern: str,
+        handler: Handler,
+        *,
+        methods: Sequence[str] = ("GET",),
+    ) -> Self:
+        """Register ``handler`` for paths fully matching ``pattern``.
+
+        Returns ``self``, so registrations chain. ``pattern`` is a regex matched
+        against the path with :meth:`~re.Pattern.fullmatch`; use named groups for
+        path parameters.
+
+        **Trailing slash.** The path is tried as sent, then again without a single
+        trailing slash. A source that tolerates ``/objects/`` for ``/objects``
+        needs no ``/?`` in the pattern, and an exact match always beats the
+        normalised retry, so a route written with a trailing slash still owns it.
+        """
+        upper = frozenset(method.upper() for method in methods)
+        if not upper:
+            raise FakeSourceRouteError(
+                message="route requires at least one HTTP method"
+            )
+        self._routes.append(
+            _Route(
+                pattern=re.compile(pattern),
+                methods=upper,
+                handler=handler,
+            )
+        )
+        return self
+
+    @property
+    def routes(self) -> Sequence[tuple[str, frozenset[str]]]:
+        """The registered routes as ``(pattern, methods)``, in match order."""
+        return [(route.pattern.pattern, route.methods) for route in self._routes]
+
+    @property
+    def base_url(self) -> str:
+        """``http://127.0.0.1:<port>`` — the value a fixture yields.
+
+        Only meaningful while the server is running; raises otherwise, because a
+        base URL for a stopped server is a hang or a connection error later, far
+        from its cause.
+        """
+        if self._server is None:
+            raise FakeSourceNotRunningError(
+                message=f"{self.name} is not running — use it as a context "
+                "manager or call start() before reading base_url"
+            )
+        host, port = self._server.server_address[:2]
+        host_text = host.decode() if isinstance(host, bytes) else str(host)
+        return f"http://{host_text}:{port}"
+
+    @property
+    def port(self) -> int:
+        """The ephemeral port the server bound."""
+        if self._server is None:
+            raise FakeSourceNotRunningError(message=f"{self.name} is not running")
+        return int(self._server.server_address[1])
+
+    @property
+    def requests(self) -> Sequence[FakeRequest]:
+        """Every request received, in arrival order — matched and unmatched."""
+        with self._lock:
+            return list(self._requests)
+
+    @property
+    def unmatched(self) -> Sequence[FakeRequest]:
+        """Requests no route matched, i.e. every fast 404 this server served.
+
+        Non-empty means the connector's extract called an endpoint the fake does
+        not model, so whatever the test asserted was asserted against a 404.
+        """
+        with self._lock:
+            return list(self._unmatched)
+
+    def hits(self, pattern: str) -> int:
+        """How many requests matched the route registered with ``pattern``."""
+        with self._lock:
+            return sum(
+                count
+                for index, count in self._hits.items()
+                if self._routes[index].pattern.pattern == pattern
+            )
+
+    def unused_routes(self) -> Sequence[str]:
+        """Patterns of routes no request ever matched.
+
+        A route the extract never called is either dead fixture weight or a code
+        path the test believes it covers and does not.
+        """
+        with self._lock:
+            return [
+                route.pattern.pattern
+                for index, route in enumerate(self._routes)
+                if not self._hits.get(index)
+            ]
+
+    def reset(self) -> None:
+        """Forget all recorded requests and route hits, keeping the server up.
+
+        The move that lets one session-scoped fake serve per-test assertions.
+        """
+        with self._lock:
+            self._requests.clear()
+            self._unmatched.clear()
+            self._hits.clear()
+
+    def start(self) -> Self:
+        """Bind an ephemeral loopback port and serve in a daemon thread."""
+        if self._server is not None:
+            return self
+        server = _FakeSourceServer((_LOOPBACK, 0), _make_handler_class(self))
+        thread = threading.Thread(
+            target=server.serve_forever,
+            name=f"{self.name}-server",
+            daemon=True,
+        )
+        thread.start()
+        self._server = server
+        self._thread = thread
+        return self
+
+    def stop(self) -> None:
+        """Shut the server down and wait for the threads it started. Idempotent.
+
+        The per-connection handler threads are waited on too, not just the accept
+        loop's. An idle keep-alive connection leaves its handler blocked in
+        ``readline``, which ``shutdown()`` does nothing about — so the handler
+        class carries a socket ``timeout`` (``connection_timeout``): the read wakes,
+        the handler closes the connection, and the thread exits to be joined here.
+        The wait is bounded by ``connection_timeout`` plus a grace period; any
+        thread still alive when that budget runs out is logged by name and
+        abandoned, not joined further.
+        """
+        server, thread = self._server, self._thread
+        self._server = None
+        self._thread = None
+        if server is None and thread is None:
+            return
+        pending: list[threading.Thread] = []
+        if server is not None:
+            server.shutdown()
+            pending.extend(server.handler_threads())
+            server.server_close()
+        if thread is not None:
+            pending.append(thread)
+        budget = self.connection_timeout + _JOIN_GRACE_SECONDS
+        deadline = time.monotonic() + budget
+        for pending_thread in pending:
+            pending_thread.join(timeout=max(0.0, deadline - time.monotonic()))
+        stranded = sorted(item.name for item in pending if item.is_alive())
+        if stranded:
+            logger.warning(
+                "%s stop() left %d thread(s) running after %.1fs: %s",
+                self.name,
+                len(stranded),
+                budget,
+                ", ".join(stranded),
+            )
+
+    def __enter__(self) -> Self:
+        return self.start()
+
+    def __exit__(self, *_exc: object) -> None:
+        self.stop()
+
+    def _dispatch(self, request: FakeRequest) -> FakeResponse:
+        with self._lock:
+            self._requests.append(request)
+
+        if self.authorize is not None:
+            try:
+                denied = _coerce(self.authorize(request))
+            except Exception as exc:
+                logger.warning(
+                    "%s authorize hook raised: %r", self.name, exc, exc_info=True
+                )
+                return FakeResponse.json_(
+                    {"error": "fake source authorize raised", "detail": repr(exc)},
+                    status=500,
+                )
+            if denied is not None:
+                return denied
+
+        selected = self._select(request)
+        if selected is None:
+            return self._record_unmatched(request)
+
+        index, route, match = selected
+        with self._lock:
+            self._hits[index] = self._hits.get(index, 0) + 1
+        matched = FakeRequest(
+            method=request.method,
+            path=request.path,
+            params=request.params,
+            query=request.query,
+            path_params=match.groupdict(),
+            headers=request.headers,
+            body=request.body,
+        )
+        try:
+            response = _coerce(route.handler(matched))
+        except Exception as exc:
+            logger.warning(
+                "%s handler for %r raised: %r",
+                self.name,
+                route.pattern.pattern,
+                exc,
+                exc_info=True,
+            )
+            return FakeResponse.json_(
+                {"error": "fake source handler raised", "detail": repr(exc)},
+                status=500,
+            )
+        return response if response is not None else _not_found(self.not_found_body)
+
+    def _select(self, request: FakeRequest) -> tuple[int, _Route, re.Match[str]] | None:
+        """The first registered route matching the path and method.
+
+        The path as sent is resolved fully before the trailing-slash-stripped form
+        is tried, so an exact match can never lose to a normalised one.
+        """
+        for path in _candidate_paths(request.path):
+            for index, route in enumerate(self._routes):
+                match = route.matches_path(path)
+                if match is None or request.method not in route.methods:
+                    continue
+                return index, route, match
+        return None
+
+    def _record_unmatched(self, request: FakeRequest) -> FakeResponse:
+        with self._lock:
+            self._unmatched.append(request)
+        if self.warn_unmatched:
+            logger.warning(
+                "%s has no route for %s %s — answering 404",
+                self.name,
+                request.method,
+                request.path,
+            )
+        return _not_found(self.not_found_body)
+
+
+def _not_found(body: object) -> FakeResponse:
+    return FakeResponse(status=404, body=body)
+
+
+def _coerce(result: HandlerResult) -> FakeResponse | None:
+    """Normalise a handler's return value into a :class:`FakeResponse`, or ``None``.
+
+    Raising inside a handler or authorizer is caught by the dispatcher and
+    answered with a 500, so a bug in either answers the client instead of
+    leaving it hanging on the socket.
+    """
+    if result is None:
+        return None
+    if isinstance(result, FakeResponse):
+        return result
+    if isinstance(result, tuple) and len(result) == 2 and isinstance(result[0], int):
+        return FakeResponse(status=result[0], body=result[1])
+    return FakeResponse(status=200, body=result)
+
+
+def _make_handler_class(fake: HttpFakeSource) -> type[BaseHTTPRequestHandler]:
+    """Build the handler class bound to one :class:`HttpFakeSource`.
+
+    Every verb in :data:`_METHODS` is bound to the same dispatcher. That is the
+    catch-all: a ``POST`` to a GET-only fake gets a 404, not a 501 with a body
+    the connector's client may not expect — and never a socket that just sits
+    there while the client waits for a response that no ``do_POST`` will write.
+
+    The class-level ``timeout`` is the other half of a clean teardown: it puts a
+    read deadline on each accepted connection, so a handler parked in ``readline``
+    on an idle keep-alive socket wakes, closes, and lets its thread end instead of
+    outliving :meth:`HttpFakeSource.stop`.
+    """
+
+    class _Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+        server_version = "HttpFakeSource/1.0"
+        timeout = fake.connection_timeout
+
+        def log_message(self, format: str, *args: Any) -> None:
+            """Silenced: the default access log is stderr noise under pytest."""
+
+        def _read_chunked_body(self) -> bytes | None:
+            """Decode a ``Transfer-Encoding: chunked`` body, or ``None`` if malformed."""
+            decoded = bytearray()
+            while True:
+                line = self.rfile.readline(_MAX_CHUNK_LINE_BYTES + 1)
+                if not line or len(line) > _MAX_CHUNK_LINE_BYTES:
+                    return None
+                try:
+                    size = int(line.split(b";", 1)[0].strip(), 16)
+                except ValueError:
+                    return None
+                if size < 0 or len(decoded) + size > _MAX_BODY_BYTES:
+                    return None
+                if size == 0:
+                    break
+                chunk = self.rfile.read(size)
+                if len(chunk) != size or self.rfile.read(2) != b"\r\n":
+                    return None
+                decoded += chunk
+            while True:
+                line = self.rfile.readline(_MAX_CHUNK_LINE_BYTES + 1)
+                if not line or len(line) > _MAX_CHUNK_LINE_BYTES:
+                    return None
+                if line in (b"\r\n", b"\n"):
+                    return bytes(decoded)
+
+        def _read_body(self) -> tuple[bytes, int | None]:
+            """Read the request body, returning it with a refusal status or ``None``."""
+            encoding = self.headers.get("Transfer-Encoding", "")
+            if "chunked" in encoding.lower():
+                decoded = self._read_chunked_body()
+                return (b"", 400) if decoded is None else (decoded, None)
+            raw = (self.headers.get("Content-Length") or "").strip()
+            if not raw:
+                return b"", None
+            try:
+                length = int(raw)
+            except ValueError:
+                return b"", 400
+            if length < 0:
+                return b"", 400
+            if length > _MAX_BODY_BYTES:
+                return b"", 413
+            payload = self.rfile.read(length) if length else b""
+            return (payload, None) if len(payload) == length else (b"", 400)
+
+        def _handle(self) -> None:
+            split = urlsplit(self.path)
+            query = parse_qs(split.query, keep_blank_values=True)
+            body, refusal = self._read_body()
+            if refusal is not None:
+                self.close_connection = True
+                logger.warning(
+                    "%s could not read the body of %s %s — answering %s",
+                    fake.name,
+                    self.command.upper(),
+                    split.path,
+                    refusal,
+                )
+                self._respond(
+                    FakeResponse.json_(
+                        _BODY_REFUSALS[refusal], status=refusal, Connection="close"
+                    ),
+                    self.command.upper(),
+                    server_owned=True,
+                )
+                return
+            request = FakeRequest(
+                method=self.command.upper(),
+                path=split.path,
+                params={key: values[0] for key, values in query.items() if values},
+                query=query,
+                path_params={},
+                headers=dict(self.headers.items()),
+                body=body,
+            )
+            self._respond(fake._dispatch(request), request.method)
+
+        def _respond(
+            self, response: FakeResponse, method: str, *, server_owned: bool = False
+        ) -> None:
+            """Write *response*.
+
+            ``server_owned`` marks a response this module generated itself (the
+            body refusals, which must send ``Connection: close``). Only handler
+            headers are filtered — a handler cannot be allowed to set framing,
+            but the server still needs to.
+            """
+            payload, content_type = response.encode(fake.default_content_type)
+            if method == "HEAD":
+                payload = b""
+            self.send_response(response.status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(payload)))
+            for key, value in response.headers.items():
+                if not server_owned and key.lower() in _RESERVED_RESPONSE_HEADERS:
+                    logger.warning(
+                        "%s dropped handler-supplied %r header: the server owns "
+                        "response framing",
+                        fake.name,
+                        key,
+                    )
+                    continue
+                self.send_header(key, value)
+            self.end_headers()
+            if payload:
+                self.wfile.write(payload)
+
+    for method in _METHODS:
+        setattr(_Handler, f"do_{method}", _Handler._handle)
+    return _Handler
+
+
+class HttpFakeSourceFactory:
+    """The fakes one pytest session built, owned in one place.
+
+    Backs the shipped ``http_fake_source_factory`` fixture in
+    :mod:`application_sdk.testing.fixtures`. Routes are the per-connector part and
+    stay in the connector's own session fixture; starting the servers, resetting
+    recordings before every test and stopping everything at the end are the same
+    everywhere and happen here::
+
+        @pytest.fixture(scope="session")
+        def source_url(http_fake_source_factory) -> str:
+            fake = http_fake_source_factory(name="my-source")
+            fake.route(r"/api/v1/objects", list_objects)
+            return fake.base_url
+    """
+
+    def __init__(self) -> None:
+        self._sources: list[HttpFakeSource] = []
+
+    def __call__(
+        self,
+        *,
+        routes: Iterable[tuple[str, Handler]] = (),
+        default_content_type: str = "application/json",
+        not_found_body: object = None,
+        authorize: Authorizer | None = None,
+        warn_unmatched: bool = True,
+        name: str = "fake-source",
+        connection_timeout: float = _CONNECTION_TIMEOUT_SECONDS,
+    ) -> HttpFakeSource:
+        """Build and start one fake; the parameters are :class:`HttpFakeSource`'s."""
+        source = HttpFakeSource(
+            routes=routes,
+            default_content_type=default_content_type,
+            not_found_body=not_found_body,
+            authorize=authorize,
+            warn_unmatched=warn_unmatched,
+            name=name,
+            connection_timeout=connection_timeout,
+        )
+        self._sources.append(source)
+        try:
+            source.start()
+        except Exception:
+            self._sources.remove(source)
+            raise
+        return source
+
+    @property
+    def sources(self) -> Sequence[HttpFakeSource]:
+        """Every fake built so far, in creation order."""
+        return list(self._sources)
+
+    def reset_all(self) -> None:
+        """:meth:`HttpFakeSource.reset` every fake, leaving the servers running."""
+        for source in self._sources:
+            source.reset()
+
+    def stop_all(self) -> None:
+        """Stop every fake, newest first, and forget them."""
+        sources, self._sources = self._sources, []
+        for source in reversed(sources):
+            source.stop()

--- a/application_sdk/testing/fake_source.py
+++ b/application_sdk/testing/fake_source.py
@@ -192,7 +192,7 @@ class FakeResponse:
         headers: Mapping[str, str] | None = None,
         **header_kwargs: str,
     ) -> FakeResponse:
-        """A JSON response; ``body`` is serialised with :func:`json.dumps`."""
+        """A JSON response; ``body`` is serialised with :func:`orjson.dumps`."""
         return cls(
             status=status,
             body=body,
@@ -794,16 +794,16 @@ class HttpFakeSourceFactory:
     """The fakes one pytest session built, owned in one place.
 
     Backs the shipped ``http_fake_source_factory`` fixture in
-    :mod:`application_sdk.testing.fixtures`. Routes are the per-connector part and
-    stay in the connector's own session fixture; starting the servers, resetting
-    recordings before every test and stopping everything at the end are the same
-    everywhere and happen here::
+    :mod:`application_sdk.testing.integration.fixtures`. Routes are the
+    per-connector part and stay in the connector's own session fixture; starting
+    the servers, resetting recordings before every test and stopping everything at
+    the end are the same everywhere and happen here::
 
         @pytest.fixture(scope="session")
-        def source_url(http_fake_source_factory) -> str:
+        def integration_source(http_fake_source_factory) -> HttpFakeSource:
             fake = http_fake_source_factory(name="my-source")
             fake.route(r"/api/v1/objects", list_objects)
-            return fake.base_url
+            return fake
     """
 
     def __init__(self) -> None:

--- a/application_sdk/testing/fixtures.py
+++ b/application_sdk/testing/fixtures.py
@@ -8,18 +8,11 @@ Or import everything via the testing module::
 
     from application_sdk.testing import app_context, mock_state_store
 
-For an HTTP source with no container to pull, ``http_fake_source_factory`` fills
-the testcontainer slot. Build the fake in a session-scoped fixture and return
-its base URL; recordings are reset automatically before every test::
-
-    @pytest.fixture(scope="session")
-    def source_url(http_fake_source_factory) -> str:
-        fake = http_fake_source_factory(name="my-source")
-        fake.route(r"/api/v1/objects", list_objects)
-        return fake.base_url
-
-The autouse reset only applies where these fixtures are visible, so a conftest
-must import ``reset_http_fake_sources`` alongside ``http_fake_source_factory``.
+These are the cross-tier fixtures — registry isolation, mocked infrastructure,
+logger-state restoration. The integration tier's own fixtures, including
+``http_fake_source_factory`` for an HTTP source with no container to pull, live
+in :mod:`application_sdk.testing.integration.fixtures` and are star-imported
+from a connector's ``tests/integration/conftest.py`` as one unit.
 """
 
 from collections.abc import Generator
@@ -30,7 +23,6 @@ from application_sdk.app.context import AppContext
 from application_sdk.app.registry import AppRegistry, TaskRegistry
 from application_sdk.constants import LOCAL_WORKFLOW_ID
 from application_sdk.observability.logger_adaptor import AtlanLoggerAdapter
-from application_sdk.testing.fake_source import HttpFakeSourceFactory
 from application_sdk.testing.mocks import (
     MockBinding,
     MockCredentialStore,
@@ -39,8 +31,6 @@ from application_sdk.testing.mocks import (
     MockSecretStore,
     MockStateStore,
 )
-
-_ACTIVE_FACTORY: HttpFakeSourceFactory | None = None
 
 
 @pytest.fixture
@@ -168,61 +158,3 @@ def restore_logger_init_flags() -> Generator[None, None, None]:
             AtlanLoggerAdapter._initialized = True
         if flush_task_started:
             AtlanLoggerAdapter._flush_task_started = True
-
-
-@pytest.fixture(scope="session")
-def http_fake_source_factory() -> Generator[HttpFakeSourceFactory, None, None]:
-    """Session-scoped factory for started HttpFakeSource servers.
-
-    The slot a testcontainer fixture occupies, for an HTTP source with no image to
-    pull. Call it from the connector's own session-scoped fixture to build a fake,
-    register that connector's routes on the returned instance, and return its
-    ``base_url``; every fake built here is stopped when the session ends::
-
-        @pytest.fixture(scope="session")
-        def source_url(http_fake_source_factory) -> str:
-            fake = http_fake_source_factory(name="my-source")
-            fake.route(r"/api/v1/objects", list_objects)
-            return fake.base_url
-
-    Once this fixture is live, ``reset_http_fake_sources`` clears every fake's
-    recorded requests and route hits before each test, so per-test assertions
-    never read a previous test's traffic.
-    """
-    global _ACTIVE_FACTORY
-    factory = HttpFakeSourceFactory()
-    _ACTIVE_FACTORY = factory
-    try:
-        yield factory
-    finally:
-        _ACTIVE_FACTORY = None
-        factory.stop_all()
-
-
-@pytest.fixture(autouse=True)
-def reset_http_fake_sources(request: pytest.FixtureRequest) -> None:
-    """Reset every session fake before each test, once the factory exists.
-
-    Autouse and function-scoped, so the pairing between the session factory and
-    the per-test reset is structural rather than something every test remembers
-    to request. Tests running before the factory is first instantiated have no
-    fakes to reset and pay nothing.
-    """
-    del request
-    if _ACTIVE_FACTORY is not None:
-        _ACTIVE_FACTORY.reset_all()
-
-
-@pytest.fixture
-def clean_http_fake_sources(
-    http_fake_source_factory: HttpFakeSourceFactory,
-) -> Generator[HttpFakeSourceFactory, None, None]:
-    """The session factory, with recordings reset before and after the test.
-
-    The before-test reset already happens automatically via
-    ``reset_http_fake_sources``; this fixture exists for suites that want to
-    request the factory explicitly, and it additionally resets after the test.
-    """
-    http_fake_source_factory.reset_all()
-    yield http_fake_source_factory
-    http_fake_source_factory.reset_all()

--- a/application_sdk/testing/fixtures.py
+++ b/application_sdk/testing/fixtures.py
@@ -7,6 +7,19 @@ Import these fixtures in your conftest.py or test files::
 Or import everything via the testing module::
 
     from application_sdk.testing import app_context, mock_state_store
+
+For an HTTP source with no container to pull, ``http_fake_source_factory`` fills
+the testcontainer slot. Build the fake in a session-scoped fixture and return
+its base URL; recordings are reset automatically before every test::
+
+    @pytest.fixture(scope="session")
+    def source_url(http_fake_source_factory) -> str:
+        fake = http_fake_source_factory(name="my-source")
+        fake.route(r"/api/v1/objects", list_objects)
+        return fake.base_url
+
+The autouse reset only applies where these fixtures are visible, so a conftest
+must import ``reset_http_fake_sources`` alongside ``http_fake_source_factory``.
 """
 
 from collections.abc import Generator
@@ -17,6 +30,7 @@ from application_sdk.app.context import AppContext
 from application_sdk.app.registry import AppRegistry, TaskRegistry
 from application_sdk.constants import LOCAL_WORKFLOW_ID
 from application_sdk.observability.logger_adaptor import AtlanLoggerAdapter
+from application_sdk.testing.fake_source import HttpFakeSourceFactory
 from application_sdk.testing.mocks import (
     MockBinding,
     MockCredentialStore,
@@ -25,6 +39,8 @@ from application_sdk.testing.mocks import (
     MockSecretStore,
     MockStateStore,
 )
+
+_ACTIVE_FACTORY: HttpFakeSourceFactory | None = None
 
 
 @pytest.fixture
@@ -152,3 +168,61 @@ def restore_logger_init_flags() -> Generator[None, None, None]:
             AtlanLoggerAdapter._initialized = True
         if flush_task_started:
             AtlanLoggerAdapter._flush_task_started = True
+
+
+@pytest.fixture(scope="session")
+def http_fake_source_factory() -> Generator[HttpFakeSourceFactory, None, None]:
+    """Session-scoped factory for started HttpFakeSource servers.
+
+    The slot a testcontainer fixture occupies, for an HTTP source with no image to
+    pull. Call it from the connector's own session-scoped fixture to build a fake,
+    register that connector's routes on the returned instance, and return its
+    ``base_url``; every fake built here is stopped when the session ends::
+
+        @pytest.fixture(scope="session")
+        def source_url(http_fake_source_factory) -> str:
+            fake = http_fake_source_factory(name="my-source")
+            fake.route(r"/api/v1/objects", list_objects)
+            return fake.base_url
+
+    Once this fixture is live, ``reset_http_fake_sources`` clears every fake's
+    recorded requests and route hits before each test, so per-test assertions
+    never read a previous test's traffic.
+    """
+    global _ACTIVE_FACTORY
+    factory = HttpFakeSourceFactory()
+    _ACTIVE_FACTORY = factory
+    try:
+        yield factory
+    finally:
+        _ACTIVE_FACTORY = None
+        factory.stop_all()
+
+
+@pytest.fixture(autouse=True)
+def reset_http_fake_sources(request: pytest.FixtureRequest) -> None:
+    """Reset every session fake before each test, once the factory exists.
+
+    Autouse and function-scoped, so the pairing between the session factory and
+    the per-test reset is structural rather than something every test remembers
+    to request. Tests running before the factory is first instantiated have no
+    fakes to reset and pay nothing.
+    """
+    del request
+    if _ACTIVE_FACTORY is not None:
+        _ACTIVE_FACTORY.reset_all()
+
+
+@pytest.fixture
+def clean_http_fake_sources(
+    http_fake_source_factory: HttpFakeSourceFactory,
+) -> Generator[HttpFakeSourceFactory, None, None]:
+    """The session factory, with recordings reset before and after the test.
+
+    The before-test reset already happens automatically via
+    ``reset_http_fake_sources``; this fixture exists for suites that want to
+    request the factory explicitly, and it additionally resets after the test.
+    """
+    http_fake_source_factory.reset_all()
+    yield http_fake_source_factory
+    http_fake_source_factory.reset_all()

--- a/application_sdk/testing/integration/comparison.py
+++ b/application_sdk/testing/integration/comparison.py
@@ -40,34 +40,17 @@ from typing import Any
 import orjson
 
 from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.testing.volatile_fields import (
+    ENVIRONMENT_SCOPED_FIELDS,
+    ENVIRONMENT_SCOPED_NESTED_FIELDS,
+    RUN_VOLATILE_FIELDS,
+)
 
 logger = get_logger(__name__)
 
-# Fields that change between runs and should be ignored by default
-DEFAULT_IGNORED_FIELDS: set[str] = {
-    "qualifiedName",
-    "connectionQualifiedName",
-    "lastSyncWorkflowName",
-    "lastSyncRun",
-    "lastSyncRunAt",
-    "tenantId",
-    "connectionName",
-    "databaseQualifiedName",
-    "schemaQualifiedName",
-    "tableQualifiedName",
-    "viewQualifiedName",
-}
+DEFAULT_IGNORED_FIELDS: set[str] = set(RUN_VOLATILE_FIELDS | ENVIRONMENT_SCOPED_FIELDS)
 
-# Nested reference fields that contain run-specific qualified names
-DEFAULT_IGNORED_NESTED_FIELDS: set[str] = {
-    "atlanSchema",
-    "database",
-    "table",
-    "view",
-    "materialisedView",
-    "parentTable",
-    "tablePartition",
-}
+DEFAULT_IGNORED_NESTED_FIELDS: set[str] = set(ENVIRONMENT_SCOPED_NESTED_FIELDS)
 
 
 @dataclass

--- a/application_sdk/testing/integration/fixtures.py
+++ b/application_sdk/testing/integration/fixtures.py
@@ -30,6 +30,12 @@ ordinary pytest fixtures; a connector star-imports them and overrides the
     def integration_source():
         ...  # a testcontainer, an HTTP fake, whatever this connector extracts from
 
+A source with no image to pull uses :func:`http_fake_source_factory`, which ships
+here rather than in :mod:`application_sdk.testing.fixtures` precisely so that the
+factory and its autouse ``reset_http_fake_sources`` arrive together with the rest
+of the kit — a suite cannot pick up one and miss the other. See
+``docs/guides/integration-fixtures.md``.
+
 Everything else is a plain pytest override. A suite that seeds credentials
 overrides ``integration_secrets``; one that needs a real store overrides
 ``infrastructure`` itself; one that wants Prometheus on overrides
@@ -129,6 +135,7 @@ import pytest
 import pytest_asyncio
 
 from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.testing.fake_source import HttpFakeSourceFactory
 from application_sdk.testing.integration._errors import (
     AppRegistrationMissingError,
     IntegrationEnvOrderingError,
@@ -143,6 +150,15 @@ if TYPE_CHECKING:
     from application_sdk.infrastructure.context import InfrastructureContext
 
 logger = get_logger(__name__)
+
+_ACTIVE_FAKE_SOURCE_FACTORY: HttpFakeSourceFactory | None = None
+"""The live ``http_fake_source_factory``, or ``None`` before one is requested.
+
+Module-level rather than a fixture dependency because ``reset_http_fake_sources``
+must not *instantiate* the session factory — an autouse fixture that requested it
+would stand up a server for every suite that star-imports the kit, including the
+ones whose source is a container.
+"""
 
 CLEANUP_INTERCEPTOR_ENV = "APPLICATION_SDK_ENABLE_CLEANUP_INTERCEPTOR"
 """Env var gating ``App.on_complete()``'s file and object-store cleanup."""
@@ -453,6 +469,51 @@ def integration_source() -> object:
 
 
 @pytest.fixture(scope="session")
+def http_fake_source_factory() -> Iterator[HttpFakeSourceFactory]:
+    """Session-scoped factory for started :class:`HttpFakeSource` servers.
+
+    The slot a testcontainer fixture occupies, for an HTTP source with no image
+    to pull. Build the fake in the connector's ``integration_source`` override,
+    register that connector's routes on it, and return it — the kit hands it to
+    ``integration_secrets`` and otherwise leaves it alone, exactly as it would a
+    container::
+
+        @pytest.fixture(scope="session")
+        def integration_source(http_fake_source_factory) -> HttpFakeSource:
+            fake = http_fake_source_factory(name="my-source")
+            fake.route(r"/api/v1/objects", list_objects)
+            return fake
+
+    Every fake built here is stopped when the session ends, and
+    ``reset_http_fake_sources`` clears each one's per-test recordings before
+    every test. Both arrive with the same star-import as the rest of the kit, so
+    a suite cannot pick up the factory and miss the reset.
+    """
+    global _ACTIVE_FAKE_SOURCE_FACTORY
+    factory = HttpFakeSourceFactory()
+    _ACTIVE_FAKE_SOURCE_FACTORY = factory
+    try:
+        yield factory
+    finally:
+        _ACTIVE_FAKE_SOURCE_FACTORY = None
+        factory.stop_all()
+
+
+@pytest.fixture(autouse=True)
+def reset_http_fake_sources() -> None:
+    """Reset every session fake's per-test recordings, once a factory is live.
+
+    Autouse and function-scoped, so the pairing with the session factory is
+    structural rather than something each test remembers to request. Tests that
+    run before the factory is first instantiated have no fakes to reset and pay
+    nothing. ``HttpFakeSource.unused_routes()`` reads a lifetime counter this
+    does not touch, so the per-suite dead-route assertion still works.
+    """
+    if _ACTIVE_FAKE_SOURCE_FACTORY is not None:
+        _ACTIVE_FAKE_SOURCE_FACTORY.reset_all()
+
+
+@pytest.fixture(scope="session")
 def integration_secrets(integration_source: object) -> Mapping[str, str]:
     """Seed for the mocked secret store, as a ``{key: json}`` mapping.
 
@@ -653,6 +714,7 @@ __all__ = [
     "KitOptions",
     "embedded_temporal",
     "executor",
+    "http_fake_source_factory",
     "infrastructure",
     "integration_app_cls",
     "integration_options",
@@ -660,6 +722,7 @@ __all__ = [
     "integration_source",
     "integration_task_queue",
     "kit_infrastructure",
+    "reset_http_fake_sources",
     "store_root",
     "temporal_client",
     "worker",

--- a/application_sdk/testing/parity/comparator.py
+++ b/application_sdk/testing/parity/comparator.py
@@ -5,6 +5,7 @@ joins on qualifiedName, and classifies each asset as ADDED, REMOVED,
 MODIFIED, or UNCHANGED.
 """
 
+from collections.abc import Collection
 from pathlib import Path
 from typing import Any
 
@@ -12,15 +13,11 @@ import orjson
 
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.testing.parity.models import AssetDiff, CategoryResult, FieldDiff
+from application_sdk.testing.volatile_fields import RUN_VOLATILE_FIELDS
 
 logger = get_logger(__name__)
 
-# Fields that change every run and must be ignored in comparison.
-VOLATILE_FIELDS: set[str] = {
-    "lastSyncWorkflowName",
-    "lastSyncRun",
-    "lastSyncRunAt",
-}
+VOLATILE_FIELDS: set[str] = set(RUN_VOLATILE_FIELDS)
 
 
 def load_ndjson(directory: Path) -> list[dict[str, Any]]:
@@ -48,14 +45,21 @@ def load_ndjson(directory: Path) -> list[dict[str, Any]]:
     return assets
 
 
-def strip_volatile(obj: Any) -> Any:
-    """Recursively remove volatile fields from dicts and lists."""
+def strip_volatile(obj: Any, fields: Collection[str] | None = None) -> Any:
+    """Recursively remove volatile fields from dicts and lists.
+
+    Args:
+        obj: Any JSON-shaped value. Dicts and lists are descended into; scalars
+            are returned unchanged.
+        fields: Field names to strip at every depth. Defaults to
+            :data:`VOLATILE_FIELDS`.
+    """
+    if fields is None:
+        fields = VOLATILE_FIELDS
     if isinstance(obj, dict):
-        return {
-            k: strip_volatile(v) for k, v in obj.items() if k not in VOLATILE_FIELDS
-        }
+        return {k: strip_volatile(v, fields) for k, v in obj.items() if k not in fields}
     if isinstance(obj, list):
-        return [strip_volatile(item) for item in obj]
+        return [strip_volatile(item, fields) for item in obj]
     return obj
 
 

--- a/application_sdk/testing/volatile_fields.py
+++ b/application_sdk/testing/volatile_fields.py
@@ -1,0 +1,87 @@
+"""Canonical field-set definitions for metadata comparison.
+
+Two distinct concepts were previously conflated across the SDK's comparison
+engines, and they are not the same thing wearing two names.
+
+**Run-volatile** (:data:`RUN_VOLATILE_FIELDS`) — fields whose value changes on
+every extraction run of the same source against the same environment. A
+differing value carries no information, so they must be stripped before *any*
+comparison, whatever its purpose.
+
+**Environment-scoped** (:data:`ENVIRONMENT_SCOPED_FIELDS` and
+:data:`ENVIRONMENT_SCOPED_NESTED_FIELDS`) — fields whose value is stable across
+runs but differs when the same source is extracted against a *different*
+tenant, connection, or connector instance. Whether they are noise depends
+entirely on what is being compared:
+
+* Comparing an extraction against a baseline captured on *different*
+  infrastructure (the integration-test case), these must be ignored — the
+  connection name and every ``qualifiedName`` derived from it legitimately
+  differ, and reporting them would bury the real diffs.
+* Comparing an extraction against a golden fixture captured from the *same*
+  environment and re-baselined in place (the golden-corpus case), these must be
+  **kept**. ``qualifiedName`` is the comparison key there, and a differing
+  ``qualifiedName`` is a real regression in qualified-name construction — one of
+  the highest-value bugs the diff can catch. Ignoring it would be
+  self-defeating.
+
+Which is why there is one documented constant per concept rather than one
+merged list: consumers compose the sets their own comparison actually needs.
+
+The run-volatile set is the intersection of what the SDK's two comparison
+engines (:mod:`application_sdk.testing.integration.comparison` and
+:mod:`application_sdk.testing.parity.comparator`) each stripped before they
+shared this module. Connector-specific additions beyond these three are passed
+per-call rather than added here.
+"""
+
+RUN_VOLATILE_FIELDS: frozenset[str] = frozenset(
+    {
+        "lastSyncRun",
+        "lastSyncRunAt",
+        "lastSyncWorkflowName",
+    }
+)
+"""Fields that change on every run. Strip before any comparison."""
+
+ENVIRONMENT_SCOPED_FIELDS: frozenset[str] = frozenset(
+    {
+        "connectionName",
+        "connectionQualifiedName",
+        "databaseQualifiedName",
+        "qualifiedName",
+        "schemaQualifiedName",
+        "tableQualifiedName",
+        "tenantId",
+        "viewQualifiedName",
+    }
+)
+"""Fields that differ between environments but are stable across runs.
+
+Ignore when the baseline came from other infrastructure; keep when comparing
+against a golden fixture captured from the same environment.
+"""
+
+ENVIRONMENT_SCOPED_NESTED_FIELDS: frozenset[str] = frozenset(
+    {
+        "atlanSchema",
+        "database",
+        "materialisedView",
+        "parentTable",
+        "table",
+        "tablePartition",
+        "view",
+    }
+)
+"""Attributes holding nested reference objects with environment-scoped contents.
+
+These name whole reference *attributes* rather than leaf keys: the objects they
+contain carry qualified names throughout, so environment-scoped comparison
+skips the attribute entirely instead of descending into it.
+"""
+
+__all__ = [
+    "ENVIRONMENT_SCOPED_FIELDS",
+    "ENVIRONMENT_SCOPED_NESTED_FIELDS",
+    "RUN_VOLATILE_FIELDS",
+]

--- a/application_sdk/testing/volatile_fields.py
+++ b/application_sdk/testing/volatile_fields.py
@@ -31,8 +31,14 @@ merged list: consumers compose the sets their own comparison actually needs.
 The run-volatile set is the intersection of what the SDK's two comparison
 engines (:mod:`application_sdk.testing.integration.comparison` and
 :mod:`application_sdk.testing.parity.comparator`) each stripped before they
-shared this module. Connector-specific additions beyond these three are passed
-per-call rather than added here.
+shared this module, and it agrees with what the connector suites independently
+found: MicroStrategy's transformer emits exactly these three keys and no
+``__timestamp`` and no ``guid``; NetSuite's strips these three plus any key
+containing ``__timestamp``; PowerCenter's transform emits none of them at all,
+because its ``id`` is a deterministic uuid5. Three sources, no fourth field —
+which is why the set is fixed here rather than negotiated per connector.
+Connector-specific additions (NetSuite's ``__timestamp`` suffix rule, say) are
+passed per-call rather than added here.
 """
 
 RUN_VOLATILE_FIELDS: frozenset[str] = frozenset(

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.30.0
-source-sha:    411ea0f885b449725bf7b6ff37cebbe2c7fe67e1
-source-date:   2026-08-28T17:31:07+01:00
+source-sha:    4fb03c85dbad5d801a15ae097874b05dbd29c8dc
+source-date:   2026-08-28T17:32:50+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 42 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 6 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 298 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 297 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -3429,14 +3429,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Import:** `from application_sdk.testing.fake_source import FakeSourceNotRunningError`
 - **Signature:** `class FakeSourceNotRunningError(*, ...)`
 - **Summary:** ``base_url`` or ``port`` was read before the server was started.
-- **Defined in:** `application_sdk/testing/fake_source.py`
+- **Defined in:** `application_sdk/testing/_errors.py`
 
 #### `FakeSourceRouteError`
 
 - **Import:** `from application_sdk.testing.fake_source import FakeSourceRouteError`
 - **Signature:** `class FakeSourceRouteError(*, ...)`
 - **Summary:** A route was registered with no HTTP methods.
-- **Defined in:** `application_sdk/testing/fake_source.py`
+- **Defined in:** `application_sdk/testing/_errors.py`
 
 #### `FieldDiff`
 
@@ -4188,13 +4188,6 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** AppRegistry reset before and after each test.
 - **Defined in:** `application_sdk/testing/fixtures.py`
 
-#### `clean_http_fake_sources`
-
-- **Import:** `from application_sdk.testing import clean_http_fake_sources`
-- **Signature:** `clean_http_fake_sources(http_fake_source_factory: HttpFakeSourceFactory)`
-- **Summary:** The session factory, with recordings reset before and after the test.
-- **Defined in:** `application_sdk/testing/fixtures.py`
-
 #### `clean_task_registry`
 
 - **Import:** `from application_sdk.testing import clean_task_registry`
@@ -4588,10 +4581,10 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 
 #### `http_fake_source_factory`
 
-- **Import:** `from application_sdk.testing import http_fake_source_factory`
-- **Signature:** `http_fake_source_factory()`
-- **Summary:** Session-scoped factory for started HttpFakeSource servers.
-- **Defined in:** `application_sdk/testing/fixtures.py`
+- **Import:** `from application_sdk.testing.integration.fixtures import http_fake_source_factory`
+- **Signature:** `http_fake_source_factory() -> Iterator[HttpFakeSourceFactory]`
+- **Summary:** Session-scoped factory for started :class:`HttpFakeSource` servers.
+- **Defined in:** `application_sdk/testing/integration/fixtures.py`
 
 #### `infrastructure`
 
@@ -4922,10 +4915,10 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 
 #### `reset_http_fake_sources`
 
-- **Import:** `from application_sdk.testing import reset_http_fake_sources`
-- **Signature:** `reset_http_fake_sources(request: pytest.FixtureRequest)`
-- **Summary:** Reset every session fake before each test, once the factory exists.
-- **Defined in:** `application_sdk/testing/fixtures.py`
+- **Import:** `from application_sdk.testing.integration.fixtures import reset_http_fake_sources`
+- **Signature:** `reset_http_fake_sources() -> None`
+- **Summary:** Reset every session fake's per-test recordings, once a factory is live.
+- **Defined in:** `application_sdk/testing/integration/fixtures.py`
 
 #### `restore_logger_init_flags`
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.30.0
-source-sha:    c049bdfc7f824a45030a685534708e6389a08b4b
-source-date:   2026-08-28T12:21:21+01:00
+source-sha:    411ea0f885b449725bf7b6ff37cebbe2c7fe67e1
+source-date:   2026-08-28T17:31:07+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 42 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 6 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 283 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 298 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -3408,6 +3408,36 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** The budget ran out while work was still progressing.
 - **Defined in:** `application_sdk/testing/harness/outcome.py`
 
+#### `FakeRequest`
+
+- **Import:** `from application_sdk.testing import FakeRequest`
+- **Also importable from:** `application_sdk.testing.fake_source`
+- **Signature:** `class FakeRequest(method: str, ...)`
+- **Summary:** One inbound request, parsed into the pieces a handler actually wants.
+- **Defined in:** `application_sdk/testing/fake_source.py`
+
+#### `FakeResponse`
+
+- **Import:** `from application_sdk.testing import FakeResponse`
+- **Also importable from:** `application_sdk.testing.fake_source`
+- **Signature:** `class FakeResponse(status: int = 200, ...)`
+- **Summary:** What a handler returns: a status, a body, and optional headers.
+- **Defined in:** `application_sdk/testing/fake_source.py`
+
+#### `FakeSourceNotRunningError`
+
+- **Import:** `from application_sdk.testing.fake_source import FakeSourceNotRunningError`
+- **Signature:** `class FakeSourceNotRunningError(*, ...)`
+- **Summary:** ``base_url`` or ``port`` was read before the server was started.
+- **Defined in:** `application_sdk/testing/fake_source.py`
+
+#### `FakeSourceRouteError`
+
+- **Import:** `from application_sdk.testing.fake_source import FakeSourceRouteError`
+- **Signature:** `class FakeSourceRouteError(*, ...)`
+- **Summary:** A route was registered with no HTTP methods.
+- **Defined in:** `application_sdk/testing/fake_source.py`
+
 #### `FieldDiff`
 
 - **Import:** `from application_sdk.testing.parity import FieldDiff`
@@ -3465,6 +3495,22 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `class HealthReading(*, status: int | None = None, error: str = '')`
 - **Summary:** One reading of an HTTP health endpoint.
 - **Defined in:** `application_sdk/testing/harness/preconditions.py`
+
+#### `HttpFakeSource`
+
+- **Import:** `from application_sdk.testing import HttpFakeSource`
+- **Also importable from:** `application_sdk.testing.fake_source`
+- **Signature:** `class HttpFakeSource(*, ...)`
+- **Summary:** A loopback HTTP server that replays a connector's reconstructed responses.
+- **Defined in:** `application_sdk/testing/fake_source.py`
+
+#### `HttpFakeSourceFactory`
+
+- **Import:** `from application_sdk.testing import HttpFakeSourceFactory`
+- **Also importable from:** `application_sdk.testing.fake_source`
+- **Signature:** `class HttpFakeSourceFactory()`
+- **Summary:** The fakes one pytest session built, owned in one place.
+- **Defined in:** `application_sdk/testing/fake_source.py`
 
 #### `HttpRequest`
 
@@ -4142,6 +4188,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** AppRegistry reset before and after each test.
 - **Defined in:** `application_sdk/testing/fixtures.py`
 
+#### `clean_http_fake_sources`
+
+- **Import:** `from application_sdk.testing import clean_http_fake_sources`
+- **Signature:** `clean_http_fake_sources(http_fake_source_factory: HttpFakeSourceFactory)`
+- **Summary:** The session factory, with recordings reset before and after the test.
+- **Defined in:** `application_sdk/testing/fixtures.py`
+
 #### `clean_task_registry`
 
 - **Import:** `from application_sdk.testing import clean_task_registry`
@@ -4533,6 +4586,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Assert *invariant* holds for every reading across the whole budget.
 - **Defined in:** `application_sdk/testing/harness/waiting.py`
 
+#### `http_fake_source_factory`
+
+- **Import:** `from application_sdk.testing import http_fake_source_factory`
+- **Signature:** `http_fake_source_factory()`
+- **Summary:** Session-scoped factory for started HttpFakeSource servers.
+- **Defined in:** `application_sdk/testing/fixtures.py`
+
 #### `infrastructure`
 
 - **Import:** `from application_sdk.testing.integration.fixtures import infrastructure`
@@ -4860,6 +4920,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Return *text* with credential-shaped and literally-known values blanked.
 - **Defined in:** `application_sdk/testing/harness/evidence.py`
 
+#### `reset_http_fake_sources`
+
+- **Import:** `from application_sdk.testing import reset_http_fake_sources`
+- **Signature:** `reset_http_fake_sources(request: pytest.FixtureRequest)`
+- **Summary:** Reset every session fake before each test, once the factory exists.
+- **Defined in:** `application_sdk/testing/fixtures.py`
+
 #### `restore_logger_init_flags`
 
 - **Import:** `from application_sdk.testing import restore_logger_init_flags`
@@ -5018,6 +5085,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** _(no docstring)_
 - **Defined in:** `application_sdk/testing/integration/fixtures.py`
 
+#### `Authorizer`
+
+- **Import:** `from application_sdk.testing import Authorizer`
+- **Also importable from:** `application_sdk.testing.fake_source`
+- **Signature:** `Authorizer`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/testing/fake_source.py`
+
 #### `Classifier`
 
 - **Import:** `from application_sdk.testing.harness import Classifier`
@@ -5062,6 +5137,38 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** _(no docstring)_
 - **Defined in:** `application_sdk/testing/integration/fixtures.py`
 
+#### `ENVIRONMENT_SCOPED_FIELDS`
+
+- **Import:** `from application_sdk.testing import ENVIRONMENT_SCOPED_FIELDS`
+- **Also importable from:** `application_sdk.testing.volatile_fields`
+- **Signature:** `ENVIRONMENT_SCOPED_FIELDS: frozenset[str]`
+- **Summary:** Fields that differ between environments but are stable across runs.
+- **Defined in:** `application_sdk/testing/volatile_fields.py`
+
+#### `ENVIRONMENT_SCOPED_NESTED_FIELDS`
+
+- **Import:** `from application_sdk.testing import ENVIRONMENT_SCOPED_NESTED_FIELDS`
+- **Also importable from:** `application_sdk.testing.volatile_fields`
+- **Signature:** `ENVIRONMENT_SCOPED_NESTED_FIELDS: frozenset[str]`
+- **Summary:** Attributes holding nested reference objects with environment-scoped contents.
+- **Defined in:** `application_sdk/testing/volatile_fields.py`
+
+#### `Handler`
+
+- **Import:** `from application_sdk.testing import Handler`
+- **Also importable from:** `application_sdk.testing.fake_source`
+- **Signature:** `Handler`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/testing/fake_source.py`
+
+#### `HandlerResult`
+
+- **Import:** `from application_sdk.testing import HandlerResult`
+- **Also importable from:** `application_sdk.testing.fake_source`
+- **Signature:** `HandlerResult`
+- **Summary:** Everything :func:`_coerce` accepts from a handler or authorizer.
+- **Defined in:** `application_sdk/testing/fake_source.py`
+
 #### `Outcome`
 
 - **Import:** `from application_sdk.testing.harness import Outcome`
@@ -5098,6 +5205,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `Reading: TypeAlias`
 - **Summary:** _(no docstring)_
 - **Defined in:** `application_sdk/testing/harness/atlas/__init__.py`
+
+#### `RUN_VOLATILE_FIELDS`
+
+- **Import:** `from application_sdk.testing import RUN_VOLATILE_FIELDS`
+- **Also importable from:** `application_sdk.testing.volatile_fields`
+- **Signature:** `RUN_VOLATILE_FIELDS: frozenset[str]`
+- **Summary:** Fields that change on every run. Strip before any comparison.
+- **Defined in:** `application_sdk/testing/volatile_fields.py`
 
 #### `SampleRead`
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.30.0
-source-sha:    4fb03c85dbad5d801a15ae097874b05dbd29c8dc
-source-date:   2026-08-28T17:32:50+01:00
+source-sha:    593ec61a0e3696eb29fcaff3704f3ad15b27add8
+source-date:   2026-08-28T19:48:05+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/docs/guides/integration-fixtures.md
+++ b/docs/guides/integration-fixtures.md
@@ -73,6 +73,36 @@ def infrastructure(store_root, integration_secrets):
 
 **That makes `credential_ref` a prerequisite for adopting these fixtures, not an optional preference.** An app still routing by `credential_guid` cannot get its credentials from this store, so it has to seed a GUID via the app's `/workflows/v1/dev/local-vault` dev endpoint against a live daprd — which reintroduces the external runtime the kit exists to remove, and leaves the suite on the legacy HTTP scenario path. Migrating the app's input contract to `credential_ref` is the work that unblocks adoption; until it lands, such a connector stays on the older framework by necessity rather than by choice. Treat a `credential_guid` input as a migration item, not as a reason the kit does not apply.
 
+### Sources with no container: `HttpFakeSource`
+
+SaaS and on-prem HTTP sources have no image to pull, so `integration_source` stands up a loopback HTTP server that replays reconstructed responses instead of a testcontainer. `http_fake_source_factory` owns that server's lifecycle, and ships in the same star-import as the rest of the kit:
+
+```python
+# tests/integration/conftest.py
+from application_sdk.testing import FakeRequest, HttpFakeSource
+
+
+@pytest.fixture(scope="session")
+def integration_source(http_fake_source_factory) -> HttpFakeSource:
+    fake = http_fake_source_factory(name="my-source")
+    fake.route(r"/api/v1/objects", list_objects)
+    fake.route(r"/api/v1/objects/(?P<object_id>[^/]+)", get_object)
+    return fake
+
+
+@pytest.fixture(scope="session")
+def integration_secrets(integration_source: HttpFakeSource) -> dict[str, str]:
+    return {"my-source": json.dumps({"host": integration_source.base_url})}
+```
+
+The fake is an `integration_source` like any other — the kit hands it to `integration_secrets` and otherwise leaves it alone — so the rest of the suite reads identically whether the source is a container or a fake.
+
+What the connector supplies is the part that is genuinely per-source: the endpoint map, the response envelope, and any auth-signature scheme. Everything beneath — the threading server on an ephemeral loopback port, path dispatch with named parameters, the catch-all fast 404, request recording, the silenced access log — is the SDK's.
+
+**Two counters, two scopes.** `reset_http_fake_sources` is autouse, so every test starts with a clean `requests`, `unmatched` and `hits(pattern)` — per-test questions. `unused_routes()` reads a separate lifetime counter the reset does not clear, because "is this route dead fixture weight?" can only be answered once the whole suite has run. Assert it from a session-scoped teardown, not from inside a test.
+
+**Two assertions worth making in every fake-source suite.** `assert not fake.unmatched` catches an extract calling an endpoint the fake does not model — without it the test asserted against a 404. `assert not fake.unused_routes()` catches the reverse: a route carried in the fixture that nothing exercises.
+
 ### Why a star-import and not a `pytest11` plugin
 
 A plugin loads before any conftest runs, so a module-level `application_sdk` import inside it would snapshot `APPLICATION_NAME` / `DEPLOYMENT_NAME` into `application_sdk.constants` *before* the conftest's `os.environ.setdefault` lines execute. Importing from the conftest, below those lines, is the only placement that keeps the env-before-import rule satisfiable. That constraint decides the shape.

--- a/tests/unit/testing/integration/test_fixtures.py
+++ b/tests/unit/testing/integration/test_fixtures.py
@@ -8,6 +8,7 @@ import inspect
 import os
 import subprocess
 import sys
+import urllib.request
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -16,6 +17,7 @@ from uuid import UUID
 
 import pytest
 
+from application_sdk.testing.fake_source import HttpFakeSource, HttpFakeSourceFactory
 from application_sdk.testing.integration import _errors, fixtures
 from application_sdk.testing.integration.fixtures import (
     CLEANUP_INTERCEPTOR_ENV,
@@ -24,6 +26,11 @@ from application_sdk.testing.integration.fixtures import (
 )
 
 _APP_NAME = "kit-test-app"
+
+# What an adopting conftest gets from ``from ...integration.fixtures import *``.
+# Aliased here because this module imports the kit rather than star-importing it.
+http_fake_source_factory = fixtures.http_fake_source_factory
+reset_http_fake_sources = fixtures.reset_http_fake_sources
 
 
 def _fn(fixture: Any) -> Any:
@@ -742,3 +749,61 @@ def _capture_client(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
 class _FakeRuntime:
     host: str = "127.0.0.1:7233"
     namespace: str = "test-ns"
+
+
+@pytest.fixture(scope="session")
+def shipped_fake_source(
+    http_fake_source_factory: HttpFakeSourceFactory,
+) -> HttpFakeSource:
+    """The connector-side half of the shipped pattern: routes, nothing else."""
+    source = http_fake_source_factory(
+        name="shipped-fake-source", connection_timeout=0.2
+    )
+    source.route(r"/api/objects", lambda _r: {"items": [{"id": "obj-01"}]})
+    return source
+
+
+@pytest.mark.allow_hosts(["127.0.0.1"])
+class TestFakeSourceFixtures:
+    """The session factory plus its autouse reset, used as the kit documents."""
+
+    def test_the_session_factory_yields_a_started_server(
+        self,
+        shipped_fake_source: HttpFakeSource,
+        http_fake_source_factory: HttpFakeSourceFactory,
+    ) -> None:
+        with urllib.request.urlopen(  # noqa: S310 - loopback fake on 127.0.0.1
+            f"{shipped_fake_source.base_url}/api/objects"
+        ) as response:
+            assert response.status == 200
+        assert len(shipped_fake_source.requests) == 1
+        assert shipped_fake_source.hits(r"/api/objects") == 1
+        assert list(http_fake_source_factory.sources) == [shipped_fake_source]
+
+    def test_per_test_recordings_do_not_leak_between_tests(
+        self, shipped_fake_source: HttpFakeSource
+    ) -> None:
+        """Whichever order these two run in, each starts with a clean slate.
+
+        The assertion is deliberately not on ``unused_routes``: that reads a
+        lifetime counter the reset does not clear, so it is a per-suite answer
+        and cannot be asserted from inside one test.
+        """
+        assert list(shipped_fake_source.requests) == []
+        assert shipped_fake_source.hits(r"/api/objects") == 0
+
+    def test_the_reset_is_autouse_and_takes_no_arguments(self) -> None:
+        assert _params(fixtures.reset_http_fake_sources) == []
+        assert fixtures.reset_http_fake_sources._fixture_function_marker.autouse
+
+    def test_the_reset_is_a_noop_before_any_factory_exists(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A suite whose source is a container must not pay for this fixture."""
+        monkeypatch.setattr(fixtures, "_ACTIVE_FAKE_SOURCE_FACTORY", None)
+        assert _fn(fixtures.reset_http_fake_sources)() is None
+
+    def test_both_names_ship_in_the_kit_star_import(self) -> None:
+        """The factory and its reset are one unit: neither can be picked up alone."""
+        assert "http_fake_source_factory" in fixtures.__all__
+        assert "reset_http_fake_sources" in fixtures.__all__

--- a/tests/unit/testing/test_fake_source.py
+++ b/tests/unit/testing/test_fake_source.py
@@ -27,7 +27,6 @@ from typing import Any
 import pytest
 
 from application_sdk.testing import fake_source
-from application_sdk.testing import fixtures as sdk_fixtures
 from application_sdk.testing.fake_source import (
     FakeRequest,
     FakeResponse,
@@ -38,10 +37,6 @@ from application_sdk.testing.fake_source import (
 )
 
 pytestmark = pytest.mark.allow_hosts(["127.0.0.1"])
-
-http_fake_source_factory = sdk_fixtures.http_fake_source_factory
-clean_http_fake_sources = sdk_fixtures.clean_http_fake_sources
-reset_http_fake_sources = sdk_fixtures.reset_http_fake_sources
 
 HYPHENATED = "X-Fake-AuthToken"
 
@@ -321,7 +316,9 @@ class TestRequestBodyFraming:
         conn = _connect(echo)
         try:
             conn.request("POST", "/api/echo", body=iter([b"payload"]))
-            assert conn.getresponse().read() == b'{"body": "payload"}'
+            # Decoded, not byte-compared: the server owns response framing and
+            # its JSON writer's whitespace is not part of the contract.
+            assert json.loads(conn.getresponse().read()) == {"body": "payload"}
             conn.request("GET", "/api/objects")
             following = conn.getresponse()
             assert following.status == 200
@@ -599,6 +596,19 @@ class TestRecording:
         _json(f"{fake.base_url}/api/objects")
         assert fake.unused_routes() == [r"/api/objects/(?P<object_id>obj-\d+)"]
 
+    def test_unused_routes_survives_reset(self, fake: HttpFakeSource) -> None:
+        """The dead-route ledger is per-suite; only ``hits`` is per-test.
+
+        ``reset`` runs before every test via the kit's autouse fixture, so a
+        ``unused_routes`` that read the per-test counter would report every route
+        the *other* tests exercised — failing any suite with more than one
+        route-usage assertion.
+        """
+        _json(f"{fake.base_url}/api/objects")
+        fake.reset()
+        assert fake.hits(r"/api/objects") == 0
+        assert fake.unused_routes() == [r"/api/objects/(?P<object_id>obj-\d+)"]
+
     def test_reset_clears_recordings_but_keeps_serving(
         self, fake: HttpFakeSource
     ) -> None:
@@ -864,42 +874,6 @@ class TestHttpFakeSourceFactory:
         with pytest.raises(OSError, match="cannot bind"):
             factory(name="doomed")
         assert list(factory.sources) == []
-
-
-@pytest.fixture(scope="session")
-def shipped_fixture_source(
-    http_fake_source_factory: HttpFakeSourceFactory,
-) -> HttpFakeSource:
-    """The connector-side half of the shipped pattern: routes, nothing else."""
-    source = http_fake_source_factory(
-        name="shipped-fixture-source", connection_timeout=0.2
-    )
-    source.route(r"/api/objects", lambda _r: {"items": OBJECTS})
-    return source
-
-
-class TestShippedFixtures:
-    """The session factory plus the function-scoped reset, used as documented."""
-
-    def test_the_session_factory_yields_a_started_server(
-        self,
-        shipped_fixture_source: HttpFakeSource,
-        clean_http_fake_sources: HttpFakeSourceFactory,
-    ) -> None:
-        url = shipped_fixture_source.base_url
-        assert _json(f"{url}/api/objects") == (200, {"items": OBJECTS})
-        assert len(shipped_fixture_source.requests) == 1
-        assert shipped_fixture_source.unused_routes() == []
-        assert list(clean_http_fake_sources.sources) == [shipped_fixture_source]
-
-    def test_recordings_do_not_leak_between_tests(
-        self,
-        shipped_fixture_source: HttpFakeSource,
-        clean_http_fake_sources: HttpFakeSourceFactory,
-    ) -> None:
-        assert list(shipped_fixture_source.requests) == []
-        assert shipped_fixture_source.unused_routes() == [r"/api/objects"]
-        assert _json(f"{shipped_fixture_source.base_url}/api/objects")[0] == 200
 
 
 class TestResponseFramingIsServerOwned:

--- a/tests/unit/testing/test_fake_source.py
+++ b/tests/unit/testing/test_fake_source.py
@@ -1,0 +1,972 @@
+"""Unit tests for the HttpFakeSource primitive.
+
+All fixture data here is synthetic — this is a public repo, so no captured
+customer payloads, hostnames or object ids appear.
+
+CI runs the unit tier with ``--disable-socket --allow-unix-socket`` (see
+``.github/actions/unit-tests/action.yaml``) so a unit test cannot reach the
+network. HttpFakeSource's whole purpose is to bind a real loopback listener, so
+``pytestmark`` grants AF_INET back via ``allow_hosts`` rather than
+``enable_socket``: loopback is permitted while any connect to another host is
+still refused with ``SocketConnectBlockedError``, so the guard's intent — no
+outbound traffic from the unit tier — stays enforced.
+"""
+
+from __future__ import annotations
+
+import http.client
+import json
+import socket
+import threading
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from application_sdk.testing import fake_source
+from application_sdk.testing import fixtures as sdk_fixtures
+from application_sdk.testing.fake_source import (
+    FakeRequest,
+    FakeResponse,
+    FakeSourceNotRunningError,
+    FakeSourceRouteError,
+    HttpFakeSource,
+    HttpFakeSourceFactory,
+)
+
+pytestmark = pytest.mark.allow_hosts(["127.0.0.1"])
+
+http_fake_source_factory = sdk_fixtures.http_fake_source_factory
+clean_http_fake_sources = sdk_fixtures.clean_http_fake_sources
+reset_http_fake_sources = sdk_fixtures.reset_http_fake_sources
+
+HYPHENATED = "X-Fake-AuthToken"
+
+OBJECTS = [
+    {"id": f"obj-{index:02d}", "name": f"object {index:02d}"} for index in range(1, 8)
+]
+
+
+def _request(
+    url: str,
+    *,
+    method: str = "GET",
+    data: bytes | None = None,
+    headers: dict[str, str] | None = None,
+) -> tuple[int, bytes, dict[str, str]]:
+    """Issue one HTTP call, returning (status, body, headers) even for error codes."""
+    req = urllib.request.Request(url, data=data, method=method, headers=headers or {})
+    try:
+        with urllib.request.urlopen(req, timeout=5) as response:
+            return response.status, response.read(), dict(response.headers.items())
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read(), dict(exc.headers.items())
+
+
+def _json(url: str, **kwargs: Any) -> tuple[int, Any]:
+    status, body, _ = _request(url, **kwargs)
+    return status, json.loads(body) if body else None
+
+
+def _connect(source: HttpFakeSource) -> http.client.HTTPConnection:
+    """A raw keep-alive connection, for request framing urllib cannot express."""
+    return http.client.HTTPConnection("127.0.0.1", source.port, timeout=5)
+
+
+def _headers_only_request(
+    source: HttpFakeSource,
+    headers: dict[str, str],
+    *,
+    path: str = "/api/echo",
+    conn: http.client.HTTPConnection | None = None,
+) -> tuple[int, Any]:
+    """Send headers announcing a body, then send no body at all."""
+    connection = conn or _connect(source)
+    try:
+        connection.putrequest("POST", path, skip_host=True, skip_accept_encoding=True)
+        for key, value in headers.items():
+            connection.putheader(key, value)
+        connection.endheaders()
+        response = connection.getresponse()
+        body = response.read()
+        return response.status, json.loads(body) if body else None
+    finally:
+        if conn is None:
+            connection.close()
+
+
+def _chunked_request(
+    source: HttpFakeSource,
+    raw: bytes,
+    *,
+    half_close: bool = False,
+    path: str = "/api/echo",
+) -> tuple[int, Any]:
+    """Send a hand-written ``Transfer-Encoding: chunked`` body, valid or not."""
+    connection = _connect(source)
+    try:
+        connection.putrequest("POST", path, skip_host=True, skip_accept_encoding=True)
+        connection.putheader("Transfer-Encoding", "chunked")
+        connection.endheaders()
+        if raw:
+            connection.send(raw)
+        if half_close and connection.sock is not None:
+            connection.sock.shutdown(socket.SHUT_WR)
+        response = connection.getresponse()
+        body = response.read()
+        return response.status, json.loads(body) if body else None
+    finally:
+        connection.close()
+
+
+@pytest.fixture
+def warnings(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Capture the module logger's warnings without depending on the loguru sink."""
+    captured: list[str] = []
+
+    def record(message: str, *args: Any, **_kwargs: Any) -> None:
+        captured.append(message % args if args else message)
+
+    monkeypatch.setattr(fake_source.logger, "warning", record)
+    return captured
+
+
+@pytest.fixture
+def fake() -> Iterator[HttpFakeSource]:
+    source = HttpFakeSource(name="test-source")
+    source.route(r"/api/objects", lambda _r: {"items": OBJECTS})
+    source.route(
+        r"/api/objects/(?P<object_id>obj-\d+)",
+        lambda r: next(
+            (o for o in OBJECTS if o["id"] == r.path_params["object_id"]), None
+        ),
+    )
+    with source:
+        yield source
+
+
+class TestLifecycle:
+    def test_binds_loopback_on_ephemeral_port(self, fake: HttpFakeSource) -> None:
+        assert fake.base_url.startswith("http://127.0.0.1:")
+        assert fake.port > 0
+
+    def test_base_url_before_start_is_an_error_not_a_hang(self) -> None:
+        source = HttpFakeSource()
+        with pytest.raises(FakeSourceNotRunningError, match="not running"):
+            _ = source.base_url
+        with pytest.raises(FakeSourceNotRunningError, match="not running"):
+            _ = source.port
+
+    def test_start_is_idempotent_and_keeps_the_same_port(self) -> None:
+        source = HttpFakeSource()
+        with source:
+            first = source.port
+            source.start()
+            assert source.port == first
+
+    def test_stop_is_idempotent(self) -> None:
+        source = HttpFakeSource().start()
+        source.stop()
+        source.stop()
+        with pytest.raises(FakeSourceNotRunningError):
+            _ = source.base_url
+
+
+class TestRouting:
+    def test_static_route(self, fake: HttpFakeSource) -> None:
+        status, payload = _json(f"{fake.base_url}/api/objects")
+        assert status == 200
+        assert payload == {"items": OBJECTS}
+
+    def test_named_group_becomes_a_path_param(self, fake: HttpFakeSource) -> None:
+        status, payload = _json(f"{fake.base_url}/api/objects/obj-03")
+        assert status == 200
+        assert payload == {"id": "obj-03", "name": "object 03"}
+
+    def test_handler_returning_none_is_a_404(self, fake: HttpFakeSource) -> None:
+        status, payload = _json(f"{fake.base_url}/api/objects/obj-99")
+        assert status == 404
+        assert payload == {"error": "not found"}
+
+    def test_route_matches_full_path_not_a_prefix(self, fake: HttpFakeSource) -> None:
+        status, _ = _json(f"{fake.base_url}/api/objects/obj-03/extra")
+        assert status == 404
+
+    def test_registration_order_is_match_order(self) -> None:
+        source = HttpFakeSource()
+        source.route(r"/api/objects/special", lambda _r: {"which": "specific"})
+        source.route(r"/api/objects/(?P<name>[^/]+)", lambda _r: {"which": "broad"})
+        with source:
+            assert _json(f"{source.base_url}/api/objects/special")[1] == {
+                "which": "specific"
+            }
+            assert _json(f"{source.base_url}/api/objects/other")[1] == {
+                "which": "broad"
+            }
+
+    def test_query_string_is_not_part_of_the_matched_path(
+        self, fake: HttpFakeSource
+    ) -> None:
+        status, _ = _json(f"{fake.base_url}/api/objects?limit=2&type=a")
+        assert status == 200
+
+    def test_route_returns_self_for_chaining(self) -> None:
+        source = HttpFakeSource()
+        assert source.route(r"/a", lambda _r: {}) is source
+        assert [pattern for pattern, _ in source.routes] == ["/a"]
+
+    def test_route_requires_at_least_one_method(self) -> None:
+        with pytest.raises(FakeSourceRouteError, match="at least one HTTP method"):
+            HttpFakeSource().route(r"/a", lambda _r: {}, methods=())
+
+    def test_routes_can_be_passed_to_the_constructor(self) -> None:
+        with HttpFakeSource(routes=[(r"/ping", lambda _r: {"ok": True})]) as source:
+            assert _json(f"{source.base_url}/ping")[1] == {"ok": True}
+
+
+class TestCatchAllFastFourOhFour:
+    """The load-bearing behaviour: an unexpected call must fail, never hang."""
+
+    def test_unmatched_path_is_404(self, fake: HttpFakeSource) -> None:
+        status, payload = _json(f"{fake.base_url}/api/not/modelled")
+        assert status == 404
+        assert payload == {"error": "not found"}
+
+    @pytest.mark.parametrize(
+        "method", ["POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]
+    )
+    def test_every_verb_answers_rather_than_hanging(
+        self, fake: HttpFakeSource, method: str
+    ) -> None:
+        data = b"{}" if method in {"POST", "PUT", "PATCH"} else None
+        status, _, _ = _request(
+            f"{fake.base_url}/api/objects", method=method, data=data
+        )
+        assert status == 404
+
+    def test_wrong_method_on_a_known_path_is_404(self, fake: HttpFakeSource) -> None:
+        status, _, _ = _request(
+            f"{fake.base_url}/api/objects", method="POST", data=b"{}"
+        )
+        assert status == 404
+
+    def test_post_body_is_drained_so_the_connection_is_reusable(
+        self, fake: HttpFakeSource
+    ) -> None:
+        status, _, _ = _request(
+            f"{fake.base_url}/api/unknown", method="POST", data=b"x" * 4096
+        )
+        assert status == 404
+        assert _json(f"{fake.base_url}/api/objects")[0] == 200
+
+    def test_not_found_body_is_configurable(self) -> None:
+        source = HttpFakeSource(not_found_body={"message": "Not Found"})
+        with source:
+            assert _json(f"{source.base_url}/nope")[1] == {"message": "Not Found"}
+
+    def test_unmatched_calls_are_recorded(self, fake: HttpFakeSource) -> None:
+        _json(f"{fake.base_url}/api/absent")
+        assert [(r.method, r.path) for r in fake.unmatched] == [("GET", "/api/absent")]
+
+    def test_a_matched_route_returning_404_is_not_unmatched(
+        self, fake: HttpFakeSource
+    ) -> None:
+        _json(f"{fake.base_url}/api/objects/obj-99")
+        assert list(fake.unmatched) == []
+
+    def test_unmatched_is_logged(
+        self, fake: HttpFakeSource, warnings: list[str]
+    ) -> None:
+        _json(f"{fake.base_url}/api/absent")
+        assert any("no route for" in message for message in warnings)
+        assert any("/api/absent" in message for message in warnings)
+
+    def test_warn_unmatched_can_be_silenced(self, warnings: list[str]) -> None:
+        with HttpFakeSource(warn_unmatched=False) as source:
+            _json(f"{source.base_url}/api/absent")
+        assert warnings == []
+
+
+class TestRequestBodyFraming:
+    """A body the server cannot frame must answer and never desync the connection."""
+
+    @pytest.fixture
+    def echo(self) -> Iterator[HttpFakeSource]:
+        source = HttpFakeSource(name="echo-source")
+        source.route(
+            r"/api/echo",
+            lambda r: {"body": r.body.decode()},
+            methods=("POST",),
+        )
+        source.route(r"/api/objects", lambda _r: {"items": OBJECTS})
+        with source:
+            yield source
+
+    def test_chunked_post_body_reaches_the_handler(self, echo: HttpFakeSource) -> None:
+        conn = _connect(echo)
+        try:
+            conn.request("POST", "/api/echo", body=iter([b"one-", b"two-", b"three"]))
+            response = conn.getresponse()
+            assert response.status == 200
+            assert json.loads(response.read()) == {"body": "one-two-three"}
+        finally:
+            conn.close()
+
+    def test_chunked_post_leaves_the_next_request_uncorrupted(
+        self, echo: HttpFakeSource
+    ) -> None:
+        conn = _connect(echo)
+        try:
+            conn.request("POST", "/api/echo", body=iter([b"payload"]))
+            assert conn.getresponse().read() == b'{"body": "payload"}'
+            conn.request("GET", "/api/objects")
+            following = conn.getresponse()
+            assert following.status == 200
+            assert json.loads(following.read()) == {"items": OBJECTS}
+        finally:
+            conn.close()
+
+    def test_empty_chunked_post_is_an_empty_body(self, echo: HttpFakeSource) -> None:
+        conn = _connect(echo)
+        try:
+            conn.request("POST", "/api/echo", body=iter([]))
+            assert json.loads(conn.getresponse().read()) == {"body": ""}
+        finally:
+            conn.close()
+
+    @pytest.mark.parametrize("value", ["abc", "1.5", "-1", "0x10", "12abc"])
+    def test_unparseable_content_length_is_a_400(
+        self, echo: HttpFakeSource, value: str
+    ) -> None:
+        status, payload = _headers_only_request(echo, {"Content-Length": value})
+        assert status == 400
+        assert payload == {"error": "malformed request body"}
+
+    def test_oversize_content_length_is_a_413(self, echo: HttpFakeSource) -> None:
+        status, payload = _headers_only_request(
+            echo, {"Content-Length": str(64 * 1024 * 1024 + 1)}
+        )
+        assert status == 413
+        assert payload == {"error": "request body too large"}
+
+    @pytest.mark.parametrize(
+        ("raw", "half_close"),
+        [
+            (b"not-a-chunk-size\r\n", False),
+            (b"", True),
+            (b"-1\r\n", False),
+            (b"4000001\r\n", False),
+            (b"5\r\nab", True),
+            (b"2\r\nabXX", False),
+            (b"0\r\n", True),
+        ],
+        ids=[
+            "unparseable-size",
+            "eof-before-size",
+            "negative-size",
+            "oversize-chunk",
+            "truncated-chunk",
+            "missing-chunk-terminator",
+            "eof-in-trailers",
+        ],
+    )
+    def test_malformed_chunk_framing_is_a_400(
+        self, echo: HttpFakeSource, raw: bytes, half_close: bool
+    ) -> None:
+        status, payload = _chunked_request(echo, raw, half_close=half_close)
+        assert status == 400
+        assert payload == {"error": "malformed request body"}
+
+    @pytest.mark.parametrize(
+        ("headers", "expected"),
+        [
+            ({"Content-Length": "abc"}, 400),
+            ({"Content-Length": str(64 * 1024 * 1024 + 1)}, 413),
+        ],
+    )
+    def test_a_refused_body_closes_the_connection(
+        self, echo: HttpFakeSource, headers: dict[str, str], expected: int
+    ) -> None:
+        conn = _connect(echo)
+        try:
+            status, _ = _headers_only_request(echo, headers, conn=conn)
+            assert status == expected
+            assert conn.sock is None
+        finally:
+            conn.close()
+
+    def test_refused_body_is_logged(
+        self, echo: HttpFakeSource, warnings: list[str]
+    ) -> None:
+        _headers_only_request(echo, {"Content-Length": "abc"})
+        assert any("could not read the body" in message for message in warnings)
+
+
+class TestHandlerContract:
+    def test_dict_shorthand_is_a_200(self) -> None:
+        with HttpFakeSource(routes=[(r"/a", lambda _r: {"x": 1})]) as source:
+            assert _json(f"{source.base_url}/a") == (200, {"x": 1})
+
+    def test_list_shorthand_is_a_200(self) -> None:
+        with HttpFakeSource(routes=[(r"/a", lambda _r: [1, 2])]) as source:
+            assert _json(f"{source.base_url}/a") == (200, [1, 2])
+
+    def test_status_body_tuple_shorthand(self) -> None:
+        with HttpFakeSource(routes=[(r"/a", lambda _r: (503, {"e": "busy"}))]) as src:
+            assert _json(f"{src.base_url}/a") == (503, {"e": "busy"})
+
+    def test_fake_response_with_custom_headers(self) -> None:
+        source = HttpFakeSource(
+            routes=[
+                (
+                    r"/a",
+                    lambda _r: FakeResponse.json_(
+                        {"vertices": []}, cursorMark="off:7", totalFound="7"
+                    ),
+                )
+            ]
+        )
+        with source:
+            status, _, headers = _request(f"{source.base_url}/a")
+        assert status == 200
+        assert headers["cursorMark"] == "off:7"
+        assert headers["totalFound"] == "7"
+
+    def test_text_response_keeps_its_content_type(self) -> None:
+        source = HttpFakeSource(
+            routes=[(r"/token", lambda _r: FakeResponse.text("token-value"))]
+        )
+        with source:
+            status, body, headers = _request(f"{source.base_url}/token")
+        assert (status, body) == (200, b"token-value")
+        assert headers["Content-Type"].startswith("text/plain")
+
+    def test_xml_response_for_a_non_json_source(self) -> None:
+        xml = "<Report><Name>synthetic</Name></Report>"
+        source = HttpFakeSource(
+            routes=[
+                (
+                    r"/soap",
+                    lambda _r: FakeResponse.text(xml, content_type="text/xml"),
+                )
+            ]
+        )
+        with source:
+            status, body, headers = _request(f"{source.base_url}/soap")
+        assert (status, body) == (200, xml.encode())
+        assert headers["Content-Type"] == "text/xml"
+
+    def test_raw_bytes_are_not_re_encoded(self) -> None:
+        payload = b"\x00\x01\x02binary"
+        source = HttpFakeSource(
+            routes=[(r"/blob", lambda _r: FakeResponse.raw(payload))]
+        )
+        with source:
+            status, body, _ = _request(f"{source.base_url}/blob")
+        assert (status, body) == (200, payload)
+
+    def test_handler_exception_becomes_a_500_not_a_dropped_connection(
+        self, warnings: list[str]
+    ) -> None:
+        def boom(_request: FakeRequest) -> Any:
+            raise RuntimeError("synthetic handler bug")
+
+        with HttpFakeSource(routes=[(r"/a", boom)]) as source:
+            status, payload = _json(f"{source.base_url}/a")
+        assert status == 500
+        assert payload is not None
+        assert "synthetic handler bug" in payload["detail"]
+        assert any("raised" in message for message in warnings)
+
+    def test_head_sends_no_body_but_still_answers(self) -> None:
+        source = HttpFakeSource()
+        source.route(r"/a", lambda _r: {"x": 1}, methods=("GET", "HEAD"))
+        with source:
+            status, body, headers = _request(f"{source.base_url}/a", method="HEAD")
+        assert status == 200
+        assert body == b""
+        assert headers["Content-Length"] == "0"
+
+
+class TestFakeRequest:
+    def test_exposes_method_path_params_and_headers(self) -> None:
+        seen: list[FakeRequest] = []
+
+        def capture(request: FakeRequest) -> Any:
+            seen.append(request)
+            return {"ok": True}
+
+        source = HttpFakeSource()
+        source.route(r"/api/(?P<kind>\w+)/(?P<item_id>\w+)", capture, methods=("POST",))
+        with source:
+            _request(
+                f"{source.base_url}/api/tables/t1?verbose=true&tag=a&tag=b",
+                method="POST",
+                data=b'{"n": 1}',
+                headers={"X-Project-Id": "project-1"},
+            )
+
+        request = seen[0]
+        assert request.method == "POST"
+        assert request.path == "/api/tables/t1"
+        assert request.path_params == {"kind": "tables", "item_id": "t1"}
+        assert request.params["verbose"] == "true"
+        assert list(request.query["tag"]) == ["a", "b"]
+        assert request.json() == {"n": 1}
+        assert request.header("x-project-id") == "project-1"
+
+    def test_header_lookup_is_case_insensitive_with_a_default(self) -> None:
+        request = FakeRequest(
+            method="GET",
+            path="/a",
+            params={},
+            query={},
+            path_params={},
+            headers={"X-MSTR-ProjectID": "p1"},
+            body=b"",
+        )
+        assert request.header("x-mstr-projectid") == "p1"
+        assert request.header("absent", "fallback") == "fallback"
+
+    def test_json_returns_default_on_empty_or_malformed_body(self) -> None:
+        def build(body: bytes) -> FakeRequest:
+            return FakeRequest(
+                method="POST",
+                path="/a",
+                params={},
+                query={},
+                path_params={},
+                headers={},
+                body=body,
+            )
+
+        assert build(b"").json() is None
+        assert build(b"not json").json(default={}) == {}
+
+    def test_param_treats_blank_as_absent(self) -> None:
+        request = FakeRequest(
+            method="GET",
+            path="/a",
+            params={"cursor": "", "limit": "5"},
+            query={},
+            path_params={},
+            headers={},
+            body=b"",
+        )
+        assert request.param("cursor") is None
+        assert request.param("cursor", "start") == "start"
+        assert request.param("limit") == "5"
+
+    def test_int_param_falls_back_rather_than_raising(self) -> None:
+        request = FakeRequest(
+            method="GET",
+            path="/a",
+            params={"limit": "abc", "offset": "5", "blank": ""},
+            query={},
+            path_params={},
+            headers={},
+            body=b"",
+        )
+        assert request.int_param("limit", 100) == 100
+        assert request.int_param("offset", 0) == 5
+        assert request.int_param("blank", 7) == 7
+        assert request.int_param("absent", 9) == 9
+
+
+class TestRecording:
+    def test_requests_are_recorded_in_arrival_order(self, fake: HttpFakeSource) -> None:
+        _json(f"{fake.base_url}/api/objects")
+        _json(f"{fake.base_url}/api/objects/obj-01")
+        assert [r.path for r in fake.requests] == [
+            "/api/objects",
+            "/api/objects/obj-01",
+        ]
+
+    def test_hits_counts_per_route_pattern(self, fake: HttpFakeSource) -> None:
+        _json(f"{fake.base_url}/api/objects")
+        _json(f"{fake.base_url}/api/objects/obj-01")
+        _json(f"{fake.base_url}/api/objects/obj-02")
+        assert fake.hits(r"/api/objects") == 1
+        assert fake.hits(r"/api/objects/(?P<object_id>obj-\d+)") == 2
+        assert fake.hits(r"/never/registered") == 0
+
+    def test_unused_routes_names_what_was_never_called(
+        self, fake: HttpFakeSource
+    ) -> None:
+        _json(f"{fake.base_url}/api/objects")
+        assert fake.unused_routes() == [r"/api/objects/(?P<object_id>obj-\d+)"]
+
+    def test_reset_clears_recordings_but_keeps_serving(
+        self, fake: HttpFakeSource
+    ) -> None:
+        _json(f"{fake.base_url}/api/objects")
+        _json(f"{fake.base_url}/api/absent")
+        fake.reset()
+        assert list(fake.requests) == []
+        assert list(fake.unmatched) == []
+        assert fake.hits(r"/api/objects") == 0
+        assert _json(f"{fake.base_url}/api/objects")[0] == 200
+
+
+class TestAuthorize:
+    def test_authorizer_can_short_circuit_with_a_401(self) -> None:
+        def require_token(request: FakeRequest) -> Any:
+            if request.header("authorization") != "Bearer synthetic-token":
+                return FakeResponse.json_({"error": "unauthorized"}, status=401)
+            return None
+
+        source = HttpFakeSource(
+            routes=[(r"/api/objects", lambda _r: {"items": []})],
+            authorize=require_token,
+        )
+        with source:
+            assert _json(f"{source.base_url}/api/objects")[0] == 401
+            status, payload = _json(
+                f"{source.base_url}/api/objects",
+                headers={"Authorization": "Bearer synthetic-token"},
+            )
+        assert (status, payload) == (200, {"items": []})
+
+    def test_authorizer_returning_none_lets_the_request_through(self) -> None:
+        source = HttpFakeSource(
+            routes=[(r"/a", lambda _r: {"ok": True})],
+            authorize=lambda _r: None,
+        )
+        with source:
+            assert _json(f"{source.base_url}/a") == (200, {"ok": True})
+
+
+class TestSessionScopedFixtureShape:
+    """The primitive must survive the fixture slot a testcontainer occupies."""
+
+    def test_one_server_serves_many_sequential_tests_after_reset(
+        self, fake: HttpFakeSource
+    ) -> None:
+        for _ in range(3):
+            fake.reset()
+            assert _json(f"{fake.base_url}/api/objects") == (200, {"items": OBJECTS})
+            assert len(fake.requests) == 1
+            assert list(fake.unmatched) == []
+
+    def test_concurrent_clients_are_served(self, fake: HttpFakeSource) -> None:
+        import concurrent.futures
+
+        url = fake.base_url
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+            results = list(
+                pool.map(lambda _n: _json(f"{url}/api/objects"), range(8)),
+            )
+        assert all(result == (200, {"items": OBJECTS}) for result in results)
+        assert len(fake.requests) == 8
+
+
+def _settled_thread_count(timeout: float = 2.0) -> int:
+    """The live thread count once two consecutive samples agree.
+
+    An unrelated pool spinning up mid-measurement would otherwise make the
+    thread-baseline assertions flaky.
+    """
+    deadline = time.monotonic() + timeout
+    previous = threading.active_count()
+    while time.monotonic() < deadline:
+        time.sleep(0.05)
+        current = threading.active_count()
+        if current == previous:
+            return current
+        previous = current
+    return previous
+
+
+class TestTrailingSlash:
+    def test_a_single_trailing_slash_is_tolerated(self, fake: HttpFakeSource) -> None:
+        status, payload = _json(f"{fake.base_url}/api/objects/")
+        assert status == 200
+        assert payload == {"items": OBJECTS}
+
+    def test_the_recorded_path_keeps_the_slash_as_sent(
+        self, fake: HttpFakeSource
+    ) -> None:
+        _json(f"{fake.base_url}/api/objects/")
+        assert [r.path for r in fake.requests] == ["/api/objects/"]
+
+    def test_an_exact_match_beats_the_normalised_retry(self) -> None:
+        source = HttpFakeSource()
+        source.route(r"/api/thing/", lambda _r: {"which": "with-slash"})
+        source.route(r"/api/thing", lambda _r: {"which": "without-slash"})
+        with source:
+            assert _json(f"{source.base_url}/api/thing/")[1] == {"which": "with-slash"}
+            assert _json(f"{source.base_url}/api/thing")[1] == {
+                "which": "without-slash"
+            }
+
+    def test_a_double_trailing_slash_is_not_normalised(
+        self, fake: HttpFakeSource
+    ) -> None:
+        assert _json(f"{fake.base_url}/api/objects//")[0] == 404
+
+    def test_normalisation_does_not_turn_a_prefix_into_a_match(
+        self, fake: HttpFakeSource
+    ) -> None:
+        assert _json(f"{fake.base_url}/api/objects/obj-03/extra/")[0] == 404
+
+
+class TestThreadTeardown:
+    """stop() must join the per-connection handler threads, not just the accept loop."""
+
+    def test_stop_returns_to_the_thread_baseline(self) -> None:
+        baseline = _settled_thread_count()
+        source = HttpFakeSource(connection_timeout=0.2)
+        source.route(r"/ping", lambda _r: {"ok": True})
+        source.start()
+        try:
+            assert _json(f"{source.base_url}/ping")[0] == 200
+        finally:
+            source.stop()
+        assert threading.active_count() == baseline
+
+    def test_stop_joins_a_handler_blocked_on_an_idle_keep_alive_connection(
+        self,
+    ) -> None:
+        """The case that slipped through: the thread survived stop() in readline."""
+        baseline = _settled_thread_count()
+        source = HttpFakeSource(connection_timeout=0.2)
+        source.route(r"/ping", lambda _r: {"ok": True})
+        source.start()
+        connection = _connect(source)
+        try:
+            connection.request("GET", "/ping")
+            assert connection.getresponse().read()
+            assert threading.active_count() > baseline
+            source.stop()
+            assert threading.active_count() == baseline
+        finally:
+            connection.close()
+            source.stop()
+
+    def test_stop_warns_about_a_thread_that_outlives_the_join_budget(
+        self, warnings: list[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        release = threading.Event()
+        straggler = threading.Thread(
+            target=release.wait, name="wedged-handler", daemon=True
+        )
+        straggler.start()
+        monkeypatch.setattr(fake_source, "_JOIN_GRACE_SECONDS", 0.05)
+        monkeypatch.setattr(
+            fake_source._FakeSourceServer,
+            "handler_threads",
+            lambda _self: [straggler],
+        )
+        source = HttpFakeSource(name="wedged", connection_timeout=0.01)
+        source.start()
+        try:
+            source.stop()
+            assert any("left 1 thread(s) running" in message for message in warnings)
+            assert any("wedged-handler" in message for message in warnings)
+        finally:
+            release.set()
+            straggler.join(timeout=5)
+
+    def test_stop_on_a_never_started_source_does_nothing(
+        self, warnings: list[str]
+    ) -> None:
+        HttpFakeSource().stop()
+        assert warnings == []
+
+
+class TestHyphenatedResponseHeaders:
+    """``X-Fake-AuthToken=`` is a syntax error, so the mapping form is required."""
+
+    def test_every_constructor_accepts_a_hyphenated_header(self) -> None:
+        header = {HYPHENATED: "token-0123"}
+        assert FakeResponse.json_({}, headers=header).headers == header
+        assert FakeResponse.text("body", headers=header).headers == header
+        assert FakeResponse.raw(b"body", headers=header).headers == header
+
+    def test_keyword_headers_still_work(self) -> None:
+        assert FakeResponse.json_({}, X_Token="a").headers == {"X_Token": "a"}
+        assert FakeResponse.text("b", X_Token="a").headers == {"X_Token": "a"}
+        assert FakeResponse.raw(b"c", X_Token="a").headers == {"X_Token": "a"}
+
+    def test_the_two_forms_combine(self) -> None:
+        response = FakeResponse.json_({}, headers={HYPHENATED: "a"}, X_Plain="b")
+        assert response.headers == {HYPHENATED: "a", "X_Plain": "b"}
+
+    def test_a_keyword_wins_over_the_mapping_on_the_same_key(self) -> None:
+        response = FakeResponse.json_(
+            {}, headers={"X_Token": "from-mapping"}, X_Token="from-keyword"
+        )
+        assert response.headers == {"X_Token": "from-keyword"}
+
+    def test_positional_status_and_content_type_are_unchanged(self) -> None:
+        assert FakeResponse.json_({}, 201).status == 201
+        assert FakeResponse.text("b", 202, "text/html").content_type == "text/html"
+        assert FakeResponse.raw(b"c", 203, "image/png").content_type == "image/png"
+
+    def test_a_hyphenated_header_reaches_the_client(self) -> None:
+        source = HttpFakeSource(
+            routes=[
+                (
+                    r"/login",
+                    lambda _r: FakeResponse.json_(
+                        {"ok": True}, headers={HYPHENATED: "token-0123"}
+                    ),
+                )
+            ]
+        )
+        with source:
+            status, _, headers = _request(f"{source.base_url}/login")
+        assert status == 200
+        assert headers[HYPHENATED] == "token-0123"
+
+
+class TestHttpFakeSourceFactory:
+    def test_builds_started_sources_and_stops_them_all(self) -> None:
+        baseline = _settled_thread_count()
+        factory = HttpFakeSourceFactory()
+        first = factory(name="first", connection_timeout=0.2)
+        second = factory(name="second", connection_timeout=0.2)
+        first.route(r"/ping", lambda _r: {"which": "first"})
+        try:
+            assert _json(f"{first.base_url}/ping")[1] == {"which": "first"}
+            assert list(factory.sources) == [first, second]
+        finally:
+            factory.stop_all()
+        assert list(factory.sources) == []
+        assert threading.active_count() == baseline
+        with pytest.raises(FakeSourceNotRunningError, match="not running"):
+            _ = first.base_url
+
+    def test_reset_all_clears_every_source(self) -> None:
+        factory = HttpFakeSourceFactory()
+        source = factory(name="resettable", connection_timeout=0.2)
+        source.route(r"/ping", lambda _r: {"ok": True})
+        try:
+            _json(f"{source.base_url}/ping")
+            assert source.hits(r"/ping") == 1
+            factory.reset_all()
+            assert source.hits(r"/ping") == 0
+            assert list(source.requests) == []
+        finally:
+            factory.stop_all()
+
+    def test_a_source_that_fails_to_start_is_not_remembered(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def boom(_self: HttpFakeSource) -> None:
+            raise OSError("cannot bind")
+
+        monkeypatch.setattr(HttpFakeSource, "start", boom)
+        factory = HttpFakeSourceFactory()
+        with pytest.raises(OSError, match="cannot bind"):
+            factory(name="doomed")
+        assert list(factory.sources) == []
+
+
+@pytest.fixture(scope="session")
+def shipped_fixture_source(
+    http_fake_source_factory: HttpFakeSourceFactory,
+) -> HttpFakeSource:
+    """The connector-side half of the shipped pattern: routes, nothing else."""
+    source = http_fake_source_factory(
+        name="shipped-fixture-source", connection_timeout=0.2
+    )
+    source.route(r"/api/objects", lambda _r: {"items": OBJECTS})
+    return source
+
+
+class TestShippedFixtures:
+    """The session factory plus the function-scoped reset, used as documented."""
+
+    def test_the_session_factory_yields_a_started_server(
+        self,
+        shipped_fixture_source: HttpFakeSource,
+        clean_http_fake_sources: HttpFakeSourceFactory,
+    ) -> None:
+        url = shipped_fixture_source.base_url
+        assert _json(f"{url}/api/objects") == (200, {"items": OBJECTS})
+        assert len(shipped_fixture_source.requests) == 1
+        assert shipped_fixture_source.unused_routes() == []
+        assert list(clean_http_fake_sources.sources) == [shipped_fixture_source]
+
+    def test_recordings_do_not_leak_between_tests(
+        self,
+        shipped_fixture_source: HttpFakeSource,
+        clean_http_fake_sources: HttpFakeSourceFactory,
+    ) -> None:
+        assert list(shipped_fixture_source.requests) == []
+        assert shipped_fixture_source.unused_routes() == [r"/api/objects"]
+        assert _json(f"{shipped_fixture_source.base_url}/api/objects")[0] == 200
+
+
+class TestResponseFramingIsServerOwned:
+    """A handler must not be able to put a second framing header on the wire."""
+
+    def test_handler_content_length_is_dropped(self) -> None:
+        fake = HttpFakeSource(name="framing")
+        fake.route(
+            r"/dup",
+            lambda _r: FakeResponse.json_({"a": 1}, headers={"Content-Length": "999"}),
+        )
+        with fake:
+            conn = http.client.HTTPConnection("127.0.0.1", fake.port, timeout=5)
+            conn.request("GET", "/dup")
+            response = conn.getresponse()
+            lengths = [
+                v for k, v in response.getheaders() if k.lower() == "content-length"
+            ]
+            body = response.read()
+            conn.close()
+        assert lengths == [
+            str(len(body))
+        ], f"expected exactly the server's own Content-Length, got {lengths!r}"
+
+    @pytest.mark.parametrize("header", ["Transfer-Encoding", "Connection"])
+    def test_hop_by_hop_headers_are_dropped(self, header: str) -> None:
+        fake = HttpFakeSource(name="framing")
+        fake.route(
+            r"/x", lambda _r: FakeResponse.json_({"a": 1}, headers={header: "chunked"})
+        )
+        with fake:
+            conn = http.client.HTTPConnection("127.0.0.1", fake.port, timeout=5)
+            conn.request("GET", "/x")
+            response = conn.getresponse()
+            sent = [v for k, v in response.getheaders() if k.lower() == header.lower()]
+            response.read()
+            conn.close()
+        assert sent == [], f"{header} should not be echoed from a handler, got {sent!r}"
+
+    def test_a_non_framing_header_still_reaches_the_client(self) -> None:
+        fake = HttpFakeSource(name="framing")
+        fake.route(
+            r"/x", lambda _r: FakeResponse.json_({"a": 1}, headers={"X-Cursor": "abc"})
+        )
+        with fake:
+            conn = http.client.HTTPConnection("127.0.0.1", fake.port, timeout=5)
+            conn.request("GET", "/x")
+            response = conn.getresponse()
+            assert response.getheader("X-Cursor") == "abc"
+            response.read()
+            conn.close()
+
+
+class TestRaisingAuthorizeAnswers:
+    """An authorize hook is consumer code: a bug in it must answer, not hang."""
+
+    def test_raising_authorize_returns_500(self) -> None:
+        def boom(_request: FakeRequest) -> None:
+            raise RuntimeError("authorize blew up")
+
+        fake = HttpFakeSource(name="auth", authorize=boom)
+        fake.route(r"/x", lambda _r: FakeResponse.json_({"ok": True}))
+        with fake:
+            conn = http.client.HTTPConnection("127.0.0.1", fake.port, timeout=5)
+            conn.request("GET", "/x")
+            response = conn.getresponse()
+            status, body = response.status, response.read()
+            conn.close()
+        assert status == 500
+        assert b"authorize" in body

--- a/tests/unit/testing/test_volatile_fields.py
+++ b/tests/unit/testing/test_volatile_fields.py
@@ -1,0 +1,120 @@
+"""Unit tests for the canonical comparison field sets.
+
+The literal-set assertions here are deliberate regression locks. Both existing
+constants are now composed from these sets, and both are consumed by code that
+runs in production, so silent drift in either direction must fail loudly.
+"""
+
+from application_sdk.testing.integration.comparison import (
+    DEFAULT_IGNORED_FIELDS,
+    DEFAULT_IGNORED_NESTED_FIELDS,
+)
+from application_sdk.testing.parity.comparator import VOLATILE_FIELDS
+from application_sdk.testing.volatile_fields import (
+    ENVIRONMENT_SCOPED_FIELDS,
+    ENVIRONMENT_SCOPED_NESTED_FIELDS,
+    RUN_VOLATILE_FIELDS,
+)
+
+
+class TestCanonicalSets:
+    def test_run_volatile_is_exactly_the_three_run_scoped_keys(self):
+        assert RUN_VOLATILE_FIELDS == {
+            "lastSyncRun",
+            "lastSyncRunAt",
+            "lastSyncWorkflowName",
+        }
+
+    def test_environment_scoped_contents(self):
+        assert ENVIRONMENT_SCOPED_FIELDS == {
+            "connectionName",
+            "connectionQualifiedName",
+            "databaseQualifiedName",
+            "qualifiedName",
+            "schemaQualifiedName",
+            "tableQualifiedName",
+            "tenantId",
+            "viewQualifiedName",
+        }
+
+    def test_environment_scoped_nested_contents(self):
+        assert ENVIRONMENT_SCOPED_NESTED_FIELDS == {
+            "atlanSchema",
+            "database",
+            "materialisedView",
+            "parentTable",
+            "table",
+            "tablePartition",
+            "view",
+        }
+
+    def test_concepts_are_disjoint(self):
+        assert not RUN_VOLATILE_FIELDS & ENVIRONMENT_SCOPED_FIELDS
+        assert not ENVIRONMENT_SCOPED_FIELDS & ENVIRONMENT_SCOPED_NESTED_FIELDS
+
+    def test_qualified_name_is_environment_scoped_not_run_volatile(self):
+        """The distinction FND-819 exists to make.
+
+        A golden diff keys on qualifiedName, so it must not be classified as
+        run-volatile or the golden assertion would strip its own join key.
+        """
+        assert "qualifiedName" in ENVIRONMENT_SCOPED_FIELDS
+        assert "qualifiedName" not in RUN_VOLATILE_FIELDS
+
+
+class TestProductionConstantsUnchanged:
+    """Locks the two live constants to the exact contents they shipped with."""
+
+    def test_default_ignored_fields_is_the_same_eleven(self):
+        assert DEFAULT_IGNORED_FIELDS == {
+            "qualifiedName",
+            "connectionQualifiedName",
+            "lastSyncWorkflowName",
+            "lastSyncRun",
+            "lastSyncRunAt",
+            "tenantId",
+            "connectionName",
+            "databaseQualifiedName",
+            "schemaQualifiedName",
+            "tableQualifiedName",
+            "viewQualifiedName",
+        }
+        assert len(DEFAULT_IGNORED_FIELDS) == 11
+
+    def test_default_ignored_nested_fields_is_the_same_seven(self):
+        assert DEFAULT_IGNORED_NESTED_FIELDS == {
+            "atlanSchema",
+            "database",
+            "table",
+            "view",
+            "materialisedView",
+            "parentTable",
+            "tablePartition",
+        }
+        assert len(DEFAULT_IGNORED_NESTED_FIELDS) == 7
+
+    def test_parity_volatile_fields_is_the_same_three(self):
+        assert VOLATILE_FIELDS == {
+            "lastSyncWorkflowName",
+            "lastSyncRun",
+            "lastSyncRunAt",
+        }
+        assert len(VOLATILE_FIELDS) == 3
+
+    def test_default_ignored_is_the_union_of_both_concepts(self):
+        assert DEFAULT_IGNORED_FIELDS == RUN_VOLATILE_FIELDS | ENVIRONMENT_SCOPED_FIELDS
+
+    def test_parity_set_is_a_strict_subset_of_the_integration_set(self):
+        assert VOLATILE_FIELDS < DEFAULT_IGNORED_FIELDS
+
+    def test_live_constants_are_mutable_sets(self):
+        """Callers may copy/union these; the public type must not become frozen."""
+        assert isinstance(DEFAULT_IGNORED_FIELDS, set)
+        assert isinstance(DEFAULT_IGNORED_NESTED_FIELDS, set)
+        assert isinstance(VOLATILE_FIELDS, set)
+
+    def test_mutating_a_live_constant_cannot_corrupt_the_canonical_set(self):
+        copied = set(DEFAULT_IGNORED_FIELDS)
+        copied.add("injected")
+        assert "injected" not in RUN_VOLATILE_FIELDS
+        assert "injected" not in ENVIRONMENT_SCOPED_FIELDS


### PR DESCRIPTION
Closes FND-816 and FND-819. Rebased onto `main` now that #3495 has merged; this no longer stacks on anything.

## Why

Connectors with no live test source need two small SDK pieces before they can run an Integration-tier suite through `integration_kit`: a fake source that sits in the testcontainer fixture slot, and one agreed answer to "which fields are volatile". Four connector suites had written the same stdlib HTTP server independently; the SDK itself shipped two contradictory volatile-field sets.

## What

- **`HttpFakeSource`** (FND-816) — loopback-only stdlib HTTP server on an ephemeral port. Regex route table with named path params (first registered match per path candidate wins, exact path before trailing-slash-normalised), recorded `requests` and `unmatched` calls, route hit counts, context-manager lifecycle, `base_url`. Handler results are typed (`HandlerResult`), misuse raises typed leaves (`FakeSourceRouteError`, `FakeSourceNotRunningError`, in `testing/_errors.py` beside `testing/integration/_errors.py`). Endpoint maps, response envelopes and auth handling stay with the connector — those are irreducible per source.
- **Its fixtures ship in the integration kit**, not beside the class: `http_fake_source_factory` (session) plus the autouse `reset_http_fake_sources` live in `application_sdk.testing.integration.fixtures`, so a connector's single kit star-import brings the factory and its reset together and there is no second module to know about. The fake is an `integration_source` like any other.
- **`volatile_fields`** (FND-819) — `RUN_VOLATILE_FIELDS`, `ENVIRONMENT_SCOPED_FIELDS`, `ENVIRONMENT_SCOPED_NESTED_FIELDS` as three documented concepts, not one list. `integration/comparison.py` and `parity/comparator.py` now derive their existing sets from them; resolved values unchanged (11 + 7, and 3). The docstring records the three connector data points (MicroStrategy, NetSuite, PowerCenter) the run-volatile set was checked against.

## Two counters, two scopes

`hits(pattern)` answers "did *this test* call that endpoint?" and the autouse reset clears it. `unused_routes()` answers "is this route dead fixture weight?", which can only be answered once the whole suite has run, so it reads a lifetime counter `reset()` does not clear. One counter serving both fails any suite with more than one route-usage assertion.

## What touches existing callers

Only the two constant re-sourcings in `comparison.py` (consumed by the legacy `integration/runner.py`) and `comparator.py`. Both behaviour-neutral.

## Deliberately excluded

Pagination helpers, query-constrained routes, the multi-host story and a golden-corpus loader. No source-less connector has yet run through the kit, so the shape those need is not known. FND-816 has been trimmed to match, with the remainder tracked in FND-1044 (blocked on FND-821); the code is parked in draft #3498. `assert_extract_roundtrip` is dropped rather than deferred — it asserts below the app, skipping every `@task`, the entrypoint orchestration and Temporal, which contradicts the FND-815 contract invariant.

## Validation

`tests/unit`: 9270 passed, 9 skipped. Pre-commit (ruff + pyright) clean. Conformance: no unsuppressed findings in the changed files — the two JSON seams moved to orjson (O001) and the four deliberate protocol-error fallbacks carry `# conformance: ignore[E007]` with rationale.
