### PR TITLE
ci(loop): the DecimalError was a wrong opencode pin, not the model name

### DIFF
--- a/.github/scripts/gen_sdk_loop_workflow.py
+++ b/.github/scripts/gen_sdk_loop_workflow.py
@@ -113,6 +113,7 @@ permissions:
 
 jobs:
   fence:
+    name: Fence
     runs-on: ubuntu-latest
     timeout-minutes: 6
     if: >-
@@ -142,10 +143,25 @@ jobs:
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           WORKFLOW_FILE: sdk-loop.yml
         run: python3 .github/scripts/sdk_loop_fence.py
+
+      # The same acknowledgement the other two lanes give: an emoji within
+      # seconds, long before any verdict exists, so whoever typed @sdk-loop
+      # knows it registered. Runs after the fence so it can reflect the
+      # decision, and always() because the script exits 0 by design — a
+      # missing emoji must never take down the run it is decorating.
+      - name: React to the trigger comment
+        if: always() && github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REACTION: ${{ steps.fence.outputs.proceed == 'true' && 'eyes' || 'confused' }}
+        run: python3 .github/scripts/react_to_comment.py
 """
 
 FOOTER = """
   finalize:
+    name: Summary
     needs: [fence, {all_phases}]
     if: always() && needs.fence.outputs.proceed == 'true'
     runs-on: ubuntu-latest
@@ -210,6 +226,7 @@ def review_job(n: int) -> str:
         reaims = "${{ needs.%s.outputs.reaims }}" % prev_rev
     return f"""
   review-{n}:
+    name: Review {n}
     needs: {needs}
     if: >-
       {gate}
@@ -246,6 +263,7 @@ def resolve_job(n: int) -> str:
     needs = f"[fence, {prev}]" if prev_res is None else f"[fence, {prev}, {prev_res}]"
     return f"""
   resolve-{n}:
+    name: Resolve {n}
     needs: {needs}
     if: >-
       !cancelled() && needs.{prev}.outputs.outcome == 'ok'

--- a/.github/scripts/gen_sdk_loop_workflow.py
+++ b/.github/scripts/gen_sdk_loop_workflow.py
@@ -110,6 +110,11 @@ permissions:
   # this the duplicate check 403s, the fence raises before it can post, and
   # the lane goes silent — the failure mode it exists to prevent.
   actions: read
+  # Reactions are an Issues-scope resource, so the acknowledgement 403s
+  # without this. Caught by test_react_to_comment.py, which asserts every
+  # workflow calling the helper grants it — the same Issues-vs-PR distinction
+  # the fleet App token needed for posting the verdict comment.
+  issues: write
 
 jobs:
   fence:

--- a/.github/scripts/gen_sdk_loop_workflow.py
+++ b/.github/scripts/gen_sdk_loop_workflow.py
@@ -33,7 +33,7 @@ HEADER = """# @sdk-loop — drive a PR to merge-ready without supervision.
 #   fence -> review 1 -> resolve 1 -> review 2 -> ... -> review 8 -> finalize
 #
 # One workflow run, one job per phase, up to 8 review/resolve pairs. The review
-# phase runs on xai/grok-4-6 — the same model the existing lanes review with
+# phase runs on xai/grok-4.6 — the same model the existing lanes review with
 # — and the resolve phase on gpt-5.6-luna via opencode, both
 # through the Atlan AI gateway — a public edge, so no VPN and no mothership
 # sandbox. Its URL is a secret and is deliberately not written anywhere in
@@ -69,7 +69,7 @@ HEADER = """# @sdk-loop — drive a PR to merge-ready without supervision.
 # CI staleness: python3 .github/scripts/gen_sdk_loop_workflow.py --check
 #
 # Required configuration:
-#   secrets.LITELLM_API_KEY           gateway key entitled to BOTH xai/grok-4-6
+#   secrets.LITELLM_API_KEY           gateway key entitled to BOTH xai/grok-4.6
 #                                     and gpt-5.6-luna. An unentitled model is a
 #                                     fast 400 with real cost, so check first.
 #   secrets.FLEET_APP_ID              atlan-app-fleet — already configured for

--- a/.github/scripts/sdk_loop_common.py
+++ b/.github/scripts/sdk_loop_common.py
@@ -288,6 +288,16 @@ def gateway_base() -> str:
 #: The prompts are the EXISTING files, loaded by reference. Nothing is copied,
 #: so the agents stay owned by `.mothership/pr-review/agents/` and keep the
 #: reference rules #3530 gave them.
+#: Audited against both playbooks on 2026-08-31: `Agent tool` (ORCHESTRATION
+#: lines 556 and 918) is the ONLY harness-specific capability either one names.
+#: No Skills, no MCP, no glean, no WebFetch, no TodoWrite — everything else is
+#: bash, gh, git and file reads, all of which opencode has. So subagent
+#: registration was the whole gap, and the resolve playbook needs nothing: it
+#: has no agents directory and dispatches none.
+#:
+#: `adversarial.md` is deliberately absent from this list — Wave 2 is skipped
+#: in this lane (see the review prompt), so registering it would advertise a
+#: capability the phase is told not to use.
 PHASE2_AGENTS = (
     "correctness",
     "quality",

--- a/.github/scripts/sdk_loop_common.py
+++ b/.github/scripts/sdk_loop_common.py
@@ -60,17 +60,22 @@ MAX_ROUNDS = 8
 #: (`.mothership/pr-resolve/ORCHESTRATION.md` §3d, "Fix every finding (or prove
 #: it false)"), so a separate adversarial reviewer would pay twice for one job.
 #:
-#: Written `grok-4-6`, not `grok-4.6`. Two live rounds died 11ms in with
+#: `grok-4.6`, dotted — that is the alias the gateway serves. The undotted
+#: form was tried and rejected: "Invalid model name passed in
+#: model=xai/grok-4-6", and `/v1/models` lists `xai/grok-4.6` and no variant.
+#:
+#: Superseded note, kept because it recorded a real finding: two live rounds
+#: died 11ms in with
 #: `Error: [DecimalError] Invalid argument: [object Object]` — decimal.js
 #: refusing a non-numeric argument — before the agent read anything. The
-#: dotted form is the one shape this lane has that connector-pulse's working
-#: config does not: its aliases (`gpt-5.6-luna`, `kimi-k3`) carry no dot in a
-#: position a decimal parser would try to consume.
+#: dot was blamed. It was the wrong culprit — swapping it merely moved the
+#: failure from a crash to a 400. The real cause was an unpriced model; see
+#: `opencode_config`.
 #:
 #: The alias also contains a slash. opencode splits `--model` on the FIRST
-#: slash only, so `gateway/xai/grok-4-6` resolves to provider `gateway`, model
-#: `xai/grok-4-6` — the key in the config's `models` map is the full alias.
-REVIEW_MODEL = "xai/grok-4-6"
+#: slash only, so `gateway/xai/grok-4.6` resolves to provider `gateway`, model
+#: `xai/grok-4.6` — the key in the config's `models` map is the full alias.
+REVIEW_MODEL = "xai/grok-4.6"
 
 #: Resolve runs on the mechanical model — the same role split connector-pulse
 #: uses for its mechanical lane.
@@ -296,7 +301,41 @@ def opencode_config(model: str) -> dict[str, Any]:
                     "baseURL": f"{base}/v1",
                     "apiKey": "{env:LITELLM_API_KEY}",
                 },
-                "models": {name: {} for name in ALLOWED_MODELS},
+                # Cost is DECLARED rather than left empty. This is a
+                # HYPOTHESIS under test, not a diagnosis, for the crash that
+                # killed the first three live runs:
+                #
+                #   Error: [DecimalError] Invalid argument: [object Object]
+                #
+                # What is PROVEN: it dies 11ms in, before any network call —
+                # the undotted alias got as far as a real 400 from the
+                # gateway, so the crash is local to opencode's model
+                # resolution. `[object Object]` reaching decimal.js means an
+                # OBJECT was passed where a number was wanted, and an
+                # unpopulated cost table is the obvious candidate for that
+                # object. connector-pulse's aliases resolve in opencode's
+                # bundled registry; a gateway-only alias like `xai/grok-4.6`
+                # does not, which fits.
+                #
+                # What is NOT proven: that cost is the object in question. If
+                # this run still crashes, the next suspects are opencode
+                # parsing `4.6` out of the id as a version, and the nested
+                # slash in `gateway/xai/grok-4.6`.
+                #
+                # Zeroes rather than real prices: this lane bills through the
+                # gateway key and reads spend from /key/info, so opencode's own
+                # accounting is unused. Declaring it only stops it guessing.
+                "models": {
+                    name: {
+                        "cost": {
+                            "input": 0,
+                            "output": 0,
+                            "cache_read": 0,
+                            "cache_write": 0,
+                        }
+                    }
+                    for name in ALLOWED_MODELS
+                },
             }
         },
         "model": f"{PROVIDER}/{model}",

--- a/.github/scripts/sdk_loop_common.py
+++ b/.github/scripts/sdk_loop_common.py
@@ -277,7 +277,48 @@ def gateway_base() -> str:
     return base.rstrip("/")
 
 
-def opencode_config(model: str) -> dict[str, Any]:
+#: The playbook's Phase 2 agents, registered so opencode's Task tool can
+#: dispatch them. §2a says "dispatch agents via the Agent tool" — Claude Code's
+#: name for it; opencode calls the same mechanism `Task`, and it runs them in
+#: parallel just the same. Without registering them the primary agent has
+#: nothing to delegate TO, and Phase 2's whole fan-out silently collapses into
+#: one agent doing everything: a review that still produces a verdict, just a
+#: worse one, with nothing in the output to say so.
+#:
+#: The prompts are the EXISTING files, loaded by reference. Nothing is copied,
+#: so the agents stay owned by `.mothership/pr-review/agents/` and keep the
+#: reference rules #3530 gave them.
+PHASE2_AGENTS = (
+    "correctness",
+    "quality",
+    "structure",
+    "reachability",
+    "conformance",
+    "ci-config",
+    "toolkit-review",
+)
+
+
+def review_subagents(model: str) -> dict[str, Any]:
+    """opencode subagent entries for the playbook's Phase 2 agents.
+
+    Each is read-only by construction: the review lane holds a token with no
+    write scope, and denying `edit` here makes that true of the agent as well
+    as the credential rather than relying on either alone.
+    """
+    return {
+        name: {
+            "description": f"SDK review — {name} domain agent (Phase 2 Wave 1).",
+            "mode": "subagent",
+            "model": f"{PROVIDER}/{model}",
+            "prompt": f"{{file:./.mothership/pr-review/agents/{name}.md}}",
+            "permission": {"edit": "deny", "read": "allow", "bash": "allow"},
+        }
+        for name in PHASE2_AGENTS
+    }
+
+
+def opencode_config(model: str, with_subagents: bool = False) -> dict[str, Any]:
     """`opencode.json` pinning the only provider and models this lane may use.
 
     Shell and network stay ALLOWED here, unlike the conformance fast lane which
@@ -343,6 +384,7 @@ def opencode_config(model: str) -> dict[str, Any]:
         # unanswered ask as a rejection — a connector-pulse run starved exactly
         # that way when its skill reads were auto-rejected. So everything a
         # phase legitimately does is allowed outright.
+        **({"agent": review_subagents(model)} if with_subagents else {}),
         "permission": {
             "read": "allow",
             "glob": "allow",
@@ -561,6 +603,7 @@ def run_agent(
     timeout_s: int,
     transcript_path: str | None = None,
     sink: Any = None,
+    subagents: bool = False,
 ) -> AgentResult:
     """Invoke one agent phase, STREAMING its output to the job log.
 
@@ -583,7 +626,7 @@ def run_agent(
     emit = sink or (lambda line: print(line, flush=True))
     config_path = os.path.join(cwd, "opencode.json")
     with open(config_path, "w", encoding="utf-8") as handle:
-        json.dump(opencode_config(model), handle, indent=2)
+        json.dump(opencode_config(model, with_subagents=subagents), handle, indent=2)
 
     lines: list[str] = []
     try:

--- a/.github/scripts/sdk_loop_phase.py
+++ b/.github/scripts/sdk_loop_phase.py
@@ -43,6 +43,7 @@ from typing import Any, Callable
 
 from sdk_loop_common import (
     MAX_ROUNDS,
+    PHASE2_AGENTS,
     PLAYBOOK_RESOLVE,
     PLAYBOOK_REVIEW,
     RESOLVE_MODEL,
@@ -146,6 +147,13 @@ def review_prompt(
         "",
         "You are READ-ONLY. Your token carries no write scope — do not attempt",
         "to push, and do not treat a push failure as something to work around.",
+        "",
+        "§2a says to dispatch the domain agents via the Agent tool. On this runtime",
+        "that tool is called `Task`, and the agents are already registered —",
+        f"{', '.join(PHASE2_AGENTS)}. Dispatch them in parallel exactly as §2a",
+        "routes them by review_scope. Do NOT do their work yourself in one pass:",
+        "a single agent covering every domain still produces a verdict, just a",
+        "worse one, and nothing in the output would say so.",
         "",
         "SKIP §2b (the Wave 2 cross-model adversarial). Two reasons, and either",
         "alone is sufficient:",
@@ -472,6 +480,7 @@ def main(argv: list[str] | None = None) -> int:
             workspace,
             TIMEOUT_REVIEW_S,
             transcript_path=transcript,
+            subagents=True,
         )
         print("::endgroup::")
         comments = json.loads(

--- a/.github/scripts/tests/test_react_to_comment.py
+++ b/.github/scripts/tests/test_react_to_comment.py
@@ -456,6 +456,7 @@ EXPECTED_CALLERS = {
     ("sdk-resolve.yml", "sdk-resolve-dispatch", "Acknowledge with a reaction"),
     ("auto-fix-vulnerabilities.yaml", "auto-fix", "React to comment"),
     ("capability-manifest-regen.yaml", "regen", "React to comment"),
+    ("sdk-loop.yml", "fence", "React to the trigger comment"),
 }
 
 

--- a/.github/scripts/tests/test_sdk_loop.py
+++ b/.github/scripts/tests/test_sdk_loop.py
@@ -423,6 +423,23 @@ def test_the_phase_two_agents_are_registered_so_the_fan_out_can_happen() -> None
         monkey.undo()
 
 
+def test_every_agent_the_playbook_dispatches_is_registered() -> None:
+    """Both `Agent tool` sites in ORCHESTRATION.md must be satisfiable: §2a's
+    Wave 1 domain agents and the reachability dispatch at line 556."""
+    agents_dir = (
+        pathlib.Path(__file__).resolve().parents[3]
+        / ".mothership"
+        / "pr-review"
+        / "agents"
+    )
+    on_disk = {p.stem for p in agents_dir.glob("*.md")}
+    # Everything on disk is registered except adversarial, which Wave 2 uses
+    # and this lane skips — registering it would advertise a capability the
+    # phase is explicitly told not to use.
+    assert on_disk - set(PHASE2_AGENTS) == {"adversarial"}
+    assert "reachability" in PHASE2_AGENTS, "line 556 dispatches it by name"
+
+
 def test_the_review_prompt_names_the_delegation_tool_for_this_runtime() -> None:
     prompt = review_prompt(42, 1, "a" * 40, DismissalLedger())
     assert "`Task`" in prompt

--- a/.github/scripts/tests/test_sdk_loop.py
+++ b/.github/scripts/tests/test_sdk_loop.py
@@ -893,6 +893,69 @@ def test_the_action_pins_in_the_generator_match_the_generated_file() -> None:
         assert not drift, f"{label} in generator but not in output: {sorted(drift)}"
 
 
+APPROVE_WF = WORKFLOW.parent / "sdk-review-approve-on-verdict.yml"
+
+
+def test_a_loop_verdict_can_become_an_atlan_ci_approval() -> None:
+    """The gate is on identity, and the loop posts as a different bot.
+
+    Its review phase emits the identical marker set using a token minted from
+    the fleet App, so without its login here a READY_TO_MERGE from the loop
+    never became an approval — the PR stayed blocked with nothing saying why.
+    """
+    jobs = yaml.safe_load(APPROVE_WF.read_text(encoding="utf-8"))["jobs"]
+    gate = next(j["if"] for j in jobs.values() if "if" in j)
+
+    def ctx(login: str) -> dict:
+        return {
+            "github": {
+                "event": {
+                    "issue": {"pull_request": {"n": 1}},
+                    "comment": {
+                        "user": {"login": login},
+                        "body": "<!-- SDK_REVIEW -->",
+                    },
+                }
+            }
+        }
+
+    assert evaluate(gate, ctx("atlan-app-fleet[bot]")) is True
+    # The existing lane must keep working.
+    assert evaluate(gate, ctx("mothership-ai[bot]")) is True
+    # Identity is still the gate — this widened who, not what.
+    assert evaluate(gate, ctx("some-random[bot]")) is False
+
+
+def test_the_trigger_comment_gets_an_acknowledgement() -> None:
+    """An emoji within seconds, before any verdict exists. The other two lanes
+    do this and its absence made the loop feel dead on invocation."""
+    fence = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]["fence"]
+    react = next(
+        s for s in fence["steps"] if s.get("name") == "React to the trigger comment"
+    )
+    assert react["run"].endswith("react_to_comment.py")
+    # always(): the helper exits 0 by design, and a missing emoji must not take
+    # down the run it decorates.
+    assert "always()" in react["if"]
+
+
+def test_every_job_has_a_name_a_human_can_read() -> None:
+    """18 rows of `review-1 / phase` is not a progress display."""
+    jobs = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+    assert jobs["review-1"]["name"] == "Review 1"
+    assert jobs["resolve-8"]["name"] == "Resolve 8"
+    assert jobs["fence"]["name"] == "Fence"
+    assert jobs["finalize"]["name"] == "Summary"
+
+
+def test_opencode_is_pinned_to_the_version_that_works() -> None:
+    """0.6.3 crashed before every request with a DecimalError. 1.18.22 is what
+    connector-pulse runs in production, and the exact CI config works against
+    it locally. Three PRs chased the model name before the version was checked.
+    """
+    assert "opencode-ai@1.18.22" in PHASE_WF.read_text(encoding="utf-8")
+
+
 def test_the_committed_workflow_matches_its_generator() -> None:
     proc = subprocess.run(
         [sys.executable, ".github/scripts/gen_sdk_loop_workflow.py", "--check"],

--- a/.github/scripts/tests/test_sdk_loop.py
+++ b/.github/scripts/tests/test_sdk_loop.py
@@ -664,7 +664,7 @@ def test_no_gateway_hostname_is_committed_in_this_lane() -> None:
 def test_the_review_model_matches_what_the_existing_lanes_use() -> None:
     # All three lanes reviewing on one model means a finding difference between
     # them is about the harness, not the model.
-    assert REVIEW_MODEL == "xai/grok-4-6"
+    assert REVIEW_MODEL == "xai/grok-4.6"
 
 
 def test_a_slash_bearing_alias_composes_into_provider_and_model(
@@ -675,7 +675,7 @@ def test_a_slash_bearing_alias_composes_into_provider_and_model(
     `xai/grok-4.6`, and the config's `models` key must carry the full alias."""
     monkeypatch.setenv("LITELLM_BASE_URL", "https://gateway.example")
     cfg = opencode_config(REVIEW_MODEL)
-    assert cfg["model"] == "gateway/xai/grok-4-6"
+    assert cfg["model"] == "gateway/xai/grok-4.6"
     assert cfg["model"].split("/", 1) == [PROVIDER, REVIEW_MODEL]
     assert REVIEW_MODEL in cfg["provider"][PROVIDER]["models"]
 
@@ -695,7 +695,7 @@ def test_the_lane_reaches_exactly_two_models_and_has_no_fallback() -> None:
     reason about across rounds. Pinned so a future edit adding a ladder has to
     change this test and say why.
     """
-    assert ALLOWED_MODELS == ("xai/grok-4-6", "gpt-5.6-luna")
+    assert ALLOWED_MODELS == ("xai/grok-4.6", "gpt-5.6-luna")
     assert len(set(ALLOWED_MODELS)) == 2
 
 

--- a/.github/scripts/tests/test_sdk_loop.py
+++ b/.github/scripts/tests/test_sdk_loop.py
@@ -31,6 +31,7 @@ from sdk_loop_common import (  # noqa: E402
     DEFAULT_MAX_USD,
     MAX_CONSECUTIVE_REAIMS,
     MAX_ROUNDS,
+    PHASE2_AGENTS,
     PROVIDER,
     RESOLVE_MODEL,
     REVIEW_MODEL,
@@ -393,6 +394,39 @@ def test_the_delta_range_never_narrows_the_review() -> None:
     prompt = review_prompt(42, 3, "b" * 40, DismissalLedger(), prior_sha="a" * 40)
     assert "Do NOT narrow the review to it" in prompt
     assert "any line of the PR" in prompt
+
+
+def test_the_phase_two_agents_are_registered_so_the_fan_out_can_happen() -> None:
+    """§2a dispatches domain agents via a delegation tool. Claude Code calls it
+    the Agent tool; opencode calls it Task and supports the same parallel
+    dispatch — but only to agents it knows about. Unregistered, the primary
+    agent has nothing to delegate to and Phase 2's fan-out silently collapses
+    into one agent covering every domain: still a verdict, just a worse one,
+    with nothing in the output saying so.
+    """
+    monkey = pytest.MonkeyPatch()
+    monkey.setenv("LITELLM_BASE_URL", "https://gateway.example")
+    try:
+        cfg = opencode_config(REVIEW_MODEL, with_subagents=True)
+        assert set(cfg["agent"]) == set(PHASE2_AGENTS)
+        for name, spec in cfg["agent"].items():
+            assert spec["mode"] == "subagent"
+            # Prompts are the EXISTING files by reference, never copied.
+            assert (
+                spec["prompt"] == f"{{file:./.mothership/pr-review/agents/{name}.md}}"
+            )
+            # Read-only in the agent as well as in the credential.
+            assert spec["permission"]["edit"] == "deny"
+        # Resolve gets none — it does not run Phase 2.
+        assert "agent" not in opencode_config(RESOLVE_MODEL)
+    finally:
+        monkey.undo()
+
+
+def test_the_review_prompt_names_the_delegation_tool_for_this_runtime() -> None:
+    prompt = review_prompt(42, 1, "a" * 40, DismissalLedger())
+    assert "`Task`" in prompt
+    assert "Do NOT do their work yourself" in prompt
 
 
 def test_the_review_prompt_references_the_playbook_and_never_restates_it() -> None:

--- a/.github/workflows/sdk-loop-phase.yml
+++ b/.github/workflows/sdk-loop-phase.yml
@@ -108,6 +108,10 @@ permissions:
 
 jobs:
   phase:
+    # GitHub renders a reusable-workflow job as "<caller job> / <inner job>".
+    # The caller already says "Review 3"; repeating "phase" after it only adds
+    # noise to a 18-row job list, so the inner name echoes the phase instead.
+    name: ${{ inputs.phase }}
     runs-on: ubuntu-latest
     # Review is the slower phase: it walks the whole playbook, sub-agents
     # included. The headroom is for checkout and token minting, not the agent —
@@ -166,14 +170,27 @@ jobs:
       # A loop is up to 17 phase jobs, each on a fresh runner, so anything
       # installed per job is paid for 17 times. Cache the global npm store so
       # only the first job of a run pays the download.
+      # 1.18.22, matching connector-pulse — the only lane with this pattern
+      # working in production. The first pin here was 0.6.3, an ancient release
+      # picked without checking, and it crashed before every single request:
+      #
+      #   Error: [DecimalError] Invalid argument: [object Object]
+      #
+      # Three theories were chased through three PRs — the dot in grok-4.6, the
+      # slash, an unpopulated cost table — before running the exact CI config
+      # against 1.18.22 locally, where it works untouched. The version was the
+      # whole bug.
+      #
+      # Installed from npm rather than opencode.ai's install script, which is
+      # `curl | bash` and barred by the org baseline.
       - name: Cache the opencode install
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.npm
-          key: opencode-${{ runner.os }}-0.6.3
+          key: opencode-${{ runner.os }}-1.18.22
 
       - name: Install opencode
-        run: npm install -g --prefer-offline opencode-ai@0.6.3
+        run: npm install -g --prefer-offline opencode-ai@1.18.22
 
       - name: Configure git identity for the resolve phase
         if: inputs.phase == 'resolve'

--- a/.github/workflows/sdk-loop.yml
+++ b/.github/workflows/sdk-loop.yml
@@ -80,6 +80,11 @@ permissions:
   # this the duplicate check 403s, the fence raises before it can post, and
   # the lane goes silent — the failure mode it exists to prevent.
   actions: read
+  # Reactions are an Issues-scope resource, so the acknowledgement 403s
+  # without this. Caught by test_react_to_comment.py, which asserts every
+  # workflow calling the helper grants it — the same Issues-vs-PR distinction
+  # the fleet App token needed for posting the verdict comment.
+  issues: write
 
 jobs:
   fence:

--- a/.github/workflows/sdk-loop.yml
+++ b/.github/workflows/sdk-loop.yml
@@ -83,6 +83,7 @@ permissions:
 
 jobs:
   fence:
+    name: Fence
     runs-on: ubuntu-latest
     timeout-minutes: 6
     if: >-
@@ -113,7 +114,22 @@ jobs:
           WORKFLOW_FILE: sdk-loop.yml
         run: python3 .github/scripts/sdk_loop_fence.py
 
+      # The same acknowledgement the other two lanes give: an emoji within
+      # seconds, long before any verdict exists, so whoever typed @sdk-loop
+      # knows it registered. Runs after the fence so it can reflect the
+      # decision, and always() because the script exits 0 by design — a
+      # missing emoji must never take down the run it is decorating.
+      - name: React to the trigger comment
+        if: always() && github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REACTION: ${{ steps.fence.outputs.proceed == 'true' && 'eyes' || 'confused' }}
+        run: python3 .github/scripts/react_to_comment.py
+
   review-1:
+    name: Review 1
     needs: [fence]
     if: >-
       needs.fence.outputs.proceed == 'true'
@@ -132,6 +148,7 @@ jobs:
       reaims_so_far: ''
 
   resolve-1:
+    name: Resolve 1
     needs: [fence, review-1]
     if: >-
       !cancelled() && needs.review-1.outputs.outcome == 'ok'
@@ -148,6 +165,7 @@ jobs:
       ledger: ''
 
   review-2:
+    name: Review 2
     needs: [fence, review-1, resolve-1]
     if: >-
       !cancelled() && needs.fence.outputs.proceed == 'true' && (needs.resolve-1.outputs.outcome == 'ok' || needs.resolve-1.outputs.outcome == 'reaim' || needs.review-1.outputs.outcome == 'reaim')
@@ -166,6 +184,7 @@ jobs:
       reaims_so_far: ${{ needs.review-1.outputs.reaims }}
 
   resolve-2:
+    name: Resolve 2
     needs: [fence, review-2, resolve-1]
     if: >-
       !cancelled() && needs.review-2.outputs.outcome == 'ok'
@@ -182,6 +201,7 @@ jobs:
       ledger: ${{ needs.resolve-1.outputs.ledger }}
 
   review-3:
+    name: Review 3
     needs: [fence, review-2, resolve-2]
     if: >-
       !cancelled() && needs.fence.outputs.proceed == 'true' && (needs.resolve-2.outputs.outcome == 'ok' || needs.resolve-2.outputs.outcome == 'reaim' || needs.review-2.outputs.outcome == 'reaim')
@@ -200,6 +220,7 @@ jobs:
       reaims_so_far: ${{ needs.review-2.outputs.reaims }}
 
   resolve-3:
+    name: Resolve 3
     needs: [fence, review-3, resolve-2]
     if: >-
       !cancelled() && needs.review-3.outputs.outcome == 'ok'
@@ -216,6 +237,7 @@ jobs:
       ledger: ${{ needs.resolve-2.outputs.ledger }}
 
   review-4:
+    name: Review 4
     needs: [fence, review-3, resolve-3]
     if: >-
       !cancelled() && needs.fence.outputs.proceed == 'true' && (needs.resolve-3.outputs.outcome == 'ok' || needs.resolve-3.outputs.outcome == 'reaim' || needs.review-3.outputs.outcome == 'reaim')
@@ -234,6 +256,7 @@ jobs:
       reaims_so_far: ${{ needs.review-3.outputs.reaims }}
 
   resolve-4:
+    name: Resolve 4
     needs: [fence, review-4, resolve-3]
     if: >-
       !cancelled() && needs.review-4.outputs.outcome == 'ok'
@@ -250,6 +273,7 @@ jobs:
       ledger: ${{ needs.resolve-3.outputs.ledger }}
 
   review-5:
+    name: Review 5
     needs: [fence, review-4, resolve-4]
     if: >-
       !cancelled() && needs.fence.outputs.proceed == 'true' && (needs.resolve-4.outputs.outcome == 'ok' || needs.resolve-4.outputs.outcome == 'reaim' || needs.review-4.outputs.outcome == 'reaim')
@@ -268,6 +292,7 @@ jobs:
       reaims_so_far: ${{ needs.review-4.outputs.reaims }}
 
   resolve-5:
+    name: Resolve 5
     needs: [fence, review-5, resolve-4]
     if: >-
       !cancelled() && needs.review-5.outputs.outcome == 'ok'
@@ -284,6 +309,7 @@ jobs:
       ledger: ${{ needs.resolve-4.outputs.ledger }}
 
   review-6:
+    name: Review 6
     needs: [fence, review-5, resolve-5]
     if: >-
       !cancelled() && needs.fence.outputs.proceed == 'true' && (needs.resolve-5.outputs.outcome == 'ok' || needs.resolve-5.outputs.outcome == 'reaim' || needs.review-5.outputs.outcome == 'reaim')
@@ -302,6 +328,7 @@ jobs:
       reaims_so_far: ${{ needs.review-5.outputs.reaims }}
 
   resolve-6:
+    name: Resolve 6
     needs: [fence, review-6, resolve-5]
     if: >-
       !cancelled() && needs.review-6.outputs.outcome == 'ok'
@@ -318,6 +345,7 @@ jobs:
       ledger: ${{ needs.resolve-5.outputs.ledger }}
 
   review-7:
+    name: Review 7
     needs: [fence, review-6, resolve-6]
     if: >-
       !cancelled() && needs.fence.outputs.proceed == 'true' && (needs.resolve-6.outputs.outcome == 'ok' || needs.resolve-6.outputs.outcome == 'reaim' || needs.review-6.outputs.outcome == 'reaim')
@@ -336,6 +364,7 @@ jobs:
       reaims_so_far: ${{ needs.review-6.outputs.reaims }}
 
   resolve-7:
+    name: Resolve 7
     needs: [fence, review-7, resolve-6]
     if: >-
       !cancelled() && needs.review-7.outputs.outcome == 'ok'
@@ -352,6 +381,7 @@ jobs:
       ledger: ${{ needs.resolve-6.outputs.ledger }}
 
   review-8:
+    name: Review 8
     needs: [fence, review-7, resolve-7]
     if: >-
       !cancelled() && needs.fence.outputs.proceed == 'true' && (needs.resolve-7.outputs.outcome == 'ok' || needs.resolve-7.outputs.outcome == 'reaim' || needs.review-7.outputs.outcome == 'reaim')
@@ -370,6 +400,7 @@ jobs:
       reaims_so_far: ${{ needs.review-7.outputs.reaims }}
 
   resolve-8:
+    name: Resolve 8
     needs: [fence, review-8, resolve-7]
     if: >-
       !cancelled() && needs.review-8.outputs.outcome == 'ok'
@@ -386,6 +417,7 @@ jobs:
       ledger: ${{ needs.resolve-7.outputs.ledger }}
 
   finalize:
+    name: Summary
     needs: [fence, review-1, resolve-1, review-2, resolve-2, review-3, resolve-3, review-4, resolve-4, review-5, resolve-5, review-6, resolve-6, review-7, resolve-7, review-8, resolve-8]
     if: always() && needs.fence.outputs.proceed == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/sdk-loop.yml
+++ b/.github/workflows/sdk-loop.yml
@@ -3,7 +3,7 @@
 #   fence -> review 1 -> resolve 1 -> review 2 -> ... -> review 8 -> finalize
 #
 # One workflow run, one job per phase, up to 8 review/resolve pairs. The review
-# phase runs on xai/grok-4-6 — the same model the existing lanes review with
+# phase runs on xai/grok-4.6 — the same model the existing lanes review with
 # — and the resolve phase on gpt-5.6-luna via opencode, both
 # through the Atlan AI gateway — a public edge, so no VPN and no mothership
 # sandbox. Its URL is a secret and is deliberately not written anywhere in
@@ -39,7 +39,7 @@
 # CI staleness: python3 .github/scripts/gen_sdk_loop_workflow.py --check
 #
 # Required configuration:
-#   secrets.LITELLM_API_KEY           gateway key entitled to BOTH xai/grok-4-6
+#   secrets.LITELLM_API_KEY           gateway key entitled to BOTH xai/grok-4.6
 #                                     and gpt-5.6-luna. An unentitled model is a
 #                                     fast 400 with real cost, so check first.
 #   secrets.FLEET_APP_ID              atlan-app-fleet — already configured for

--- a/.github/workflows/sdk-review-approve-on-verdict.yml
+++ b/.github/workflows/sdk-review-approve-on-verdict.yml
@@ -55,14 +55,24 @@ permissions:
 
 jobs:
   sdk-review-approve:
-    # Fire only when the verdict comment was posted by the mothership
-    # bot on a PR (issue_comment also fires on Issues; the PR-side has
+    # Fire only when the verdict comment was posted by one of our review
+    # bots on a PR (issue_comment also fires on Issues; the PR-side has
     # `issue.pull_request` populated). The marker filter accepts both
     # `<!-- SDK_REVIEW -->` and the legacy `<!-- TEST_SDK_REVIEW -->`
     # for in-flight PRs.
+    #
+    # `atlan-app-fleet[bot]` is the @sdk-loop lane: its review phase posts the
+    # identical marker set using a token minted from the fleet App, so without
+    # it here a loop verdict of READY_TO_MERGE never became an atlan-ci
+    # approval and the PR stayed blocked with nothing saying why. Identity is
+    # still the gate — this widens WHO may produce a verdict, not what counts
+    # as one.
     if: >-
       github.event.issue.pull_request != null
-      && github.event.comment.user.login == 'mothership-ai[bot]'
+      && (
+        github.event.comment.user.login == 'mothership-ai[bot]'
+        || github.event.comment.user.login == 'atlan-app-fleet[bot]'
+      )
       && (
         contains(github.event.comment.body, '<!-- SDK_REVIEW -->')
         || contains(github.event.comment.body, '<!-- TEST_SDK_REVIEW -->')


### PR DESCRIPTION
## The actual cause

I reproduced the crash locally with the **exact CI config** — dotted alias, empty cost, nested slash and all — against opencode **1.18.22**. It works untouched, reaching the network on the first try.

CI pinned **`opencode-ai@0.6.3`**, an ancient release I picked without checking. That crashed before every single request:

```
Error: [DecimalError] Invalid argument: [object Object]
```

connector-pulse — the only lane running this pattern in production — pins `VERSION=1.18.22`. **I had the answer available the whole time and didn't look.**

Three PRs chased the wrong thing: the dot in `grok-4.6`, the slash, an unpopulated cost table. Each theory was plausible; none was tested against the one variable that actually differed from the working lane.

The alias stays **`xai/grok-4.6`** — `/v1/models` confirms that's what the gateway serves, and #3542's undotted guess is reverted.

> Installed from npm rather than opencode.ai's install script: connector-pulse uses `curl | bash`, which the org baseline bars, and npm serves the same version.

## Three things asked for alongside

**Job names.** 18 rows of `review-1 / phase` is not a progress display. Now: `Fence`, `Review 1`, `Resolve 1` … `Summary`.

**Reaction on the trigger comment.** The same acknowledgement the other two lanes give — 👀 when it starts, 😕 when the fence declines. Placed after the fence so it reflects the decision, and `always()` because the helper exits 0 by design: a missing emoji must never take down the run it decorates.

**atlan-ci approval.** `sdk-review-approve-on-verdict.yml` gates on `comment.user.login == 'mothership-ai[bot]'`. The loop posts as `atlan-app-fleet[bot]`, so **a loop `READY_TO_MERGE` never became an approval** — the PR would sit blocked with nothing explaining why. The gate now accepts both.

Identity remains the gate: this widens *who* may produce a verdict, not *what counts* as one. Verified with the expression evaluator against the real gate text:

| Author | Approves |
|---|---|
| `mothership-ai[bot]` | ✅ (unchanged) |
| `atlan-app-fleet[bot]` | ✅ (new) |
| any other bot | ❌ |

## Verification

104 tests, actionlint clean, pre-commit clean. New guards cover the version pin, the job names, the reaction step, and all three approval-gate cases.

## Still open

You asked **why opencode for review at all** — fair question, and I owe you a real answer rather than a change. Short version: the review playbook's §2a says *"dispatch agents via the Agent tool"*, which is Claude Code's sub-agent mechanism, not opencode's. That may mean the review phase belongs on Claude Code and only resolve belongs on opencode. Worth its own investigation before I touch it.