### PR TITLE
ci(fix): retry transient GraphQL failures in the fleet scan (FND-909)

### DIFF
--- a/.github/scripts/renovate_fleet_scan.py
+++ b/.github/scripts/renovate_fleet_scan.py
@@ -32,6 +32,7 @@ import argparse
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -48,6 +49,22 @@ MAX_PAGES = 50
 # pre-filter it backs up should leave a handful of candidates fleet-wide, and
 # anything over the cap is reported rather than silently dropped.
 MAX_LOCK_FETCHES = 25
+
+# Transient GitHub-side failures. A fleet pass issues on the order of a hundred
+# GraphQL calls (paginated search plus one lock fetch per candidate), so the
+# chance of meeting at least one 502 approaches certainty — and before FND-909
+# a single one aborted the whole run. Every scheduled dashboard run failed this
+# way for ten days straight, all with `502 Bad Gateway` from _post_graphql.
+#
+# 5xx only. A 401/403 is a token problem and a 422 is a malformed query; both
+# would fail identically on every attempt, so retrying them only delays the
+# report of a fault that needs a human.
+_RETRYABLE_STATUS = frozenset({500, 502, 503, 504})
+GRAPHQL_ATTEMPTS = 4
+# 1s, 2s, 4s between the four attempts. Bounded at ~7s added latency in the worst
+# case, against a job that already runs for minutes — cheap enough that it is not
+# worth making configurable, and short enough not to mask a sustained outage.
+_BACKOFF_BASE_SECONDS = 1.0
 
 _OPEN_PR_FIELDS = """
 number
@@ -134,7 +151,8 @@ def build_graphql_payload(search_query: str, fields: str, after: Optional[str]) 
     return {"query": query}
 
 
-def _post_graphql(token: str, payload: dict) -> dict:
+def _post_graphql_once(token: str, payload: dict) -> dict:
+    """One GraphQL POST. Raises RuntimeError on any failure; see _post_graphql."""
     req = urllib.request.Request(
         GRAPHQL_URL,
         data=json.dumps(payload).encode(),
@@ -162,6 +180,56 @@ def _post_graphql(token: str, payload: dict) -> dict:
         raise RuntimeError(f"GraphQL request failed: {exc}") from exc
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"GraphQL response was not JSON: {exc}") from exc
+
+
+def _is_retryable(exc: RuntimeError) -> bool:
+    """Is this failure worth another attempt?
+
+    Matched on the message because _post_graphql_once has already normalised
+    every failure to RuntimeError — deliberately, so callers that degrade on one
+    need a single handler. Keeping that normalisation and re-deriving the status
+    here beats leaking HTTPError back out to every caller for the sake of retry.
+    """
+    text = str(exc)
+    if any(f"failed: {status} " in text for status in _RETRYABLE_STATUS):
+        return True
+    # Transport-level: connection reset, DNS blip, read timeout. None of these
+    # carry a status, and all are the same kind of transient as a 502.
+    return "failed: <urlopen error" in text or "timed out" in text.lower()
+
+
+def _post_graphql(
+    token: str,
+    payload: dict,
+    *,
+    attempts: int = GRAPHQL_ATTEMPTS,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict:
+    """POST with bounded exponential backoff on transient GitHub failures.
+
+    ``sleep`` is injected so tests exercise the real retry path without wall-clock
+    delay — patching ``time.sleep`` globally would reach anything else running in
+    the same process.
+    """
+    last: RuntimeError
+    for attempt in range(1, attempts + 1):
+        try:
+            return _post_graphql_once(token, payload)
+        except RuntimeError as exc:
+            last = exc
+            if attempt == attempts or not _is_retryable(exc):
+                raise
+            delay = _BACKOFF_BASE_SECONDS * (2 ** (attempt - 1))
+            # Visible in the job log: a run that succeeded only after three
+            # retries is healthy-but-degraded, and that is worth seeing before
+            # it becomes a run that fails outright.
+            print(
+                f"::warning::GraphQL attempt {attempt}/{attempts} failed "
+                f"({exc}); retrying in {delay:.0f}s",
+                file=sys.stderr,
+            )
+            sleep(delay)
+    raise last  # unreachable: the loop either returns or raises
 
 
 def fetch_all_prs(

--- a/.github/scripts/tests/test_renovate_fleet_scan.py
+++ b/.github/scripts/tests/test_renovate_fleet_scan.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import sys
 from pathlib import Path
@@ -554,7 +555,9 @@ def test_post_graphql_wraps_transport_errors_as_runtime_error(monkeypatch):
 
     monkeypatch.setattr(rfs.urllib.request, "urlopen", boom)
     try:
-        rfs._post_graphql("tok", {"query": "{}"})
+        # _post_graphql_once, not _post_graphql: the wrapping under test lives
+        # there now, and going through the retry wrapper would sleep for real.
+        rfs._post_graphql_once("tok", {"query": "{}"})
         assert False, "expected RuntimeError"
     except RuntimeError as exc:
         assert "name resolution failed" in str(exc)
@@ -568,7 +571,7 @@ def test_post_graphql_wraps_timeouts_as_runtime_error(monkeypatch):
 
     monkeypatch.setattr(rfs.urllib.request, "urlopen", boom)
     try:
-        rfs._post_graphql("tok", {"query": "{}"})
+        rfs._post_graphql_once("tok", {"query": "{}"})
         assert False, "expected RuntimeError"
     except RuntimeError as exc:
         assert "timed out" in str(exc)
@@ -585,3 +588,155 @@ def test_fetch_lock_texts_survives_a_transport_failure(capsys):
     assert rfs.fetch_lock_texts("tok", prs, flaky_post) == 0
     assert "uvLockText" not in prs[0]
     assert "could not read uv.lock" in capsys.readouterr().err
+
+
+# --- transient-failure retry (FND-909) ------------------------------------
+#
+# Every scheduled renovate-dashboard run failed for ten days straight, all with
+# `502 Bad Gateway` out of _post_graphql, because one transient GitHub-side
+# failure aborted the whole fleet pass. A pass issues on the order of a hundred
+# GraphQL calls, so meeting at least one 502 is close to certain.
+
+
+class _ScriptedPost:
+    """Stands in for _post_graphql_once, replaying a scripted list of outcomes.
+
+    Each item is either an exception to raise or a dict to return, so a test can
+    say "fail twice, then succeed" without touching the network.
+    """
+
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = 0
+
+    def __call__(self, token, payload):
+        self.calls += 1
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def _wrapped(status: int, reason: str = "Bad Gateway") -> RuntimeError:
+    """A RuntimeError shaped exactly as _post_graphql_once normalises an HTTPError."""
+    return RuntimeError(f"GraphQL request failed: {status} {reason}: <html>")
+
+
+def test_retries_past_a_502_and_succeeds(monkeypatch):
+    # The exact failure that took the dashboard down for ten days.
+    post = _ScriptedPost([_wrapped(502), _wrapped(502), {"data": {"ok": True}}])
+    monkeypatch.setattr(rfs, "_post_graphql_once", post)
+    slept = []
+
+    result = rfs._post_graphql("tok", {}, sleep=slept.append)
+
+    assert result == {"data": {"ok": True}}
+    assert post.calls == 3
+    assert slept == [1.0, 2.0]  # exponential, and it really did back off
+
+
+def test_retry_gives_up_at_the_attempt_cap(monkeypatch):
+    # A sustained outage still fails the run rather than retrying forever.
+    post = _ScriptedPost([_wrapped(502)] * rfs.GRAPHQL_ATTEMPTS)
+    monkeypatch.setattr(rfs, "_post_graphql_once", post)
+
+    try:
+        rfs._post_graphql("tok", {}, sleep=lambda _: None)
+        assert False, "expected RuntimeError"
+    except RuntimeError as exc:
+        assert "502" in str(exc)
+    assert post.calls == rfs.GRAPHQL_ATTEMPTS
+
+
+def test_retry_covers_every_transient_status(monkeypatch):
+    # 500/503/504 are the same class of GitHub-side blip as 502.
+    for status in (500, 503, 504):
+        post = _ScriptedPost([_wrapped(status), {"ok": 1}])
+        monkeypatch.setattr(rfs, "_post_graphql_once", post)
+
+        assert rfs._post_graphql("tok", {}, sleep=lambda _: None) == {"ok": 1}
+        assert post.calls == 2, f"{status} should have been retried"
+
+
+def test_does_not_retry_an_auth_failure(monkeypatch):
+    # A 401 fails identically every attempt; retrying only delays the report.
+    post = _ScriptedPost([_wrapped(401, "Unauthorized")])
+    monkeypatch.setattr(rfs, "_post_graphql_once", post)
+
+    try:
+        rfs._post_graphql("tok", {}, sleep=lambda _: None)
+        assert False, "expected RuntimeError"
+    except RuntimeError as exc:
+        assert "401" in str(exc)
+    assert post.calls == 1
+
+
+def test_does_not_retry_a_malformed_query(monkeypatch):
+    # 422 means the query is wrong — a human's problem, not the network's.
+    post = _ScriptedPost([_wrapped(422, "Unprocessable Entity")])
+    monkeypatch.setattr(rfs, "_post_graphql_once", post)
+
+    try:
+        rfs._post_graphql("tok", {}, sleep=lambda _: None)
+        assert False, "expected RuntimeError"
+    except RuntimeError as exc:
+        assert "422" in str(exc)
+    assert post.calls == 1
+
+
+def test_retries_a_transport_failure(monkeypatch):
+    # Connection reset / DNS blip carries no status but is the same transient.
+    post = _ScriptedPost(
+        [
+            RuntimeError("GraphQL request failed: <urlopen error [Errno 104] reset>"),
+            {"ok": 1},
+        ]
+    )
+    monkeypatch.setattr(rfs, "_post_graphql_once", post)
+
+    assert rfs._post_graphql("tok", {}, sleep=lambda _: None) == {"ok": 1}
+    assert post.calls == 2
+
+
+def test_retries_a_read_timeout(monkeypatch):
+    post = _ScriptedPost(
+        [
+            RuntimeError("GraphQL request failed: The read operation timed out"),
+            {"ok": 1},
+        ]
+    )
+    monkeypatch.setattr(rfs, "_post_graphql_once", post)
+
+    assert rfs._post_graphql("tok", {}, sleep=lambda _: None) == {"ok": 1}
+    assert post.calls == 2
+
+
+def test_a_successful_first_attempt_never_sleeps(monkeypatch):
+    # The happy path must not pay for the retry machinery.
+    post = _ScriptedPost([{"data": {}}])
+    monkeypatch.setattr(rfs, "_post_graphql_once", post)
+    slept = []
+
+    rfs._post_graphql("tok", {}, sleep=slept.append)
+
+    assert post.calls == 1
+    assert slept == []
+
+
+def test_retry_warns_so_a_degraded_run_is_visible(monkeypatch, capsys):
+    # A run that only succeeded after three retries is healthy-but-degraded, and
+    # worth seeing before it becomes a run that fails outright.
+    post = _ScriptedPost([_wrapped(502), {"ok": 1}])
+    monkeypatch.setattr(rfs, "_post_graphql_once", post)
+
+    rfs._post_graphql("tok", {}, sleep=lambda _: None)
+
+    assert "::warning::GraphQL attempt 1/4 failed" in capsys.readouterr().err
+
+
+def test_retry_is_wired_into_the_default_post_fn():
+    # fetch_all_prs and fetch_lock_texts default their `post` argument, so a fix
+    # that retried in a function nothing called would leave the outage in place.
+    for fn in (rfs.fetch_all_prs, rfs.fetch_lock_texts):
+        default = inspect.signature(fn).parameters["post"].default
+        assert default is rfs._post_graphql, f"{fn.__name__} bypasses the retry"


### PR DESCRIPTION
## Problem

Every scheduled `renovate-dashboard.yaml` run has failed for ten days. 40 consecutive failures, **zero successes** in the last 40 scheduled runs, oldest listed 2026-08-19T18:08Z — all with the same error, oldest and newest identical:

```
File ".github/scripts/renovate_fleet_scan.py", line 149, in _post_graphql
urllib.error.HTTPError: HTTP Error 502: Bad Gateway
RuntimeError: GraphQL request failed: 502 Bad Gateway
```

`_post_graphql` had no retry. A fleet pass issues on the order of a hundred GraphQL calls — paginated search across ~80 repos, plus one lock fetch per candidate — so meeting at least one transient 502 is close to certain, and a single one aborted the whole run before any repo file was written.

None of this is visible from the workflow definition, which is why it ran unnoticed for ten days. Two consequences:

* **The fleet dashboard is stale.** `k.atlan.dev/renovate-dashboard/` has had no full-fleet update in ten days, and `fleet.json` with it. The only succeeding runs were the push-based single-repo dispatches from `renovate-auto-approve-reusable`, which deliberately skip fleet aggregation.
* **The refusal alarm from #3505 could never fire.** It is the last step in a job that dies at "Gather Renovate PR data", so a scheduled run never reached it. The step was correct and tested — it simply could not execute. This PR is what makes that one real.

## Change

Split the POST in two:

* `_post_graphql_once` — the previous body, unchanged. Still normalises every failure to `RuntimeError` so callers that degrade on one (`fetch_lock_texts` skips the PR) keep needing a single handler.
* `_post_graphql` — retries it with bounded exponential backoff. Four attempts, 1s/2s/4s, ~7s worst-case added latency against a job that already runs for minutes.

Retries `500/502/503/504` and transport-level failures (connection reset, DNS blip, read timeout). **Deliberately does not retry `401/403/422`** — a token problem or a malformed query fails identically on every attempt, so retrying only delays reporting a fault that needs a human.

Each retry prints a `::warning::`, so a run that succeeded only on the third attempt reads as healthy-but-degraded rather than silently fine. That is the signal that would have caught this drifting toward failure before it became a hard outage.

`sleep` is injected rather than patched globally, so the tests exercise the real retry path with no wall-clock cost and without reaching anything else in the process.

## Validation

* **52 tests pass** in the fleet-scan suite.
* **Mutation-verified rather than assumed.** Setting `GRAPHQL_ATTEMPTS = 1` fails exactly the five tests that cover retry behaviour and no others — so the retry is load-bearing, not decorative.
* **The wiring is pinned too.** One test asserts `fetch_all_prs` and `fetch_lock_texts` both default their `post` argument to the retrying wrapper. A retry added to a function nothing calls would have left the outage exactly where it was, and nothing else in the suite would have noticed.
* The two pre-existing tests covering error *wrapping* now target `_post_graphql_once` directly — that is where the behaviour under test moved, and routing them through the wrapper would have made them sleep for real.

## Security-relevant

No change to what is requested, sent, or authenticated — only how many times a failed request is re-attempted. Touches `.github/scripts/` only; no workflow or permission change.

Follows #3490 and #3505 on FND-909.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
