### PR TITLE
ci(review): give every reference file an owner, and let agents read their own

### DIFF
--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -333,23 +333,38 @@ BUDGET
     changed" — skip delta scoping and run the full review. Only
     `DELTA_KNOWN=1` activates step 11b.
 
-6d. **Read `references/*.md` — unless no agent will run.** Skip this read
-    entirely when Phase 2 is going to be skipped, because the files exist to
-    inform agents and there will be no agent to inform:
+6d. **Do NOT read `references/*.md`. The agents that use them read them.**
 
-    - `review_scope` is `docs-only` (§2a: "SKIP Phase 2 entirely"), or
-    - `DELTA_KNOWN=1` and `DELTA_LINES == 0` (§11b: a verification-only
-      re-review "skip[s] Wave 1 and Wave 2 discovery entirely").
+    Each Phase 2 agent now names the reference files it owns, at the top of
+    its own `agents/*.md`, and reads them itself:
 
-    Otherwise read them as before. This is a load-ordering change only — the
-    same files reach the same agents on every review that dispatches one, so
-    no finding this review could have made becomes unreachable.
+    | Agent | Owns |
+    |---|---|
+    | `correctness.md` | `security-rules`, `v3-architecture-rules`, `performance-rules` |
+    | `quality.md` | `code-quality-rules`, `test-quality-rules`, `dx-rules`, `retro-log` |
+    | `structure.md` | `structural-rules`, `v3-architecture-rules` |
+    | `ci-config.md`, `conformance.md` | `retro-log` |
+    | `toolkit-review.md` | `toolkit-consumer-registry` |
 
-    Why it is worth a step of its own: at ~125 KB these files are the single
-    largest input to a review, they are resent on every agentic turn, and the
-    two cases above are exactly the cheap reviews that currently pay the most
-    for work they do not do. In a multi-round `@sdk-loop` drive the
-    zero-delta case is the common one, not the exception.
+    The ownership is derived from each agent's own Domain Tags, not assigned
+    by hand: `[SEC]` → security-rules, `[QUAL]` → code-quality-rules, and so
+    on. A file owned by two agents is read by both — they are separate
+    contexts, and sharing costs nothing.
+
+    Why this is a real change and not tidying: these files are ~125 KB, the
+    single largest input to a review, and reading them here loaded ALL of them
+    for EVERY review no matter which agents ran. A `minor` PR dispatches only
+    `correctness` and paid for nine files to use two. Reading them at the point
+    of use also fixes an older ambiguity — §2a said each agent receives "their
+    reference rules" without anywhere defining which those were, so six of the
+    nine files were named by nothing at all and reached agents only because the
+    orchestrator had globbed everything.
+
+    You still read `severity-rubric.yaml`, `CLAUDE.md`, `review-policy.md` and
+    `review.yaml` in step 6: those govern YOUR decisions, not an agent's.
+
+    Exception: §1b-toolkit reads `toolkit-consumer-registry.md` directly,
+    because it needs the registry before any agent is dispatched.
 
 7. **Always run a standard review.** There is a single mode. Ignore any
    free-form text after `@sdk-review` (`COMMENTER_INTENT`) — there are no
@@ -936,7 +951,9 @@ The SDK domain agents (correctness/quality/structure) review `application_sdk/**
 `packages/conformance/**` for Temporal/Dapr review.
 
 Each agent receives: PR diff (or partition), full file contents,
-holistic annotations, their reference rules, reachability output.
+holistic annotations, reachability output. It reads its own reference rules
+(named at the top of its `agents/*.md`) — you do not hand them over, and per
+§6d you no longer hold them.
 For `mixed-sdk-toolkit`, partition context by path: SDK agents receive only
 `application_sdk/**`, SDK tests, and config files relevant to SDK behavior;
 `toolkit-review.md` receives `contract-toolkit/**` and toolkit-related config.

--- a/.mothership/pr-review/agents/correctness.md
+++ b/.mothership/pr-review/agents/correctness.md
@@ -5,6 +5,17 @@
 You are a senior reviewer covering correctness for the Atlan application-sdk v3.
 Your domain spans: architecture (ADRs), security, and logical correctness.
 
+## Reference Rules — read these first
+
+- `.mothership/pr-review/references/security-rules.md`
+- `.mothership/pr-review/references/v3-architecture-rules.md`
+- `.mothership/pr-review/references/performance-rules.md`
+
+These are yours to read; the orchestrator no longer loads every reference file
+for every review. [SEC] maps to security-rules, [ARCH] to v3-architecture-rules, and [BUG] to performance-rules — blocking-in-async, unbounded memory, missing timeouts and N+1 are bugs in an async SDK, not style.
+
+Cite the rule you are applying, per the reporting instructions below.
+
 ## Domain Tags
 
 Tag every finding with its underlying domain:

--- a/.mothership/pr-review/agents/quality.md
+++ b/.mothership/pr-review/agents/quality.md
@@ -5,6 +5,18 @@
 You are a senior reviewer covering quality for the Atlan application-sdk v3.
 Your domain spans: code quality, test coverage, and developer experience.
 
+## Reference Rules — read these first
+
+- `.mothership/pr-review/references/code-quality-rules.md`
+- `.mothership/pr-review/references/test-quality-rules.md`
+- `.mothership/pr-review/references/dx-rules.md`
+- `.mothership/pr-review/references/retro-log.md`
+
+These are yours to read; the orchestrator no longer loads every reference file
+for every review. [QUAL] maps to code-quality-rules, [TEST] to test-quality-rules and [DX] to dx-rules, which this file already cites by section.
+
+Cite the rule you are applying, per the reporting instructions below.
+
 ## Domain Tags
 
 Tag every finding with its underlying domain:

--- a/.mothership/pr-review/agents/structure.md
+++ b/.mothership/pr-review/agents/structure.md
@@ -6,6 +6,16 @@ You are a holistic reviewer for the Atlan application-sdk v3.
 You look at the big picture, not individual lines. Your job is to catch
 the things line-level reviewers miss.
 
+## Reference Rules — read these first
+
+- `.mothership/pr-review/references/structural-rules.md`
+- `.mothership/pr-review/references/v3-architecture-rules.md`
+
+These are yours to read; the orchestrator no longer loads every reference file
+for every review. [STRUCT] maps to structural-rules; v3-architecture-rules is shared with correctness because layering violations read as both.
+
+Cite the rule you are applying, per the reporting instructions below.
+
 ## Domain Tags
 
 Tag every finding `[STRUCT]`.


### PR DESCRIPTION
## The gap

§2a said each agent receives *"their reference rules"*. **Nothing anywhere defined which those were.**

| Reference file | Named by, before this PR |
|---|---|
| `retro-log.md` | ci-config, conformance, quality |
| `dx-rules.md` | quality |
| `toolkit-consumer-registry.md` | toolkit-review, §1b-toolkit |
| `code-quality-rules.md` | — |
| `performance-rules.md` | — |
| `security-rules.md` | — |
| `structural-rules.md` | — |
| `test-quality-rules.md` | — |
| `v3-architecture-rules.md` | — |

**Six files, 90.6 KB, named by nothing.** They reached agents only because Phase 0 globbed everything and passed an unspecified subset at its own discretion. Nobody could tell whether `security-rules.md` was informing the correctness agent or just sitting in context being paid for.

## The change

Each agent now names the files it owns, at the top of its own `agents/*.md`, and reads them itself. `§6d` stops globbing.

**The mapping is derived from each agent's own Domain Tags, not assigned by hand:**

| Agent | Tags | Owns |
|---|---|---|
| `correctness.md` | `[ARCH] [SEC] [BUG]` | `security-rules`, `v3-architecture-rules`, `performance-rules` |
| `quality.md` | `[QUAL] [TEST] [DX]` | `code-quality-rules`, `test-quality-rules`, `dx-rules`, `retro-log` |
| `structure.md` | `[STRUCT]` | `structural-rules`, `v3-architecture-rules` |
| `ci-config.md`, `conformance.md` | — | `retro-log` *(unchanged)* |
| `toolkit-review.md` | — | `toolkit-consumer-registry` *(unchanged)* |

`performance-rules` lands on **correctness** because its sections are blocking-in-async, unbounded memory, missing timeouts and N+1 — bugs in an async SDK, not style. `v3-architecture-rules` is shared between correctness and structure, because a layering violation reads as both and two agents are two contexts.

## Why it is worth doing

These files are **~125 KB — the single largest input to a review**, resent on every agentic turn. The orchestrator loaded *all* of them for *every* review regardless of routing. A `minor` PR dispatches only `correctness` and paid for nine files to use three.

Measured over 61 stamped sdk-review runs in this repo: median $8.24 a review, and cost is almost **uncorrelated with PR size (r = 0.20)**. The diff is not the cost — the fixed prefix is. This trims the fixed prefix in proportion to what each review actually routes to.

## Coverage is not narrowed

Every file reachable before is still reachable, now by a **named reader** instead of a glob. Verified: all nine have at least one owner, none orphaned.

The orchestrator still reads `severity-rubric.yaml`, `CLAUDE.md`, `review-policy.md` and `review.yaml` in step 6 — those govern *its* decisions, not an agent's. §1b-toolkit still reads the consumer registry directly, because it needs the registry before any agent is dispatched.

## Reviewer's attention

The mapping is the part worth checking. It follows the Domain Tags mechanically, but if you'd place `performance-rules` on `quality` rather than `correctness`, or want `v3-architecture-rules` on structure alone, say so — that is a coverage judgement and I'd rather change it than have it be quietly wrong.

Follows #3528, which deferred the same load past scope classification.