### PR TITLE
ci(loop): @sdk-loop could not start — resolve read outputs from a job it did not need

### DIFF
--- a/.github/scripts/gen_sdk_loop_workflow.py
+++ b/.github/scripts/gen_sdk_loop_workflow.py
@@ -121,8 +121,8 @@ jobs:
       base_sha: ${{ steps.fence.outputs.base_sha }}
       reason: ${{ steps.fence.outputs.reason }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
       - name: Authorize, dismiss duplicates, pin the baseline
@@ -146,8 +146,8 @@ FOOTER = """
     runs-on: ubuntu-latest
     timeout-minutes: 6
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
       - name: Post the run summary
@@ -230,9 +230,15 @@ def resolve_job(n: int) -> str:
     """
     prev = f"review-{n}"
     prev_res = f"resolve-{n - 1}" if n > 1 else None
+    # The ledger comes from the PREVIOUS resolve, so that job has to be in
+    # `needs` — GitHub rejects the whole workflow at parse time for a
+    # `needs.<job>` reference to a job the caller does not depend on, which
+    # means no jobs run and the fence never gets to say why. The `!cancelled()`
+    # in the gate keeps a skipped previous resolve from blocking this one.
+    needs = f"[fence, {prev}]" if prev_res is None else f"[fence, {prev}, {prev_res}]"
     return f"""
   resolve-{n}:
-    needs: [fence, {prev}]
+    needs: {needs}
     if: >-
       !cancelled() && needs.{prev}.outputs.outcome == 'ok'
     uses: ./.github/workflows/sdk-loop-phase.yml

--- a/.github/scripts/tests/test_sdk_loop.py
+++ b/.github/scripts/tests/test_sdk_loop.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import pathlib
+import re
 import subprocess
 import sys
 
@@ -700,6 +701,40 @@ def test_a_dismissed_run_starts_no_rounds() -> None:
 # ---------------------------------------------------------------------------
 # Generated workflow freshness
 # ---------------------------------------------------------------------------
+
+
+def test_no_job_reads_outputs_from_a_job_it_does_not_need() -> None:
+    """GitHub rejects the WHOLE workflow at parse time for this, so no job runs
+    and the fence never gets to say why — the user sees total silence from a
+    lane whose whole point is that it always answers.
+
+    Shipped exactly this way: resolve-N read needs.resolve-(N-1).outputs.ledger
+    while declaring only [fence, review-N]. Four live invocations produced a
+    startup failure with zero jobs and zero comments before it was found.
+    """
+    jobs = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+    dangling = []
+    for name, job in jobs.items():
+        needs = job.get("needs") or []
+        needs = [needs] if isinstance(needs, str) else needs
+        body = yaml.dump({k: v for k, v in job.items() if k != "needs"})
+        for ref in sorted(set(re.findall(r"needs\.([A-Za-z0-9_-]+)\.", body))):
+            if ref not in needs:
+                dangling.append(f"{name} reads needs.{ref}, needs={needs}")
+    assert not dangling, "dangling needs references:\n  " + "\n  ".join(dangling)
+
+
+def test_the_action_pins_in_the_generator_match_the_generated_file() -> None:
+    """Renovate edits the generated workflow, not the template that produced
+    it, so a bump silently desyncs the two and the freshness gate goes red on
+    main. It did, within hours of merge."""
+    gen = (
+        pathlib.Path(__file__).resolve().parents[1] / "gen_sdk_loop_workflow.py"
+    ).read_text(encoding="utf-8")
+    pin = re.compile(r"uses: (actions/[a-z-]+@[0-9a-f]{40})")
+    assert set(pin.findall(gen)) <= set(
+        pin.findall(WORKFLOW.read_text(encoding="utf-8"))
+    )
 
 
 def test_the_committed_workflow_matches_its_generator() -> None:

--- a/.github/workflows/sdk-loop.yml
+++ b/.github/workflows/sdk-loop.yml
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.14'
+          python-version: '3.12'
       - name: Authorize, dismiss duplicates, pin the baseline
         id: fence
         env:
@@ -159,7 +159,7 @@ jobs:
       spent_so_far: ${{ needs.resolve-1.outputs.spent_total || needs.review-1.outputs.spent_total }}
 
   resolve-2:
-    needs: [fence, review-2]
+    needs: [fence, review-2, resolve-1]
     if: >-
       !cancelled() && needs.review-2.outputs.outcome == 'ok'
     uses: ./.github/workflows/sdk-loop-phase.yml
@@ -192,7 +192,7 @@ jobs:
       spent_so_far: ${{ needs.resolve-2.outputs.spent_total || needs.review-2.outputs.spent_total }}
 
   resolve-3:
-    needs: [fence, review-3]
+    needs: [fence, review-3, resolve-2]
     if: >-
       !cancelled() && needs.review-3.outputs.outcome == 'ok'
     uses: ./.github/workflows/sdk-loop-phase.yml
@@ -225,7 +225,7 @@ jobs:
       spent_so_far: ${{ needs.resolve-3.outputs.spent_total || needs.review-3.outputs.spent_total }}
 
   resolve-4:
-    needs: [fence, review-4]
+    needs: [fence, review-4, resolve-3]
     if: >-
       !cancelled() && needs.review-4.outputs.outcome == 'ok'
     uses: ./.github/workflows/sdk-loop-phase.yml
@@ -258,7 +258,7 @@ jobs:
       spent_so_far: ${{ needs.resolve-4.outputs.spent_total || needs.review-4.outputs.spent_total }}
 
   resolve-5:
-    needs: [fence, review-5]
+    needs: [fence, review-5, resolve-4]
     if: >-
       !cancelled() && needs.review-5.outputs.outcome == 'ok'
     uses: ./.github/workflows/sdk-loop-phase.yml
@@ -291,7 +291,7 @@ jobs:
       spent_so_far: ${{ needs.resolve-5.outputs.spent_total || needs.review-5.outputs.spent_total }}
 
   resolve-6:
-    needs: [fence, review-6]
+    needs: [fence, review-6, resolve-5]
     if: >-
       !cancelled() && needs.review-6.outputs.outcome == 'ok'
     uses: ./.github/workflows/sdk-loop-phase.yml
@@ -324,7 +324,7 @@ jobs:
       spent_so_far: ${{ needs.resolve-6.outputs.spent_total || needs.review-6.outputs.spent_total }}
 
   resolve-7:
-    needs: [fence, review-7]
+    needs: [fence, review-7, resolve-6]
     if: >-
       !cancelled() && needs.review-7.outputs.outcome == 'ok'
     uses: ./.github/workflows/sdk-loop-phase.yml
@@ -357,7 +357,7 @@ jobs:
       spent_so_far: ${{ needs.resolve-7.outputs.spent_total || needs.review-7.outputs.spent_total }}
 
   resolve-8:
-    needs: [fence, review-8]
+    needs: [fence, review-8, resolve-7]
     if: >-
       !cancelled() && needs.review-8.outputs.outcome == 'ok'
     uses: ./.github/workflows/sdk-loop-phase.yml
@@ -381,7 +381,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.14'
+          python-version: '3.12'
       - name: Post the run summary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## The lane cannot start

`resolve-N` interpolated `needs.resolve-(N-1).outputs.ledger` while declaring only `needs: [fence, review-N]`.

GitHub rejects the **entire workflow at parse time** for a `needs.<job>` reference to a job the caller doesn't depend on. So no job ran — **including the fence**, whose entire purpose is to say what happened.

Four live `@sdk-loop` invocations on #3474 produced a startup failure with **zero jobs and zero comments**. Total silence, from a lane designed never to be silent. That's how it was found.

The previous resolve is now in `needs`. The gate already carries `!cancelled()`, so a skipped previous resolve still doesn't block the next one.

## Main's freshness gate is also red

Renovate (#3534) bumped `checkout` v4→v7 and `setup-python` v5→v7 in the **generated** `sdk-loop.yml`, but not in `gen_sdk_loop_workflow.py` that produces it. `--check` has failed on main since that merged.

The generator now carries the same SHAs and regenerates byte-identically.

## Two guards

Both failures were invisible to the 88-test suite that was supposed to cover this file, so neither is left to care:

- **No job may read `needs.<x>` for an `<x>` outside its own `needs`.** Worth a test rather than vigilance precisely because the symptom is *silence*, not an error message.
- **The generator's action pins must be a subset of the generated file's**, so the next Renovate bump fails here instead of on main.

## Follow-up, separately

Teach Renovate to bump the generator too — the repo already extends `github-actions` to non-default paths (see the `github-actions` block in `renovate.json`), so a `customManagers` entry would stop the two drifting in the first place rather than catching it after.