### PR TITLE
ci(perf): sync the dashboard payload instead of a cp per file (FND-909)

### DIFF
--- a/.github/scripts/renovate_dashboard_stage.py
+++ b/.github/scripts/renovate_dashboard_stage.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Stage the Renovate dashboard's S3 payload as one directory tree (FND-909).
+
+The deploy step used to walk the scanner's output repo by repo, issuing an
+`aws s3 cp` per file and, for history, a download and an upload per file. At 548
+repos that is ~1,644 sequential CLI invocations, each paying process startup on
+top of the request. Measured 2026-08-29: 39m18s, which overran the job's
+45-minute ceiling and killed the run *after* a successful scan — so the dashboard
+still did not publish and the alarm step never ran.
+
+This script does the part that never needed the network: it merges the run's new
+history into the existing history already downloaded, and lays everything out in
+a single directory that mirrors the S3 prefix exactly. The workflow then moves it
+with two `aws s3 sync` calls (one down, one up), which parallelise internally.
+
+Layout produced under --stage-dir, mirroring s3://<bucket>/renovate-dashboard/:
+
+    repos/<slug>.json       every per-repo summary the scanner emitted
+    history/<slug>.jsonl    existing history + this run's rows, deduplicated
+    fleet.json              full-fleet runs only
+
+Single-repo mode writes no fleet.json and no fleet history: the scanner only has
+data for one repo, so publishing either would overwrite the real fleet aggregate
+with a partial view. That decision lives here rather than in the workflow because
+`docs/standards/ci.md` keeps branching logic out of YAML, where it cannot be
+regression-tested.
+
+Usage:
+    renovate_dashboard_stage.py --output-dir /tmp/renovate-output \\
+        --existing-history-dir /tmp/existing-history \\
+        --stage-dir /tmp/renovate-stage [--single-repo owner/name]
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+from typing import Optional
+
+# The scanner names fleet-wide history differently from a repo's, and it must
+# never be treated as a repo slug.
+FLEET_SLUG = "fleet"
+HISTORY_PREFIX = "history_"
+HISTORY_SUFFIX = ".jsonl"
+
+
+def merge_history(existing: Optional[Path], new: Path) -> str:
+    """Existing rows plus this run's, deduplicated, in stable sorted order.
+
+    Mirrors the `cat ... | sort -u` the shell loop did. Sorting is what makes a
+    same-day rerun idempotent: the scanner writes one row per repo per run, and
+    an identical row must not accumulate.
+    """
+    rows: set[str] = set()
+    for path in (existing, new):
+        if path is None or not path.is_file():
+            continue
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            if line.strip():
+                rows.add(line)
+    return "".join(f"{row}\n" for row in sorted(rows))
+
+
+def stage(
+    output_dir: Path,
+    existing_history_dir: Path,
+    stage_dir: Path,
+    single_repo: str = "",
+) -> dict[str, int]:
+    """Build the upload tree. Returns counts for the workflow log."""
+    repos_out = stage_dir / "repos"
+    history_out = stage_dir / "history"
+    repos_out.mkdir(parents=True, exist_ok=True)
+    history_out.mkdir(parents=True, exist_ok=True)
+
+    repo_files = sorted((output_dir / "repos").glob("*.json"))
+    for path in repo_files:
+        shutil.copyfile(path, repos_out / path.name)
+
+    merged = 0
+    for path in sorted(output_dir.glob(f"{HISTORY_PREFIX}*{HISTORY_SUFFIX}")):
+        slug = path.name[len(HISTORY_PREFIX) : -len(HISTORY_SUFFIX)]
+        if slug == FLEET_SLUG:
+            continue  # handled below, and only for full-fleet runs
+        existing = existing_history_dir / f"{slug}{HISTORY_SUFFIX}"
+        (history_out / f"{slug}{HISTORY_SUFFIX}").write_text(
+            merge_history(existing, path), encoding="utf-8"
+        )
+        merged += 1
+
+    fleet_written = 0
+    if not single_repo:
+        fleet_json = output_dir / "fleet.json"
+        if fleet_json.is_file():
+            shutil.copyfile(fleet_json, stage_dir / "fleet.json")
+            fleet_written = 1
+        fleet_history = output_dir / f"{HISTORY_PREFIX}{FLEET_SLUG}{HISTORY_SUFFIX}"
+        if fleet_history.is_file():
+            existing = existing_history_dir / f"{FLEET_SLUG}{HISTORY_SUFFIX}"
+            (history_out / f"{FLEET_SLUG}{HISTORY_SUFFIX}").write_text(
+                merge_history(existing, fleet_history), encoding="utf-8"
+            )
+
+    return {
+        "repos": len(repo_files),
+        "histories": merged,
+        "fleet_json": fleet_written,
+    }
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--existing-history-dir", required=True, type=Path)
+    parser.add_argument("--stage-dir", required=True, type=Path)
+    parser.add_argument(
+        "--single-repo",
+        default="",
+        help="non-empty for a single-repo scan: suppresses fleet aggregates",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.output_dir.is_dir():
+        print(f"scanner output not found: {args.output_dir}", file=sys.stderr)
+        return 1
+
+    counts = stage(
+        args.output_dir,
+        args.existing_history_dir,
+        args.stage_dir,
+        args.single_repo,
+    )
+    print(
+        f"staged {counts['repos']} repo files, {counts['histories']} histories, "
+        f"fleet.json={'yes' if counts['fleet_json'] else 'no'}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/renovate_dashboard_stage.py
+++ b/.github/scripts/renovate_dashboard_stage.py
@@ -93,9 +93,18 @@ def stage(
     fleet_written = 0
     if not single_repo:
         fleet_json = output_dir / "fleet.json"
-        if fleet_json.is_file():
-            shutil.copyfile(fleet_json, stage_dir / "fleet.json")
-            fleet_written = 1
+        if not fleet_json.is_file():
+            # Fail closed, matching publish_fleet_dashboard.py. Staging the
+            # per-repo files without the aggregate would publish a dashboard
+            # whose fleet numbers silently belong to the previous run. The
+            # `aws s3 cp` this replaced got that for free under `set -euo
+            # pipefail`; skipping the file quietly would be a regression.
+            raise RuntimeError(
+                f"{fleet_json} is missing on a full-fleet run — refusing to "
+                "stage per-repo data without the aggregate the dashboard reads"
+            )
+        shutil.copyfile(fleet_json, stage_dir / "fleet.json")
+        fleet_written = 1
         fleet_history = output_dir / f"{HISTORY_PREFIX}{FLEET_SLUG}{HISTORY_SUFFIX}"
         if fleet_history.is_file():
             existing = existing_history_dir / f"{FLEET_SLUG}{HISTORY_SUFFIX}"
@@ -126,12 +135,16 @@ def main(argv: Optional[list[str]] = None) -> int:
         print(f"scanner output not found: {args.output_dir}", file=sys.stderr)
         return 1
 
-    counts = stage(
-        args.output_dir,
-        args.existing_history_dir,
-        args.stage_dir,
-        args.single_repo,
-    )
+    try:
+        counts = stage(
+            args.output_dir,
+            args.existing_history_dir,
+            args.stage_dir,
+            args.single_repo,
+        )
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
     print(
         f"staged {counts['repos']} repo files, {counts['histories']} histories, "
         f"fleet.json={'yes' if counts['fleet_json'] else 'no'}"

--- a/.github/scripts/tests/test_renovate_dashboard_stage.py
+++ b/.github/scripts/tests/test_renovate_dashboard_stage.py
@@ -1,0 +1,168 @@
+"""Tests for the Renovate dashboard staging step (FND-909).
+
+The behaviour being preserved is what the old shell loops did, minus the network:
+merge each repo's history with what is already published, deduplicate, and keep
+fleet aggregates off single-repo runs. Getting the merge wrong loses published
+history, which is unrecoverable — hence the emphasis on the merge cases.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__))))
+
+import renovate_dashboard_stage as stage  # noqa: E402
+
+
+def _scanner_output(tmp_path, repos=(), histories=None, fleet=True):
+    """Lay out a directory shaped like the renovate-scan CLI's --out."""
+    out = tmp_path / "output"
+    (out / "repos").mkdir(parents=True)
+    for slug in repos:
+        (out / "repos" / f"{slug}.json").write_text(json.dumps([{"number": 1}]))
+    for slug, rows in (histories or {}).items():
+        (out / f"history_{slug}.jsonl").write_text("".join(f"{r}\n" for r in rows))
+    if fleet:
+        (out / "fleet.json").write_text(json.dumps({"totalOpenPRs": 3}))
+    return out
+
+
+def _existing(tmp_path, histories=None):
+    existing = tmp_path / "existing"
+    existing.mkdir()
+    for slug, rows in (histories or {}).items():
+        (existing / f"{slug}.jsonl").write_text("".join(f"{r}\n" for r in rows))
+    return existing
+
+
+def test_every_repo_summary_is_staged(tmp_path):
+    out = _scanner_output(tmp_path, repos=["atlanhq_a", "atlanhq_b"])
+    counts = stage.stage(out, _existing(tmp_path), tmp_path / "stage")
+
+    staged = sorted(p.name for p in (tmp_path / "stage" / "repos").glob("*.json"))
+    assert staged == ["atlanhq_a.json", "atlanhq_b.json"]
+    assert counts["repos"] == 2
+
+
+def test_history_merges_existing_with_new(tmp_path):
+    out = _scanner_output(tmp_path, histories={"atlanhq_a": ['{"d":"2026-08-29"}']})
+    existing = _existing(tmp_path, {"atlanhq_a": ['{"d":"2026-08-28"}']})
+
+    stage.stage(out, existing, tmp_path / "stage")
+
+    lines = (tmp_path / "stage" / "history" / "atlanhq_a.jsonl").read_text().split()
+    assert lines == ['{"d":"2026-08-28"}', '{"d":"2026-08-29"}']
+
+
+def test_history_is_idempotent_across_reruns(tmp_path):
+    # Two runs the same day emit an identical row; it must not accumulate.
+    row = '{"d":"2026-08-29","open":5}'
+    out = _scanner_output(tmp_path, histories={"atlanhq_a": [row]})
+    existing = _existing(tmp_path, {"atlanhq_a": [row]})
+
+    stage.stage(out, existing, tmp_path / "stage")
+
+    assert (
+        tmp_path / "stage" / "history" / "atlanhq_a.jsonl"
+    ).read_text() == f"{row}\n"
+
+
+def test_history_survives_a_repo_with_no_published_history(tmp_path):
+    # First time a repo is seen: no existing file, and that is not an error.
+    out = _scanner_output(tmp_path, histories={"atlanhq_new": ['{"d":"2026-08-29"}']})
+
+    stage.stage(out, _existing(tmp_path), tmp_path / "stage")
+
+    assert (tmp_path / "stage" / "history" / "atlanhq_new.jsonl").read_text() == (
+        '{"d":"2026-08-29"}\n'
+    )
+
+
+def test_full_fleet_run_stages_fleet_aggregates(tmp_path):
+    out = _scanner_output(tmp_path, histories={"fleet": ['{"d":"2026-08-29"}']})
+    existing = _existing(tmp_path, {"fleet": ['{"d":"2026-08-28"}']})
+
+    counts = stage.stage(out, existing, tmp_path / "stage", single_repo="")
+
+    assert (tmp_path / "stage" / "fleet.json").is_file()
+    assert counts["fleet_json"] == 1
+    fleet_history = tmp_path / "stage" / "history" / "fleet.jsonl"
+    assert fleet_history.read_text().split() == [
+        '{"d":"2026-08-28"}',
+        '{"d":"2026-08-29"}',
+    ]
+
+
+def test_single_repo_run_never_stages_fleet_aggregates(tmp_path):
+    # The scanner only has one repo's data; publishing either would overwrite the
+    # real fleet view with a partial one.
+    out = _scanner_output(tmp_path, histories={"fleet": ['{"d":"2026-08-29"}']})
+
+    counts = stage.stage(
+        out, _existing(tmp_path), tmp_path / "stage", single_repo="atlanhq/a"
+    )
+
+    assert not (tmp_path / "stage" / "fleet.json").exists()
+    assert not (tmp_path / "stage" / "history" / "fleet.jsonl").exists()
+    assert counts["fleet_json"] == 0
+
+
+def test_fleet_history_is_never_staged_as_a_repo(tmp_path):
+    # history_fleet.jsonl sits beside the per-repo files and must not be treated
+    # as a repo named "fleet" — the old shell loop skipped it explicitly.
+    out = _scanner_output(
+        tmp_path, histories={"fleet": ['{"d":"1"}'], "atlanhq_a": ['{"d":"2"}']}
+    )
+
+    counts = stage.stage(out, _existing(tmp_path), tmp_path / "stage", single_repo="x")
+
+    assert counts["histories"] == 1  # atlanhq_a only
+
+
+def test_blank_lines_are_dropped(tmp_path):
+    out = _scanner_output(tmp_path, histories={"atlanhq_a": ['{"d":"1"}', "", "  "]})
+
+    stage.stage(out, _existing(tmp_path), tmp_path / "stage")
+
+    assert (tmp_path / "stage" / "history" / "atlanhq_a.jsonl").read_text() == (
+        '{"d":"1"}\n'
+    )
+
+
+def test_main_reports_missing_scanner_output(tmp_path, capsys):
+    rc = stage.main(
+        [
+            "--output-dir",
+            str(tmp_path / "nope"),
+            "--existing-history-dir",
+            str(tmp_path),
+            "--stage-dir",
+            str(tmp_path / "stage"),
+        ]
+    )
+
+    assert rc == 1
+    assert "scanner output not found" in capsys.readouterr().err
+
+
+def test_main_stages_end_to_end(tmp_path, capsys):
+    out = _scanner_output(
+        tmp_path, repos=["atlanhq_a"], histories={"atlanhq_a": ['{"d":"1"}']}
+    )
+
+    rc = stage.main(
+        [
+            "--output-dir",
+            str(out),
+            "--existing-history-dir",
+            str(_existing(tmp_path)),
+            "--stage-dir",
+            str(tmp_path / "stage"),
+        ]
+    )
+
+    assert rc == 0
+    assert "staged 1 repo files, 1 histories, fleet.json=yes" in capsys.readouterr().out

--- a/.github/scripts/tests/test_renovate_dashboard_stage.py
+++ b/.github/scripts/tests/test_renovate_dashboard_stage.py
@@ -132,6 +132,53 @@ def test_blank_lines_are_dropped(tmp_path):
     )
 
 
+def test_full_fleet_run_refuses_to_stage_without_the_aggregate(tmp_path):
+    """Fail closed: per-repo files without fleet.json publish stale fleet numbers.
+
+    The `aws s3 cp` this replaced got that for free under `set -euo pipefail`.
+    Skipping a missing file quietly would leave the dashboard showing the
+    previous run's aggregate beside this run's per-repo data, with nothing red.
+    """
+    out = _scanner_output(tmp_path, repos=["atlanhq_a"], fleet=False)
+
+    try:
+        stage.stage(out, _existing(tmp_path), tmp_path / "stage", single_repo="")
+        assert False, "expected RuntimeError"
+    except RuntimeError as exc:
+        assert "refusing to stage" in str(exc)
+
+
+def test_single_repo_run_tolerates_a_missing_aggregate(tmp_path):
+    # Single-repo mode never publishes fleet.json, so its absence is expected
+    # rather than a fault — the guard above must not fire here.
+    out = _scanner_output(tmp_path, repos=["atlanhq_a"], fleet=False)
+
+    counts = stage.stage(
+        out, _existing(tmp_path), tmp_path / "stage", single_repo="atlanhq/a"
+    )
+
+    assert counts["repos"] == 1
+    assert counts["fleet_json"] == 0
+
+
+def test_main_exits_nonzero_when_the_aggregate_is_missing(tmp_path, capsys):
+    out = _scanner_output(tmp_path, repos=["atlanhq_a"], fleet=False)
+
+    rc = stage.main(
+        [
+            "--output-dir",
+            str(out),
+            "--existing-history-dir",
+            str(_existing(tmp_path)),
+            "--stage-dir",
+            str(tmp_path / "stage"),
+        ]
+    )
+
+    assert rc == 1
+    assert "refusing to stage" in capsys.readouterr().err
+
+
 def test_main_reports_missing_scanner_output(tmp_path, capsys):
     rc = stage.main(
         [

--- a/.github/workflows/renovate-dashboard.yaml
+++ b/.github/workflows/renovate-dashboard.yaml
@@ -157,11 +157,30 @@ jobs:
           set -euo pipefail
           PREFIX="renovate-dashboard"
 
-          # Per-repo summaries — upload every file the scanner emitted.
-          for f in /tmp/renovate-output/repos/*.json; do
-            [ -e "$f" ] || continue
-            aws s3 cp "$f" "s3://kryptonite-store/${PREFIX}/repos/$(basename "$f")"
-          done
+          # Two syncs and a local merge, rather than a cp per file. The previous
+          # loops issued ~1,644 sequential aws invocations at 548 repos (one
+          # upload per repo, plus a download and an upload per history file) and
+          # took 39m18s — overrunning the job's 45-minute ceiling and killing the
+          # run after a successful scan, so nothing published. `aws s3 sync`
+          # parallelises internally and transfers only what changed.
+
+          # Existing history down, so the merge is a local operation.
+          mkdir -p /tmp/existing-history
+          aws s3 sync "s3://kryptonite-store/${PREFIX}/history/" \
+            /tmp/existing-history/
+
+          # Build the exact tree to upload: repo summaries, merged histories, and
+          # fleet.json on full-fleet runs only. All branching lives in the script
+          # (docs/standards/ci.md), which is covered by .github/scripts/tests/.
+          python3 .github/scripts/renovate_dashboard_stage.py \
+            --output-dir /tmp/renovate-output \
+            --existing-history-dir /tmp/existing-history \
+            --stage-dir /tmp/renovate-stage \
+            --single-repo "${SINGLE_REPO:-}"
+
+          # Up in one pass. No --delete: this prefix is additive, and a partial
+          # run must never remove another run's repo files.
+          aws s3 sync /tmp/renovate-stage/ "s3://kryptonite-store/${PREFIX}/"
 
           # Regenerate manifest of all repo files present in S3.
           aws s3 ls "s3://kryptonite-store/${PREFIX}/repos/" \
@@ -170,48 +189,6 @@ jobs:
             > /tmp/renovate-output/repos.json
           aws s3 cp /tmp/renovate-output/repos.json \
             "s3://kryptonite-store/${PREFIX}/repos.json"
-
-          # Append per-repo history (download existing → merge → re-upload;
-          # sort -u deduplicates same-day reruns).
-          for f in /tmp/renovate-output/history_*.jsonl; do
-            [ -e "$f" ] || continue
-            base=$(basename "$f")          # history_<slug>.jsonl
-            slug=${base#history_}
-            slug=${slug%.jsonl}
-            # Fleet-wide history is only written on full-fleet runs (see below).
-            [ "$slug" = "fleet" ] && continue
-            HISTORY_FILE="history/${slug}.jsonl"
-            aws s3 cp \
-              "s3://kryptonite-store/${PREFIX}/${HISTORY_FILE}" \
-              /tmp/existing_renovate_history.jsonl 2>/dev/null || true
-            touch /tmp/existing_renovate_history.jsonl
-            cat /tmp/existing_renovate_history.jsonl "$f" 2>/dev/null \
-              | sort -u \
-              > /tmp/merged_renovate_history.jsonl
-            aws s3 cp /tmp/merged_renovate_history.jsonl \
-              "s3://kryptonite-store/${PREFIX}/${HISTORY_FILE}"
-          done
-
-          # Fleet-wide aggregate and history — only meaningful for full-fleet runs.
-          # In single-repo mode the scanner only has data for one repo, so writing
-          # fleet.json would overwrite the real fleet aggregate with a partial view.
-          if [ -z "${SINGLE_REPO:-}" ]; then
-            aws s3 cp /tmp/renovate-output/fleet.json \
-              "s3://kryptonite-store/${PREFIX}/fleet.json"
-
-            if [ -e /tmp/renovate-output/history_fleet.jsonl ]; then
-              aws s3 cp \
-                "s3://kryptonite-store/${PREFIX}/history/fleet.jsonl" \
-                /tmp/existing_fleet_history.jsonl 2>/dev/null || true
-              touch /tmp/existing_fleet_history.jsonl
-              cat /tmp/existing_fleet_history.jsonl \
-                /tmp/renovate-output/history_fleet.jsonl 2>/dev/null \
-                | sort -u \
-                > /tmp/merged_fleet_history.jsonl
-              aws s3 cp /tmp/merged_fleet_history.jsonl \
-                "s3://kryptonite-store/${PREFIX}/history/fleet.jsonl"
-            fi
-          fi
 
           echo "Renovate dashboard updated: https://k.atlan.dev/${PREFIX}/"
 


### PR DESCRIPTION
## The scan works now; the deploy doesn't

#3511 fixed the scan, and the next full-fleet run proved it — **"Gather Renovate PR data: success"** for the first time in ten days. The run still did not publish, and the alarm step still did not execute. It hit the job's 45-minute ceiling, which GitHub reports as `cancelled` rather than `failure`:

| Step | Duration |
| -- | -- |
| Gather Renovate PR data | 5m35s ✅ |
| Run Renovate scanner | 1s ✅ |
| Deploy to Kryptonite | **39m18s — killed at the ceiling** |
| Alarm on refusals | skipped |

The deploy walked the scanner's output one file at a time: an `aws s3 cp` per repo summary, plus a download *and* an upload per history file. At 548 repos that is **~1,644 sequential CLI invocations**, each paying process startup on top of the request. That was survivable when this lane last ran green and the fleet was a fraction of the size. It isn't now.

## Change

Two syncs and a local merge:

1. `aws s3 sync` the published history **down**, once.
2. `renovate_dashboard_stage.py` merges it with this run's rows and lays out a single directory mirroring the S3 prefix exactly — repo summaries, merged histories, and `fleet.json` on full-fleet runs only.
3. `aws s3 sync` that tree **up**, once. No `--delete`: the prefix is additive, and a partial run must never remove another run's repo files.

The branching the shell was doing — skip fleet history when walking per-repo files, suppress fleet aggregates in single-repo mode — moves into the script, where it is covered by tests. `docs/standards/ci.md` keeps that logic out of YAML precisely because it can't be regression-tested there, so this also pays down the inline `if`/loop debt in that step rather than adding to it.

## Validation

Merge semantics are unchanged from the `cat ... | sort -u` they replace, including the deduplication that makes a same-day rerun idempotent. Ten tests cover the cases that **lose published history** if they regress, which is unrecoverable:

* an existing repo (existing + new rows, sorted, deduplicated)
* a repo seen for the first time (no published history — not an error)
* an identical rerun row (must not accumulate)
* fleet history never mistaken for a repo named `fleet`
* single-repo mode never staging fleet aggregates over the real fleet view

**Measured at real fleet scale** — 548 repos, a year of history each — the local staging step takes **0.26s**.

## What I could not verify

The remaining cost is the two `aws s3 sync` calls. They parallelise internally and transfer only what changed, but the deploy role is only assumable in CI, so I could not time them locally. The next full-fleet run is what confirms the end-to-end number — and, finally, whether the alarm step from #3505 executes at all.

Follows #3490, #3505, #3508, #3511 on FND-909.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
