### PR TITLE
ci(fix): tell a drifting search count from a truncated one (FND-909)

### DIFF
--- a/.github/scripts/renovate_fleet_scan.py
+++ b/.github/scripts/renovate_fleet_scan.py
@@ -57,6 +57,12 @@ GRAPHQL_URL = "https://api.github.com/graphql"
 # misclassify: `_is_uv_lock_only` and the auto-approve allowlist both need the
 # complete set, and "first 20 files happened to be uv.lock" is a wrong answer
 # that looks like a right one.
+# GitHub's search API never returns more than this many results for one query,
+# however the caller paginates. Truncation can therefore only present *at* the
+# cap — which is what separates it from the count drifting under concurrent PR
+# activity. See the shortfall branch in fetch_all_prs.
+SEARCH_RESULT_CAP = 1000
+
 OPEN_PAGE_SIZE = 25
 # The merged-PR field set carries no files and no statusCheckRollup, and was
 # measured OK at 100/50/25 — it does not need the cut.
@@ -297,11 +303,35 @@ def fetch_all_prs(
         )
 
     if issue_count is not None and len(nodes) < issue_count:
-        raise RuntimeError(
-            f"query {search_query!r} matched {issue_count} results but only "
-            f"{len(nodes)} were returned — the search API's result cap likely "
-            "truncated this query. Narrow it (e.g. split by date range) rather "
-            "than silently reporting incomplete dashboard data."
+        # A shortfall has two very different causes, and only one is a fault.
+        #
+        # Truncation: the query matched more than the search API will ever
+        # return, so pagination stops dead at the cap. The dashboard would then
+        # silently omit repos, which is worth failing the run over.
+        #
+        # Drift: `issueCount` is measured once, on the first page, while
+        # pagination takes minutes — this scan walks ~1,400 PRs. Any PR that
+        # merges or closes in between leaves the count one or two ahead of what
+        # comes back. Nothing is missing; the total simply moved.
+        #
+        # The two are distinguishable because truncation can only happen *at*
+        # the cap. Observed 2026-08-30, a scheduled run died on "matched 391
+        # results but only 390 were returned" — a single PR merging mid-walk,
+        # 609 short of any cap. Before the per-author split every slice was over
+        # the cap anyway, so the distinction never came up.
+        if len(nodes) >= SEARCH_RESULT_CAP:
+            raise RuntimeError(
+                f"query {search_query!r} matched {issue_count} results but only "
+                f"{len(nodes)} were returned — the search API's result cap "
+                "truncated this query. Narrow it (e.g. split by date range) "
+                "rather than silently reporting incomplete dashboard data."
+            )
+        print(
+            f"::warning::query {search_query!r} matched {issue_count} results "
+            f"but returned {len(nodes)} — {issue_count - len(nodes)} PR(s) "
+            "changed state during pagination. Well short of the "
+            f"{SEARCH_RESULT_CAP}-result cap, so nothing was truncated.",
+            file=sys.stderr,
         )
     return nodes
 

--- a/.github/scripts/tests/test_renovate_fleet_scan.py
+++ b/.github/scripts/tests/test_renovate_fleet_scan.py
@@ -132,11 +132,13 @@ def test_fetch_all_prs_trips_safety_backstop():
 
 
 def test_fetch_all_prs_raises_when_search_api_cap_truncates_results():
-    # The search API caps total matches (commonly ~1000) — pageInfo can report
-    # hasNextPage=False while issueCount still exceeds what was actually returned.
-    # This must fail loudly rather than silently reporting an incomplete dashboard.
+    # Real truncation presents *at* the cap: pagination stops dead having
+    # returned exactly SEARCH_RESULT_CAP nodes while issueCount is higher. This
+    # must fail loudly rather than silently reporting an incomplete dashboard.
+    capped = [{"number": n, "url": f"u{n}"} for n in range(rfs.SEARCH_RESULT_CAP)]
+
     def fake_post(token, payload):
-        return _page([{"number": 1}], has_next=False, issue_count=1500)
+        return _page(capped, has_next=False, issue_count=1500)
 
     try:
         rfs.fetch_all_prs("tok", "org:atlanhq is:pr", "number", post=fake_post)
@@ -144,6 +146,36 @@ def test_fetch_all_prs_raises_when_search_api_cap_truncates_results():
     except RuntimeError as exc:
         assert "1500" in str(exc)
         assert "cap" in str(exc).lower()
+
+
+def test_fetch_all_prs_tolerates_a_count_that_drifted_during_pagination(capsys):
+    # issueCount is measured once, on the first page, while the walk takes
+    # minutes. A PR merging in between leaves the count one ahead of what came
+    # back — nothing is missing. Observed live 2026-08-30: a scheduled run died
+    # on "matched 391 but only 390 were returned", 609 short of any cap.
+    nodes = [{"number": n, "url": f"u{n}"} for n in range(390)]
+
+    def fake_post(token, payload):
+        return _page(nodes, has_next=False, issue_count=391)
+
+    result = rfs.fetch_all_prs("tok", "org:atlanhq is:pr", "number", post=fake_post)
+
+    assert len(result) == 390
+    err = capsys.readouterr().err
+    assert "::warning::" in err
+    assert "changed state during pagination" in err
+
+
+def test_drift_tolerance_stops_exactly_at_the_cap():
+    # One node short of the cap is drift; at the cap it is truncation. Pinning
+    # the boundary keeps a future page-size change from sliding it.
+    below = [{"number": n, "url": f"u{n}"} for n in range(rfs.SEARCH_RESULT_CAP - 1)]
+
+    def fake_post(token, payload):
+        return _page(below, has_next=False, issue_count=rfs.SEARCH_RESULT_CAP + 5)
+
+    # Below the cap: tolerated, however large the reported shortfall.
+    assert len(rfs.fetch_all_prs("tok", "q", "number", post=fake_post)) == len(below)
 
 
 def test_fetch_all_prs_no_error_when_issue_count_matches_returned_nodes():
@@ -839,8 +871,10 @@ def test_fetch_by_author_deduplicates_across_slices():
 def test_fetch_by_author_still_raises_when_one_slice_is_truncated():
     # The fleet keeps growing. When a single author's slice breaches the cap in
     # turn, that must fail loudly rather than report a partial fleet.
+    capped = [{"number": n, "url": f"u{n}"} for n in range(rfs.SEARCH_RESULT_CAP)]
+
     def fake_post(token, payload):
-        return _page([{"number": 1, "url": "u1"}], has_next=False, issue_count=1500)
+        return _page(capped, has_next=False, issue_count=1500)
 
     try:
         rfs.fetch_prs_by_author(


### PR DESCRIPTION
## A moving total is not a missing result

The 12:16Z scheduled dashboard run died on this:

```
RuntimeError: query 'org:atlanhq is:pr author:app/atlan-app-fleet is:open'
matched 391 results but only 390 were returned — the search API's result cap
likely truncated this query.
```

Nothing was truncated. 390 is **610 short of any cap**.

`issueCount` is measured once, on the first page, while pagination takes minutes — this scan walks ~1,400 PRs across two searches. Any PR that merges or closes in between leaves the count one or two ahead of what comes back. The total moved; no result went missing.

## Why it only started failing now

The guard treated *every* shortfall as truncation. That was harmless before #3511: the combined org-wide query was over the cap anyway, so a shortfall really did mean truncation every time.

Slicing per author made each slice small — and turned ordinary concurrent PR activity into a failed fleet scan. This is fallout from my own change, surfacing one layer down.

## Change

Truncation can only present **at** the cap: the API stops dead having returned exactly 1000. That is the discriminator.

| Condition | Behaviour |
| -- | -- |
| `len(nodes) >= SEARCH_RESULT_CAP` and `issueCount` higher | **raise** — repos would be silently missing from the dashboard |
| shortfall below the cap | `::warning::` naming how many PRs moved, and continue |

## Validation

Three tests:

* truncation at the cap still raises;
* a 390/391 drift is tolerated and warns;
* the boundary is pinned one node below the cap, so a future page-size change cannot slide it.

Two existing tests simulated truncation with a single node and a high `issueCount`. That shape is *drift* under the new rule, so they now build a genuinely capped page — they were passing for the wrong reason before.

Mutation-verified: restoring the unconditional raise fails exactly the two drift tests and nothing else.

## Where this sits

Fourth fault in the chain behind the alarm from #3505, each only visible once the one in front was fixed: the scan couldn't run (#3511), so the deploy never ran (#3512), so this guard never got the chance to trip, so the alarm still hasn't executed once. With this one merged I'll dispatch a full-fleet run rather than wait for cron.

Follows #3490, #3505, #3508, #3511, #3512 on FND-909.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
