### PR TITLE
ci(tests): move the real-cloud storage suite onto the e2e release tier

### DIFF
--- a/.github/scripts/tests/test_label_trigger_gates.py
+++ b/.github/scripts/tests/test_label_trigger_gates.py
@@ -277,10 +277,17 @@ def test_sdr_k8s_e2e_only_reacts_to_the_e2e_label_being_added() -> None:
     )
 
 
-def test_storage_integration_only_reacts_to_its_own_label_being_added() -> None:
-    _assert_gate(
-        _gate("pull_request.yaml", "storage-integration"), "storage-integration", {}
-    )
+def test_storage_integration_only_reacts_to_the_e2e_label_being_added() -> None:
+    """FND-1153: the real-cloud storage suite rides the 'e2e' release tier.
+
+    It briefly moved onto the merge-queue-blocking SDK Gate and had to come
+    back: the Entra federated credential has no subject for a
+    `gh-readonly-queue/*` ref, so every queue entry red-lined on AADSTS700213
+    before a test ran. Asserting the label here pins the tier — a silent flip
+    back to a private 'storage-integration' label would make the suite opt-in
+    via a label nothing applies, which is how it went ~never-run before.
+    """
+    _assert_gate(_gate("pull_request.yaml", "storage-integration"), "e2e", {})
 
 
 # ── The paths the fix must not disturb ───────────────────────────────────────

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -716,19 +716,38 @@ jobs:
   # Real-cloud storage integration tests (S3 / Azure / GCS) — exercise
   # create_store_from_binding + CloudStore against real buckets/vaults using the
   # *_integration markers (excluded from default addopts; conftest skips when a
-  # cloud's creds are absent). Label-gated ('storage-integration') so it only
-  # runs on demand; the heavy/credentialed path stays off the per-PR hot path.
-  # Fork PRs are excluded (no secrets). Nightly counterpart lives in schedule.yaml.
+  # cloud's creds are absent). Fork PRs are excluded (no secrets). Nightly
+  # counterpart lives in schedule.yaml.
+  #
+  # FND-1153: gated on the SAME 'e2e' label as the other release-tier suites
+  # above, not on a private 'storage-integration' one, and deliberately NOT on
+  # the merge queue. Two reasons it stays off the required SDK Gate:
+  #
+  #   - The Entra federated identity credential is scoped to `pull_request`
+  #     subjects. A merge-queue run presents
+  #     `repo:atlanhq/application-sdk:ref:refs/heads/gh-readonly-queue/main/pr-N-<sha>`,
+  #     which matches no FIC, so the Azure login dies with AADSTS700213 about
+  #     30s in — before a single test runs. (AWS's trust policy is broad enough
+  #     to accept it; GCP's WIF attribute condition is unverified because the
+  #     step never got reached.) Re-gating this on merge_group requires fixing
+  #     those cloud-side subject conditions first.
+  #   - Even once that is fixed, the merge queue runs entries speculatively in
+  #     parallel, so every queued PR would pay three cloud logins plus real
+  #     S3 / Azure / GCS round trips whether or not it touched storage.
+  #
+  # The cost of this tier is real and accepted: the suite runs only when someone
+  # applies 'e2e', so a storage change can reach main without a real-cloud
+  # request. Apply the label on any PR touching application_sdk/storage/.
   storage-integration:
     name: Storage Integration Tests (S3 / Azure / GCS)
     # Same FND-48 shape as the e2e gates above — see build-sdk-base-image for the
     # full rationale. The previous form OR'd the event check with the state check,
     # which made the event arm redundant: `contains(...)` alone was already true
     # for the label-just-added case, so every unrelated label add on a PR carrying
-    # `storage-integration` re-ran the real-cloud suite. AND-ing it is the fix.
+    # the label re-ran the real-cloud suite. AND-ing it is the fix.
     if: |
-      contains(github.event.pull_request.labels.*.name, 'storage-integration') &&
-      (github.event.action != 'labeled' || github.event.label.name == 'storage-integration') &&
+      contains(github.event.pull_request.labels.*.name, 'e2e') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'e2e') &&
       github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
Closes FND-1153. Supersedes #3532.

## What

Gate the S3 / Azure / GCS integration suite on the `e2e` label, the same one the other release-tier suites use, instead of a private `storage-integration` label. It stays a standalone job in `pull_request.yaml` and stays off the merge queue.

## Why not the merge-queue gate

#3532 moved this suite into `sdk-tests-reusable.yaml` as a `merge_group`-only job so it would roll up into the required `SDK Gate`. In the queue it red-lined every entry in ~30s, before a single test ran:

```
AADSTS700213: No matching federated identity record found for presented assertion subject
'repo:atlanhq/application-sdk:ref:refs/heads/gh-readonly-queue/main/pr-3532-<sha>'
```

The Entra federated identity credential is scoped to `pull_request` subjects. A merge-queue run presents a `ref:refs/heads/gh-readonly-queue/main/pr-N-<sha>` subject, which matches no FIC. AWS's trust policy is broad enough to accept it; GCP's WIF attribute condition is unverified because the step was never reached.

Re-gating on `merge_group` needs those cloud-side subject conditions fixed first. Even then, the queue runs entries speculatively in parallel, so every queued PR would pay three cloud logins plus real object-store round trips whether or not it touched storage.

## What this is not

Not a bucket-concurrency problem. The write-path tests already scope every key to a per-invocation `uuid4` prefix, assert and clean up only under that prefix (`test_binding_sdr_workflow_publish.py:171`, `test_binding_sdr_atlan_upload.py:73`); the S3 binding tests are read-only list probes. Parallel entries cannot collide, so no guard is needed.

## Known cost

The suite runs only when someone applies `e2e`, so a storage change can still reach main without a real-cloud request. That is the gap #3532 was written to close, accepted deliberately for now. Moving from a label nothing applies to the one already in routine use narrows it; closing it fully is the follow-up on FND-1153.

## Verification

- `uv run pytest .github/scripts/tests/test_label_trigger_gates.py` — 12 passed. The gate test now pins the tier: a silent flip back to a private label fails it.
- `uv run pre-commit run --files .github/workflows/pull_request.yaml .github/scripts/tests/test_label_trigger_gates.py` — clean.