### PR TITLE
ci(loop): make @sdk-loop report what actually happened

### DIFF
--- a/.github/scripts/gen_sdk_loop_workflow.py
+++ b/.github/scripts/gen_sdk_loop_workflow.py
@@ -183,6 +183,7 @@ def review_job(n: int) -> str:
         ledger = "''"
         prior_sha = "''"
         spent = "''"
+        reaims = "''"
     else:
         prev_res, prev_rev = f"resolve-{n - 1}", f"review-{n - 1}"
         # Continue when the previous resolve made progress, or when either
@@ -206,6 +207,7 @@ def review_job(n: int) -> str:
             "${{ needs.%s.outputs.spent_total || needs.%s.outputs.spent_total }}"
             % (prev_res, prev_rev)
         )
+        reaims = "${{ needs.%s.outputs.reaims }}" % prev_rev
     return f"""
   review-{n}:
     needs: {needs}
@@ -223,6 +225,7 @@ def review_job(n: int) -> str:
       ledger: {ledger}
       prior_sha: {prior_sha}
       spent_so_far: {spent}
+      reaims_so_far: {reaims}
 """
 
 

--- a/.github/scripts/sdk_loop_common.py
+++ b/.github/scripts/sdk_loop_common.py
@@ -435,11 +435,35 @@ def agent_env(extra: dict[str, str] | None = None) -> dict[str, str]:
     return env
 
 
+#: opencode prints a fatal error as a line starting `Error:` and then exits 0.
+#: Seen live: `Error: [DecimalError] Invalid argument: [object Object]`, 11ms
+#: into round 1, after which the phase did nothing for four rounds while the
+#: harness read a stale third-party verdict as its own output.
+_ABORT_RE = re.compile(r"^\s*(?:\x1b\[[0-9;]*m)*Error:\s*(.+)$", re.MULTILINE)
+
+
 @dataclass(frozen=True)
 class AgentResult:
     exit_code: int
     stdout: str
     stderr: str
+
+    @property
+    def abort_reason(self) -> str:
+        """The agent's own fatal error, if it printed one."""
+        match = _ABORT_RE.search(f"{self.stdout}\n{self.stderr}")
+        return match.group(1).strip() if match else ""
+
+    @property
+    def completed(self) -> bool:
+        """Whether the agent ran to completion rather than aborting.
+
+        The exit code is useless here — opencode returns 0 on fatal errors — so
+        this reads the transcript for the error it prints on the way out. A
+        phase that aborted must be reported as failed, never left for the
+        caller to infer from whatever side effects are lying around.
+        """
+        return not self.abort_reason
 
     @property
     def looks_authenticated(self) -> bool:

--- a/.github/scripts/sdk_loop_common.py
+++ b/.github/scripts/sdk_loop_common.py
@@ -384,6 +384,25 @@ def spend_delta(before: float | None, after: float | None) -> float | None:
 DEFAULT_MAX_USD = 50.0
 
 
+#: Consecutive re-aims before the loop gives up. A re-aim is not progress —
+#: it discards the round's work and starts over — so it needs a budget of its
+#: own. Without one, a branch that keeps moving (or a harness that keeps
+#: MISREADING the head as moved) silently eats the whole round cap: a live run
+#: burned three rounds on the identical mismatch, each reporting `reaim` and
+#: advancing as though something had changed.
+MAX_CONSECUTIVE_REAIMS = 2
+
+
+def reaim_exhausted(consecutive: int) -> bool:
+    """Whether a further re-aim should stop the run instead of costing a round.
+
+    Consecutive, not cumulative: a branch legitimately edited twice over a long
+    drive is normal, whereas two re-aims back to back with no round in between
+    means the loop is not converging on any one commit.
+    """
+    return consecutive >= MAX_CONSECUTIVE_REAIMS
+
+
 def run_budget() -> float:
     raw = (os.environ.get("SDK_LOOP_MAX_USD") or "").strip()
     try:

--- a/.github/scripts/sdk_loop_finalize.py
+++ b/.github/scripts/sdk_loop_finalize.py
@@ -53,6 +53,11 @@ STOP_TEXT = {
         "starting a phase it could not afford. Raise `vars.SDK_LOOP_MAX_USD` and "
         "re-invoke to continue from where it stopped."
     ),
+    "reaim": (
+        "**Kept re-aiming.** Every round found the branch somewhere other than "
+        "where it had just reviewed, so no round ever got a clean pass at one "
+        "commit. Re-invoke once the branch settles."
+    ),
     "failed": (
         "**A phase failed.** The run stopped rather than guessing at a result — "
         "see the round table for which phase and why."
@@ -89,6 +94,12 @@ def parse_rounds(raw: str | None) -> list[Round]:
     rounds: list[Round] = []
     for item in payload:
         if not isinstance(item, dict) or not item.get("phase"):
+            continue
+        # A skipped job still emits a row, with every field empty. Counting
+        # those produced "8 review · 8 resolve" for a run where three reviews
+        # ran and nothing else did — the table then printed five blank rows
+        # implying work that never happened.
+        if not str(item.get("outcome", "")).strip():
             continue
         rounds.append(
             Round(

--- a/.github/scripts/sdk_loop_phase.py
+++ b/.github/scripts/sdk_loop_phase.py
@@ -54,6 +54,7 @@ from sdk_loop_common import (
     gateway_spend,
     head_state,
     is_verdict_comment,
+    parse_answers_trigger,
     parse_reviewed_head,
     parse_verdict,
     run_agent,
@@ -183,13 +184,28 @@ def review_prompt(
 
 
 def newest_verdict(
-    comments: list[dict[str, Any]], since_id: str | None = None
+    comments: list[dict[str, Any]],
+    since_id: str | None = None,
+    answers_trigger: str | None = None,
 ) -> dict[str, Any] | None:
-    """The most recent verdict comment, optionally newer than a given id."""
+    """The verdict THIS phase produced — not merely the newest one present.
+
+    A PR usually already carries verdicts: from `@sdk-review`, from an earlier
+    loop, from a re-review days ago. Accepting the newest of those makes a
+    phase that produced nothing look like it produced whatever was lying
+    around. Not hypothetical — it is exactly how a crashed agent got reported
+    as a re-aim, four rounds running, with the stale verdict's older
+    REVIEWED_HEAD supplying the "the head moved" signal.
+
+    So the match is on `ANSWERS_TRIGGER` when this run's trigger id is known.
+    A verdict answering someone else's request is someone else's verdict.
+    """
     best: dict[str, Any] | None = None
     for comment in comments:
         body = comment.get("body") or ""
         if not is_verdict_comment(body) or parse_verdict(body) is None:
+            continue
+        if answers_trigger and parse_answers_trigger(body) != str(answers_trigger):
             continue
         if since_id and int(comment.get("id", 0)) <= int(since_id):
             continue
@@ -221,6 +237,11 @@ def interpret_review(
     silent findings-free pass unless it is caught here, which is the most
     dangerous false success this lane can produce.
     """
+    if not result.completed:
+        return ReviewOutcome(
+            outcome=OUTCOME_FAILED,
+            detail=f"the agent aborted: {result.abort_reason}",
+        )
     if verdict_comment is None:
         detail = (
             "the gateway rejected the request (auth or model)"
@@ -238,10 +259,12 @@ def interpret_review(
         and not expected_sha.startswith(stamped)
         and not stamped.startswith(expected_sha[:7])
     ):
-        # The reviewer stamped a different sha than the one it was pointed at.
-        # Treat as a re-aim rather than trusting it: something moved.
+        # Now that only THIS run's verdict is accepted, a stamp mismatch is the
+        # reviewer disobeying, not evidence the branch moved — main() already
+        # fences the head against the remote before we get here. Reporting it
+        # as a re-aim let a broken round masquerade as progress.
         return ReviewOutcome(
-            outcome=OUTCOME_REAIM,
+            outcome=OUTCOME_FAILED,
             verdict=verdict,
             reviewed_head=stamped,
             detail=f"verdict stamps {stamped[:8]}, round expected {expected_sha[:8]}",
@@ -442,7 +465,11 @@ def main(argv: list[str] | None = None) -> int:
             ).stdout
             or "[]"
         )
-        outcome = interpret_review(result, newest_verdict(comments), state.live)
+        outcome = interpret_review(
+            result,
+            newest_verdict(comments, answers_trigger=os.environ.get("COMMENT_ID")),
+            state.live,
+        )
         cost = spend_delta(spend_before, gateway_spend())
         emit_outputs(
             outcome=outcome.outcome,

--- a/.github/scripts/sdk_loop_phase.py
+++ b/.github/scripts/sdk_loop_phase.py
@@ -57,6 +57,7 @@ from sdk_loop_common import (
     parse_answers_trigger,
     parse_reviewed_head,
     parse_verdict,
+    reaim_exhausted,
     run_agent,
     run_budget,
     spend_delta,
@@ -78,6 +79,8 @@ OUTCOME_TERMINAL_VERDICT = "terminal_verdict"
 OUTCOME_FAILED = "failed"
 #: Refused before starting, because the run has spent its allowance.
 OUTCOME_BUDGET = "budget_exhausted"
+#: Gave up re-aiming: the loop never got a clean pass at one commit.
+OUTCOME_REAIM_EXHAUSTED = "reaim_exhausted"
 
 
 def _as_float(raw: str | None) -> float | None:
@@ -417,12 +420,24 @@ def main(argv: list[str] | None = None) -> int:
     ledger = DismissalLedger.from_json(os.environ.get("LEDGER"))
 
     state = head_state(live_head(repo, head_ref), baseline, ours)
+    reaims = int(os.environ.get("REAIMS_SO_FAR") or 0)
+    if state.moved_by_other and reaim_exhausted(reaims):
+        # Stop rather than spend another round on a target that keeps moving.
+        emit_outputs(
+            outcome=OUTCOME_REAIM_EXHAUSTED,
+            new_base_sha=state.live,
+            reaims=str(reaims),
+            detail=f"{reaims} consecutive re-aims without a clean pass at one commit",
+        )
+        print(f"giving up after {reaims} consecutive re-aims")
+        return 0
     if state.moved_by_other:
         # Re-aim: discard whatever this round would have done and send the loop
         # back to review on the new head. Never resolve against a stale review.
         emit_outputs(
             outcome=OUTCOME_REAIM,
             new_base_sha=state.live,
+            reaims=str(reaims + 1),
             detail=f"head moved to {state.live[:8]} outside this run",
         )
         print(f"re-aim: head is {state.live[:8]}, expected {baseline[:8]}")
@@ -477,6 +492,7 @@ def main(argv: list[str] | None = None) -> int:
             reviewed_head=outcome.reviewed_head,
             verdict_url=outcome.verdict_url,
             detail=outcome.detail,
+            reaims="0",
             new_base_sha=state.live,
             cost="" if cost is None else f"{cost:.4f}",
             spent_total=(
@@ -517,6 +533,7 @@ def main(argv: list[str] | None = None) -> int:
         emit_outputs(
             outcome=outcome.outcome,
             pushed_sha=outcome.pushed_sha,
+            reaims="0",
             new_base_sha=after,
             ledger=ledger.to_json(),
             detail=outcome.detail,

--- a/.github/scripts/tests/test_sdk_loop.py
+++ b/.github/scripts/tests/test_sdk_loop.py
@@ -685,6 +685,20 @@ def test_an_unknown_model_fails_at_config_time_not_as_a_paid_400() -> None:
         opencode_config("gpt-nonexistent")
 
 
+def test_the_lane_reaches_exactly_two_models_and_has_no_fallback() -> None:
+    """Owner's decision: xai/grok-4.6 for review, gpt-5.6-luna for resolve,
+    nothing else.
+
+    Both existing lanes carry RETRY_MAIN_MODEL = claude-opus-5 as a second
+    attempt. This one deliberately does not: a failed phase is a failed phase,
+    and a silent retry on a different model makes cost and behaviour harder to
+    reason about across rounds. Pinned so a future edit adding a ladder has to
+    change this test and say why.
+    """
+    assert ALLOWED_MODELS == ("xai/grok-4.6", "gpt-5.6-luna")
+    assert len(set(ALLOWED_MODELS)) == 2
+
+
 def test_review_and_resolve_run_on_different_models() -> None:
     assert REVIEW_MODEL != RESOLVE_MODEL
 

--- a/.github/scripts/tests/test_sdk_loop.py
+++ b/.github/scripts/tests/test_sdk_loop.py
@@ -29,6 +29,7 @@ from _gha_expr import evaluate  # noqa: E402
 from sdk_loop_common import (  # noqa: E402
     ALLOWED_MODELS,
     DEFAULT_MAX_USD,
+    MAX_CONSECUTIVE_REAIMS,
     MAX_ROUNDS,
     PROVIDER,
     RESOLVE_MODEL,
@@ -41,6 +42,7 @@ from sdk_loop_common import (  # noqa: E402
     opencode_config,
     parse_reviewed_head,
     parse_verdict,
+    reaim_exhausted,
     run_agent,
     run_budget,
 )
@@ -971,10 +973,22 @@ def test_a_detail_containing_a_pipe_cannot_break_the_table() -> None:
     assert "a \\| b" in render(rounds, "failed", "http://run")
 
 
-def test_rounds_json_from_a_skipped_job_is_tolerated() -> None:
-    # Skipped jobs emit empty outputs; the summary must still render.
-    raw = json.dumps(
-        [{"number": 1, "phase": "review", "outcome": "", "verdict": "", "sha": ""}]
-    )
-    assert len(parse_rounds(raw)) == 1
+def test_a_skipped_round_is_not_reported_as_a_round() -> None:
+    """A skipped job still emits a row with every field empty. Counting them
+    produced "8 review · 8 resolve" for a run where three reviews ran and
+    nothing else did, then printed five blank rows implying work that never
+    happened."""
+    ran = {"number": 1, "phase": "review", "outcome": "reaim", "sha": "a" * 40}
+    skipped = {"number": 2, "phase": "resolve", "outcome": "", "verdict": "", "sha": ""}
+    assert len(parse_rounds(json.dumps([ran, skipped]))) == 1
     assert parse_rounds("not json") == []
+
+
+def test_a_reaim_streak_stops_the_run_before_it_eats_the_round_cap() -> None:
+    """A re-aim discards the round's work, so it is not progress and needs its
+    own budget. A live run burned three rounds on the identical mismatch, each
+    reporting `reaim` and advancing as though something had changed."""
+    assert not reaim_exhausted(0)
+    assert not reaim_exhausted(1)
+    assert reaim_exhausted(MAX_CONSECUTIVE_REAIMS)
+    assert MAX_CONSECUTIVE_REAIMS < MAX_ROUNDS, "must bite before the round cap"

--- a/.github/scripts/tests/test_sdk_loop.py
+++ b/.github/scripts/tests/test_sdk_loop.py
@@ -60,7 +60,6 @@ from sdk_loop_phase import (  # noqa: E402
     OUTCOME_FAILED,
     OUTCOME_NO_PROGRESS,
     OUTCOME_OK,
-    OUTCOME_REAIM,
     OUTCOME_TERMINAL_VERDICT,
     interpret_resolve,
     interpret_review,
@@ -275,11 +274,57 @@ def test_a_verdict_no_resolve_can_fix_stops_the_loop(verdict: str) -> None:
     assert outcome.outcome == OUTCOME_TERMINAL_VERDICT
 
 
-def test_a_verdict_stamped_against_another_sha_triggers_a_reaim() -> None:
+def test_a_verdict_stamped_against_another_sha_is_a_failure_not_a_reaim() -> None:
+    """Only this run's own verdict is accepted, and main() already fences the
+    head against the remote — so a stamp mismatch means the reviewer disobeyed,
+    not that the branch moved. Reporting it as a re-aim let a broken round
+    masquerade as progress: four rounds ran and none reviewed anything."""
     outcome = interpret_review(
         _ok(), _verdict_comment("NEEDS_FIXES", "b" * 40), "a" * 40
     )
-    assert outcome.outcome == OUTCOME_REAIM
+    assert outcome.outcome == OUTCOME_FAILED
+
+
+def test_an_aborted_agent_is_a_failure_whatever_it_left_behind() -> None:
+    """Live on the first run: `Error: [DecimalError] Invalid argument:
+    [object Object]` 11ms into round 1. opencode exited 0, the harness found an
+    unrelated verdict already on the PR, and called the round a re-aim."""
+    crashed = AgentResult(
+        exit_code=0,
+        stdout="I'll read the orchestration instructions.\n"
+        "Error: [DecimalError] Invalid argument: [object Object]\n",
+        stderr="",
+    )
+    assert not crashed.completed
+    assert "DecimalError" in crashed.abort_reason
+    outcome = interpret_review(
+        crashed, _verdict_comment("READY_TO_MERGE", "a" * 40), "a" * 40
+    )
+    assert outcome.outcome == OUTCOME_FAILED
+    assert "aborted" in outcome.detail
+
+
+def test_a_clean_transcript_is_not_read_as_an_abort() -> None:
+    # "Error" inside ordinary prose must not fail a round that worked.
+    fine = AgentResult(
+        exit_code=0,
+        stdout="Considered an ErrorHandler finding; dropped it.\n",
+        stderr="",
+    )
+    assert fine.completed
+
+
+def test_a_verdict_answering_someone_elses_trigger_is_not_ours() -> None:
+    """PRs carry old verdicts — from @sdk-review, from an earlier loop. Taking
+    the newest makes a phase that produced nothing look like it produced
+    whatever was lying there."""
+    mine = _verdict_comment("NEEDS_FIXES", "a" * 40, cid=9)
+    mine["body"] += "<!-- ANSWERS_TRIGGER: 555 -->\n"
+    theirs = _verdict_comment("READY_TO_MERGE", "b" * 40, cid=20)
+    theirs["body"] += "<!-- ANSWERS_TRIGGER: 111 -->\n"
+    picked = newest_verdict([mine, theirs], answers_trigger="555")
+    assert picked is not None and parse_verdict(picked["body"]) == "NEEDS_FIXES"
+    assert newest_verdict([theirs], answers_trigger="555") is None
 
 
 def test_newest_verdict_wins_over_an_older_one() -> None:

--- a/.github/workflows/sdk-loop-phase.yml
+++ b/.github/workflows/sdk-loop-phase.yml
@@ -62,6 +62,11 @@ on:
         required: false
         default: ''
         description: 'USD this run has spent already. The phase refuses to start once it reaches the allowance.'
+      reaims_so_far:
+        type: string
+        required: false
+        default: ''
+        description: 'Consecutive re-aims so far. A re-aim is not progress, so it gets a budget of its own.'
     secrets:
       LITELLM_API_KEY:
         required: true
@@ -93,6 +98,8 @@ on:
         value: ${{ jobs.phase.outputs.detail }}
       cost:
         value: ${{ jobs.phase.outputs.cost }}
+      reaims:
+        value: ${{ jobs.phase.outputs.reaims }}
       spent_total:
         value: ${{ jobs.phase.outputs.spent_total }}
 
@@ -116,6 +123,7 @@ jobs:
       ledger: ${{ steps.run.outputs.ledger }}
       detail: ${{ steps.run.outputs.detail }}
       cost: ${{ steps.run.outputs.cost }}
+      reaims: ${{ steps.run.outputs.reaims }}
       spent_total: ${{ steps.run.outputs.spent_total }}
     steps:
       - name: Mint a scoped App token
@@ -192,6 +200,7 @@ jobs:
           VERDICT_URL: ${{ inputs.verdict_url }}
           PRIOR_SHA: ${{ inputs.prior_sha }}
           SPENT_SO_FAR: ${{ inputs.spent_so_far }}
+          REAIMS_SO_FAR: ${{ inputs.reaims_so_far }}
           SDK_LOOP_MAX_USD: ${{ vars.SDK_LOOP_MAX_USD }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}

--- a/.github/workflows/sdk-loop.yml
+++ b/.github/workflows/sdk-loop.yml
@@ -129,6 +129,7 @@ jobs:
       ledger: ''
       prior_sha: ''
       spent_so_far: ''
+      reaims_so_far: ''
 
   resolve-1:
     needs: [fence, review-1]
@@ -162,6 +163,7 @@ jobs:
       ledger: ${{ needs.resolve-1.outputs.ledger }}
       prior_sha: ${{ needs.review-1.outputs.reviewed_head }}
       spent_so_far: ${{ needs.resolve-1.outputs.spent_total || needs.review-1.outputs.spent_total }}
+      reaims_so_far: ${{ needs.review-1.outputs.reaims }}
 
   resolve-2:
     needs: [fence, review-2, resolve-1]
@@ -195,6 +197,7 @@ jobs:
       ledger: ${{ needs.resolve-2.outputs.ledger }}
       prior_sha: ${{ needs.review-2.outputs.reviewed_head }}
       spent_so_far: ${{ needs.resolve-2.outputs.spent_total || needs.review-2.outputs.spent_total }}
+      reaims_so_far: ${{ needs.review-2.outputs.reaims }}
 
   resolve-3:
     needs: [fence, review-3, resolve-2]
@@ -228,6 +231,7 @@ jobs:
       ledger: ${{ needs.resolve-3.outputs.ledger }}
       prior_sha: ${{ needs.review-3.outputs.reviewed_head }}
       spent_so_far: ${{ needs.resolve-3.outputs.spent_total || needs.review-3.outputs.spent_total }}
+      reaims_so_far: ${{ needs.review-3.outputs.reaims }}
 
   resolve-4:
     needs: [fence, review-4, resolve-3]
@@ -261,6 +265,7 @@ jobs:
       ledger: ${{ needs.resolve-4.outputs.ledger }}
       prior_sha: ${{ needs.review-4.outputs.reviewed_head }}
       spent_so_far: ${{ needs.resolve-4.outputs.spent_total || needs.review-4.outputs.spent_total }}
+      reaims_so_far: ${{ needs.review-4.outputs.reaims }}
 
   resolve-5:
     needs: [fence, review-5, resolve-4]
@@ -294,6 +299,7 @@ jobs:
       ledger: ${{ needs.resolve-5.outputs.ledger }}
       prior_sha: ${{ needs.review-5.outputs.reviewed_head }}
       spent_so_far: ${{ needs.resolve-5.outputs.spent_total || needs.review-5.outputs.spent_total }}
+      reaims_so_far: ${{ needs.review-5.outputs.reaims }}
 
   resolve-6:
     needs: [fence, review-6, resolve-5]
@@ -327,6 +333,7 @@ jobs:
       ledger: ${{ needs.resolve-6.outputs.ledger }}
       prior_sha: ${{ needs.review-6.outputs.reviewed_head }}
       spent_so_far: ${{ needs.resolve-6.outputs.spent_total || needs.review-6.outputs.spent_total }}
+      reaims_so_far: ${{ needs.review-6.outputs.reaims }}
 
   resolve-7:
     needs: [fence, review-7, resolve-6]
@@ -360,6 +367,7 @@ jobs:
       ledger: ${{ needs.resolve-7.outputs.ledger }}
       prior_sha: ${{ needs.review-7.outputs.reviewed_head }}
       spent_so_far: ${{ needs.resolve-7.outputs.spent_total || needs.review-7.outputs.spent_total }}
+      reaims_so_far: ${{ needs.review-7.outputs.reaims }}
 
   resolve-8:
     needs: [fence, review-8, resolve-7]


### PR DESCRIPTION
Everything learned from the first live run of `@sdk-loop` on #3474 ([run 33390192162](https://github.com/atlanhq/application-sdk/actions/runs/33390192162)). **100 tests, actionlint clean.**

## What that run actually did

Four review rounds ran, every resolve was skipped, and **no review happened at all**:

```
12:08:17.998  I'll read the orchestration instructions...
12:08:18.008  Read .mothership/pr-review/ORCHESTRATION.md
12:08:18.009  Error: [DecimalError] Invalid argument: [object Object]
```

The agent lived **11 milliseconds**. It never fetched the diff, routed a scope, dispatched an agent, or formed a finding.

Three layers then reported success:

| Layer | Reported | Reality |
|---|---|---|
| `opencode` | exit **0** | fatal error 11ms in |
| `interpret_review` | `reaim READY_TO_MERGE` | it had produced no verdict |
| GitHub job | **`success`** | nothing happened |

That `READY_TO_MERGE` was the `@sdk-review` verdict posted **four hours earlier**. The harness took "the newest verdict comment on the PR" without checking whose it was, read the older `REVIEWED_HEAD` as *"the head moved"*, and called it a re-aim — which advances to the next review without resolving.

**A crashed agent presented as steady progress.** That is worse than failing.

## Fixes

### A verdict must be ours
Matched on `ANSWERS_TRIGGER` against this run's trigger comment. A PR almost always carries older verdicts; taking the newest makes a phase that produced nothing look like it produced whatever was lying around.

### An aborted agent is a failure
`AgentResult` reads the `Error:` line opencode prints on its way out, since the exit code can't carry this. Anchored to a line start so `ErrorHandler` in prose doesn't fail a good round — there's a test.

### A stamp mismatch is a reviewer error, not a re-aim
`main()` already fences the head against the remote, so once the verdict is scoped to this run, that mismatch can no longer mean the branch moved.

### A re-aim gets its own budget
Rounds 1–3 each reported the *identical* detail — `verdict stamps 7f4ef94, round expected 1ad5dc0` — and advanced anyway. Nothing moved between them. A re-aim discards the round's work **by design**, so it isn't progress and can't share the round budget.

`MAX_CONSECUTIVE_REAIMS = 2` stops the run instead. Consecutive rather than cumulative: a branch legitimately edited twice over a long drive is normal, two back-to-back with no completed round between them means the loop isn't converging on any one commit. A completed round resets the streak, and the cap is asserted to bite before the round cap.

### The summary counted rows, not rounds
A skipped job still emits a row with every field blank — which is why a run with three reviews reported **"8 review · 8 resolve"** and printed five empty rows implying work that never happened. Empty outcomes are dropped from both the counts and the table, and `reaim` gets a stop message of its own.

### Two models, pinned
`xai/grok-4.6` for review, `gpt-5.6-luna` for resolve, nothing else. Both existing lanes carry `RETRY_MAIN_MODEL = claude-opus-5`; this one deliberately doesn't — a silent retry on a different model would make the per-phase cost numbers lie about what produced them. A future edit adding a ladder has to change that test and say why.

## ⚠️ This does not make the lane work

The `DecimalError` is upstream in `opencode` and **is not fixed here**. With this merged the loop will *fail loudly on round 1* instead of faking four rounds — strictly better, and it gives us a real error to chase, but it is not yet a working lane.

Leading suspect is the **slash** in `xai/grok-4.6`: opencode splits `--model` on the first slash, so `gateway/xai/grok-4.6` reads as provider `gateway` + model `xai/grok-4.6`. connector-pulse's proven config only ever uses slash-free aliases. Keeping grok-4.6 is the right call for cross-lane comparability, so if that is the cause the fix belongs on our side — naming the provider entry `xai`, or registering a slash-free key that maps to the gateway model.

## Worth recording

The strict-loader guard added in #3538 caught me **reintroducing the exact duplicate-key bug it was written for** while threading the re-aim counter — `reaims_so_far` orphaned `spent_so_far`'s description, the same way `spent_so_far` orphaned `prior_sha`'s. Second time in one day; first time it didn't reach `main`.