### PR TITLE
fix(observability): forward stdlib logs without holding the InterceptHandler lock (ARUN-1218)

### DIFF
--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -535,6 +535,21 @@ class InterceptHandler(logging.Handler):
     would never reach the exporter.
     """
 
+    def handle(self, record: logging.LogRecord) -> bool:
+        # ARUN-1218: forward into loguru WITHOUT holding the stdlib handler lock.
+        # loguru serializes its own writes, so this handler's lock buys nothing
+        # here; holding it is exactly what lets a third-party ``__del__`` /
+        # finalizer log -- emitted while the event loop already holds loguru's
+        # handler lock (e.g. during a GC pass inside an async-sink emit) -- invert
+        # the two locks (ABBA) and deadlock the worker. Not taking it removes that
+        # lock-ordering hazard for every logger routed through this handler.
+        # Filtering is preserved; ``emit`` forwards to loguru, which is itself
+        # thread-safe and non-reentrant (its own guard raises rather than blocks).
+        rv = self.filter(record)
+        if rv:
+            self.emit(record)
+        return bool(rv)
+
     def emit(self, record: logging.LogRecord) -> None:
         # Suppress stdlib/third-party logs emitted from within a replaying
         # workflow so they don't duplicate alongside SDK-adapter logs.

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -2181,6 +2181,76 @@ class TestInterceptHandlerStdlibBridge:
     forward those structured fields to loguru so they reach OTLP — without
     them, every ObjectStore success / failure log loses its dimensions."""
 
+    def test_handle_does_not_take_the_handler_lock(self) -> None:
+        """ARUN-1218 regression: ``handle`` must forward into loguru WITHOUT
+        holding the stdlib handler lock. Holding it is exactly what let a
+        third-party ``__del__`` / finalizer log invert against loguru's handler
+        lock (ABBA) and freeze the worker into a Temporal poison poller."""
+        import logging
+
+        from application_sdk.observability.logger_adaptor import InterceptHandler
+
+        handler = InterceptHandler()
+
+        class _BoomLock:  # any acquisition of the handler lock fails the test
+            def acquire(self, *args: Any, **kwargs: Any) -> bool:
+                raise AssertionError("handle() acquired the handler lock")
+
+            def release(self) -> None:
+                pass
+
+            def __enter__(self) -> "_BoomLock":
+                raise AssertionError("handle() entered the handler lock")
+
+            def __exit__(self, *exc: object) -> bool:
+                return False
+
+        handler.lock = _BoomLock()  # type: ignore[assignment]
+        record = logging.LogRecord(
+            name="third_party",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="m",
+            args=(),
+            exc_info=None,
+        )
+        with mock.patch(
+            "application_sdk.observability.logger_adaptor.logger"
+        ) as mock_log:
+            handler.handle(record)  # must not raise -- the lock is never taken
+
+        # still forwarded to loguru (emit ran)
+        mock_log.opt.return_value.bind.assert_called_once()
+
+    def test_handle_preserves_the_filter_gate(self) -> None:
+        """The reimplemented ``handle`` must still apply handler filters, so a
+        record a filter rejects is never forwarded (the 504-noise filter and
+        the workflow-replay suppression both depend on this)."""
+        import logging
+
+        from application_sdk.observability.logger_adaptor import InterceptHandler
+
+        handler = InterceptHandler()
+        handler.addFilter(lambda record: False)  # reject everything
+
+        record = logging.LogRecord(
+            name="third_party",
+            level=logging.WARNING,
+            pathname=__file__,
+            lineno=1,
+            msg="dropped",
+            args=(),
+            exc_info=None,
+        )
+        with mock.patch(
+            "application_sdk.observability.logger_adaptor.logger"
+        ) as mock_log:
+            result = handler.handle(record)
+
+        assert result is False
+        mock_log.opt.assert_not_called()  # filtered out -> never forwarded
+
     def test_reserved_attrs_set_includes_modern_python_fields(self) -> None:
         """Sanity check: the auto-derived reserved set covers all the
         well-known stdlib LogRecord fields, so the bridge doesn't accidentally


### PR DESCRIPTION
## What & why

Durable, **app-agnostic** fix for the worker freeze root-caused in **ARUN-1218** (tracked as ARUN-1224). It removes the SDK's lock from this deadlock for every app, not just databricks.

The SDK bridges stdlib logging into loguru through a single root `InterceptHandler`. `logging.Handler.handle` takes the handler's own lock (an `RLock`, **α**) before `emit`, and `emit` forwards into loguru, which takes its handler lock (**β**). Every ordinary log takes **α then β**.

The event loop can take the inverse once and wedge:
1. A log on the loop holds **β**; loguru's async sink runs `loop.create_task()` under β; the allocation triggers a cyclic-GC pass; a finalizer (e.g. a `databricks-sql` `Connection.__del__`) logs → stdlib `handle` → **wants α**.
2. A worker thread mid-log holds **α** and **wants β**.

Neither yields (ABBA). The loop dies and the pod lingers as a Temporal poison poller, timing out the run's `promote-marker` child. Reproduced and root-caused on markeznp36 (see the ARUN-1218 finding + method docs, and `diagnosis/case3/ROOT_CAUSE.md`).

## The change

Override `InterceptHandler.handle` to forward **without taking the handler lock**:

```python
def handle(self, record):
    rv = self.filter(record)
    if rv:
        self.emit(record)
    return bool(rv)
```

loguru serializes its own writes, so the stdlib handler lock adds nothing here. Not holding it removes **α** from the path entirely, so **the SDK no longer contributes a lock to the cycle**: the captured inversion (α↔β) cannot form, and same-thread reentry (the `__del__` case) is caught by loguru's own guard. The filter gate (504-noise suppression, workflow-replay dropping) is preserved.

Why this and not a per-logger tweak: the bug is generic (any library that logs from a `__del__`/finalizer/GC context can trip it), and there's exactly one shared root handler, so fixing it here removes α for every app at once. Special-casing databricks in the SDK would leave every other connector exposed and violate layering (see ARUN-1224 "Scope: generic, not per-app").

## What this does not fix

β is still held while loguru's async sink runs `loop.create_task()` - an allocation, so a GC pass and arbitrary finalizers can still run under it. Any finalizer that takes a lock L which another thread holds *while logging* re-forms the cycle as β↔L. The SDK owns none of those locks; only the library with the finalizer (or the app closing its objects deterministically) can remove them.

Concrete instance today: `databricks-sql-connector` 4.3.0 holds `TelemetryClientFactory._lock` while `logger.debug` runs (`_flush_worker` → `_flush` every 300 s, `initialize_telemetry_client`, `close(host_url)`), and `Connection.__del__` → `_close` → `TelemetryClientFactory.close` takes that lock from the finalizer. All of that logging is DEBUG and `databricks.sql.*` inherit the root level, so it is reachable only with `LOG_LEVEL=DEBUG`; production INFO is not exposed.

F2 (`enqueue=True`) narrows this window but does not close it: `queue.put` allocates under β just like `create_task`. The class-level fix is app-side - close connector objects deterministically so nothing logs from `__del__`, disable connector telemetry, and keep third-party DEBUG loggers out of the bridge.

## Testing

- Two regression tests in `TestInterceptHandlerStdlibBridge`:
  - `test_handle_does_not_take_the_handler_lock` — a lock whose acquisition raises proves `handle` never takes it, while the record is still forwarded.
  - `test_handle_preserves_the_filter_gate` — a rejecting filter still drops the record (the reimplemented `handle` keeps filtering).
- `pytest tests/unit/observability/` → 558 passed, 1 skipped.
- ruff (0.6.4) check + format, isort (profile black), pyright (1.1.410) → clean; **0 new pyright errors/warnings**.

## Rollout

App-agnostic; every app picks it up on its next SDK bump. The databricks app carries a per-logger stopgap ([atlan-databricks-app#452](https://github.com/atlanhq/atlan-databricks-app/pull/452)) that sets `propagate=False` on `databricks.sql`; it also covers the β↔`TelemetryClientFactory._lock` residual above, so it is **not** reverted on this SDK bump alone. Revert it once databricks runs with connector telemetry disabled (or closes its connections deterministically), or keep it and accept the DEBUG-only residual on record. F2 is tracked in ARUN-1224 as hardening, not as the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
