### PR TITLE
feat(testing): FND-1125 add the integration kit's local-scratch fixture and two pre-run guards

### DIFF
--- a/application_sdk/testing/integration/_errors.py
+++ b/application_sdk/testing/integration/_errors.py
@@ -63,3 +63,17 @@ class AppRegistrationMissingError(PreconditionError):
     """The App under test never reached the registry create_worker snapshots."""
 
     code: ClassVar[str] = "PRECONDITION_APP_NOT_REGISTERED"
+
+
+@dataclass(kw_only=True)
+class AppNameMismatchError(PreconditionError):
+    """``ATLAN_APPLICATION_NAME`` disagrees with the App's registered name."""
+
+    code: ClassVar[str] = "PRECONDITION_APP_NAME_MISMATCH"
+
+
+@dataclass(kw_only=True)
+class InfrastructureReplacedError(PreconditionError):
+    """The global infrastructure context is no longer the one the kit installed."""
+
+    code: ClassVar[str] = "PRECONDITION_INFRASTRUCTURE_REPLACED"

--- a/application_sdk/testing/integration/fixtures.py
+++ b/application_sdk/testing/integration/fixtures.py
@@ -108,6 +108,17 @@ fixture would otherwise silently observe cleanup disabled (BLDX-1283). The optio
 is one-way: ``preserve_artifacts=False`` leaves the variable untouched rather
 than forcing ``"true"``.
 
+``store_root`` covers the object store a run writes through. The local scratch
+tree it also writes — the ``{TEMPORARY_PATH}/artifacts/apps/{APPLICATION_NAME}``
+root the SDK derives a run's paths under — is left at the SDK default unless a
+suite requests ``temporary_path``, which redirects it at a session temp dir. Two
+pre-run guards cover the ways that identity goes wrong silently:
+``_verify_app_name`` (an explicitly set ``ATLAN_APPLICATION_NAME`` that is not
+the App's registered name splits the run's identity in two) and
+``_verify_infrastructure`` (a per-test fixture that calls ``set_infrastructure``
+after the session fixture sends the run to a store the fixtures never expose).
+Both fail loudly, for the same reason the ordering and registration checks do.
+
 Mocked infrastructure is the default for this tier: ``MockSecretStore``,
 ``MockStateStore`` and a ``LocalStore`` under a session temp dir. A suite that
 needs something else overrides the ``infrastructure`` fixture — which
@@ -137,7 +148,9 @@ import pytest_asyncio
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.testing.fake_source import HttpFakeSourceFactory
 from application_sdk.testing.integration._errors import (
+    AppNameMismatchError,
     AppRegistrationMissingError,
+    InfrastructureReplacedError,
     IntegrationEnvOrderingError,
 )
 
@@ -212,6 +225,8 @@ class KitOptions:
             to ``"false"`` when unset, so the run's output files survive for the
             suite to assert on. An explicit environment value always wins.
         store_root_prefix: ``tmp_path_factory`` prefix for the LocalStore root.
+        temporary_path_prefix: ``tmp_path_factory`` prefix for the local run
+            scratch root handed out by :func:`temporary_path`.
     """
 
     data_converter: bool = True
@@ -219,6 +234,7 @@ class KitOptions:
     log_level: str = "error"
     preserve_artifacts: bool = True
     store_root_prefix: str = "sdk-store"
+    temporary_path_prefix: str = "sdk-local"
 
 
 @dataclass(frozen=True)
@@ -234,6 +250,11 @@ class AppExecutor:
     """
 
     backend: TemporalExecutorBackend
+    expected_infrastructure: object | None = None
+    """The context :func:`infrastructure` installed, re-checked before each run.
+
+    ``None`` disables the check, for an executor built outside the kit.
+    """
 
     async def execute_app(
         self,
@@ -255,6 +276,8 @@ class AppExecutor:
         from application_sdk.execution.retry import (  # noqa: PLC0415 — deferred: keeps execution (and temporalio) off the conftest's import path
             RetryPolicy,
         )
+
+        _verify_infrastructure(self.expected_infrastructure)
 
         app_name = _app_name_of(app_cls) or execution_id_prefix or "app"
         context = AppContext(
@@ -348,7 +371,84 @@ def _verify_registration(app_cls: type[App]) -> str:
                 "overrides; the import is what populates the registry."
             ),
         )
+    _verify_app_name(app_cls, app_name)
     return app_name
+
+
+def _verify_app_name(app_cls: type[App], app_name: str) -> None:
+    """Fail when an explicitly set ``ATLAN_APPLICATION_NAME`` is not the App's name.
+
+    The variable is what ``application_sdk.constants.APPLICATION_NAME`` carries,
+    and the SDK builds a run's local artifact root from it
+    (``{TEMPORARY_PATH}/artifacts/apps/{APPLICATION_NAME}/workflows/...``) while
+    the App's own registered name drives the task queue and the observability
+    tags. Disagreeing values do not fail anything loudly — the run writes its
+    files under one identity and reports itself under another, and the suite
+    looks for artifacts where they were never written.
+
+    Only an explicitly set variable is compared. An adopter who never sets it
+    gets the SDK default (``"default"``), which is a different conversation and
+    not one to fail a session over.
+    """
+    configured = os.environ.get(APPLICATION_NAME_ENV)
+    if configured is None or configured == app_name:
+        return
+    raise AppNameMismatchError(
+        message=(
+            f"{APPLICATION_NAME_ENV} is {configured!r} but {app_cls.__name__} is "
+            f"registered as {app_name!r}. The run's local artifact root is built "
+            f"from the former and its task queue and observability tags from the "
+            f"latter, so artifacts land under {configured!r} while the run reports "
+            f"itself as {app_name!r}."
+        ),
+        resource=app_cls.__name__,
+        expected_state=f"{APPLICATION_NAME_ENV} == {app_name!r}",
+        actual_state=f"{APPLICATION_NAME_ENV} == {configured!r}",
+        suggested_action=(
+            f"Set os.environ.setdefault({APPLICATION_NAME_ENV!r}, {app_name!r}) in "
+            "conftest.py, above the application_sdk imports."
+        ),
+    )
+
+
+def _verify_infrastructure(expected: object | None) -> None:
+    """Fail when something replaced the kit's infrastructure context before a run.
+
+    :func:`infrastructure` is session-scoped and installs its context globally.
+    A per-test fixture that also calls ``set_infrastructure`` — common in suites
+    that predate the kit and point the SDK at a per-test ``LocalStore`` — silently
+    wins, and the run then reads and writes a store the suite never inspects:
+    every artifact assertion fails with "no files", pointing at the App rather
+    than at the fixture that moved the store.
+    """
+    if expected is None:
+        return
+    from application_sdk.infrastructure import (  # noqa: PLC0415 — deferred: keeps the infrastructure package off the conftest's import path
+        get_infrastructure,
+    )
+
+    current = get_infrastructure()
+    if current is expected:
+        return
+    raise InfrastructureReplacedError(
+        message=(
+            "The global infrastructure context is not the one this kit installed, "
+            "so the run would use a different object store than the fixtures "
+            "expose. Something called set_infrastructure() after the session "
+            "fixture — typically a per-test autouse fixture carried over from "
+            "before the kit."
+        ),
+        resource="InfrastructureContext",
+        expected_state="the context installed by the kit's infrastructure fixture",
+        actual_state="None"
+        if current is None
+        else f"{type(current).__name__} instance",
+        suggested_action=(
+            "Have that fixture stand aside for kit tests — e.g. return early when "
+            '"executor" is in request.fixturenames — or scope it to the '
+            "directory that needs it."
+        ),
+    )
 
 
 @contextmanager
@@ -543,6 +643,38 @@ def store_root(
     return tmp_path_factory.mktemp(integration_options.store_root_prefix)
 
 
+@pytest.fixture(scope="session")
+def temporary_path(
+    tmp_path_factory: pytest.TempPathFactory, integration_options: KitOptions
+) -> Iterator[Path]:
+    """Point ``constants.TEMPORARY_PATH`` at a session temp dir, and yield it.
+
+    :func:`store_root` covers the object store; this covers the other half a run
+    touches — the local scratch tree the SDK builds a run's paths under
+    (``{TEMPORARY_PATH}/artifacts/apps/{APPLICATION_NAME}/workflows/...``).
+    Left alone it is the repo-relative ``./local/tmp/``, so a suite that asserts
+    on run files reads a directory earlier runs also wrote into, and one that
+    does not still litters the working tree.
+
+    Not autouse: requesting it is what opts a suite in, exactly as
+    ``store_root`` works. Consumers read the constant at call time
+    (``from application_sdk.constants import TEMPORARY_PATH`` inside the
+    function), so patching the module attribute reaches code already imported —
+    which is also why the patch is undone on teardown rather than left set.
+    """
+    from application_sdk import (  # noqa: PLC0415 — deferred by convention; the constant is read off the module at call time
+        constants,
+    )
+
+    path = tmp_path_factory.mktemp(integration_options.temporary_path_prefix)
+    patcher = pytest.MonkeyPatch()
+    patcher.setattr(constants, "TEMPORARY_PATH", str(path))
+    try:
+        yield path
+    finally:
+        patcher.undo()
+
+
 @contextmanager
 def kit_infrastructure(
     store_root: Path,
@@ -691,9 +823,16 @@ async def worker(
 
 @pytest.fixture(scope="session")
 def executor(
-    temporal_client: Client, worker: None, integration_task_queue: str
+    temporal_client: Client,
+    worker: None,
+    integration_task_queue: str,
+    infrastructure: InfrastructureContext,
 ) -> AppExecutor:
-    """Executor submitting to the running worker's task queue."""
+    """Executor submitting to the running worker's task queue.
+
+    Carries the installed infrastructure context so each run can check it is
+    still the live one — see :func:`_verify_infrastructure`.
+    """
     from application_sdk.execution import (  # noqa: PLC0415 — deferred: keeps temporalio off the conftest's import path
         TemporalExecutorBackend,
     )
@@ -702,7 +841,8 @@ def executor(
     return AppExecutor(
         backend=TemporalExecutorBackend(
             client=temporal_client, task_queue=integration_task_queue
-        )
+        ),
+        expected_infrastructure=infrastructure,
     )
 
 
@@ -725,5 +865,6 @@ __all__ = [
     "reset_http_fake_sources",
     "store_root",
     "temporal_client",
+    "temporary_path",
     "worker",
 ]

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.30.0
-source-sha:    17caa4a9026ff1093521f9cc70e722c574150e7c
-source-date:   2026-08-29T17:15:36+01:00
+source-sha:    22d2095e1a789aad013fab5fb9c773f41685bed4
+source-date:   2026-08-29T16:59:01Z
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 42 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 6 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 297 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 298 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -3142,7 +3142,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `AppExecutor`
 
 - **Import:** `from application_sdk.testing.integration.fixtures import AppExecutor`
-- **Signature:** `class AppExecutor(backend: TemporalExecutorBackend) -> None`
+- **Signature:** `class AppExecutor(backend: TemporalExecutorBackend, expected_infrastructure: object | None = None) -> None`
 - **Summary:** Thin shim over :class:`TemporalExecutorBackend` for integration suites.
 - **Defined in:** `application_sdk/testing/integration/fixtures.py`
 
@@ -4348,7 +4348,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `executor`
 
 - **Import:** `from application_sdk.testing.integration.fixtures import executor`
-- **Signature:** `executor(temporal_client: Client, worker: None, integration_task_queue: str) -> AppExecutor`
+- **Signature:** `executor(temporal_client: Client, ...)`
 - **Summary:** Executor submitting to the running worker's task queue.
 - **Defined in:** `application_sdk/testing/integration/fixtures.py`
 
@@ -5025,6 +5025,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Import:** `from application_sdk.testing.integration.fixtures import temporal_client`
 - **Signature:** `temporal_client(embedded_temporal: EmbeddedRuntime, ...)`
 - **Summary:** Connect to the embedded dev server, in its namespace.
+- **Defined in:** `application_sdk/testing/integration/fixtures.py`
+
+#### `temporary_path`
+
+- **Import:** `from application_sdk.testing.integration.fixtures import temporary_path`
+- **Signature:** `temporary_path(tmp_path_factory: pytest.TempPathFactory, integration_options: KitOptions) -> Iterator[Path]`
+- **Summary:** Point ``constants.TEMPORARY_PATH`` at a session temp dir, and yield it.
 - **Defined in:** `application_sdk/testing/integration/fixtures.py`
 
 #### `validate_asset`

--- a/docs/guides/integration-fixtures.md
+++ b/docs/guides/integration-fixtures.md
@@ -31,7 +31,7 @@ def integration_source():
     ...
 ```
 
-The star-import brings in the six kit fixtures (`store_root`, `infrastructure`, `embedded_temporal`, `temporal_client`, `worker`, `executor`) and the five `integration_*` override points. A connector overrides what it needs and gets the rest. There is no binding boilerplate and no names to get right; a suite whose tests already use a different name aliases in the ordinary way:
+The star-import brings in the seven kit fixtures (`store_root`, `temporary_path`, `infrastructure`, `embedded_temporal`, `temporal_client`, `worker`, `executor`) and the five `integration_*` override points. A connector overrides what it needs and gets the rest. There is no binding boilerplate and no names to get right; a suite whose tests already use a different name aliases in the ordinary way:
 
 ```python
 @pytest.fixture(scope="session")
@@ -67,6 +67,7 @@ def infrastructure(store_root, integration_secrets):
 | `integration_source` | `None` | The connector has a source to bring up: a testcontainer, an in-process HTTP fake, a credential dict. Whatever it yields is handed to `integration_secrets` and otherwise untouched. |
 | `integration_secrets` | `{}` | Credentials are read from the secret store rather than passed inline. Receives `integration_source`; returns a `{key: json}` mapping seeded into `MockSecretStore`. |
 | `integration_options` | `KitOptions()` | Any knob in the table below needs changing. |
+| `temporary_path` | Not requested — the SDK default `./local/tmp/` stands | The suite asserts on a run's **local** files. Requesting it points `constants.TEMPORARY_PATH` at a session temp dir, so run files leave the working tree and two runs of the same suite cannot read each other's artifacts. Undone on teardown. |
 | `infrastructure` | Mocked stores + `LocalStore` under `store_root` | The suite needs a real store. It receives `store_root`, `integration_source` and `integration_secrets`, so it can point at whatever the source fixture brought up. Must be a generator fixture so teardown still runs. |
 
 `integration_secrets` serves `credential_ref` named-path and agent-spec resolution only. An input routed by legacy `credential_guid` resolves through `DaprCredentialVault` over a live daprd and never reads this store.

--- a/tests/unit/testing/integration/conftest.py
+++ b/tests/unit/testing/integration/conftest.py
@@ -1,0 +1,10 @@
+"""Kit fixtures under test, imported the way an adopting conftest imports them.
+
+Importing them here rather than in the test module keeps the fixture name from
+shadowing the test parameter of the same name (ruff F811).
+"""
+
+from application_sdk.testing.integration.fixtures import (  # noqa: F401
+    integration_options,
+    temporary_path,
+)

--- a/tests/unit/testing/integration/test_kit_guards.py
+++ b/tests/unit/testing/integration/test_kit_guards.py
@@ -1,0 +1,105 @@
+"""The kit's local-scratch fixture and its two pre-run guards.
+
+Both guards exist because the failure they catch is silent. A wrong
+``ATLAN_APPLICATION_NAME`` writes a run's artifacts under one identity while the
+run reports itself under another; a replaced infrastructure context sends the
+run to a store the fixtures never expose. Neither raises on its own — the suite
+just fails later, with "no files", pointing at the App instead of the fixture.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from application_sdk import constants
+from application_sdk.infrastructure import InfrastructureContext, set_infrastructure
+from application_sdk.testing.integration._errors import (
+    AppNameMismatchError,
+    InfrastructureReplacedError,
+)
+from application_sdk.testing.integration.fixtures import (
+    APPLICATION_NAME_ENV,
+    _verify_app_name,
+    _verify_infrastructure,
+)
+
+
+class _App:
+    """Stands in for an App class; only its ``__name__`` reaches the error."""
+
+
+class TestVerifyAppName:
+    def test_passes_when_the_env_matches_the_registered_name(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(APPLICATION_NAME_ENV, "power-bi-app")
+
+        _verify_app_name(_App, "power-bi-app")
+
+    def test_raises_when_the_env_disagrees(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(APPLICATION_NAME_ENV, "powerbi")
+
+        with pytest.raises(AppNameMismatchError) as excinfo:
+            _verify_app_name(_App, "power-bi-app")
+
+        message = str(excinfo.value)
+        assert "'powerbi'" in message
+        assert "'power-bi-app'" in message
+
+    def test_ignores_an_unset_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The SDK default is ``"default"``; failing every suite that never set
+        the variable is a different conversation, not this guard's job."""
+        monkeypatch.delenv(APPLICATION_NAME_ENV, raising=False)
+
+        _verify_app_name(_App, "power-bi-app")
+
+
+@pytest.fixture(autouse=True)
+def _restore_global_infrastructure():
+    """These tests install contexts globally; put the previous one back."""
+    from application_sdk.infrastructure.context import get_infrastructure
+
+    previous = get_infrastructure()
+    yield
+    if previous is not None:
+        set_infrastructure(previous)
+
+
+class TestVerifyInfrastructure:
+    def test_passes_when_the_installed_context_is_still_live(self) -> None:
+        ctx = InfrastructureContext()
+        set_infrastructure(ctx)
+
+        _verify_infrastructure(ctx)
+
+    def test_raises_when_something_replaced_the_context(self) -> None:
+        installed = InfrastructureContext()
+        set_infrastructure(installed)
+        set_infrastructure(InfrastructureContext())
+
+        with pytest.raises(InfrastructureReplacedError) as excinfo:
+            _verify_infrastructure(installed)
+
+        assert "set_infrastructure" in str(excinfo.value)
+
+    def test_disabled_when_no_context_was_recorded(self) -> None:
+        """An executor built outside the kit has nothing to compare against."""
+        _verify_infrastructure(None)
+
+
+class TestTemporaryPath:
+    def test_redirects_the_constant_at_the_yielded_directory(
+        self, temporary_path: Path
+    ) -> None:
+        assert constants.TEMPORARY_PATH == str(temporary_path)
+        assert temporary_path.is_dir()
+
+    def test_is_not_the_repo_relative_default(self, temporary_path: Path) -> None:
+        """The point of the fixture: run files leave the working tree, and two
+        runs of the same suite do not read each other's artifacts."""
+        assert not str(temporary_path).startswith("./local")
+        assert Path(constants.TEMPORARY_PATH).is_absolute()


### PR DESCRIPTION
Three gaps found while migrating connector suites onto the integration fixture kit (#3495/#3496). The kit owned the object store a run writes through and nothing else about *where a run puts things*. All three failures below are silent today.

**Test-only:** everything is in `application_sdk/testing/`, which no running app imports.

## 1. `temporary_path` — `store_root`'s missing counterpart

`store_root` covers the object store. The local scratch tree a run also writes — the `{TEMPORARY_PATH}/artifacts/apps/{APPLICATION_NAME}/workflows/...` root `paths.derive()` builds from — was left at the SDK default `./local/tmp/`. So a suite asserting on run files reads a directory earlier runs also wrote into, and one that doesn't still litters the working tree.

Not autouse: requesting it opts a suite in, exactly as `store_root` works. The patch is undone on teardown, since consumers read the constant off the module at call time.

**17 of 74 connector suites patch this constant by hand today** and would delete that code:

`bigquery`, `cloudera-impala`, `cosmosdb`, `cosmosnosql`, `cratedb`, `databricks`, `db2`, `domo`, `fabric`, `kafka`, `microstrategy`, `powerbi`, `powercenter`, `sapase`, `tableau`, `trino`, `workdayprismanalytics`

(A further 15 reference `TEMPORARY_PATH` without assigning it, so they're unaffected either way — 32 mention it in total.)

## 2. `_verify_app_name` — a split run identity

An explicitly set `ATLAN_APPLICATION_NAME` that isn't the App's registered name sends artifacts under one identity while the task queue and observability tags carry the other. Nothing fails; the suite just looks for artifacts where they were never written. `_verify_registration` already holds both values, so the check is a few lines there.

An **unset** variable is deliberately left alone — the SDK default (`"default"`) is a separate conversation, not one to fail a session over.

**4 apps have a registered name that is not their repo slug**, so the value can't be inferred from the directory:

| app repo | registered name |
| --- | --- |
| `atlan-cosmosdb-app` | `cosmos` |
| `atlan-db2-app` | `luw`, `zos` |
| `atlan-oracle-app` | `oracle-app` |
| `atlan-powerbi-app` | `power-bi-app` |

Worth a look separately: of the 20 suites that already set the variable, `bigquery` and `tableau` set `"default"`, `postgres` sets `"acme"`, `mongodbatlas` sets `"mongodb"`. Some may be deliberate for non-kit tests — the guard only fires for a registered App, so it will say which.

## 3. `_verify_infrastructure` — a store moved out from under the run

`infrastructure` is session-scoped and installs its context **globally**. A per-test fixture that also calls `set_infrastructure` — common in suites written before the kit, which point the SDK at a per-test `LocalStore` — silently wins. The run then reads and writes a store the fixtures never expose, and every artifact assertion fails with "no files", pointing at the App rather than at the fixture that moved the store.

`AppExecutor` now carries the context `infrastructure` installed and re-checks identity before each run. `expected_infrastructure=None` disables it, for an executor built outside the kit.

**10 apps call `set_infrastructure` inside an autouse fixture; 4 of them do it in `tests/integration`** — the directory the kit lands in, so these hit it during the canonical-IT migration:

- **Will clash:** `dbt`, `fabric`, `powerbi`, `snowflake`
- Autouse elsewhere (no clash today): `bw`, `cognos`, `dataplex`, `kafka`, `mode`, `trino`

`powerbi` already hand-guards this (`atlan-powerbi-app#193`) with `if "executor" in request.fixturenames: return` — the guard's `suggested_action` points at that pattern.

## Verification

- `tests/unit/testing/ tests/unit/execution/` → **2487 passed**.
- 8 new tests in `tests/unit/testing/integration/test_kit_guards.py`: both guards' pass, fail and disabled paths, and `temporary_path` actually redirecting the constant off the repo-relative default.
- `uv run pre-commit run --files <the diff>` → all hooks pass, pyright included.
- `docs/guides/integration-fixtures.md` (fixture table + count) and `docs/agents/sdk-capabilities.md` (regenerated) updated.

## Notes

- Two new typed errors in `_errors.py`: `AppNameMismatchError`, `InfrastructureReplacedError`, both `PreconditionError` leaves like the existing ordering/registration ones.
- Guard #3 detects rather than repairs, deliberately — the fix belongs in the connector's conftest, and silently re-installing the kit's context would hide a suite that genuinely wants its own store.
- Ticket id is FND-1125 (the canonical-fixture-kit rollout this came out of); happy to retitle if it should carry its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
