### PR TITLE
ci(fix): cut query cost and slice past the search cap in the fleet scan (FND-909)

### DIFF
--- a/.github/scripts/renovate_fleet_scan.py
+++ b/.github/scripts/renovate_fleet_scan.py
@@ -39,7 +39,30 @@ from pathlib import Path
 from typing import Callable, Optional
 
 GRAPHQL_URL = "https://api.github.com/graphql"
-PAGE_SIZE = 100
+
+# Page size is per-query, because cost is per-query. GitHub bills a GraphQL
+# request by the total nodes it may return — the product of the page size and
+# every nested connection limit inside each node — and answers a request it
+# cannot serve in time with a 502 or 504 rather than a cost error.
+#
+# Measured against the live fleet on 2026-08-29 with the real _OPEN_PR_FIELDS:
+#
+#     PAGE_SIZE=100  ->  502 Bad Gateway
+#     PAGE_SIZE=50   ->  504 "We couldn't respond to your request in time"
+#     PAGE_SIZE=25   ->  OK
+#
+# and with `files(first: 100)` removed, 100 succeeds — so the nested file
+# connection is the dominant term, not the rollup. The open-PR page size is cut
+# rather than the file limit because a truncated file list would silently
+# misclassify: `_is_uv_lock_only` and the auto-approve allowlist both need the
+# complete set, and "first 20 files happened to be uv.lock" is a wrong answer
+# that looks like a right one.
+OPEN_PAGE_SIZE = 25
+# The merged-PR field set carries no files and no statusCheckRollup, and was
+# measured OK at 100/50/25 — it does not need the cut.
+MERGED_PAGE_SIZE = 100
+# Back-compat alias for callers/tests that predate the split.
+PAGE_SIZE = OPEN_PAGE_SIZE
 # Safety backstop, not a real ceiling: 50 pages x 100 = 5000 PRs in one search window,
 # far beyond any realistic fleet. Trips only if a query is unexpectedly unbounded.
 MAX_PAGES = 50
@@ -133,11 +156,19 @@ def build_search_query(scope: str, extra: str) -> str:
     return f"{scope} is:pr {authors} {extra}".strip()
 
 
-def build_graphql_payload(search_query: str, fields: str, after: Optional[str]) -> dict:
+def build_graphql_payload(
+    search_query: str,
+    fields: str,
+    after: Optional[str],
+    page_size: Optional[int] = None,
+) -> dict:
+    # Defaults to the module-level PAGE_SIZE so existing callers and tests keep
+    # working; fetch_all_prs passes the size matched to its field set.
+    first = PAGE_SIZE if page_size is None else page_size
     after_arg = f", after: {json.dumps(after)}" if after else ""
     query = f"""
     query {{
-      search(query: {json.dumps(search_query)}, type: ISSUE, first: {PAGE_SIZE}{after_arg}) {{
+      search(query: {json.dumps(search_query)}, type: ISSUE, first: {first}{after_arg}) {{
         issueCount
         pageInfo {{ hasNextPage endCursor }}
         nodes {{
@@ -237,6 +268,7 @@ def fetch_all_prs(
     search_query: str,
     fields: str,
     post: PostFn = _post_graphql,
+    page_size: Optional[int] = None,
 ) -> list[dict]:
     """Paginate a GraphQL PR search to completion. Raises on a GraphQL 'errors' response,
     or if the result was silently truncated by the search API's ~1000-item hard cap."""
@@ -244,7 +276,7 @@ def fetch_all_prs(
     issue_count: Optional[int] = None
     after: Optional[str] = None
     for _ in range(MAX_PAGES):
-        payload = build_graphql_payload(search_query, fields, after)
+        payload = build_graphql_payload(search_query, fields, after, page_size)
         data = post(token, payload)
         if "errors" in data:
             raise RuntimeError(
@@ -272,6 +304,54 @@ def fetch_all_prs(
             "than silently reporting incomplete dashboard data."
         )
     return nodes
+
+
+def fetch_prs_by_author(
+    token: str,
+    scope: str,
+    extra: str,
+    fields: str,
+    post: PostFn = _post_graphql,
+    page_size: Optional[int] = None,
+) -> list[dict]:
+    """Run the search once per Renovate author and concatenate the results.
+
+    GitHub's search API returns at most ~1000 results per query, no matter how
+    the caller paginates. Measured 2026-08-29, the combined org-wide query had
+    outgrown that:
+
+        combined open:            1003   (over the cap — truncated)
+          app/renovate:            615
+          app/atlan-app-fleet:     388
+        combined merged (30d):    1020   (over the cap — truncated)
+          app/renovate:            192
+          app/atlan-app-fleet:     828
+
+    One query per author puts every slice comfortably under the cap while
+    covering exactly the same set, because the combined query is a plain OR of
+    the same author qualifiers. It is also the narrowing that costs nothing: the
+    total PR count and page count are unchanged, only their grouping.
+
+    Deduplicated by URL. GitHub cannot attribute one PR to two authors today, so
+    the overlap is empty in practice — but a slice that silently double-counted
+    would inflate every dashboard number, and the guard is one set.
+
+    ``fetch_all_prs`` still raises if any individual slice is truncated. The
+    fleet is growing, so that will eventually fire again; the next narrowing is
+    by date range (or a shorter ``--since`` window for the merged search).
+    """
+    seen: set[str] = set()
+    out: list[dict] = []
+    for author in RENOVATE_PR_AUTHORS:
+        query = f"{scope} is:pr author:{author} {extra}".strip()
+        for node in fetch_all_prs(token, query, fields, post, page_size):
+            url = node.get("url")
+            if url is not None and url in seen:
+                continue
+            if url is not None:
+                seen.add(url)
+            out.append(node)
+    return out
 
 
 def _status_rollup_to_list(pr: dict) -> list[dict]:
@@ -483,14 +563,19 @@ def run(
     token: str,
     post: PostFn = _post_graphql,
 ) -> tuple[dict[str, list[dict]], dict[str, list[dict]]]:
-    open_nodes = fetch_all_prs(
-        token, build_search_query(scope, "is:open"), _OPEN_PR_FIELDS, post
+    # Sliced per author and paged at a size the API can actually serve — see
+    # fetch_prs_by_author for the 1000-result cap and OPEN_PAGE_SIZE for the
+    # query-cost measurements behind each number.
+    open_nodes = fetch_prs_by_author(
+        token, scope, "is:open", _OPEN_PR_FIELDS, post, OPEN_PAGE_SIZE
     )
-    merged_nodes = fetch_all_prs(
+    merged_nodes = fetch_prs_by_author(
         token,
-        build_search_query(scope, f"is:merged merged:>={since}"),
+        scope,
+        f"is:merged merged:>={since}",
         _MERGED_PR_FIELDS,
         post,
+        MERGED_PAGE_SIZE,
     )
 
     # Second pass, deliberately narrow: only the red uv.lock-only PRs, and only

--- a/.github/scripts/tests/test_renovate_fleet_scan.py
+++ b/.github/scripts/tests/test_renovate_fleet_scan.py
@@ -740,3 +740,128 @@ def test_retry_is_wired_into_the_default_post_fn():
     for fn in (rfs.fetch_all_prs, rfs.fetch_lock_texts):
         default = inspect.signature(fn).parameters["post"].default
         assert default is rfs._post_graphql, f"{fn.__name__} bypasses the retry"
+
+
+# --- query cost + the 1000-result search cap (FND-909) --------------------
+#
+# Two independent faults, both measured against the live fleet on 2026-08-29,
+# both of which failed every scheduled dashboard run:
+#
+#   1. The open-PR query cost too much. PAGE_SIZE=100 -> 502, 50 -> 504 "we
+#      couldn't respond in time", 25 -> OK. Removing files(first:100) let 100
+#      through, so the nested file connection is the dominant term.
+#   2. The combined org-wide search had outgrown the API's ~1000-result cap
+#      (open 1003, merged 1020), so even a cheap-enough query returned a
+#      silently truncated fleet.
+#
+# The retry added earlier could not help with either: both are deterministic.
+
+
+def test_open_page_size_stays_under_the_measured_ceiling():
+    # 50 returned 504 and 100 returned 502 against the real API. Anything above
+    # the measured-good 25 is a regression that only shows up in production.
+    assert rfs.OPEN_PAGE_SIZE <= 25
+
+
+def test_payload_honours_an_explicit_page_size():
+    payload = rfs.build_graphql_payload("q", "number", after=None, page_size=25)
+    assert "first: 25" in payload["query"]
+
+
+def test_payload_falls_back_to_the_module_default():
+    payload = rfs.build_graphql_payload("q", "number", after=None)
+    assert f"first: {rfs.PAGE_SIZE}" in payload["query"]
+
+
+def test_fetch_all_prs_threads_the_page_size_through():
+    # A page size that stopped at build_graphql_payload's signature would leave
+    # the 502 in place while every unit test still passed.
+    seen = []
+
+    def fake_post(token, payload):
+        seen.append(payload["query"])
+        return _page([{"number": 1, "url": "u1"}], has_next=False)
+
+    rfs.fetch_all_prs("tok", "q", "number", post=fake_post, page_size=25)
+    assert "first: 25" in seen[0]
+
+
+def test_fetch_by_author_issues_one_query_per_author():
+    # One combined OR query is what breached the cap; the split is the fix.
+    queries = []
+
+    def fake_post(token, payload):
+        queries.append(payload["query"])
+        return _page([{"number": 1, "url": f"u{len(queries)}"}], has_next=False)
+
+    rfs.fetch_prs_by_author("tok", "org:atlanhq", "is:open", "number", post=fake_post)
+
+    assert len(queries) == len(rfs.RENOVATE_PR_AUTHORS)
+    for author in rfs.RENOVATE_PR_AUTHORS:
+        assert any(f"author:{author}" in q for q in queries), author
+    # Each slice names exactly one author — an OR would defeat the whole point.
+    for q in queries:
+        assert sum(f"author:{a}" in q for a in rfs.RENOVATE_PR_AUTHORS) == 1
+
+
+def test_fetch_by_author_concatenates_every_slice():
+    pages = [
+        _page([{"number": 1, "url": "u1"}], has_next=False),
+        _page([{"number": 2, "url": "u2"}], has_next=False),
+    ]
+
+    def fake_post(token, payload):
+        return pages.pop(0)
+
+    result = rfs.fetch_prs_by_author(
+        "tok", "org:atlanhq", "is:open", "number", post=fake_post
+    )
+    assert [pr["number"] for pr in result] == [1, 2]
+
+
+def test_fetch_by_author_deduplicates_across_slices():
+    # Defensive: GitHub cannot attribute one PR to two authors today, but a
+    # double-counted PR would inflate every number on the dashboard.
+    pages = [
+        _page([{"number": 1, "url": "same"}], has_next=False),
+        _page([{"number": 1, "url": "same"}], has_next=False),
+    ]
+
+    def fake_post(token, payload):
+        return pages.pop(0)
+
+    result = rfs.fetch_prs_by_author(
+        "tok", "org:atlanhq", "is:open", "number", post=fake_post
+    )
+    assert len(result) == 1
+
+
+def test_fetch_by_author_still_raises_when_one_slice_is_truncated():
+    # The fleet keeps growing. When a single author's slice breaches the cap in
+    # turn, that must fail loudly rather than report a partial fleet.
+    def fake_post(token, payload):
+        return _page([{"number": 1, "url": "u1"}], has_next=False, issue_count=1500)
+
+    try:
+        rfs.fetch_prs_by_author(
+            "tok", "org:atlanhq", "is:open", "number", post=fake_post
+        )
+        assert False, "expected RuntimeError"
+    except RuntimeError as exc:
+        assert "cap" in str(exc).lower()
+
+
+def test_the_scan_entrypoint_uses_the_sliced_fetch_with_measured_page_sizes():
+    # The wiring pin. A fix that lives in a function the entrypoint never calls
+    # would leave the outage exactly where it was, and every test above would
+    # still pass. Read the source rather than trusting the call site by eye.
+    source = inspect.getsource(rfs.run)
+    assert "fetch_prs_by_author" in source
+    assert "fetch_all_prs(" not in source, "run must not use the unsliced fetch"
+    assert "OPEN_PAGE_SIZE" in source
+    assert "MERGED_PAGE_SIZE" in source
+
+
+def test_main_delegates_to_run():
+    # The pin above reads run(); this is what makes run() the real entrypoint.
+    assert "run(" in inspect.getsource(rfs.main)


### PR DESCRIPTION
## #3508 did not fix the outage

It added retry on my assumption that the 502s were transient. The first full-fleet run after it merged shows the retry working exactly as designed, and the run failing anyway:

```
##[warning]GraphQL attempt 1/4 failed (502 Bad Gateway)
##[warning]GraphQL attempt 2/4 failed (502 Bad Gateway)
##[warning]GraphQL attempt 3/4 failed (502 Bad Gateway)
RuntimeError: GraphQL request failed: 502 Bad Gateway
```

Four attempts, all 502 — which falsifies "transient" and points at something deterministic. Bisecting the query against the live fleet found **two** faults, both of which had to be fixed before a scan could complete.

## 1. The open-PR query cost more than GitHub would serve

GitHub bills a GraphQL request by the nodes it *may* return — page size times every nested connection limit inside each node — and answers what it cannot serve in time with a 502/504 rather than a cost error. Measured against the live fleet with the real `_OPEN_PR_FIELDS`:

| Page size | Result |
| -- | -- |
| 100 | `502 Bad Gateway` |
| 50 | `504 "We couldn't respond to your request in time"` |
| 25 | OK |
| 100, with `files(first: 100)` removed | OK |

So the nested file connection is the dominant term, not the rollup.

Page size is cut rather than the file limit, deliberately. A truncated file list misclassifies *silently*: `_is_uv_lock_only` and the auto-approve allowlist both need the complete set, and "the first 20 files happened to be uv.lock" is a wrong answer that looks like a right one. Page size is now per-query — the merged-PR field set carries no files and no `statusCheckRollup`, measured fine at 100/50/25, and keeps 100.

## 2. The fleet had outgrown the search API's ~1000-result cap

Even a cheap-enough query came back truncated:

| Query | Total | `app/renovate` | `app/atlan-app-fleet` |
| -- | -- | -- | -- |
| open | **1003** | 615 | 388 |
| merged (30d) | **1020** | 192 | 828 |

The combined query is a plain OR of the same author qualifiers, so one query per author covers exactly the same set with every slice comfortably under the cap. It also costs nothing: total PR count and page count are unchanged, only their grouping.

Results are deduplicated by URL. GitHub cannot attribute one PR to two authors today, so the overlap is empty in practice — but a double-counted PR would inflate every number on the dashboard, and the guard is one set.

The existing truncation guard is kept, so the next breach fails loudly rather than reporting a partial fleet. It **will** fire again as the fleet grows; the next narrowing is by date range, or a shorter `--since` for the merged search.

#3508's retry is kept — transport blips are real, and it is what proved these 502s were not one.

## Validation

**Live against the real API, not just fixtures.** A full scan now completes in **274s** — 998 open PRs across 548 repos, plus 1025 merged — well inside the job's 45-minute timeout. Before this it failed in every configuration tried.

62 tests pass. Both fixes are mutation-verified:

* restoring `OPEN_PAGE_SIZE = 100` fails the measured-ceiling guard;
* routing the entrypoint back through the unsliced `fetch_all_prs` fails the wiring pin.

That wiring pin earned itself immediately: it caught my own wrong assumption that the fetch calls lived in `main()` rather than `run()`. Without it the "fix" would have sat in a function the entrypoint never called, with every other test still green — which is exactly how #3508 shipped without fixing anything.

## Security-relevant

No change to what is requested, sent, or authenticated — only how many results a page asks for and how the search is partitioned. `.github/scripts/` only; no workflow or permission change.

Follows #3490, #3505, #3508 on FND-909.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
