### PR TITLE
ci(loop): try the undotted grok alias for @sdk-loop

### DIFF
--- a/.github/scripts/gen_sdk_loop_workflow.py
+++ b/.github/scripts/gen_sdk_loop_workflow.py
@@ -33,7 +33,7 @@ HEADER = """# @sdk-loop — drive a PR to merge-ready without supervision.
 #   fence -> review 1 -> resolve 1 -> review 2 -> ... -> review 8 -> finalize
 #
 # One workflow run, one job per phase, up to 8 review/resolve pairs. The review
-# phase runs on xai/grok-4.6 — the same model the existing lanes review with
+# phase runs on xai/grok-4-6 — the same model the existing lanes review with
 # — and the resolve phase on gpt-5.6-luna via opencode, both
 # through the Atlan AI gateway — a public edge, so no VPN and no mothership
 # sandbox. Its URL is a secret and is deliberately not written anywhere in
@@ -69,7 +69,7 @@ HEADER = """# @sdk-loop — drive a PR to merge-ready without supervision.
 # CI staleness: python3 .github/scripts/gen_sdk_loop_workflow.py --check
 #
 # Required configuration:
-#   secrets.LITELLM_API_KEY           gateway key entitled to BOTH xai/grok-4.6
+#   secrets.LITELLM_API_KEY           gateway key entitled to BOTH xai/grok-4-6
 #                                     and gpt-5.6-luna. An unentitled model is a
 #                                     fast 400 with real cost, so check first.
 #   secrets.FLEET_APP_ID              atlan-app-fleet — already configured for

--- a/.github/scripts/sdk_loop_common.py
+++ b/.github/scripts/sdk_loop_common.py
@@ -60,11 +60,17 @@ MAX_ROUNDS = 8
 #: (`.mothership/pr-resolve/ORCHESTRATION.md` §3d, "Fix every finding (or prove
 #: it false)"), so a separate adversarial reviewer would pay twice for one job.
 #:
-#: The alias contains a slash. opencode splits `--model` on the FIRST slash
-#: only, so `gateway/xai/grok-4.6` resolves to provider `gateway`, model
-#: `xai/grok-4.6` — and the key in the config's `models` map has to be the
-#: full alias, slash included.
-REVIEW_MODEL = "xai/grok-4.6"
+#: Written `grok-4-6`, not `grok-4.6`. Two live rounds died 11ms in with
+#: `Error: [DecimalError] Invalid argument: [object Object]` — decimal.js
+#: refusing a non-numeric argument — before the agent read anything. The
+#: dotted form is the one shape this lane has that connector-pulse's working
+#: config does not: its aliases (`gpt-5.6-luna`, `kimi-k3`) carry no dot in a
+#: position a decimal parser would try to consume.
+#:
+#: The alias also contains a slash. opencode splits `--model` on the FIRST
+#: slash only, so `gateway/xai/grok-4-6` resolves to provider `gateway`, model
+#: `xai/grok-4-6` — the key in the config's `models` map is the full alias.
+REVIEW_MODEL = "xai/grok-4-6"
 
 #: Resolve runs on the mechanical model — the same role split connector-pulse
 #: uses for its mechanical lane.

--- a/.github/scripts/tests/test_sdk_loop.py
+++ b/.github/scripts/tests/test_sdk_loop.py
@@ -664,7 +664,7 @@ def test_no_gateway_hostname_is_committed_in_this_lane() -> None:
 def test_the_review_model_matches_what_the_existing_lanes_use() -> None:
     # All three lanes reviewing on one model means a finding difference between
     # them is about the harness, not the model.
-    assert REVIEW_MODEL == "xai/grok-4.6"
+    assert REVIEW_MODEL == "xai/grok-4-6"
 
 
 def test_a_slash_bearing_alias_composes_into_provider_and_model(
@@ -675,7 +675,7 @@ def test_a_slash_bearing_alias_composes_into_provider_and_model(
     `xai/grok-4.6`, and the config's `models` key must carry the full alias."""
     monkeypatch.setenv("LITELLM_BASE_URL", "https://gateway.example")
     cfg = opencode_config(REVIEW_MODEL)
-    assert cfg["model"] == "gateway/xai/grok-4.6"
+    assert cfg["model"] == "gateway/xai/grok-4-6"
     assert cfg["model"].split("/", 1) == [PROVIDER, REVIEW_MODEL]
     assert REVIEW_MODEL in cfg["provider"][PROVIDER]["models"]
 
@@ -695,7 +695,7 @@ def test_the_lane_reaches_exactly_two_models_and_has_no_fallback() -> None:
     reason about across rounds. Pinned so a future edit adding a ladder has to
     change this test and say why.
     """
-    assert ALLOWED_MODELS == ("xai/grok-4.6", "gpt-5.6-luna")
+    assert ALLOWED_MODELS == ("xai/grok-4-6", "gpt-5.6-luna")
     assert len(set(ALLOWED_MODELS)) == 2
 
 

--- a/.github/workflows/sdk-loop.yml
+++ b/.github/workflows/sdk-loop.yml
@@ -3,7 +3,7 @@
 #   fence -> review 1 -> resolve 1 -> review 2 -> ... -> review 8 -> finalize
 #
 # One workflow run, one job per phase, up to 8 review/resolve pairs. The review
-# phase runs on xai/grok-4.6 — the same model the existing lanes review with
+# phase runs on xai/grok-4-6 — the same model the existing lanes review with
 # — and the resolve phase on gpt-5.6-luna via opencode, both
 # through the Atlan AI gateway — a public edge, so no VPN and no mothership
 # sandbox. Its URL is a secret and is deliberately not written anywhere in
@@ -39,7 +39,7 @@
 # CI staleness: python3 .github/scripts/gen_sdk_loop_workflow.py --check
 #
 # Required configuration:
-#   secrets.LITELLM_API_KEY           gateway key entitled to BOTH xai/grok-4.6
+#   secrets.LITELLM_API_KEY           gateway key entitled to BOTH xai/grok-4-6
 #                                     and gpt-5.6-luna. An unentitled model is a
 #                                     fast 400 with real cost, so check first.
 #   secrets.FLEET_APP_ID              atlan-app-fleet — already configured for


### PR DESCRIPTION
## The failure

Two live rounds of `@sdk-loop`, both dead **11 ms in**, before the agent read anything:

```
Error: [DecimalError] Invalid argument: [object Object]
```

`decimal.js` refusing a non-numeric argument. The agent never fetched a diff, so nothing in the review path can be responsible — it fails while opencode is still resolving the model.

Good news from that run: with #3541 merged, the phase now correctly reports **`review-1 / phase: failure`** instead of faking a re-aim. That's how we can see this at all.

## Why the dot

connector-pulse runs the *same* opencode-on-gateway pattern successfully with `gpt-5.6-luna` and `kimi-k3`. Neither carries a dot in a position that reads as a version number. **`grok-4.6` does**, and `4.6` is exactly what a decimal parser would try to consume.

That makes the dot the highest-value single thing to change: `REVIEW_MODEL` becomes `xai/grok-4-6`.

## This is a hypothesis, not a diagnosis

And it's deliberately cheap to falsify. If the gateway doesn't serve that alias, the request comes back a fast 400 — which `AgentResult.looks_authenticated` already classifies as a gateway rejection and reports as a failed round *with the reason*. So one run distinguishes:

| Next run says | Means |
|---|---|
| review completes | the dot was it |
| `Invalid model name` / gateway rejection | alias doesn't exist; revert and try the slash |
| `DecimalError` again | dot was innocent — next suspects are the slash, or the empty `models: {}` entry |

## Scope

Only this lane's review alias moves, and only until we know why. Resolve stays on `gpt-5.6-luna`; `@sdk-review` and `@sdk-resolve` keep `xai/grok-4.6` untouched.

100 tests pass; actionlint clean.