### PR TITLE
ci(loop): give a doubting sub-agent somewhere to stop

### DIFF
--- a/.github/scripts/sdk_loop_common.py
+++ b/.github/scripts/sdk_loop_common.py
@@ -309,6 +309,43 @@ PHASE2_AGENTS = (
 )
 
 
+#: Prepended to every sub-agent brief. Deliberately NOT a ban on reading
+#: third-party source — that is how a reviewer catches "you are calling this
+#: with the wrong semantics", which is some of the most valuable output a
+#: review produces. What went wrong in the run this is written from was the
+#: manner, not the act: the agent went external before checking the answer
+#: already recorded in the repo it was reviewing, re-read one scratch file
+#: five times, and kept going after two sources had failed to settle the
+#: question. Each re-read also re-enters the context, which is why later steps
+#: got slower as it went.
+RESEARCH_DISCIPLINE = """## Before you research anything outside this repo
+
+1. **Check local prior art first — then judge it, do not re-derive it.** The
+   answer is often already recorded here: a comment beside the code, a lint
+   config that grandfathers a case *with its reasoning*, `retro-log.md`, the
+   reference rules you own. Verifying a suppression is your job — a reviewer
+   who accepts every "false positive, I checked" is how bad ignores land — but
+   verifying it means **judging whether the stated evidence is specific and
+   checkable**, not independently rebuilding the proof. A justification that
+   quotes the vendor's documented behaviour and names the exception is
+   evidence. Cite it and move on.
+2. **Fetch once.** A file you have already read is already in your context.
+   Re-reading it tells you nothing new and makes every later step slower.
+3. **Doubt becomes a FINDING, not more research.** This is the rule that was
+   missing. If the local justification does not convince you, the output is a
+   finding against the justification — "this suppression cites X, which I could
+   not confirm; here is what would settle it" — raised at the tier the risk
+   deserves. It is NOT an instruction to keep digging until you are certain.
+   Two lookups is the bound; past that you are spending the review's budget to
+   answer a question the finding could have handed to a human in one line.
+4. **Targeted, not wholesale.** Grep for the symbol you need. Do not pull
+   whole source files or rendered HTML pages into context to search them.
+
+Reading a dependency's real source to check behaviour your code relies on is
+legitimate and encouraged. Reverse-engineering a linter's internal tables to
+second-guess a decision this repo has already documented is not."""
+
+
 def _agent_prompt(name: str) -> str:
     """The playbook's agent brief, read from this runner's own checkout.
 
@@ -357,7 +394,7 @@ def review_subagents(model: str) -> dict[str, Any]:
             # the sub-agent no instructions at all and look exactly like a slow
             # review. Reading it in Python removes the question: the file is
             # either present or the phase fails loudly with a traceback.
-            "prompt": _agent_prompt(name),
+            "prompt": f"{RESEARCH_DISCIPLINE}\n\n{_agent_prompt(name)}",
             # Enumerated in full, mirroring the primary agent, because a
             # PARTIAL block here was not equivalent: `external_directory` and
             # `doom_loop` ask unless listed, headless opencode has nobody to
@@ -383,10 +420,26 @@ def review_subagents(model: str) -> dict[str, Any]:
                 "lsp": "allow",
                 "question": "allow",
                 "external_directory": "allow",
-                "doom_loop": "allow",
                 "edit": "deny",
                 "webfetch": "deny",
                 "websearch": "deny",
+                # DENIED, reversing this lane's original setting. `doom_loop`
+                # is opencode's own repetition detector, and allowing it turns
+                # the detector off. A live ci-config sub-agent then spent 19
+                # steps and 18 minutes on one question its own repo already
+                # answers in a comment, re-reading the same scratch file five
+                # times and re-fetching the same fact from two sources — the
+                # exact shape the detector exists to catch.
+                #
+                # The original justification was that the playbook "re-runs
+                # similar greps across a large diff". That is the PARENT's
+                # behaviour — phase-boundary budget checks, offset re-reads of
+                # the playbook — and the parent keeps `allow` below. A
+                # single-domain sub-agent repeating itself is not being
+                # thorough. It also still has `maxSteps` under it, so a
+                # detector false positive costs a partial finding set, never
+                # the phase.
+                "doom_loop": "deny",
             },
         }
         for name in PHASE2_AGENTS
@@ -583,7 +636,14 @@ def format_usage(usage: dict[str, int]) -> str:
 #: burned three rounds on the identical mismatch, each reporting `reaim` and
 #: advancing as though something had changed.
 #: Hard cap on a sub-agent's agentic iterations. See `review_subagents`.
-SUBAGENT_MAX_STEPS = 60
+#:
+#: Lowered from 60. That figure assumed a flat cost per step, and measurement
+#: says otherwise: a live sub-agent's step latency ran 14s, 35s, 68s, 58s,
+#: 121s as its context grew with each tool result it accumulated. 60 steps of
+#: that is not the ~13 minutes the original comment claimed; it is over an
+#: hour, and the idle watchdog cannot help because a looping agent is
+#: producing output the whole time.
+SUBAGENT_MAX_STEPS = 25
 
 #: Kill an agent that has printed nothing for this long. Sized off measurement,
 #: not taste: across observed runs the longest gap between two output lines in a

--- a/.github/scripts/tests/test_sdk_loop.py
+++ b/.github/scripts/tests/test_sdk_loop.py
@@ -37,8 +37,10 @@ from sdk_loop_common import (  # noqa: E402
     MAX_ROUNDS,
     PHASE2_AGENTS,
     PROVIDER,
+    RESEARCH_DISCIPLINE,
     RESOLVE_MODEL,
     REVIEW_MODEL,
+    SUBAGENT_MAX_STEPS,
     AgentResult,
     DismissalLedger,
     _follow_opencode_log,
@@ -406,6 +408,62 @@ def test_the_delta_range_never_narrows_the_review() -> None:
     assert "any line of the PR" in prompt
 
 
+def test_sub_agents_keep_opencodes_repetition_detector_switched_on() -> None:
+    """`doom_loop: allow` turns opencode's own loop detector OFF, and this lane
+    shipped it that way. A live ci-config sub-agent then spent 19 steps and 18
+    minutes on one question the repo already answers in a comment, re-reading
+    the same scratch file five times.
+
+    The parent keeps `allow` on purpose — its phase-boundary budget checks and
+    offset re-reads of the playbook are repetition by design, and nothing has
+    been observed looping there. The asymmetry is the point of this test.
+    """
+    monkey = pytest.MonkeyPatch()
+    monkey.setenv("LITELLM_BASE_URL", "https://gateway.example")
+    try:
+        cfg = opencode_config(REVIEW_MODEL, with_subagents=True)
+    finally:
+        monkey.undo()
+
+    for name, spec in cfg["agent"].items():
+        assert (
+            spec["permission"]["doom_loop"] == "deny"
+        ), f"{name} must not have opencode's repetition detector disabled"
+    assert cfg["permission"]["doom_loop"] == "allow", (
+        "the primary orchestrates by design-repeated steps; only sub-agents "
+        "were observed looping"
+    )
+
+
+def test_sub_agents_are_told_to_check_local_prior_art_before_researching() -> None:
+    """Not a ban on reading third-party source — that is how a reviewer catches
+    a wrong-semantics call. The rule is about order and bound: the run this is
+    written from went external to re-derive a fact its own repo documents, then
+    kept going after two sources had failed to settle it."""
+    monkey = pytest.MonkeyPatch()
+    monkey.setenv("LITELLM_BASE_URL", "https://gateway.example")
+    try:
+        cfg = opencode_config(REVIEW_MODEL, with_subagents=True)
+    finally:
+        monkey.undo()
+
+    for name, spec in cfg["agent"].items():
+        assert (
+            RESEARCH_DISCIPLINE in spec["prompt"]
+        ), f"{name} is missing the research-discipline preamble"
+    # The capability itself must survive: a ban would cost real findings.
+    assert "legitimate and encouraged" in RESEARCH_DISCIPLINE
+
+
+def test_the_sub_agent_step_cap_is_below_the_observed_runaway() -> None:
+    """Sizing this off a flat per-step cost was the original mistake. Measured
+    step latency climbed 14s, 35s, 68s, 58s, 121s as context accumulated, so 60
+    steps was never the ~13 minutes its comment claimed."""
+    assert (
+        SUBAGENT_MAX_STEPS <= 25
+    ), "a cap this lane cannot reach inside its own time budget is not a cap"
+
+
 def test_the_lane_marker_matches_the_playbook_contract() -> None:
     """One string, two files — the shape that rots without anyone noticing.
 
@@ -456,7 +514,9 @@ def test_the_phase_two_agents_are_registered_so_the_fan_out_can_happen() -> None
             # a verdict. Asserting against the file's real bytes also proves
             # the brief exists, which the string form never did.
             brief = pathlib.Path(f".mothership/pr-review/agents/{name}.md")
-            assert spec["prompt"] == brief.read_text(encoding="utf-8")
+            assert (
+                brief.read_text(encoding="utf-8") in spec["prompt"]
+            ), f"{name}'s prompt must carry its playbook brief verbatim"
             assert spec["prompt"].strip(), f"{name} brief is empty"
             # Read-only in the agent as well as in the credential.
             assert spec["permission"]["edit"] == "deny"


### PR DESCRIPTION
A `ci-config` sub-agent spent **19 steps and 18 minutes** of a live review on one question: *is `job.workflow_sha` real?*

```
17:17  curl  raw.githubusercontent.com/rhysd/actionlint/.../linter.go
17:17  curl  api.github.com/repos/rhysd/actionlint/contents
17:18  curl  .../expr_type.go   .../project.go
17:26  curl  docs.github.com/en/actions/.../contexts   →  grep the HTML
17:28  read  /tmp/actionlint-linter.go        ← 5th read of the same file
```

Step latency climbed **14s → 35s → 68s → 58s → 121s** as each result accumulated in its context.

## It was right to look

The PR under review adds *"ignore this linter error, I checked."* A reviewer that accepts every such claim is how bad suppressions get merged. **Verifying it is the job.**

The problem is that the answer was already there — `.github/actionlint.yaml` grandfathers the rule with its reasoning beside it, quoting GitHub's documented behaviour and naming the one exception (unavailable on GHES) — and the agent had **nowhere to stop**:

- no sense that a justification quoting vendor documentation *is* evidence
- no exit for unresolved doubt other than another source
- every automatic brake switched off

So it escalated sources until something else stopped it.

## Three changes — one undoing a mistake of mine

**1. `doom_loop: "deny"` on sub-agents.** This is opencode's own repetition detector, and I had set it to `allow`, which turns it **off**. My justification was that the playbook *"re-runs similar greps across a large diff"* — but that's the **parent's** behaviour (phase-boundary budget checks, offset re-reads). The parent keeps `allow`; nothing has been observed looping there. The asymmetry is deliberate and pinned by a test.

**2. `SUBAGENT_MAX_STEPS` 60 → 25.** Sixty was sized on a *flat* cost per step. Step cost isn't flat — it grows with context — so 60 was never the "~13 minutes" its comment claimed. The idle watchdog can't help either: **a looping agent produces output the whole time.**

**3. A research rule prefixed to every sub-agent brief** — keeping the capability, bounding the manner:

| | |
|---|---|
| Local prior art first — and **judge** it, don't rebuild its proof | a justification quoting vendor docs is evidence; cite it and move on |
| Fetch once | a file already read is already in context |
| **Doubt becomes a finding, not more research** | *"this cites X, which I could not confirm"* hands it to a human in one line |
| Targeted, not wholesale | grep the symbol; don't pull HTML pages into context |

Explicitly **not** a ban on reading third-party source — that's how a reviewer catches a wrong-semantics call against a dependency, and it stays encouraged. A test asserts that sentence survives, so a future tightening can't quietly turn it into a ban.

## Testing

123 loop tests pass. Three new: the doom_loop asymmetry (sub-agents deny / parent allow), the research preamble reaching every agent with the capability intact, and the step cap.

Prefixed in Python rather than in the playbook so it doesn't collide with the in-flight `ORCHESTRATION.md` work in #3558.
