### PR TITLE
fix(conformance): alarm when a lock refusal outlives the reaper (FND-909)

### DIFF
--- a/.github/scripts/renovate_refusal_alarm.py
+++ b/.github/scripts/renovate_refusal_alarm.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Fail the dashboard run when a bounded-lock refusal outlived the reaper (FND-909).
+
+Reads what the Renovate dashboard scanner already produced — no GitHub API calls,
+no second fleet walk. ``renovate-dashboard.yaml`` runs the scanner every six hours
+and writes ``fleet.json`` plus one ``repos/<slug>.json`` per repo; this reads that
+output and turns one classification into a failing check.
+
+Why this exists
+---------------
+The reaper step in ``renovate.yaml`` deletes a self-healing lock refusal on sight,
+and by design it never fails its own job — Renovate has to run either way, so a
+reaper outage costs a cycle of recovery latency rather than the lock refresh
+itself. The consequence is that the outage is *silent*: the fleet run stays green
+and a lock PR simply sits red in some repo nobody is watching, which is the
+FND-909 freeze all over again.
+
+``BlockingReason.BOUNDED_LOCK_REFUSAL_EXPIRED`` is exactly that state — a refusal
+the reaper should already have cleared (see ``bounded_lock_refusal_state`` in the
+conformance classifier for the two clocks that reach it). Any count above zero
+means the reaper did not run, so it is an alarm rather than a dashboard tile.
+
+What it deliberately does not alarm on
+--------------------------------------
+``BOUNDED_LOCK_REFUSAL_STANDING`` — a refusal stamped with a reason no amount of
+waiting fixes (a broken interpreter, an unsatisfiable floor, a yanked-pin
+rollback). The reaper leaves those alone on purpose and a human owns the branch.
+They are printed, and they do not fail the run: a standing fault that a human is
+legitimately still working through must not red a scheduled job every six hours,
+or the alarm becomes noise and stops being read.
+
+Usage::
+
+    python3 renovate_refusal_alarm.py --out-dir /tmp/renovate-output
+    python3 renovate_refusal_alarm.py --out-dir /tmp/renovate-output --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Optional
+
+# Mirrors conformance.renovate.models.BlockingReason. Kept as literals rather
+# than an import because this script runs as a bare `python3` on the runner,
+# outside the uv environment the scanner itself runs in.
+EXPIRED = "bounded_lock_refusal_expired"
+STANDING = "bounded_lock_refusal_standing"
+
+
+def _load(path: str) -> Optional[dict]:
+    """Parse one JSON file, or None if it is missing or malformed."""
+    try:
+        with open(path, encoding="utf-8") as handle:
+            loaded = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def offenders(out_dir: str, reason: str) -> list[dict]:
+    """Every open PR in the scanner's per-repo output blocked for ``reason``.
+
+    Read from ``repos/*.json`` rather than ``fleet.json`` because the aggregate
+    carries counts alone. An alarm that says "1 frozen refusal" and cannot say
+    where sends the reader back to the dashboard to find it by hand.
+    """
+    repos_dir = os.path.join(out_dir, "repos")
+    try:
+        names = sorted(os.listdir(repos_dir))
+    except OSError:
+        return []
+
+    found: list[dict] = []
+    for name in names:
+        if not name.endswith(".json"):
+            continue
+        report = _load(os.path.join(repos_dir, name))
+        if report is None:
+            print(f"::warning::unreadable repo report: {name}", file=sys.stderr)
+            continue
+        for pr in report.get("openPRs") or []:
+            if pr.get("blockingReason") != reason:
+                continue
+            found.append(
+                {
+                    "repo": report.get("repo", name[: -len(".json")]),
+                    "number": pr.get("number"),
+                    "url": pr.get("url", ""),
+                    "window": pr.get("lockRefusalWindow", ""),
+                    "reason": pr.get("lockRefusalReason", ""),
+                    "ageDays": pr.get("ageDays", 0),
+                }
+            )
+    return found
+
+
+def _describe(pr: dict) -> str:
+    # prAge, not age: the classifier decides on the *branch head's* commit date,
+    # which Renovate rewrites in place, so PR age is context and not the clock
+    # anything here was judged against. Naming it plainly beats a reader assuming
+    # the two are the same number.
+    stamp = pr["reason"] or "unstamped"
+    return (
+        f"  {pr['repo']}#{pr['number']}  {stamp}"
+        f"  window={pr['window'] or '-'}  prAge={pr['ageDays']}d\n"
+        f"    {pr['url']}"
+    )
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out-dir",
+        required=True,
+        help="directory the renovate-scan CLI wrote (contains fleet.json, repos/)",
+    )
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args(argv)
+
+    frozen = offenders(args.out_dir, EXPIRED)
+    standing = offenders(args.out_dir, STANDING)
+
+    if args.json:
+        print(json.dumps({"frozen": frozen, "standing": standing}, indent=2))
+    else:
+        print(f"frozen self-healing refusals: {len(frozen)}")
+        for pr in frozen:
+            print(_describe(pr))
+        print(f"standing faults (human-owned, not alarmed): {len(standing)}")
+        for pr in standing:
+            print(_describe(pr))
+
+    if standing:
+        # Visible, never fatal: these are red on purpose until a human clears them.
+        print(
+            f"::warning::{len(standing)} bounded-lock refusal(s) need a human — "
+            "a standing fault does not clear on its own"
+        )
+    if frozen:
+        print(
+            f"::error::{len(frozen)} bounded-lock refusal(s) outlived the reaper — "
+            "the reaper step in renovate.yaml is not clearing self-healing "
+            "refusals (FND-909)",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_renovate_refusal_alarm.py
+++ b/.github/scripts/tests/test_renovate_refusal_alarm.py
@@ -29,8 +29,10 @@ import renovate_uv_lock_bounded as bounded  # noqa: E402
 
 try:  # The vocabulary pin's other half — see _classifier() below.
     from conformance.renovate import classify as _conformance_classify
+    from conformance.renovate.models import BlockingReason as _BlockingReason
 except ImportError:  # pragma: no cover - depends on the runner's environment
     _conformance_classify = None  # type: ignore[assignment]
+    _BlockingReason = None  # type: ignore[assignment]
 
 
 def _write_repo_report(out_dir, slug: str, prs: list[dict]) -> None:
@@ -160,9 +162,32 @@ def _classifier():
     return _conformance_classify
 
 
+def _classifier_models():
+    """`BlockingReason`, or a skip when the package is not installed."""
+    if _BlockingReason is None:  # pragma: no cover - depends on runner env
+        pytest.skip("conformance package not installed in this environment")
+    return _BlockingReason
+
+
 def test_self_healing_vocabulary_matches_the_classifier() -> None:
     """The set the driver stamps and the set the reader trusts must be identical."""
     assert bounded.SELF_HEALING_REFUSALS == _classifier().SELF_HEALING_REFUSALS
+
+
+def test_alarm_blocking_reasons_match_the_classifier_enum() -> None:
+    """The alarm's literals must equal the enum values the scanner actually emits.
+
+    Same drift as the self-healing set, one layer down and easier to miss: the
+    alarm matches `blockingReason` as a bare string because it runs outside the
+    uv environment and cannot import BlockingReason. Every other test in this
+    file asserts against `alarm.EXPIRED` itself, so renaming the enum value would
+    leave both suites green while the dashboard run went silent on a real freeze
+    — the alarm would simply match nothing. This is the only assertion that
+    would catch it.
+    """
+    reasons = _classifier_models()
+    assert alarm.EXPIRED == reasons.BOUNDED_LOCK_REFUSAL_EXPIRED.value
+    assert alarm.STANDING == reasons.BOUNDED_LOCK_REFUSAL_STANDING.value
 
 
 def test_every_reason_the_driver_can_write_is_known_to_the_reader() -> None:
@@ -172,15 +197,20 @@ def test_every_reason_the_driver_can_write_is_known_to_the_reader() -> None:
     a machine — but it is only safe because the reader treats "not self-healing"
     as standing rather than ignoring the stamp. Pin the whole writable set so a
     new refusal path cannot land without someone reading this.
+
+    The writable set is collected from the driver module rather than hand-listed:
+    a literal set would silently omit a newly added REFUSAL_* constant, which is
+    precisely the case this test exists to notice.
     """
     classify = _classifier()
     writable = {
-        bounded.REFUSAL_WINDOW_EMPTY,
-        bounded.REFUSAL_NO_PACKAGING,
-        bounded.REFUSAL_UNSATISFIABLE_FLOOR,
-        bounded.REFUSAL_FLOOR_ADMITTED_STILL_FAILED,
-        bounded.REFUSAL_ROLLBACK,
+        getattr(bounded, name)
+        for name in dir(bounded)
+        if name.startswith("REFUSAL_") and isinstance(getattr(bounded, name), str)
     }
+    # Guard the collection itself: a rename of the REFUSAL_* prefix would empty
+    # the set and make every assertion below vacuously true.
+    assert len(writable) == 5, f"unexpected refusal constants: {sorted(writable)}"
     standing = writable - classify.SELF_HEALING_REFUSALS
 
     assert standing == {

--- a/.github/scripts/tests/test_renovate_refusal_alarm.py
+++ b/.github/scripts/tests/test_renovate_refusal_alarm.py
@@ -1,0 +1,191 @@
+"""Tests for the bounded-lock refusal alarm (FND-909).
+
+Two things are under test here. The first is the alarm's own logic: which
+classifications fail the run, which are merely reported, and that it stays quiet
+on a healthy fleet.
+
+The second is the vocabulary pin at the bottom. The driver that *writes* refusal
+stamps and the classifier that *reads* them hold separate copies of the
+self-healing set, because the driver runs as a bare `python3` on the fleet runner
+and cannot import the conformance package. Separate copies can drift, and the way
+they would drift is silent: add a self-healing reason to the writer alone and the
+reader classifies it as a standing fault, so the alarm never fires and the freeze
+is invisible again — exactly the FND-909 failure. The pin turns that into a red
+test instead.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__))))
+
+import renovate_refusal_alarm as alarm  # noqa: E402
+import renovate_uv_lock_bounded as bounded  # noqa: E402
+
+try:  # The vocabulary pin's other half — see _classifier() below.
+    from conformance.renovate import classify as _conformance_classify
+except ImportError:  # pragma: no cover - depends on the runner's environment
+    _conformance_classify = None  # type: ignore[assignment]
+
+
+def _write_repo_report(out_dir, slug: str, prs: list[dict]) -> None:
+    """Write one repos/<slug>.json in the shape the renovate-scan CLI emits."""
+    repos = out_dir / "repos"
+    repos.mkdir(parents=True, exist_ok=True)
+    (repos / f"{slug}.json").write_text(
+        json.dumps({"repo": f"atlanhq/{slug}", "openPRs": prs}),
+        encoding="utf-8",
+    )
+
+
+def _pr(number: int, reason: str, blocking: str, age: int = 1) -> dict:
+    return {
+        "number": number,
+        "url": f"https://github.com/atlanhq/example/pull/{number}",
+        "blockingReason": blocking,
+        "lockRefusalWindow": "P3D",
+        "lockRefusalReason": reason,
+        "ageDays": age,
+    }
+
+
+def test_clean_fleet_passes(tmp_path, capsys) -> None:
+    _write_repo_report(tmp_path, "app-one", [_pr(1, "", "checks_failing")])
+
+    assert alarm.main(["--out-dir", str(tmp_path)]) == 0
+    assert "frozen self-healing refusals: 0" in capsys.readouterr().out
+
+
+def test_frozen_refusal_fails_the_run(tmp_path, capsys) -> None:
+    _write_repo_report(
+        tmp_path, "app-one", [_pr(410, "window-empty", alarm.EXPIRED, age=2)]
+    )
+
+    assert alarm.main(["--out-dir", str(tmp_path)]) == 1
+    captured = capsys.readouterr()
+    assert "app-one#410" in captured.out
+    assert "outlived the reaper" in captured.err
+
+
+def test_standing_fault_is_reported_but_never_fatal(tmp_path, capsys) -> None:
+    """A wedge a human owns must not red a six-hourly job until they clear it."""
+    _write_repo_report(
+        tmp_path, "app-two", [_pr(77, "yanked-pin", alarm.STANDING, age=9)]
+    )
+
+    assert alarm.main(["--out-dir", str(tmp_path)]) == 0
+    captured = capsys.readouterr()
+    assert "standing faults (human-owned, not alarmed): 1" in captured.out
+    assert "::warning::" in captured.out
+    assert captured.err == ""
+
+
+def test_frozen_still_fails_when_a_standing_fault_is_also_present(tmp_path) -> None:
+    """The quiet case must not suppress the loud one."""
+    _write_repo_report(tmp_path, "app-one", [_pr(410, "window-empty", alarm.EXPIRED)])
+    _write_repo_report(tmp_path, "app-two", [_pr(77, "rollback", alarm.STANDING)])
+
+    assert alarm.main(["--out-dir", str(tmp_path)]) == 1
+
+
+def test_offenders_names_the_repo_and_pr(tmp_path) -> None:
+    """The aggregate carries counts alone; the alarm has to say where."""
+    _write_repo_report(
+        tmp_path, "app-one", [_pr(410, "window-empty", alarm.EXPIRED, age=3)]
+    )
+
+    found = alarm.offenders(str(tmp_path), alarm.EXPIRED)
+
+    assert found == [
+        {
+            "repo": "atlanhq/app-one",
+            "number": 410,
+            "url": "https://github.com/atlanhq/example/pull/410",
+            "window": "P3D",
+            "reason": "window-empty",
+            "ageDays": 3,
+        }
+    ]
+
+
+def test_missing_output_directory_is_not_an_alarm(tmp_path) -> None:
+    """A scanner that wrote nothing is a scanner failure, not a frozen refusal.
+
+    The scanner step precedes this one and fails the job on its own if it breaks.
+    Reporting a phantom freeze here would point the reader at the wrong system.
+    """
+    assert alarm.main(["--out-dir", str(tmp_path / "nonexistent")]) == 0
+
+
+def test_malformed_repo_report_warns_and_keeps_going(tmp_path, capsys) -> None:
+    """One corrupt file must not hide a real freeze in the next one."""
+    repos = tmp_path / "repos"
+    repos.mkdir(parents=True)
+    (repos / "broken.json").write_text("{not json", encoding="utf-8")
+    _write_repo_report(tmp_path, "app-one", [_pr(410, "window-empty", alarm.EXPIRED)])
+
+    assert alarm.main(["--out-dir", str(tmp_path)]) == 1
+    assert "unreadable repo report" in capsys.readouterr().err
+
+
+def test_json_output_is_machine_readable(tmp_path, capsys) -> None:
+    _write_repo_report(tmp_path, "app-one", [_pr(410, "window-empty", alarm.EXPIRED)])
+
+    alarm.main(["--out-dir", str(tmp_path), "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert [p["number"] for p in payload["frozen"]] == [410]
+    assert payload["standing"] == []
+
+
+# --- the writer/reader vocabulary pin -------------------------------------
+
+
+def _classifier():
+    """The conformance classifier, or a skip when it is not installed.
+
+    Optional at import time: the CI-script suite is runnable on a bare
+    interpreter, and these two tests are the only ones in it that need the
+    package. Skipping keeps the rest working there while the pin still fires in
+    any environment that has both — which the repo's own
+    `uv sync --all-extras --all-groups` always does.
+    """
+    if _conformance_classify is None:  # pragma: no cover - depends on runner env
+        pytest.skip("conformance package not installed in this environment")
+    return _conformance_classify
+
+
+def test_self_healing_vocabulary_matches_the_classifier() -> None:
+    """The set the driver stamps and the set the reader trusts must be identical."""
+    assert bounded.SELF_HEALING_REFUSALS == _classifier().SELF_HEALING_REFUSALS
+
+
+def test_every_reason_the_driver_can_write_is_known_to_the_reader() -> None:
+    """A reason outside the reader's vocabulary must still classify as standing.
+
+    That is the safe direction — an unrecognised reason gets a human rather than
+    a machine — but it is only safe because the reader treats "not self-healing"
+    as standing rather than ignoring the stamp. Pin the whole writable set so a
+    new refusal path cannot land without someone reading this.
+    """
+    classify = _classifier()
+    writable = {
+        bounded.REFUSAL_WINDOW_EMPTY,
+        bounded.REFUSAL_NO_PACKAGING,
+        bounded.REFUSAL_UNSATISFIABLE_FLOOR,
+        bounded.REFUSAL_FLOOR_ADMITTED_STILL_FAILED,
+        bounded.REFUSAL_ROLLBACK,
+    }
+    standing = writable - classify.SELF_HEALING_REFUSALS
+
+    assert standing == {
+        "no-packaging",
+        "unsatisfiable-floor",
+        "floor-admitted-still-failed",
+        "rollback",
+    }

--- a/.github/workflows/renovate-dashboard.yaml
+++ b/.github/workflows/renovate-dashboard.yaml
@@ -214,3 +214,17 @@ jobs:
           fi
 
           echo "Renovate dashboard updated: https://k.atlan.dev/${PREFIX}/"
+
+      # Last, and deliberately after the deploy: this step can fail the job, and
+      # a dashboard that stops publishing because it found something to report
+      # would take out the view someone needs to act on the report.
+      #
+      # Full-fleet runs only. Single-repo mode is dispatched per PR-gate
+      # evaluation by renovate-auto-approve-reusable, where a fleet-wide health
+      # verdict does not belong and would red an unrelated repo's workflow.
+      - name: Alarm on refusals the reaper should have cleared
+        if: ${{ !inputs.repo }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/renovate_refusal_alarm.py \
+            --out-dir /tmp/renovate-output

--- a/docs/standards/ci.md
+++ b/docs/standards/ci.md
@@ -258,20 +258,54 @@ versions plus a bare `[options]` table — the one lever the driver holds over a
 *required* check, since `uv sync --locked` then rejects the lock and
 `scan / Build Image` holds the branch. Two consequences follow, and both bite:
 
-**Nothing expires it.** The branch is not behind its base, so Renovate reuses it
-without re-running `postUpgradeTasks`, and the marker committed into `uv.lock`
-carries no clock. Observed 2026-08-24: five fleet lock PRs sat frozen for two to
-four days after the window that blocked them had opened. Recovery is to delete
-the branch and let the next pass rebuild it — `recreateClosed: true` in the shared
-preset is what makes that safe.
+**Nothing expired it, so the driver stamps why it refused.** The branch is not
+behind its base, so Renovate reuses it without re-running `postUpgradeTasks`, and
+the marker committed into `uv.lock` carries no clock. Observed 2026-08-24: five
+fleet lock PRs sat frozen for two to four days after the window that blocked them
+had opened. `withhold()` now writes the reason on the tripwire's own line
+(FND-909), which is what lets a machine tell the two kinds apart:
 
-**The fleet dashboard names it.** `conformance.renovate.classify` splits that
-shape out of `checks_failing` as `bounded_lock_refusal_expired` (FND-782) once
-four things hold: the PR is lock-maintenance, its diff is a `uv.lock` and nothing
-else, that lock carries a lone `exclude-newer-span` (uv's own `[options]` always
-records the absolute `exclude-newer` beside it, so a lone span is the driver's
-signature), and the branch head is at least as old as the window it names. It
-reports; it does not self-heal. A recurrence is meant to be visible, not absorbed.
+```
+exclude-newer-span = "P3D"  # refusal: window-empty
+```
+
+Only `window-empty` heals on its own — the bound admitted nothing on that pass,
+which the next slice of window routinely fixes. A broken interpreter, an
+unsatisfiable floor, a floor that was admitted and still failed, and a yanked-pin
+rollback are standing faults that waiting never clears.
+
+**A reaper clears the self-healing half.** `renovate_reap_refused_locks.py` runs
+immediately before Renovate in each repo's matrix job, deletes a stamped
+`window-empty` branch on sight, and Renovate rebuilds it in the same pass —
+`recreateClosed: true` in the shared preset is what makes that safe. Standing
+faults keep their tripwire and stay red for a human; recycling a real wedge every
+four hours would hide it behind a lane that looks busy. An *unstamped* tripwire
+is also left alone: "no reason given" must never read as self-healing.
+
+**The fleet dashboard names both, and one of them alarms.**
+`conformance.renovate.classify` splits the shape out of `checks_failing` once
+three things hold — the PR is lock-maintenance, its diff is a `uv.lock` and
+nothing else, and that lock carries a lone `exclude-newer-span` (uv's own
+`[options]` always records the absolute `exclude-newer` beside it, so a lone span
+is the driver's signature). The stamp then decides which finding it is:
+
+| Finding | When | Who acts |
+| -- | -- | -- |
+| `bounded_lock_refusal_standing` | stamped with a reason outside the self-healing set, immediately | a human |
+| `bounded_lock_refusal_expired` | stamped self-healing and older than `REAPER_GRACE` (two fleet passes), **or** unstamped and older than the window it names | nobody — the reaper should already have taken it |
+
+`renovate_refusal_alarm.py` runs last in `renovate-dashboard.yaml` and fails the
+run on `bounded_lock_refusal_expired`, because reaching that state means the
+reaper did not run — and the reaper never fails its own job, so the outage is
+otherwise silent. Standing faults are printed and never fatal: a wedge a human is
+legitimately still working through must not red a six-hourly job, or the alarm
+stops being read.
+
+The self-healing vocabulary lives twice — in the driver that writes stamps and in
+the classifier that reads them — because the driver runs as a bare `python3` on
+the fleet runner and cannot import the conformance package. A test in
+`.github/scripts/tests/` pins the two equal; without it, adding a reason to the
+writer alone would silently make the alarm stop firing.
 
 ## The release-age bound on application-sdk's own lock refresh
 

--- a/packages/conformance/conformance/renovate/classify.py
+++ b/packages/conformance/conformance/renovate/classify.py
@@ -81,6 +81,29 @@ STALE_AFTER_DAYS = 1
 _WINDOW_RE = re.compile(r"^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?)?$")
 
 
+# The refusal reasons ``withhold()`` stamps onto the tripwire line, split by
+# whether waiting fixes them. The writer's copy of this vocabulary lives in
+# ``.github/scripts/renovate_uv_lock_bounded.py``; the two are pinned equal by a
+# test in ``.github/scripts/tests/`` rather than shared by import, because the
+# driver runs as a bare ``python3`` script on the fleet runner with no venv and
+# so cannot import this package.
+#
+# Only ``window-empty`` heals on its own: the bound admitted nothing on the pass
+# that wrote it, which the next slice of window routinely fixes. The rest are
+# standing faults — a broken interpreter, an unsatisfiable floor, a floor that
+# was admitted and still failed, a yanked-pin rollback — where waiting changes
+# nothing and a human owns the branch.
+SELF_HEALING_REFUSALS = frozenset({"window-empty"})
+
+# How long a self-healing refusal may sit before its survival is itself the
+# finding. The reaper step in renovate.yaml deletes one on sight and the fleet
+# cron is four-hourly, so anything past two passes means the reaper did not run.
+# Deliberately not the refusal's own window: that clock answers "would the bound
+# admit something now?", which stops being the question once something is
+# supposed to have deleted the branch regardless of what the bound would admit.
+REAPER_GRACE = timedelta(hours=9)
+
+
 def _non_dep_files(files: list[str]) -> list[str]:
     return [f for f in files if not _DEP_FILE_RE.match(f)]
 
@@ -94,14 +117,23 @@ def parse_window(window: str) -> Optional[timedelta]:
     return timedelta(days=days, hours=hours, minutes=minutes)
 
 
-def lock_refusal_window(lock_text: str) -> str:
-    """The release-age window named by a bounded-lock *refusal* tripwire, or "".
+def parse_refusal_options(lock_text: str) -> tuple[str, str]:
+    """The bounded-lock refusal tripwire's ``(window, reason)``, or ``("", "")``.
+
+    One parser behind two accessors — :func:`lock_refusal_window` and
+    :func:`lock_refusal_reason` — rather than two line loops that could disagree
+    about what counts as a tripwire.
 
     ``withhold()`` in ``.github/scripts/renovate_uv_lock_bounded.py`` refuses a
-    lock refresh by writing the baseline versions plus a bare ``[options]`` table::
+    lock refresh by writing the baseline versions plus a bare ``[options]`` table,
+    stamped since FND-909 with why it refused::
 
         [options]
-        exclude-newer-span = "P3D"
+        exclude-newer-span = "P3D"  # refusal: window-empty
+
+    The reason is empty for a tripwire written before that stamp existed. "No
+    reason given" must never read as self-healing, so callers treat an unstamped
+    tripwire as the pre-FND-909 shape and fall back to the window clock.
 
     That table is the refusal's only durable trace — nothing else on the PR
     records it — and it is precisely what ``uv sync --locked`` rejects, which is
@@ -121,12 +153,13 @@ def lock_refusal_window(lock_text: str) -> str:
     and needs six lines of it.
     """
     span = ""
+    reason = ""
     in_options = False
     for raw in lock_text.splitlines():
         line = raw.strip()
         if line.startswith("[options."):
             # uv's own per-package ceiling subtable. Never written by withhold().
-            return ""
+            return "", ""
         if line.startswith("[options]"):
             in_options = True
             continue
@@ -140,10 +173,31 @@ def lock_refusal_window(lock_text: str) -> str:
         key, _, value = line.partition("=")
         if key.strip() == "exclude-newer":
             # uv wrote this table, not the driver.
-            return ""
+            return "", ""
         if key.strip() == "exclude-newer-span":
-            span = value.split("#")[0].strip().strip("\"'")
-    return span
+            head, _, stamp = value.partition("#")
+            span = head.strip().strip("\"'")
+            stamp = stamp.strip()
+            if stamp.startswith("refusal:"):
+                reason = stamp[len("refusal:") :].strip()
+    return span, reason
+
+
+def lock_refusal_window(lock_text: str) -> str:
+    """The release-age window a bounded-lock refusal tripwire names, or "".
+
+    See :func:`parse_refusal_options` for the shape being read.
+    """
+    return parse_refusal_options(lock_text)[0]
+
+
+def lock_refusal_reason(lock_text: str) -> str:
+    """Why the driver refused, per the tripwire's stamp, or "" if unstamped.
+
+    A reason outside :data:`SELF_HEALING_REFUSALS` is a standing fault: waiting
+    does not clear it and the reaper deliberately leaves it alone.
+    """
+    return parse_refusal_options(lock_text)[1]
 
 
 def _is_uv_lock_only(files: list[str]) -> bool:
@@ -151,47 +205,66 @@ def _is_uv_lock_only(files: list[str]) -> bool:
     return len(files) == 1 and files[0].rsplit("/", 1)[-1] == "uv.lock"
 
 
-def bounded_lock_refusal_expired(
+def bounded_lock_refusal_state(
     pr: RenovatePR, category: Category, now: datetime
-) -> bool:
-    """Is this red PR a bounded-lock refusal whose window has already elapsed?
+) -> Optional[BlockingReason]:
+    """Which bounded-lock refusal this red PR is, or ``None`` if it is not one.
 
-    Four conditions, all machine-checkable and none heuristic:
+    Three conditions identify a refusal at all, machine-checkable and none
+    heuristic: it is a lock-maintenance PR, the diff is a ``uv.lock`` and nothing
+    else, and that lock carries the driver's tripwire (see
+    :func:`parse_refusal_options`).
 
-    1. it is a lock-maintenance PR,
-    2. the diff is a ``uv.lock`` and nothing else,
-    3. that lock carries the driver's refusal tripwire (see
-       :func:`lock_refusal_window`), and
-    4. the branch head is at least as old as the window the tripwire names.
+    What separates the two findings is the tripwire's stamp, because they have
+    different owners and different clocks:
 
-    (4) is what makes the refusal *expired* rather than merely present. A refusal
-    written at ``T`` was caused by content published inside ``(T - W, T]``; by
-    ``T + W`` every one of those releases is at least ``W`` old, so the same
-    resolve would now be admitted. ``head_committed_at`` is the right clock and
-    ``created_at`` is not: Renovate rewrites a lock branch in place, so a PR opened
-    a week ago may carry a refusal written an hour ago.
+    ``BOUNDED_LOCK_REFUSAL_STANDING``
+        A reason outside :data:`SELF_HEALING_REFUSALS` — a broken interpreter, an
+        unsatisfiable floor, a yanked-pin rollback. Waiting fixes none of them and
+        the reaper leaves them alone by design, so this is reported the moment it
+        is seen. No clock: an age gate here would only delay a human looking at a
+        branch that was never going to recover on its own.
 
-    What this deliberately does not claim is *which* refusal path wrote the
-    tripwire — ``withhold()`` is also called for an unsatisfiable floor and for the
-    rollback gate, and those do not expire with the clock. The signal is honest
-    about that: it says the tripwire is on and the window it names has elapsed,
-    which is already strictly more than ``checks_failing`` conveys, and the first
-    triage step (look at the branch; delete it to force a fresh resolve) is the
-    same either way.
+    ``BOUNDED_LOCK_REFUSAL_EXPIRED``
+        A refusal that should already be gone. Two clocks reach it, and which one
+        applies depends on whether the tripwire is stamped:
+
+        *Stamped self-healing* — the reaper deletes these on sight, so the finding
+        is not "would the bound admit something now?" but "why is this still
+        here?". :data:`REAPER_GRACE` (two fleet passes) is the answer, and the
+        refusal's own window stops being relevant once something is supposed to
+        have deleted the branch regardless of what the bound would admit.
+
+        *Unstamped* — written before FND-909, so the reason is unknowable and the
+        reaper correctly ignores it. Falls back to the original window clock: a
+        refusal written at ``T`` was caused by content published inside
+        ``(T - W, T]``, so by ``T + W`` every one of those releases is at least
+        ``W`` old and the same resolve would now be admitted. "No reason given"
+        must never read as self-healing, so this path never claims the shorter
+        grace.
+
+    ``head_committed_at`` is the right clock for both and ``created_at`` is not:
+    Renovate rewrites a lock branch in place, so a PR opened a week ago may carry
+    a refusal written an hour ago.
     """
     if category is not Category.LOCK_MAINTENANCE:
-        return False
+        return None
     if not _is_uv_lock_only(pr.files):
-        return False
+        return None
     window = parse_window(pr.lock_refusal_window)
     if window is None:
-        return False
+        return None
+
+    reason = pr.lock_refusal_reason
+    if reason and reason not in SELF_HEALING_REFUSALS:
+        return BlockingReason.BOUNDED_LOCK_REFUSAL_STANDING
+
     head = pr.head_committed_at
     if head is None:
         # No clock for the branch head — the input predates the field. Report the
         # ordinary red-build reason rather than guessing from created_at, which
         # Renovate's in-place branch rewrites make unrelated to the refusal.
-        return False
+        return None
     # Both sides get the same naive->UTC coercion classify() applies to
     # created_at. Normalising only one of them makes a naive clock a TypeError on
     # subtraction rather than a wrong-by-an-offset answer, which is a worse
@@ -200,7 +273,10 @@ def bounded_lock_refusal_expired(
         head = head.replace(tzinfo=timezone.utc)
     if now.tzinfo is None:
         now = now.replace(tzinfo=timezone.utc)
-    return now - head >= window
+    grace = REAPER_GRACE if reason in SELF_HEALING_REFUSALS else window
+    if now - head >= grace:
+        return BlockingReason.BOUNDED_LOCK_REFUSAL_EXPIRED
+    return None
 
 
 def categorize(pr: RenovatePR) -> Category:
@@ -410,11 +486,13 @@ def blocking_reason(
 
     if pr.checks_state == ChecksState.FAILING:
         # Red is ordinarily a human's problem and age adds nothing to it. One
-        # shape is different: a bounded-lock refusal is red by design and nothing
-        # will ever re-evaluate it, so once its window has elapsed it is frozen
-        # rather than broken. Separate it out so the dashboard can say which.
-        if bounded_lock_refusal_expired(pr, category, now):
-            return BlockingReason.BOUNDED_LOCK_REFUSAL_EXPIRED
+        # shape is different: a bounded-lock refusal is red by design, so it is
+        # either frozen past when the reaper should have cleared it, or a standing
+        # fault waiting on a human. Separate both out so the dashboard can say
+        # which, and so an alarm can fire on the first without the second.
+        refusal = bounded_lock_refusal_state(pr, category, now)
+        if refusal is not None:
+            return refusal
         return BlockingReason.CHECKS_FAILING
     if pr.checks_state == ChecksState.PENDING:
         return BlockingReason.CHECKS_PENDING

--- a/packages/conformance/conformance/renovate/models.py
+++ b/packages/conformance/conformance/renovate/models.py
@@ -49,8 +49,22 @@ class BlockingReason(str, Enum):
         # so Renovate reuses it without re-running postUpgradeTasks, and the marker
         # committed into uv.lock carries no clock. Recovery is to delete the branch
         # and let the next Renovate pass rebuild it (recreateClosed: true in the
-        # shared preset makes that safe). FND-782; mechanism in FND-695.
+        # shared preset makes that safe) — which is what the reaper step in
+        # renovate.yaml now does automatically, so reaching this state at all
+        # means the reaper did not run. FND-782; mechanism in FND-695.
         "bounded_lock_refusal_expired"
+    )
+    BOUNDED_LOCK_REFUSAL_STANDING = (
+        # The other half of a bounded-lock refusal: the driver stamped a reason
+        # that waiting does not fix — a broken interpreter, an unsatisfiable
+        # floor, a floor that was admitted and still failed, a yanked-pin
+        # rollback. The reaper deliberately leaves these alone, because recycling
+        # a real wedge every four hours would hide it behind a lane that looks
+        # busy. A human owns the branch. Distinct from
+        # BOUNDED_LOCK_REFUSAL_EXPIRED so an alarm can fire on a reaper outage
+        # without also firing on every fault a human is legitimately still
+        # working through. FND-909.
+        "bounded_lock_refusal_standing"
     )
     MERGE_CONFLICT = "merge_conflict"  # mergeable=CONFLICTING
     NON_DEP_FILES = "non_dep_files"  # changed files outside auto-approve allowlist
@@ -130,6 +144,11 @@ class RenovatePR:
     # branch's uv.lock ("P3D"), or "" when the lock has no tripwire. Parsed out by
     # scan._parse_pr so the multi-hundred-KB lock text itself is never retained.
     lock_refusal_window: str = ""
+    # Raw: why the driver refused, per the stamp on the tripwire line
+    # ("window-empty"), or "" for an unstamped tripwire — one written before
+    # FND-909, or no tripwire at all. Empty is deliberately not self-healing:
+    # classify falls back to the window clock rather than assuming a reason.
+    lock_refusal_reason: str = ""
     # populated by classify()
     category: Category = Category.UNKNOWN
     update_type: UpdateType = UpdateType.UNKNOWN

--- a/packages/conformance/conformance/renovate/scan.py
+++ b/packages/conformance/conformance/renovate/scan.py
@@ -21,7 +21,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
-from conformance.renovate.classify import classify, lock_refusal_window
+from conformance.renovate.classify import classify, parse_refusal_options
 from conformance.renovate.models import (
     AutoMergeStats,
     BlockingReason,
@@ -109,8 +109,9 @@ def _parse_pr(raw: dict) -> Optional[RenovatePR]:
     Two fields beyond that schema are read when present, both supplied by
     renovate_fleet_scan.py: ``headCommittedAt`` and ``uvLockText`` (the branch
     head's uv.lock, fetched only for the handful of PRs that could be carrying a
-    bounded-lock refusal). The text is reduced to its window here and dropped —
-    the model never holds the lockfile.
+    bounded-lock refusal). The text is reduced to its window and refusal reason
+    here and dropped — the model never holds the lockfile. One parse, not one per
+    field: these locks run to several MB.
     """
     try:
         created = datetime.fromisoformat(raw["createdAt"].replace("Z", "+00:00"))
@@ -118,6 +119,9 @@ def _parse_pr(raw: dict) -> Optional[RenovatePR]:
         labels = [lb["name"] for lb in raw.get("labels", [])]
         files = [f["path"] for f in raw.get("files", [])]
         rollup = raw.get("statusCheckRollup") or []
+        refusal_window, refusal_reason = parse_refusal_options(
+            raw.get("uvLockText") or ""
+        )
         return RenovatePR(
             number=raw["number"],
             url=raw["url"],
@@ -134,7 +138,8 @@ def _parse_pr(raw: dict) -> Optional[RenovatePR]:
             body=raw.get("body") or "",
             auto_merge_enabled=bool(raw.get("autoMergeEnabled") or False),
             head_committed_at=_parse_head_committed_at(raw),
-            lock_refusal_window=lock_refusal_window(raw.get("uvLockText") or ""),
+            lock_refusal_window=refusal_window,
+            lock_refusal_reason=refusal_reason,
         )
     except (KeyError, ValueError) as exc:
         print(f"Warning: skipping malformed PR record: {exc}", file=sys.stderr)
@@ -238,12 +243,14 @@ def _pr_to_dict(pr: RenovatePR) -> dict:
         "updatedAt": pr.updated_at.isoformat(),
         # Bounded-lock refusal evidence, so a blockingReason of
         # bounded_lock_refusal_expired can be rendered with the window it named
-        # and how long the branch has actually been frozen. Both null/empty on
+        # and how long the branch has actually been frozen, and so the standing
+        # variant can name the fault a human has to clear. All null/empty on
         # every PR that carries no tripwire, which is nearly all of them.
         "headCommittedAt": pr.head_committed_at.isoformat()
         if pr.head_committed_at
         else None,
         "lockRefusalWindow": pr.lock_refusal_window,
+        "lockRefusalReason": pr.lock_refusal_reason,
         # Which packages this PR delivers (parsed from body table / title) —
         # lets the fleet-freshness dashboard join "repo behind on tool X" to
         # the exact PR that fixes it. Empty for lock-maintenance PRs.

--- a/packages/conformance/tests/test_renovate_classify.py
+++ b/packages/conformance/tests/test_renovate_classify.py
@@ -6,9 +6,10 @@ from datetime import datetime, timedelta, timezone
 
 from conformance.renovate.classify import (
     STALE_AFTER_DAYS,
-    bounded_lock_refusal_expired,
+    bounded_lock_refusal_state,
     classify,
 )
+from conformance.renovate.classify import lock_refusal_reason as extract_refusal_reason
 from conformance.renovate.classify import lock_refusal_window as extract_refusal_window
 from conformance.renovate.classify import parse_window
 from conformance.renovate.models import (
@@ -46,6 +47,7 @@ def make_pr(
     auto_merge_enabled: bool = False,
     head_committed_at: datetime | None = None,
     lock_refusal_window: str = "",
+    lock_refusal_reason: str = "",
 ) -> RenovatePR:
     """Construct an unclassified RenovatePR with sane defaults for one scenario."""
     return RenovatePR(
@@ -65,6 +67,7 @@ def make_pr(
         auto_merge_enabled=auto_merge_enabled,
         head_committed_at=head_committed_at,
         lock_refusal_window=lock_refusal_window,
+        lock_refusal_reason=lock_refusal_reason,
     )
 
 
@@ -707,8 +710,13 @@ def _refusal_pr(
     files: list[str] | None = None,
     labels: list[str] | None = None,
     checks_state: ChecksState = ChecksState.FAILING,
+    reason: str = "",
 ) -> RenovatePR:
-    """A red, uv.lock-only lock-maintenance PR carrying an expired tripwire."""
+    """A red, uv.lock-only lock-maintenance PR carrying an expired tripwire.
+
+    ``reason`` defaults to unstamped — the pre-FND-909 shape, which is judged
+    against the window it names rather than the reaper's grace.
+    """
     return make_pr(
         labels=labels if labels is not None else ["update:lock-maintenance"],
         title="Lock file maintenance",
@@ -718,6 +726,7 @@ def _refusal_pr(
         created_at=_OLD,
         head_committed_at=_NOW - head_age,
         lock_refusal_window=window,
+        lock_refusal_reason=reason,
     )
 
 
@@ -746,6 +755,37 @@ def test_refusal_window_empty_for_uv_written_options() -> None:
 
 def test_refusal_window_empty_for_ordinary_lock() -> None:
     assert extract_refusal_window(_PLAIN_LOCK) == ""
+
+
+def test_refusal_reason_read_from_a_stamped_tripwire() -> None:
+    stamped = _TRIPWIRE_LOCK.replace(
+        'exclude-newer-span = "P3D"',
+        'exclude-newer-span = "P3D"  # refusal: window-empty',
+    )
+    assert extract_refusal_reason(stamped) == "window-empty"
+    # The stamp must not corrupt the window every existing reader already parses.
+    assert extract_refusal_window(stamped) == "P3D"
+
+
+def test_refusal_reason_empty_for_an_unstamped_tripwire() -> None:
+    # Pre-FND-909 shape: a tripwire is present, but it names no reason.
+    assert extract_refusal_window(_TRIPWIRE_LOCK) == "P3D"
+    assert extract_refusal_reason(_TRIPWIRE_LOCK) == ""
+
+
+def test_refusal_reason_ignores_a_comment_that_is_not_a_stamp() -> None:
+    # Only the driver's `refusal:` prefix counts; a stray comment is not a reason.
+    lock = _TRIPWIRE_LOCK.replace(
+        'exclude-newer-span = "P3D"',
+        'exclude-newer-span = "P3D"  # set by hand, do not edit',
+    )
+    assert extract_refusal_reason(lock) == ""
+    assert extract_refusal_window(lock) == "P3D"
+
+
+def test_refusal_reason_empty_for_uv_written_options() -> None:
+    # uv's own table is not a refusal at all, so it names no reason either.
+    assert extract_refusal_reason(_UV_OWN_OPTIONS_LOCK) == ""
 
 
 def test_refusal_window_ignores_a_span_outside_the_options_table() -> None:
@@ -836,8 +876,80 @@ def test_refusal_expiry_tolerates_a_naive_clock_from_a_caller() -> None:
     # UTC coercion classify() applies to created_at.
     naive_now = _NOW.replace(tzinfo=None)
     assert (
-        bounded_lock_refusal_expired(
-            _refusal_pr(), Category.LOCK_MAINTENANCE, naive_now
-        )
-        is True
+        bounded_lock_refusal_state(_refusal_pr(), Category.LOCK_MAINTENANCE, naive_now)
+        is BlockingReason.BOUNDED_LOCK_REFUSAL_EXPIRED
     )
+
+
+# --- the stamped split (FND-909) ------------------------------------------
+
+
+def test_stamped_self_healing_refusal_expires_on_the_reaper_grace() -> None:
+    """Past two fleet passes the reaper should have deleted this branch.
+
+    Well inside the P3D window it names, so the window clock alone would still
+    call it live — the point of the stamp is that the window stopped being the
+    question once something is supposed to delete the branch regardless.
+    """
+    pr = classify(_refusal_pr(reason="window-empty", head_age=timedelta(hours=10)))
+    assert pr.blocking_reason is BlockingReason.BOUNDED_LOCK_REFUSAL_EXPIRED
+
+
+def test_stamped_self_healing_refusal_is_not_flagged_within_the_grace() -> None:
+    """One missed pass is latency, not an outage. The reaper gets two."""
+    pr = classify(_refusal_pr(reason="window-empty", head_age=timedelta(hours=5)))
+    assert pr.blocking_reason is BlockingReason.CHECKS_FAILING
+
+
+def test_standing_fault_is_reported_immediately() -> None:
+    """No clock: waiting never clears it, so an age gate would only delay a human."""
+    pr = classify(_refusal_pr(reason="rollback", head_age=timedelta(minutes=1)))
+    assert pr.blocking_reason is BlockingReason.BOUNDED_LOCK_REFUSAL_STANDING
+
+
+def test_standing_fault_never_ages_into_the_reaper_signal() -> None:
+    """An old wedge is still a human's, not evidence the reaper broke."""
+    pr = classify(
+        _refusal_pr(reason="unsatisfiable-floor", head_age=timedelta(days=30))
+    )
+    assert pr.blocking_reason is BlockingReason.BOUNDED_LOCK_REFUSAL_STANDING
+
+
+def test_standing_fault_is_reported_without_a_head_clock() -> None:
+    """The stamp alone is enough; the standing path never reaches the clock."""
+    pr = classify(
+        make_pr(
+            labels=["update:lock-maintenance"],
+            title="Lock file maintenance",
+            branch="renovate/lock-file-maintenance",
+            checks_state=ChecksState.FAILING,
+            files=["uv.lock"],
+            created_at=_OLD,
+            head_committed_at=None,
+            lock_refusal_window="P3D",
+            lock_refusal_reason="no-packaging",
+        )
+    )
+    assert pr.blocking_reason is BlockingReason.BOUNDED_LOCK_REFUSAL_STANDING
+
+
+def test_an_unrecognised_reason_is_treated_as_standing() -> None:
+    """The safe direction: an unknown stamp gets a human, never the shorter clock.
+
+    A refusal path added to the driver without updating the reader must not
+    inherit self-healing by accident — that would have the alarm stay quiet on a
+    real wedge.
+    """
+    pr = classify(_refusal_pr(reason="some-future-reason", head_age=timedelta(days=9)))
+    assert pr.blocking_reason is BlockingReason.BOUNDED_LOCK_REFUSAL_STANDING
+
+
+def test_unstamped_tripwire_keeps_the_window_clock() -> None:
+    """Pre-FND-909 locks carry no reason; "none given" must not read as healing.
+
+    Ten hours is past the reaper grace but well inside P3D. A stamped
+    self-healing refusal would be flagged here; an unstamped one must not be,
+    because nothing claims the reaper was ever going to take it.
+    """
+    pr = classify(_refusal_pr(reason="", head_age=timedelta(hours=10)))
+    assert pr.blocking_reason is BlockingReason.CHECKS_FAILING


### PR DESCRIPTION
## Problem

The reaper added in #3490 deletes a self-healing lock refusal on sight, and by design it never fails its own job — Renovate has to run either way, so a reaper outage should cost a cycle of recovery latency rather than the lock refresh itself.

The cost of that choice is that the outage is **silent**. The fleet run stays green and a lock PR simply sits red in a repo nobody is watching, which is the FND-909 freeze again. Nothing would have caught it: today's verification happened because a human noticed a red PR and asked.

`renovate-dashboard.yaml` already scans the whole fleet every six hours and classifies every open Renovate PR — but it renders a tile, it does not fail. And its `bounded_lock_refusal_expired` signal could not have told a reaper outage from an ordinary wedge anyway: `lock_refusal_window` split the tripwire line on `#` and discarded the driver's stamp, so a `window-empty` freeze and a yanked-pin rollback were indistinguishable. Its own docstring said so.

## Change

**1. Carry the stamp instead of discarding it.** `parse_refusal_options` is now one parser behind two accessors (`lock_refusal_window`, `lock_refusal_reason`) rather than two line loops that could disagree about what counts as a tripwire. `RenovatePR` gains `lock_refusal_reason`; `scan._parse_pr` parses the lock once for both, since these locks run to several MB.

**2. Split the finding in two,** because the two halves have different owners and different clocks:

| Finding | When | Who acts |
| -- | -- | -- |
| `bounded_lock_refusal_standing` | stamped with a reason outside the self-healing set — immediately, no clock | a human |
| `bounded_lock_refusal_expired` | stamped self-healing and older than `REAPER_GRACE` (two fleet passes), **or** unstamped and older than the window it names | nobody: the reaper should already have taken it |

The two clocks differ deliberately. Once something is supposed to delete the branch regardless, "would the bound admit something now?" stops being the question — so a stamped self-healing refusal is judged against the reaper's cadence, not its own window. Unstamped tripwires keep the window clock: **"no reason given" must never read as self-healing**, which is the one mistake that would recycle a real wedge forever.

**3. Alarm on the half that means a machine failed.** `renovate_refusal_alarm.py` fails the dashboard run on `bounded_lock_refusal_expired` and only warns on standing faults — a wedge a human is legitimately still working through must not red a six-hourly job, or the alarm stops being read. It runs **last, after the S3 deploy**, so a run that finds something to report still publishes the dashboard someone needs in order to act on it. Full-fleet mode only: single-repo mode is dispatched per PR-gate evaluation by `renovate-auto-approve-reusable`, where a fleet-wide verdict does not belong.

**No new fleet scanning.** This reads what the scanner already wrote. That workflow moved to batched GraphQL precisely because per-repo walks were the dominant source of rate-limit pressure; a second scanner would reintroduce it. (This is why the `renovate_lock_refusal_census.py` approach from #3490 is *not* wired to a cron — it remains a manual tool.)

**4. A vocabulary pin.** The self-healing set now lives in two places: the driver writes stamps as a bare `python3` on the fleet runner and cannot import the conformance package. A test pins the two equal, because the drift is silent in the dangerous direction — add a reason to the writer alone and the reader classifies it as standing, so the alarm never fires and the freeze is invisible again.

## Validation

* **Unit** — 100 tests across the two suites; full CI-script suite 3475 passed.
* **End-to-end against the real `renovate-scan` CLI**, not hand-built dicts: three crafted PRs (12h-old `window-empty`, 1h-old `rollback`, 2h-old `window-empty`) classify as expired / standing / still-inside-grace, `fleet.json` carries all three counts, and the alarm exits 1 naming only the frozen one.
* **The mechanism this guards is itself now verified live.** Three complete cycles were observed on `atlan-openapi-app` while writing this, including the reap → green → merge chain that #3490 listed as outstanding:

  | Pass | What happened |
  | -- | -- |
  | 2026-08-28 16:01Z | reaped #410 (`window-empty`), rebuilt as #411 — 20s apart, same job |
  | 2026-08-28 21:56Z | reaped #411, rebuilt as #412 (`uv.lock +57/−57`, no tripwire) |
  | 2026-08-28 22:08Z | #412 merged — 5 min after creation |

  Fleet census the same day: 80 open lock PRs, 0 frozen, 0 standing faults, 0 unstamped tripwires.

## Security-relevant

Touches `.github/workflows/renovate-dashboard.yaml`, a CI control-plane file. The new step grants no permission the job did not already hold, makes no network call, and reads only files the preceding step wrote in the same job.

Relates to FND-909; the classifier gap it closes was left open by FND-782.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
