### PR TITLE
ci(vpn): try Twingate first, keep GlobalProtect as fallback

### DIFF
--- a/.github/actions/twingate-connect/action.yml
+++ b/.github/actions/twingate-connect/action.yml
@@ -1,0 +1,100 @@
+name: 'Twingate Connect'
+description: >
+  Connect the runner to Twingate with a service-account key, then verify the
+  tunnel actually reaches the dispatch target. Drop-in alternative to
+  globalprotect-connect: same mothership-url probe, same `connected` output.
+
+  Why this exists: GlobalProtect authenticates CI as a *human* against a /24
+  DHCP pool capped at ~252 concurrent sessions, shared with every engineer on
+  the VPN. Runs fail with `Assign private IP address failed` when the pool is
+  full, which is unrelated to whether the review itself would have passed.
+  A Twingate service account has no pool - it is a machine identity scoped to
+  the specific resources this workflow needs.
+
+inputs:
+  service-key:
+    description: >
+      Twingate service-account key (the JSON blob shown once at key creation).
+      Store as an Actions secret; never inline it.
+    required: true
+  mothership-url:
+    description: >
+      Host probed once the tunnel is up. The probe is the success criterion:
+      a connected client does not by itself prove the private host is
+      reachable. (Probing an unrelated host is precisely the bug #2577 fixed
+      for globalprotect-connect - kept that lesson here.)
+    required: false
+    default: 'https://mothership.atlan.dev'
+  probe-attempts:
+    description: 'How many times to poll the probe target before giving up.'
+    required: false
+    default: '10'
+
+outputs:
+  connected:
+    description: "'true' when the tunnel is up and the probe returned 200."
+    value: ${{ steps.connect.outputs.connected }}
+
+runs:
+  using: composite
+  steps:
+    # Twingate publish an official GitHub Action (twingate/github-action), but
+    # docs/standards/ci.md requires third-party actions to be SHA-pinned and
+    # this is their documented manual recipe, which is the same three commands
+    # with no extra supply-chain surface. Kept as shell for that reason.
+    - name: Connect to Twingate and verify reachability
+      id: connect
+      shell: bash
+      env:
+        # Passed via env rather than ${{ }} interpolation so the key never
+        # appears in the script as shell source text.
+        TWINGATE_SERVICE_KEY: ${{ inputs.service-key }}
+        MOTHERSHIP_URL: ${{ inputs.mothership-url }}
+        PROBE_ATTEMPTS: ${{ inputs.probe-attempts }}
+      run: |
+        set -uo pipefail
+
+        if [ -z "${TWINGATE_SERVICE_KEY}" ]; then
+          echo "::error::service-key resolved empty. Add TWINGATE_SERVICE_KEY to this repo's Actions secrets (Settings -> Secrets and variables -> Actions)."
+          exit 1
+        fi
+
+        echo "::group::Install Twingate client"
+        echo "deb [trusted=yes] https://packages.twingate.com/apt/ /" \
+          | sudo tee /etc/apt/sources.list.d/twingate.list >/dev/null
+        sudo apt-get update -yq
+        sudo apt-get install -yq twingate
+        echo "::endgroup::"
+
+        echo "::group::Start headless client"
+        printf '%s' "${TWINGATE_SERVICE_KEY}" | sudo twingate setup --headless=-
+        sudo twingate start
+
+        # glibc's resolver sends parallel A/AAAA queries and stalls for 5s when
+        # the server answers out of order. Twingate document this; without the
+        # fix the probe below intermittently looks like a flaky network.
+        grep -q '^options single-request' /etc/resolv.conf \
+          || echo 'options single-request' | sudo tee -a /etc/resolv.conf >/dev/null
+
+        twingate status || true
+        echo "::endgroup::"
+
+        echo "Probing ${MOTHERSHIP_URL}/health"
+        for i in $(seq 1 "${PROBE_ATTEMPTS}"); do
+          code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "${MOTHERSHIP_URL}/health" || echo 000)"
+          if [ "${code}" = "200" ]; then
+            echo "connected=true" >> "$GITHUB_OUTPUT"
+            echo "Tunnel up and ${MOTHERSHIP_URL} reachable (attempt ${i})."
+            exit 0
+          fi
+          echo "  attempt ${i}/${PROBE_ATTEMPTS}: HTTP ${code}"
+          sleep 3
+        done
+
+        echo "connected=false" >> "$GITHUB_OUTPUT"
+        echo "::error::Twingate started but ${MOTHERSHIP_URL}/health never returned 200. Falling back to GlobalProtect."
+        echo "::group::Diagnostics"
+        twingate status || true
+        sudo journalctl -u twingate --no-pager -n 50 2>/dev/null || true
+        echo "::endgroup::"
+        exit 1

--- a/.github/actions/twingate-connect/action.yml
+++ b/.github/actions/twingate-connect/action.yml
@@ -28,7 +28,7 @@ inputs:
   probe-attempts:
     description: 'How many times to poll the probe target before giving up.'
     required: false
-    default: '10'
+    default: '6'
 
 outputs:
   connected:
@@ -54,6 +54,12 @@ runs:
       run: |
         set -uo pipefail
 
+        # An unset repo variable arrives as an EMPTY STRING, which overrides the
+        # action's `default:` (GitHub only applies defaults for omitted inputs).
+        # Without this the probe URL becomes "/health" and every attempt fails,
+        # which reads as "Twingate is broken" when the tunnel is fine.
+        MOTHERSHIP_URL="${MOTHERSHIP_URL:-https://mothership.atlan.dev}"
+
         if [ -z "${TWINGATE_SERVICE_KEY}" ]; then
           echo "::error::service-key resolved empty. Add TWINGATE_SERVICE_KEY to this repo's Actions secrets (Settings -> Secrets and variables -> Actions)."
           exit 1
@@ -62,13 +68,27 @@ runs:
         echo "::group::Install Twingate client"
         echo "deb [trusted=yes] https://packages.twingate.com/apt/ /" \
           | sudo tee /etc/apt/sources.list.d/twingate.list >/dev/null
-        sudo apt-get update -yq
-        sudo apt-get install -yq twingate
+        # Refresh only the Twingate list. A full `apt-get update` pulls every
+        # repo the runner image ships and fails the step if any one of them is
+        # having a bad day - unrelated to us.
+        sudo apt-get update -yq \
+          -o Dir::Etc::sourcelist="sources.list.d/twingate.list" \
+          -o Dir::Etc::sourceparts="-" \
+          -o APT::Get::List-Cleanup="0" || {
+            echo "::error::apt-get update failed for the Twingate repo."; exit 1; }
+        sudo apt-get install -yq twingate || {
+            echo "::error::twingate package failed to install."; exit 1; }
         echo "::endgroup::"
 
         echo "::group::Start headless client"
-        printf '%s' "${TWINGATE_SERVICE_KEY}" | sudo twingate setup --headless=-
-        sudo twingate start
+        # Checked explicitly: the script deliberately does not `set -e`, so an
+        # unchecked failure here would fall through to the probe and be reported
+        # as "reachability failed" - the wrong diagnosis, which is the exact
+        # class of bug #2577 fixed for globalprotect-connect.
+        printf '%s' "${TWINGATE_SERVICE_KEY}" | sudo twingate setup --headless=- || {
+            echo "::error::twingate setup failed - the service key was rejected."; exit 1; }
+        sudo twingate start || {
+            echo "::error::twingate start failed."; exit 1; }
 
         # glibc's resolver sends parallel A/AAAA queries and stalls for 5s when
         # the server answers out of order. Twingate document this; without the
@@ -81,7 +101,7 @@ runs:
 
         echo "Probing ${MOTHERSHIP_URL}/health"
         for i in $(seq 1 "${PROBE_ATTEMPTS}"); do
-          code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "${MOTHERSHIP_URL}/health" || echo 000)"
+          code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "${MOTHERSHIP_URL}/health" || echo 000)"
           if [ "${code}" = "200" ]; then
             echo "connected=true" >> "$GITHUB_OUTPUT"
             echo "Tunnel up and ${MOTHERSHIP_URL} reachable (attempt ${i})."

--- a/.github/actions/twingate-connect/action.yml
+++ b/.github/actions/twingate-connect/action.yml
@@ -66,7 +66,14 @@ runs:
         fi
 
         echo "::group::Install Twingate client"
-        echo "deb [trusted=yes] https://packages.twingate.com/apt/ /" \
+        # signed-by, not trusted=yes. This is the install path Twingate's own
+        # Linux docs use; the trusted=yes form in their CI snippet disables
+        # signature verification for a package that then runs as root and
+        # creates network interfaces on the runner.
+        curl -fsSL https://packages.twingate.com/apt/gpg.key \
+          | sudo gpg --dearmor -o /usr/share/keyrings/twingate-client-keyring.gpg || {
+            echo "::error::could not fetch the Twingate signing key."; exit 1; }
+        echo "deb [signed-by=/usr/share/keyrings/twingate-client-keyring.gpg] https://packages.twingate.com/apt/ * *" \
           | sudo tee /etc/apt/sources.list.d/twingate.list >/dev/null
         # Refresh only the Twingate list. A full `apt-get update` pulls every
         # repo the runner image ships and fails the step if any one of them is
@@ -80,15 +87,32 @@ runs:
             echo "::error::twingate package failed to install."; exit 1; }
         echo "::endgroup::"
 
+        # Snapshot before the client rewrites resolvers, so the failure path
+        # can put the runner back the way it found it.
+        sudo cp /etc/resolv.conf /tmp/resolv.conf.pre-twingate || true
+
+        # A failed probe must not leave tun0, its routes and its resolvers in
+        # place: openconnect then builds the GlobalProtect tunnel on the same
+        # runner, and two clients fighting over routing and DNS is how a
+        # working fallback becomes a broken one. The failure path has to be
+        # clean, not merely non-zero - otherwise the "cannot make things worse
+        # than main" property this PR claims is not actually true.
+        teardown() {
+          echo "::group::Teardown before GlobalProtect fallback"
+          sudo twingate stop || true
+          sudo cp /tmp/resolv.conf.pre-twingate /etc/resolv.conf || true
+          echo "::endgroup::"
+        }
+
         echo "::group::Start headless client"
         # Checked explicitly: the script deliberately does not `set -e`, so an
         # unchecked failure here would fall through to the probe and be reported
         # as "reachability failed" - the wrong diagnosis, which is the exact
         # class of bug #2577 fixed for globalprotect-connect.
         printf '%s' "${TWINGATE_SERVICE_KEY}" | sudo twingate setup --headless=- || {
-            echo "::error::twingate setup failed - the service key was rejected."; exit 1; }
+            echo "::error::twingate setup failed - the service key was rejected."; teardown; exit 1; }
         sudo twingate start || {
-            echo "::error::twingate start failed."; exit 1; }
+            echo "::error::twingate start failed."; teardown; exit 1; }
 
         # glibc's resolver sends parallel A/AAAA queries and stalls for 5s when
         # the server answers out of order. Twingate document this; without the
@@ -117,4 +141,5 @@ runs:
         twingate status || true
         sudo journalctl -u twingate --no-pager -n 50 2>/dev/null || true
         echo "::endgroup::"
+        teardown
         exit 1

--- a/.github/workflows/sdk-resolve.yml
+++ b/.github/workflows/sdk-resolve.yml
@@ -16,9 +16,10 @@
 #
 # Required configuration (shared with sdk-review.yml):
 #   secrets.HARNESS_TOKEN           Bearer token for /api/sandbox/execute.
-#   secrets.GLOBALPROTECT_USERNAME  VPN auth.
-#   secrets.GLOBALPROTECT_PASSWORD  VPN auth.
-#   vars.GLOBALPROTECT_PORTAL_URL   VPN portal URL.
+#   secrets.TWINGATE_SERVICE_KEY    Twingate service-account key (primary).
+#   secrets.GLOBALPROTECT_USERNAME  Fallback VPN auth, used only if the
+#   secrets.GLOBALPROTECT_PASSWORD  Twingate step fails.
+#   vars.GLOBALPROTECT_PORTAL_URL   Fallback VPN portal URL.
 #   vars.MOTHERSHIP_URL             e.g. https://mothership.atlan.dev
 #
 # Optional configuration:
@@ -126,6 +127,17 @@ jobs:
               body,
             });
 
+      # Twingate first; GlobalProtect below is the automatic fallback. See the
+      # equivalent block in sdk-review.yml for the full rationale.
+      - name: Connect to Twingate
+        id: twingate
+        uses: ./.github/actions/twingate-connect
+        continue-on-error: true
+        timeout-minutes: 3
+        with:
+          service-key: ${{ secrets.TWINGATE_SERVICE_KEY }}
+          mothership-url: ${{ vars.MOTHERSHIP_URL }}
+
       # timeout-minutes: 5 is a runner-enforced hard cap on each step. The
       # inner nick-fields/retry timeout_minutes is best-effort — it SIGTERMs
       # the bash subshell, but sudo/openconnect children survive parent
@@ -136,6 +148,7 @@ jobs:
       # three retries are separately-capped steps, not uncapped inner loops.
       - name: Connect to VPN (attempt 1/3)
         id: vpn1
+        if: steps.twingate.outcome == 'failure'
         uses: ./.github/actions/globalprotect-connect
         continue-on-error: true
         timeout-minutes: 5

--- a/.github/workflows/sdk-resolve.yml
+++ b/.github/workflows/sdk-resolve.yml
@@ -133,7 +133,7 @@ jobs:
         id: twingate
         uses: ./.github/actions/twingate-connect
         continue-on-error: true
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           service-key: ${{ secrets.TWINGATE_SERVICE_KEY }}
           mothership-url: ${{ vars.MOTHERSHIP_URL }}

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -43,9 +43,12 @@
 #                                      Must be a valid entry in mothership's
 #                                      SANDBOX_API_KEYS map under caller_id
 #                                      "application-sdk".
-#   secrets.GLOBALPROTECT_USERNAME     VPN auth (mothership.atlan.dev is on
-#   secrets.GLOBALPROTECT_PASSWORD     the private network).
-#   vars.GLOBALPROTECT_PORTAL_URL      VPN portal URL.
+#   secrets.TWINGATE_SERVICE_KEY       Twingate service-account key. Primary
+#                                      path to mothership.atlan.dev, which is
+#                                      on the private network.
+#   secrets.GLOBALPROTECT_USERNAME     Fallback VPN auth, used only if the
+#   secrets.GLOBALPROTECT_PASSWORD     Twingate step fails. Remove both once
+#   vars.GLOBALPROTECT_PORTAL_URL      Twingate is proven here.
 #   vars.MOTHERSHIP_URL                e.g. https://mothership.atlan.dev
 
 name: SDK Review (mothership)
@@ -526,6 +529,24 @@ jobs:
               target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             });
 
+      # Twingate first. A service account is a machine identity with no shared
+      # IP pool, so it neither consumes nor is starved by the GlobalProtect
+      # pool whose exhaustion causes most of this workflow's failures.
+      #
+      # GlobalProtect stays below as an automatic fallback: if this step fails
+      # for any reason, vpn1-vpn3 run exactly as they do today and behaviour is
+      # unchanged. Once Twingate has proven itself here, delete vpn1-vpn3, the
+      # notify/fail pair keyed off vpn3, and the GLOBALPROTECT_* secrets.
+      - name: Connect to Twingate
+        id: twingate
+        if: steps.lock_gate.outputs.decision != 'skip'
+        uses: ./.github/actions/twingate-connect
+        continue-on-error: true
+        timeout-minutes: 3
+        with:
+          service-key: ${{ secrets.TWINGATE_SERVICE_KEY }}
+          mothership-url: ${{ vars.MOTHERSHIP_URL }}
+
       # max-attempts: '1' overrides the action's internal default of 3 so
       # each outer step is one real attempt, not three. Three outer steps
       # cap total VPN time at ~15 min in the worst case.
@@ -538,7 +559,7 @@ jobs:
       # guarantee the step terminates and the next attempt fires.
       - name: Connect to VPN (attempt 1/3)
         id: vpn1
-        if: steps.lock_gate.outputs.decision != 'skip'
+        if: steps.lock_gate.outputs.decision != 'skip' && steps.twingate.outcome == 'failure'
         uses: ./.github/actions/globalprotect-connect
         continue-on-error: true
         timeout-minutes: 5

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -542,7 +542,7 @@ jobs:
         if: steps.lock_gate.outputs.decision != 'skip'
         uses: ./.github/actions/twingate-connect
         continue-on-error: true
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           service-key: ${{ secrets.TWINGATE_SERVICE_KEY }}
           mothership-url: ${{ vars.MOTHERSHIP_URL }}


### PR DESCRIPTION
## Why

`@sdk-review` and `@sdk-resolve` authenticate to the private network as a
**human** — a shared GlobalProtect credential against a /24 DHCP pool capped at
~252 concurrent sessions, shared with every engineer on the VPN. When the pool
is full the run dies with `Assign private IP address failed` before a sandbox
is ever dispatched. That failure has nothing to do with whether the review
would have passed.

Measured over the workflow's first six weeks: 698 invocations, 45% success, and
~85% of a sampled 106 failures never reached the review at all.

A Twingate service account is a **machine identity**. There is no IP pool, so
these runs neither consume nor are starved by the human VPN. It also scopes CI
to the two hosts it actually needs rather than the whole network.

## What changes

- New composite action `.github/actions/twingate-connect` — installs the
  Twingate client, starts it headless with a service key, then probes
  `${MOTHERSHIP_URL}/health`. Same interface and same success criterion as
  `globalprotect-connect`.
- `sdk-review.yml` / `sdk-resolve.yml` — one new step before the existing VPN
  ladder, and `vpn1` now additionally requires
  `steps.twingate.outcome == 'failure'`.

**Nothing is removed.** If the Twingate step fails for any reason, `vpn1`–`vpn3`
run exactly as they do today and behaviour is identical to `main`. Additive and
revertible in one commit.

## The Twingate side is already live

No coordination needed — this works the moment it merges:

- Service account `svc-gha-application-sdk` created, scoped to exactly
  `mothership.atlan.dev` and `api.dataforge.atlan.dev` and nothing else.
- `TWINGATE_SERVICE_KEY` is already set as a repository secret.
- Both hosts exist as Twingate resources in the IT-Prod remote network.

## Notes for review

- **Why shell and not `twingate/github-action`.** Twingate publish an official
  action, but `docs/standards/ci.md` requires third-party actions to be
  SHA-pinned, and their documented manual recipe is the same three commands
  with no added supply-chain surface. Happy to switch if you'd rather.
- **The probe is the success criterion, not "client connected."** A connected
  client does not prove the private host is reachable — that's the bug #2577
  fixed for GlobalProtect, and the lesson is carried over.
- **`options single-request`.** glibc's resolver sends parallel A/AAAA queries
  and stalls 5s when the server answers out of order. Twingate document this;
  without it the probe intermittently looks like a flaky network.
- The service key is passed via `env:` rather than `${{ }}` interpolation, so it
  never appears as shell source text.

## Follow-ups (not in this PR)

- `sdk-evolution-cron.yml` and `vuln-triage-cron.yml` use the same action and
  take the same change.
- `atlanhq/connector-pulse` — 14 workflows, and its `globalprotect-vpn`
  concurrency group can be deleted once migrated (FND-190), restoring
  parallelism.
- The rover sandbox runs its own separate tunnel via `ensureVpn()` in
  `rover-worker/src/index.ts`. Different repo, different owner.
- Once proven, delete `vpn1`–`vpn3`, the notify/fail pair keyed off `vpn3`, and
  the `GLOBALPROTECT_*` secrets.
