### PR TITLE
fix(testing): stop a reset of the logger init flags leaking to the next test (FND-976)

### DIFF
--- a/application_sdk/testing/__init__.py
+++ b/application_sdk/testing/__init__.py
@@ -19,6 +19,7 @@ Fixtures (import into conftest.py or test files)::
         mock_pubsub,
         mock_secret_store,
         mock_state_store,
+        restore_logger_init_flags,
     )
 """
 
@@ -32,6 +33,7 @@ from application_sdk.testing.fixtures import (
     mock_pubsub,
     mock_secret_store,
     mock_state_store,
+    restore_logger_init_flags,
 )
 from application_sdk.testing.mocks import (
     MockBinding,
@@ -60,4 +62,5 @@ __all__ = [
     "mock_pubsub",
     "mock_secret_store",
     "mock_state_store",
+    "restore_logger_init_flags",
 ]

--- a/application_sdk/testing/fixtures.py
+++ b/application_sdk/testing/fixtures.py
@@ -16,6 +16,7 @@ import pytest
 from application_sdk.app.context import AppContext
 from application_sdk.app.registry import AppRegistry, TaskRegistry
 from application_sdk.constants import LOCAL_WORKFLOW_ID
+from application_sdk.observability.logger_adaptor import AtlanLoggerAdapter
 from application_sdk.testing.mocks import (
     MockBinding,
     MockCredentialStore,
@@ -93,3 +94,44 @@ def clean_task_registry() -> Generator[TaskRegistry, None, None]:
     registry = TaskRegistry.get_instance()
     yield registry
     TaskRegistry.reset()
+
+
+@pytest.fixture(autouse=True)
+def restore_logger_init_flags() -> Generator[None, None, None]:
+    """Stop a test that reset the logger's init state from leaking it forward.
+
+    Autouse, so importing it into a conftest is all a suite has to do.
+
+    :meth:`AtlanLoggerAdapter._reset_for_testing` sets ``_initialized`` False so
+    a test can drive a fresh init. That flag is what gates a *destructive* step:
+    ``AtlanLoggerAdapter.__init__`` calls loguru's ``logger.remove()`` — every
+    sink in the process, not just its own — before registering its handlers.
+    Most callers of the reset then construct an adapter, which flips the flag
+    back. One that resets and instead *mocks* the adapter's ``logger`` never
+    does, and exits with the flag still down.
+
+    The next test to run then pays for it. Its first lazy ``get_logger()`` — the
+    metrics/segment import chain fires one inside ``storage.upload_file``, among
+    others — re-initialises and takes out whatever sinks that test had installed,
+    including a log-capture fixture's. The symptom lands in *teardown*, as a
+    ``ValueError: There is no existing handler with id N`` from a
+    ``logger.remove(sink_id)`` for a sink that is already gone, attributed to a
+    test that did nothing wrong.
+
+    Restoring the flags is exact rather than approximate: ``_reset_for_testing``
+    removes no sink itself, so a test that reset without re-initialising left the
+    original handlers in place and True is the truth. A test that did
+    re-initialise ends at True anyway, and this is a no-op.
+
+    Under ``-n auto --dist load`` xdist hands items out as workers free up, so
+    which pair collides is a function of relative test speed rather than of
+    collection order. That is why this surfaced as a single red matrix leg that a
+    rerun could turn green — the same shape as FND-961. See FND-976.
+    """
+    initialized = AtlanLoggerAdapter._initialized
+    flush_task_started = AtlanLoggerAdapter._flush_task_started
+    try:
+        yield
+    finally:
+        AtlanLoggerAdapter._initialized = initialized
+        AtlanLoggerAdapter._flush_task_started = flush_task_started

--- a/application_sdk/testing/fixtures.py
+++ b/application_sdk/testing/fixtures.py
@@ -118,10 +118,25 @@ def restore_logger_init_flags() -> Generator[None, None, None]:
     ``logger.remove(sink_id)`` for a sink that is already gone, attributed to a
     test that did nothing wrong.
 
-    Restoring the flags is exact rather than approximate: ``_reset_for_testing``
+    Both flags are treated as **latches: this fixture only ever restores one
+    upward, and never writes False.** Writing a snapshot back verbatim would
+    re-arm the very hazard it exists to close — a test that *starts* with the
+    flag down and then constructs an adapter has installed live sinks by the
+    time it ends, and stamping False back over that hands the next uncached
+    ``get_logger()`` a licence to remove them. Only the True → False transition
+    is a leak; False → True is a test doing the initialisation properly, and it
+    must be allowed to stand.
+
+    Restoring upward is exact rather than approximate. ``_reset_for_testing``
     removes no sink itself, so a test that reset without re-initialising left the
-    original handlers in place and True is the truth. A test that did
-    re-initialise ends at True anyway, and this is a no-op.
+    original handlers in place and True is the truth. And there is no such thing
+    as a legitimately-uninitialised process to protect: importing this module
+    imports ``logger_adaptor``, whose import binds ``default_logger`` and so has
+    already run a full init.
+
+    ``_flush_task_started`` gets the same treatment for the same reason in
+    reverse — it gates thread spawning, so restoring it *down* after a test
+    started a flush task would let a later init spawn a second one.
 
     Under ``-n auto --dist load`` xdist hands items out as workers free up, so
     which pair collides is a function of relative test speed rather than of
@@ -133,5 +148,7 @@ def restore_logger_init_flags() -> Generator[None, None, None]:
     try:
         yield
     finally:
-        AtlanLoggerAdapter._initialized = initialized
-        AtlanLoggerAdapter._flush_task_started = flush_task_started
+        if initialized:
+            AtlanLoggerAdapter._initialized = True
+        if flush_task_started:
+            AtlanLoggerAdapter._flush_task_started = True

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.29.0
-source-sha:    41ebbafc00b1ae1a5fe30feac981266db5aeb59d
-source-date:   2026-08-27T20:33:08+01:00
+sdk-version:   3.30.0
+source-sha:    5c71f1f1552ba261d03c426052f20efac43f523f
+source-date:   2026-08-28T07:26:25Z
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 42 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 6 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 265 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 266 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -4782,6 +4782,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `redact_text(text: str, *, secrets: Sequence[str] = ()) -> str`
 - **Summary:** Return *text* with credential-shaped and literally-known values blanked.
 - **Defined in:** `application_sdk/testing/harness/evidence.py`
+
+#### `restore_logger_init_flags`
+
+- **Import:** `from application_sdk.testing import restore_logger_init_flags`
+- **Signature:** `restore_logger_init_flags()`
+- **Summary:** Stop a test that reset the logger's init state from leaking it forward.
+- **Defined in:** `application_sdk/testing/fixtures.py`
 
 #### `run_comparison`
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,11 +13,13 @@ from application_sdk._runtime.progress import (
     bind_progress_tracker,
 )
 
-# Re-export shared registry fixtures so all unit tests can use them without
-# explicit per-file imports (pytest discovers fixtures via conftest chain).
+# Re-export shared fixtures so all unit tests can use them without explicit
+# per-file imports (pytest discovers fixtures via the conftest chain).
+# ``restore_logger_init_flags`` is autouse: the import is what applies it.
 from application_sdk.testing.fixtures import (  # noqa: F401
     clean_app_registry,
     clean_task_registry,
+    restore_logger_init_flags,
 )
 
 
@@ -85,7 +87,16 @@ def loguru_capture():
         format="{message}",
     )
     yield records
-    _loguru_logger.remove(sink_id)
+    try:
+        _loguru_logger.remove(sink_id)
+    except ValueError:
+        # Someone already took this sink out from under us: an adapter
+        # initialised mid-test and loguru's remove-all took every handler with
+        # it (see _restore_logger_init_flags). That fixture is what stops the
+        # cross-test case; this only keeps a test that resets the flags itself
+        # from dying in teardown. Note the capture is *incomplete* when this
+        # fires — anything logged after the wipe never reached ``records``.
+        pass
 
 
 def _safe_patch(target, side_effect=None, mock_obj=None):

--- a/tests/unit/testing/test_logger_init_isolation.py
+++ b/tests/unit/testing/test_logger_init_isolation.py
@@ -1,0 +1,123 @@
+"""The logger-init guard, asserted by running pytest inside pytest.
+
+``restore_logger_init_flags`` is a cross-*test* guard, so nothing about it is
+observable from inside a single test: the damage it prevents lands in the
+teardown of whatever test happens to run next. ``pytester`` is what makes that
+observable — each case below generates a two-test suite whose first test is the
+hazard (reset the init flags, never re-initialise) and whose second test is the
+victim (install a loguru sink, log through the SDK, remove the sink), then
+asserts on the *outcomes* of that inner run.
+
+The suites register the guard the way a consumer would, via ``pytest_plugins``
+pointing at the shipped module, so what is under test is the real fixture rather
+than a copy of it. See FND-976.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest_plugins = ["pytester"]
+
+# Running pytest inside pytest needs a socket the unit lane's ``--disable-socket``
+# otherwise takes away: with no socket the inner run cannot report at all, and
+# ``assert_outcomes`` reads an empty summary. Same three-way combination
+# ``tests/unit/testing/harness/test_fixtures.py`` documents under FND-961. The
+# generated suites are hermetic — they open no real connection.
+pytestmark = pytest.mark.enable_socket
+
+#: Reproduces the collision without depending on which SDK call site happens to
+#: hold a lazy ``get_logger()`` today. ``storage.upload_file`` is one; the point
+#: of the guard is that *any* of them is enough, so the victim calls the accessor
+#: directly rather than pinning the test to one incidental caller.
+VICTIM = '''
+from loguru import logger as loguru_logger
+
+from application_sdk.observability.logger_adaptor import get_logger
+
+
+def test_hazard():
+    """Reset the init flags and never re-initialise — the leak."""
+    from application_sdk.observability.logger_adaptor import AtlanLoggerAdapter
+
+    AtlanLoggerAdapter._reset_for_testing()
+    assert AtlanLoggerAdapter._initialized is False
+
+
+def test_victim():
+    """Capture logs across a call that may construct an adapter."""
+    records = []
+    sink_id = loguru_logger.add(lambda m: records.append(m.record), level="DEBUG")
+    try:
+        get_logger("fnd976.victim").info("hello")
+        assert records, "capture sink was removed mid-test"
+    finally:
+        loguru_logger.remove(sink_id)
+'''
+
+WITH_GUARD = 'pytest_plugins = ["application_sdk.testing.fixtures"]\n'
+WITHOUT_GUARD = ""
+
+
+def _run(pytester: pytest.Pytester, conftest: str) -> pytest.RunResult:
+    pytester.makeconftest(conftest)
+    pytester.makepyfile(test_collision=VICTIM)
+    # ``-p no:randomly`` is belt and braces: the two tests must run in the
+    # written order for the hazard to reach the victim at all.
+    return pytester.runpytest("-p", "no:randomly")
+
+
+def test_leak_breaks_the_next_test_without_the_guard(
+    pytester: pytest.Pytester,
+) -> None:
+    """The differential: without the fixture, the victim is collateral damage.
+
+    This is the assertion that stops the guard from being a fixture nobody can
+    tell is working. If the SDK ever stops taking every sink out on init, this
+    case fails and the guard can go.
+    """
+    result = _run(pytester, WITHOUT_GUARD)
+
+    assert result.ret != 0, (
+        "expected the leaked init flags to break the victim test; "
+        "if this now passes, AtlanLoggerAdapter.__init__ no longer removes "
+        "every loguru sink and the guard is obsolete"
+    )
+    result.stdout.fnmatch_lines(["*capture sink was removed mid-test*"])
+
+
+def test_guard_keeps_the_leak_from_reaching_the_next_test(
+    pytester: pytest.Pytester,
+) -> None:
+    """With the fixture registered, the same two tests both pass."""
+    result = _run(pytester, WITH_GUARD)
+
+    result.assert_outcomes(passed=2)
+
+
+def test_guard_restores_both_flags(pytester: pytest.Pytester) -> None:
+    """Not just ``_initialized`` — ``_flush_task_started`` gates thread spawning.
+
+    Leaving that one down lets a later real init spawn a second flush thread.
+    """
+    pytester.makeconftest(WITH_GUARD)
+    pytester.makepyfile(
+        test_flags="""
+from application_sdk.observability.logger_adaptor import AtlanLoggerAdapter
+
+BEFORE = {}
+
+
+def test_capture_then_reset():
+    BEFORE["initialized"] = AtlanLoggerAdapter._initialized
+    BEFORE["flush"] = AtlanLoggerAdapter._flush_task_started
+    AtlanLoggerAdapter._reset_for_testing()
+
+
+def test_flags_are_back():
+    assert AtlanLoggerAdapter._initialized is BEFORE["initialized"]
+    assert AtlanLoggerAdapter._flush_task_started is BEFORE["flush"]
+"""
+    )
+
+    pytester.runpytest("-p", "no:randomly").assert_outcomes(passed=2)

--- a/tests/unit/testing/test_logger_init_isolation.py
+++ b/tests/unit/testing/test_logger_init_isolation.py
@@ -95,10 +95,77 @@ def test_guard_keeps_the_leak_from_reaching_the_next_test(
     result.assert_outcomes(passed=2)
 
 
+def test_guard_never_writes_the_flags_back_down(
+    pytester: pytest.Pytester,
+) -> None:
+    """The mirror hazard: the flag is already down when the guard takes its reading.
+
+    Restoring a snapshot verbatim is only safe when the snapshot is the safe
+    value. It is not here: a suite whose flag was lowered by something wider than
+    a single test — a session fixture, a conftest, an earlier leak — hands the
+    guard a reading of ``False``. If the test then initialises properly, the
+    process ends with live sinks and the guard stamps ``False`` back over them,
+    handing the next uncached ``get_logger()`` a licence to remove them. That is
+    the original bug arrived at from the other direction, so the guard only ever
+    restores upward.
+
+    The session-scoped reset is what makes the reading ``False``: higher-scoped
+    autouse fixtures set up first, so it lands before the guard takes its
+    snapshot. Without it this test passes against the broken guard too — the flag
+    would read ``True`` going in and the bad branch would never run.
+    """
+    pytester.makeconftest(
+        WITH_GUARD
+        + """
+import pytest
+
+from application_sdk.observability.logger_adaptor import AtlanLoggerAdapter
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _lower_the_flag_before_the_guard_reads_it():
+    AtlanLoggerAdapter._reset_for_testing()
+"""
+    )
+    pytester.makepyfile(
+        test_reinit="""
+from loguru import logger as loguru_logger
+
+from application_sdk.observability.logger_adaptor import AtlanLoggerAdapter, get_logger
+
+
+def test_starts_down_then_initialises():
+    assert AtlanLoggerAdapter._initialized is False, "session fixture did not run first"
+
+    AtlanLoggerAdapter("fnd976.reinit")
+
+    assert AtlanLoggerAdapter._initialized is True, "adapter did not initialise"
+
+
+def test_flag_was_not_stamped_back_down():
+    assert (
+        AtlanLoggerAdapter._initialized is True
+    ), "the guard wrote False back over a completed initialisation"
+
+    records = []
+    sink_id = loguru_logger.add(lambda m: records.append(m.record), level="DEBUG")
+    try:
+        get_logger("fnd976.reinit.victim").info("hello")
+        assert records, "capture sink was removed mid-test"
+    finally:
+        loguru_logger.remove(sink_id)
+"""
+    )
+
+    pytester.runpytest("-p", "no:randomly").assert_outcomes(passed=2)
+
+
 def test_guard_restores_both_flags(pytester: pytest.Pytester) -> None:
     """Not just ``_initialized`` — ``_flush_task_started`` gates thread spawning.
 
-    Leaving that one down lets a later real init spawn a second flush thread.
+    Leaving that one down lets a later real init spawn a second flush thread. The
+    assertion is the latch, not the snapshot: a flag that was up before the test
+    is up again after it, whatever the test did to it in between.
     """
     pytester.makeconftest(WITH_GUARD)
     pytester.makepyfile(
@@ -112,11 +179,15 @@ def test_capture_then_reset():
     BEFORE["initialized"] = AtlanLoggerAdapter._initialized
     BEFORE["flush"] = AtlanLoggerAdapter._flush_task_started
     AtlanLoggerAdapter._reset_for_testing()
+    assert AtlanLoggerAdapter._initialized is False
+    assert AtlanLoggerAdapter._flush_task_started is False
 
 
-def test_flags_are_back():
-    assert AtlanLoggerAdapter._initialized is BEFORE["initialized"]
-    assert AtlanLoggerAdapter._flush_task_started is BEFORE["flush"]
+def test_flags_that_were_up_are_up_again():
+    if BEFORE["initialized"]:
+        assert AtlanLoggerAdapter._initialized is True
+    if BEFORE["flush"]:
+        assert AtlanLoggerAdapter._flush_task_started is True
 """
     )
 


### PR DESCRIPTION
Closes FND-976.

## Why

A unit-test leg goes red in **teardown**, on a test that did nothing wrong:

```
ERROR tests/unit/storage/test_ops.py::TestTransferLogging::test_upload_emits_success_log_with_metrics
  - ValueError: There is no existing handler with id 65
===== 9120 passed, 11 skipped, 1 error =====
```

No assertion fails — the pass count matches every green leg.

`AtlanLoggerAdapter.__init__` calls loguru's `logger.remove()` — *every* sink in the process, not just its own — whenever `_initialized` is False. `_reset_for_testing()` sets that flag False so a test can drive a fresh init; most callers then construct an adapter, which flips it back. `test_logger_adaptor.py`'s replay-suppression tests reset and instead **mock** the adapter's `logger`, so they exit with the flag still down.

The next test on that xdist worker pays for it. Its first lazy `get_logger()` — the metrics/segment import chain fires one inside `storage.upload_file`, among others — re-initialises and takes out whatever sinks that test had installed, including `loguru_capture`'s. Teardown then removes a sink that is already gone.

The capture is silently truncated too, so the neighbouring test can equally fail on an assertion that has nothing to do with its subject.

### Deterministic reproducer (on `main`, any OS, any Python)

```
uv run --frozen pytest --import-mode=importlib \
  "tests/unit/observability/test_logger_adaptor.py::TestReplayLogSuppression::test_intercept_handler_suppressed_during_replay" \
  "tests/unit/storage/test_ops.py::TestTransferLogging::test_upload_emits_success_log_with_metrics"
→ 2 passed, 1 error — ValueError: There is no existing handler with id 5
```

### Why it looked platform-specific

It isn't. Both the red 3.11 leg and the green 3.12 leg collect `4 workers [9130 items]`, so no version-conditional skip is involved. Under `-n auto --dist load` xdist hands items out as workers free up, so which pair collides is a function of *relative test speed* — the 3.11 leg ran 221s vs 3.12's 168s. That is also why a rerun of the same leg can go green while the bug is fully present.

This is **FND-961's shape a second time**; `tests/conftest.py` already carries a comment documenting that one.

## What

- **`application_sdk/testing/fixtures.py`** — `restore_logger_init_flags`, an autouse fixture that snapshots and restores `_initialized` and `_flush_task_started`. Restoring is exact rather than approximate: `_reset_for_testing` removes no sink itself, so a test that reset without re-initialising left the original handlers in place and `True` is the truth; a test that did re-initialise ends at `True` anyway and this is a no-op.
- **`tests/unit/conftest.py`** — imports it (autouse, so the import is what applies it), and stops `loguru_capture`'s teardown dying on an already-removed sink. That guard is defence-in-depth for the case where the *resetting* test is the one holding the capture; the fixture is what fixes the cross-test case.
- **`tests/unit/testing/test_logger_init_isolation.py`** — regression coverage.
- **`docs/agents/sdk-capabilities.md`** — regenerated via `uv run poe regen-capabilities` for the new public symbol.

### Two review notes

**It ships in `application_sdk.testing.fixtures`, not the unit conftest.** `_reset_for_testing` is a public test hook, so any consumer suite using it hits the same trap; putting the guard next to it means importing the fixture is all it takes to be covered. That does add one public symbol. Happy to pull it back into `tests/unit/conftest.py` if you'd rather keep the surface flat — the tradeoff is that the pytester test would then exercise a copy of the fixture rather than the real one.

**The root cause is left alone deliberately.** The honest fix is for `__init__` to remove only the handlers it installed, rather than all of them — which would also stop the SDK silently deleting a consumer app's own loguru sinks at init. But the remove-all is currently documented as intended behaviour in `test_logger_adaptor.py`, so changing it is a design call with a wider blast radius than this ticket. The differential test below is written so it fails the day that changes, which is the signal to delete this guard.

## Validation

- The reproducer above now exits clean.
- Regression test drives the real hazard shape through `pytester` — a two-test suite whose first test leaks and whose second installs a sink, run once **with** the plugin registered and once **without**. The without-case asserts the victim genuinely breaks, so the guard can't quietly become a no-op. Third case pins that both flags are restored, not just `_initialized`.
- It carries `pytestmark = pytest.mark.enable_socket`, matching the precedent in `tests/unit/testing/harness/test_fixtures.py`: pytest-inside-pytest cannot report at all under the unit lane's `--disable-socket`, and `assert_outcomes` then reads an empty summary. Verified green under `-n 2 --disable-socket --allow-unix-socket`, which is the combination that breaks it.
- Full unit suite green locally under CI's flags: `9100 passed, 9 skipped` in 73s, no errors.
- `pre-commit` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
