### PR TITLE
ci(loop): tell "the branch moved" apart from "we moved the branch"

### DIFF
--- a/.github/scripts/sdk_loop_phase.py
+++ b/.github/scripts/sdk_loop_phase.py
@@ -399,12 +399,28 @@ def interpret_resolve(
     head_before: str,
     head_after: str,
     dismissals: list[dict[str, str]] | None = None,
+    local_head: str = "",
 ) -> ResolveOutcome:
     """Success is an observed effect, never an exit code.
 
     A resolve round counts only when the branch actually moved. A round that
     changed the tree but failed to push is a FAILURE, not progress: the loop
     must not report a fix that no one can see.
+
+    "Moved" has to mean moved BY US, though, and two remote reads cannot tell
+    the difference. `moved_by_other` guards this, but only once, before the
+    agent launches — so a push landing during the two to five minutes the
+    resolver runs (Renovate, a base merge, a person) shows up here as
+    `head_after != head_before` and is claimed as our own fix. *local_head* is
+    the discriminator: if this phase committed and pushed, the workspace HEAD
+    is what GitHub now has; if somebody else pushed, ours is stale. Passing it
+    empty keeps the old remote-only behaviour for callers that have no
+    workspace.
+
+    A push of ours followed by someone else's reads as not-ours and re-aims.
+    That is the safe direction to be wrong in: the next review re-reads the
+    real head either way, so the cost is one round, and the alternative is
+    reporting a fix that is not there.
     """
     dismissed = tuple(dismissals or ())
     if not result.looks_authenticated:
@@ -412,6 +428,15 @@ def interpret_resolve(
             OUTCOME_FAILED, detail="the gateway rejected the request (auth or model)"
         )
     if head_after != head_before:
+        if local_head and head_after != local_head:
+            return ResolveOutcome(
+                OUTCOME_REAIM,
+                dismissals=dismissed,
+                detail=(
+                    f"head moved to {head_after[:8]} while this round ran, and it "
+                    "is not our commit"
+                ),
+            )
         return ResolveOutcome(OUTCOME_OK, pushed_sha=head_after, dismissals=dismissed)
     if tree_changed:
         return ResolveOutcome(
@@ -555,8 +580,13 @@ def main(argv: list[str] | None = None) -> int:
             if "sdk-loop-" not in line and ".sdk-loop-rgcfg" not in line
         ).strip()
         after = live_head(repo, head_ref)
+        # Read from OUR checkout, so "the branch moved" can be told apart from
+        # "we moved the branch".
+        local = _sh(["git", "rev-parse", "HEAD"], cwd=workspace).stdout.strip()
         dismissals = parse_dismissals(f"{result.stdout}\n{result.stderr}")
-        outcome = interpret_resolve(result, bool(dirty), before, after, dismissals)
+        outcome = interpret_resolve(
+            result, bool(dirty), before, after, dismissals, local_head=local
+        )
         # Measured here rather than inherited: `cost` and `usage` were only
         # ever assigned inside the review branch, so every resolve phase
         # reached `emit_outputs` with both names unbound and died on a
@@ -570,7 +600,11 @@ def main(argv: list[str] | None = None) -> int:
         emit_outputs(
             outcome=outcome.outcome,
             pushed_sha=outcome.pushed_sha,
-            reaims="0",
+            # A resolve that re-aimed has to advance the counter for the same
+            # reason the pre-flight re-aim does: `reaim_exhausted` is what
+            # stops the loop chasing a branch somebody keeps pushing to, and a
+            # counter reset to zero on every re-aim can never reach its cap.
+            reaims=str(reaims + 1) if outcome.outcome == OUTCOME_REAIM else "0",
             new_base_sha=after,
             ledger=ledger.to_json(),
             detail=outcome.detail,

--- a/.github/scripts/tests/test_sdk_loop.py
+++ b/.github/scripts/tests/test_sdk_loop.py
@@ -73,6 +73,7 @@ from sdk_loop_phase import (  # noqa: E402
     OUTCOME_FAILED,
     OUTCOME_NO_PROGRESS,
     OUTCOME_OK,
+    OUTCOME_REAIM,
     OUTCOME_TERMINAL_VERDICT,
     interpret_resolve,
     interpret_review,
@@ -596,6 +597,39 @@ def test_an_empty_ledger_adds_nothing_to_the_prompt() -> None:
 # ---------------------------------------------------------------------------
 # Observability — a running phase must not look identical to a stalled one
 # ---------------------------------------------------------------------------
+
+
+def test_a_push_by_someone_else_mid_resolve_is_not_claimed_as_our_fix() -> None:
+    """ "The branch moved" and "we moved the branch" are different claims.
+
+    `moved_by_other` catches an outside push, but only once, before the agent
+    launches. A resolve runs two to five minutes, and a push landing inside
+    that window (Renovate, a base merge, a person) leaves head_after !=
+    head_before with nothing of ours in it. Read remotely-only, that is
+    indistinguishable from a successful fix — so the round reports a commit it
+    never made, and any unpushed work it did have is discarded as "success".
+
+    The workspace HEAD is what separates the two: ours is stale exactly when
+    somebody else pushed.
+    """
+    ok = AgentResult(exit_code=0, stdout="", stderr="")
+
+    ours = interpret_resolve(ok, True, "a" * 40, "b" * 40, local_head="b" * 40)
+    assert ours.outcome == OUTCOME_OK
+    assert ours.pushed_sha == "b" * 40
+
+    theirs = interpret_resolve(ok, False, "a" * 40, "c" * 40, local_head="a" * 40)
+    assert theirs.outcome == OUTCOME_REAIM
+    assert theirs.pushed_sha == "", "never attribute someone else's commit to us"
+
+    # Our commit exists locally but the push lost the race to theirs. Not ours:
+    # the fix is not on the branch, whatever the tree says.
+    lost = interpret_resolve(ok, True, "a" * 40, "c" * 40, local_head="b" * 40)
+    assert lost.outcome == OUTCOME_REAIM
+
+    # No workspace to read (unit callers): old remote-only behaviour stands.
+    legacy = interpret_resolve(ok, True, "a" * 40, "b" * 40)
+    assert legacy.outcome == OUTCOME_OK
 
 
 def test_a_quiet_sub_agent_is_not_killed_while_its_internal_log_moves() -> None:


### PR DESCRIPTION
A resolve round decides success by reading the PR head **before** the agent runs and **after**, and calling a difference a successful push.

That much is deliberate. `opencode` exits `0` even when it died, so an exit code proves nothing — the lane keys on observed git effects instead, and the docstring says so: *"success is an observed effect, never an exit code."*

But two remote reads only establish that **the branch moved**. Not **who moved it**.

## The window

```
14:00  before = abc123          ← read GitHub
14:01  resolve agent starts
14:03        ← Renovate pushes def456 to the same branch
14:04  agent finishes, having fixed nothing
14:04  after  = def456          ← read GitHub

       after != before   →   "Success — pushed def456"
```

`moved_by_other` is the guard for exactly this, and it works — but it runs **once, before the agent launches**. A resolve runs two to five minutes. Anything landing inside that window sails through.

## Two failures, one of them silent

1. The round reports a commit it never made.
2. Worse: if the resolver **did** have a fix it failed to push, that dirty tree is discarded and the round *still* reports success — so real work is lost quietly instead of as the failure it is.

## The fix

The workspace HEAD separates the two cases: if this phase committed and pushed, ours is what GitHub now has; if somebody else pushed, ours is stale.

```python
if local_head and head_after != local_head:
    → re-aim, not success
```

| scenario | `local` | `after` | outcome |
|---|---|---|---|
| we committed + pushed | `bbb` | `bbb` | ✅ `ok` |
| we idled, they pushed | `aaa` | `ccc` | 🔁 `reaim` |
| we committed, lost the push race | `bbb` | `ccc` | 🔁 `reaim` |
| no workspace (unit callers) | `""` | — | ✅ old behaviour |

Row 3 is conservative — we *did* push, but somebody landed on top. **That's the safe direction to be wrong in:** the next review re-reads the real head either way, so the cost is one round, against reporting a fix that is not on the branch.

## Also: the re-aim counter

A re-aim on this path now increments `reaims`, for the same reason the pre-flight one does. `reaim_exhausted` is what stops the loop chasing a branch somebody keeps pushing to — and a counter reset to zero on every re-aim can never reach its cap.

## Severity — this was never a merge-safety bug

The verdict comes from the **review** phase, which reads the real code. A lost fix surfaced as the same findings raised again next round, so the loop self-corrected. What it cost was **a wasted round and a round table that said something untrue**.

Pre-existing; not introduced by #3551.

## Testing

Four cases, including the no-workspace caller that keeps the old behaviour. Verified against the unfixed code — the test fails there, so it pins the regression rather than describing it. 121 loop tests pass; pre-commit clean including pyright.
