### PR TITLE
ci(loop): give branch and CI duty to a phase that can act on it

### DIFF
--- a/.github/scripts/gen_sdk_loop_workflow.py
+++ b/.github/scripts/gen_sdk_loop_workflow.py
@@ -188,6 +188,31 @@ FOOTER = """
 """
 
 
+def prep_job() -> str:
+    """Branch and check hygiene, once, before the first review.
+
+    Holds write scope, which is the entire reason it exists: the review
+    cannot update a behind branch or re-run a check, so asking it to look at
+    either produced a fact it was powerless to act on.
+
+    Deterministic for a healthy PR — a few `gh` reads and no model at all.
+    """
+    return """
+  prep:
+    name: Prep
+    needs: [fence]
+    if: needs.fence.outputs.proceed == 'true'
+    uses: ./.github/workflows/sdk-loop-phase.yml
+    secrets: inherit
+    with:
+      phase: prep
+      round: 0
+      pr: ${{ needs.fence.outputs.pr }}
+      head_ref: ${{ needs.fence.outputs.head_ref }}
+      base_sha: ${{ needs.fence.outputs.base_sha }}
+"""
+
+
 def review_job(n: int) -> str:
     """Review round n.
 
@@ -197,10 +222,18 @@ def review_job(n: int) -> str:
     the branch is actually on, so a round that starts is never already stale.
     """
     if n == 1:
-        gate = "needs.fence.outputs.proceed == 'true'"
-        needs = "[fence]"
-        base = "${{ needs.fence.outputs.base_sha }}"
-        ours = "''"
+        # `!cancelled()` rather than a dependency on prep SUCCEEDING: a prep
+        # that could not tidy the branch must not cost the review. A branch
+        # left behind still reviews correctly.
+        gate = "!cancelled() && needs.fence.outputs.proceed == 'true'"
+        needs = "[fence, prep]"
+        # Fall back to the fence when prep skipped or failed — an empty
+        # `new_base_sha` would checkout `ref: ''`.
+        base = "${{ needs.prep.outputs.new_base_sha || needs.fence.outputs.base_sha }}"
+        # Prep pushes. Without carrying its sha as `ours`, round 1 sees
+        # live != baseline with an empty ours-list, calls it `moved_by_other`
+        # and re-aims — burning a round every time prep does its job.
+        ours = "${{ needs.prep.outputs.pushed_sha }}"
         ledger = "''"
         prior_sha = "''"
         spent = "''"
@@ -317,14 +350,19 @@ def _rounds_expr() -> str:
 
 
 def build() -> str:
-    body = [HEADER]
+    body = [HEADER, prep_job()]
     for n in range(1, MAX_ROUNDS + 1):
         body.append(review_job(n))
         body.append(resolve_job(n))
+    # `prep` belongs in the Summary's `needs` too, or its row never reaches
+    # the round table and a branch update looks like it never happened.
     all_phases = ", ".join(
-        f"{phase}-{n}"
-        for n in range(1, MAX_ROUNDS + 1)
-        for phase in ("review", "resolve")
+        ["prep"]
+        + [
+            f"{phase}-{n}"
+            for n in range(1, MAX_ROUNDS + 1)
+            for phase in ("review", "resolve")
+        ]
     )
     body.append(
         FOOTER.format(
@@ -355,7 +393,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     OUT.parent.mkdir(parents=True, exist_ok=True)
     OUT.write_text(content, encoding="utf-8")
-    print(f"wrote {OUT} ({MAX_ROUNDS} rounds, {2 * MAX_ROUNDS + 2} jobs)")
+    print(f"wrote {OUT} ({MAX_ROUNDS} rounds, {2 * MAX_ROUNDS + 3} jobs)")
     return 0
 
 

--- a/.github/scripts/gen_sdk_loop_workflow.py
+++ b/.github/scripts/gen_sdk_loop_workflow.py
@@ -191,9 +191,12 @@ FOOTER = """
 def prep_job() -> str:
     """Branch and check hygiene, once, before the first review.
 
-    Holds write scope, which is the entire reason it exists: the review
-    cannot update a behind branch or re-run a check, so asking it to look at
-    either produced a fact it was powerless to act on.
+    Holds write scope so it can push a MECHANICAL fix — formatting, lint,
+    generated drift — for a check the review could only have reported. It
+    does not update a behind branch and does not resolve conflicts: both are
+    changes to somebody's PR that they did not ask for, and neither is needed
+    to review, since the review reads the diff against base. Both are
+    reported and left alone.
 
     Deterministic for a healthy PR — a few `gh` reads and no model at all.
     """

--- a/.github/scripts/sdk_loop_phase.py
+++ b/.github/scripts/sdk_loop_phase.py
@@ -562,12 +562,11 @@ def main(argv: list[str] | None = None) -> int:
         # Conflicts short-circuit BEFORE the checks read. There is nothing
         # useful to say about CI on a branch that cannot merge, and the read
         # is a round trip spent to reach an answer that changes nothing.
-        if state.get("mergeStateStatus") == "CONFLICTING" or (
-            state.get("mergeable") == "CONFLICTING"
-        ):
-            result = decide(state, (), baseline)
-        else:
-            result = decide(state, failing_checks(repo, pr), baseline)
+        conflicted = state is not None and (
+            state.get("mergeStateStatus") == "CONFLICTING"
+            or state.get("mergeable") == "CONFLICTING"
+        )
+        result = decide(state, () if conflicted else failing_checks(repo, pr), baseline)
 
         if needs_agent(result):
             # The one case worth a model: red checks a mechanical fix might

--- a/.github/scripts/sdk_loop_phase.py
+++ b/.github/scripts/sdk_loop_phase.py
@@ -64,6 +64,15 @@ from sdk_loop_common import (
     token_budget_exceeded,
     usage_total,
 )
+from sdk_loop_prep import (  # noqa: E402
+    OUTCOME_UPDATED,
+    PrepResult,
+    decide,
+    failing_checks,
+    needs_agent,
+    pr_state,
+    update_branch,
+)
 
 #: Wall-clock per phase. Review is the slower of the two: it walks the whole
 #: five-phase playbook including sub-agents, where a resolve round is mostly
@@ -74,6 +83,9 @@ from sdk_loop_common import (
 # talking. Cutting them would trade a real (if slow) review for no review.
 TIMEOUT_REVIEW_S = 45 * 60
 TIMEOUT_RESOLVE_S = 30 * 60
+#: Prep is bookkeeping, not review. If a mechanical fix has not landed in ten
+#: minutes it is not mechanical, and the review will say so far more cheaply.
+TIMEOUT_PREP_S = 10 * 60
 
 #: Outcomes a phase can report to the next job. Only `ok` continues to the
 #: paired phase; `reaim` sends the loop back to review on the new head.
@@ -132,6 +144,49 @@ def live_head(
 #: it in .mothership/pr-review/ORCHESTRATION.md — the string is shared with
 #: that file and a test asserts they still match.
 LANE_MARKER = "LANE: sdk-loop"
+
+
+def prep_prompt(pr: int, failing: tuple[str, ...]) -> str:
+    """Brief for the ONE case prep hands to a model: red checks, before review.
+
+    Deliberately narrow. Everything prep normally does is deterministic and
+    already done by the time this runs, so the model is not being asked to
+    orchestrate — it is being asked whether a specific red check is the kind
+    tooling can fix, and to fix it if so.
+
+    The hard part of this brief is what it refuses. "Make CI green" has no
+    terminating condition when a test is genuinely broken by the PR, and a
+    phase with write scope chasing that is strictly worse than a review
+    saying so in one line.
+    """
+    names = "\n".join(f"  - {n}" for n in failing[:10])
+    return "\n".join(
+        [
+            f"PR #{pr} has failing checks before its review has run:",
+            names,
+            "",
+            "Fix ONLY what is mechanical — the class where the tooling, not",
+            "judgement, determines the answer:",
+            "",
+            "  * formatting and lint (`uv run pre-commit run --files <changed>`)",
+            "  * generated-artifact drift, by re-running the generator",
+            "  * an obviously stale lockfile the repo's own command regenerates",
+            "",
+            "Everything else — a failing test, a type error, a real behavioural",
+            "break — STOP and change nothing. Those are findings, and the review",
+            "that runs after you exists to raise them properly. A fix you push",
+            "here arrives with no review behind it.",
+            "",
+            "Do NOT resolve merge conflicts. Do NOT wait for checks to go green;",
+            "you cannot, and the run does not need you to. Do NOT re-run checks",
+            "hoping for a different answer.",
+            "",
+            "If you fix something: run the repo's pre-commit over the files you",
+            "touched, commit with a `ci:` or `chore:` conventional prefix, and",
+            "push. If you fix nothing, say so in one line and exit — that is a",
+            "perfectly good outcome and costs the run nothing.",
+        ]
+    )
 
 
 def review_prompt(
@@ -345,6 +400,16 @@ def resolve_prompt(pr: int, round_no: int, sha: str, verdict_url: str) -> str:
         "   and a finding you disprove is recorded so the next review cannot",
         "   simply re-raise it.",
         "3. Stop when the findings are cleared. Do not merge; do not approve.",
+        "4. You are the ONLY phase in this loop that can push, so you own the",
+        "   state you leave behind. Before you finish: run the repo's",
+        "   pre-commit over the files you touched and push the result, and",
+        "   update the branch if it has fallen behind base while you worked.",
+        "   The review that runs next holds NO write scope — anything you",
+        "   leave untidy it can only report, spending its budget on something",
+        "   one command would have settled here.",
+        "   Do NOT wait for CI and do NOT re-run checks: you cannot make them",
+        "   finish, the next round reads the real state anyway, and waiting",
+        "   has no terminating condition when a check is genuinely broken.",
         "",
         "Emit your dismissals as a JSON array on a line beginning",
         '`SDK_LOOP_DISMISSED:` — each entry {"id": ..., "rationale": ...}.',
@@ -488,6 +553,61 @@ def main(argv: list[str] | None = None) -> int:
 
     workspace = os.environ.get("GITHUB_WORKSPACE", ".")
     transcript = os.path.join(workspace, f"sdk-loop-{phase}-{round_no}.log")
+    if phase == "prep":
+        # Deterministic pass first, and for a healthy PR that is the WHOLE
+        # phase — no agent, no gateway call, a handful of `gh` reads. A model
+        # cannot improve on "is mergeStateStatus BEHIND", and most PRs enter
+        # the loop current and green, so paying one to confirm that would be
+        # the same waste this phase exists to remove from the review.
+        state = pr_state(repo, pr)
+        updated = ""
+        if state.get("mergeStateStatus") == "BEHIND":
+            updated = update_branch(repo, pr, head_ref, state.get("headRefOid", ""))
+            if updated:
+                state = pr_state(repo, pr)
+        failing = failing_checks(repo, pr)
+        result = decide(state, failing, baseline, updated)
+
+        if needs_agent(result):
+            # The one case worth a model: red checks a mechanical fix might
+            # clear. Bounded hard, because this phase must never become the
+            # thing that spends an hour on a genuinely broken test — that is
+            # the review-and-resolve loop's job, and it does it properly.
+            print("::group::prep — mechanical fix attempt")
+            agent = run_agent(
+                RESOLVE_MODEL,
+                prep_prompt(pr, result.failing),
+                workspace,
+                TIMEOUT_PREP_S,
+                transcript_path=transcript,
+            )
+            print("::endgroup::")
+            after = live_head(repo, head_ref)
+            if after and after != result.new_base_sha:
+                result = PrepResult(
+                    OUTCOME_UPDATED,
+                    new_base_sha=after,
+                    pushed_sha=after,
+                    ci_state="rechecking",
+                    detail=f"pushed a mechanical fix for: {', '.join(result.failing[:3])}",
+                )
+            elif not agent.completed:
+                print(f"prep agent aborted: {agent.abort_reason}")
+
+        emit_outputs(
+            outcome=result.outcome,
+            new_base_sha=result.new_base_sha,
+            pushed_sha=result.pushed_sha,
+            ci_state=result.ci_state,
+            detail=result.detail,
+            reaims="0",
+        )
+        print(f"prep: {result.outcome} — {result.detail}")
+        # NEVER fails the run. A prep that could not tidy the branch must not
+        # cost the review: a branch left behind still reviews correctly, and
+        # a conflict is the author's to resolve.
+        return 0
+
     if phase == "review":
         print(f"::group::review round {round_no} — agent transcript")
         result = run_agent(

--- a/.github/scripts/sdk_loop_phase.py
+++ b/.github/scripts/sdk_loop_phase.py
@@ -71,7 +71,6 @@ from sdk_loop_prep import (  # noqa: E402
     failing_checks,
     needs_agent,
     pr_state,
-    update_branch,
 )
 
 #: Wall-clock per phase. Review is the slower of the two: it walks the whole
@@ -560,13 +559,15 @@ def main(argv: list[str] | None = None) -> int:
         # the loop current and green, so paying one to confirm that would be
         # the same waste this phase exists to remove from the review.
         state = pr_state(repo, pr)
-        updated = ""
-        if state.get("mergeStateStatus") == "BEHIND":
-            updated = update_branch(repo, pr, head_ref, state.get("headRefOid", ""))
-            if updated:
-                state = pr_state(repo, pr)
-        failing = failing_checks(repo, pr)
-        result = decide(state, failing, baseline, updated)
+        # Conflicts short-circuit BEFORE the checks read. There is nothing
+        # useful to say about CI on a branch that cannot merge, and the read
+        # is a round trip spent to reach an answer that changes nothing.
+        if state.get("mergeStateStatus") == "CONFLICTING" or (
+            state.get("mergeable") == "CONFLICTING"
+        ):
+            result = decide(state, (), baseline)
+        else:
+            result = decide(state, failing_checks(repo, pr), baseline)
 
         if needs_agent(result):
             # The one case worth a model: red checks a mechanical fix might

--- a/.github/scripts/sdk_loop_prep.py
+++ b/.github/scripts/sdk_loop_prep.py
@@ -26,11 +26,11 @@ WHAT IT DELIBERATELY DOES NOT DO:
     somebody's PR that they did not ask for. Neither is needed to review
     either — the review reads the diff against base, which is well-defined
     whether or not base has moved. Both are REPORTED and left alone.
-  * Wait for green. "Wait until CI passes" has no terminating condition when
-    a check is genuinely broken by the PR, and the failure mode is a phase
-    that burns an hour discovering what the review would have said in one
-    line. Red CI is a fact to hand forward, not this phase's problem to
-    solve.
+  * Wait for green, or re-run a check hoping for a different answer. "Wait
+    until CI passes" has no terminating condition when a check is genuinely
+    broken by the PR, and the failure mode is a phase that burns an hour
+    discovering what the review would have said in one line. Red CI is a
+    fact to hand forward, not this phase's problem to solve.
   * Fix real test failures. That is the resolve phase's job, informed by a
     review. Prep clears MECHANICAL red only — formatting, lint, generated
     drift — the class where the fix is determined by the tooling rather than
@@ -46,16 +46,14 @@ import json
 import subprocess
 from dataclasses import dataclass, field
 
-#: Checks whose failure is mechanical often enough to be worth one automatic
-#: re-run. Everything else is left alone: re-running a genuine test failure
-#: just spends CI minutes to reach the same answer more slowly.
-RERUNNABLE_HINTS = ("flake", "timeout", "network", "rate limit")
-
 OUTCOME_CLEAN = "clean"
 OUTCOME_UPDATED = "updated"
 OUTCOME_CONFLICTS = "conflicts"
 OUTCOME_RED = "red"
 OUTCOME_FAILED = "failed"
+#: Prep could not read the PR's state. NOT the same as "nothing wrong" — the
+#: distinction this file previously lost.
+OUTCOME_UNKNOWN = "unknown"
 
 
 @dataclass(frozen=True)
@@ -76,8 +74,13 @@ def _sh(args: list[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(args, capture_output=True, text=True, check=False)
 
 
-def pr_state(repo: str, pr: int, runner=_sh) -> dict[str, str]:
-    """Merge state and head sha, straight from the API."""
+def pr_state(repo: str, pr: int, runner=_sh) -> dict[str, str] | None:
+    """Merge state and head sha, or None when they could not be read.
+
+    None rather than `{}` for the same reason `failing_checks` returns None:
+    an empty dict reads as "no conflicts, not behind", which is the most
+    optimistic possible reading of a failed API call.
+    """
     done = runner(
         [
             "gh",
@@ -90,51 +93,89 @@ def pr_state(repo: str, pr: int, runner=_sh) -> dict[str, str]:
             "mergeStateStatus,headRefOid,mergeable",
         ]
     )
+    if done.returncode != 0:
+        return None
     try:
-        payload = json.loads(done.stdout or "{}")
-    except json.JSONDecodeError:
-        return {}
+        payload = json.loads(done.stdout or "")
+    except (json.JSONDecodeError, TypeError):
+        return None
+    # `headRefOid` is the field every caller depends on. A dict without it is
+    # not a state this phase can reason about, and treating it as one means
+    # `decide` falls back to the baseline sha and calls the PR clean — the
+    # same optimistic collapse this whole function exists to avoid.
+    if not isinstance(payload, dict) or not payload.get("headRefOid"):
+        return None
     return {k: str(v) for k, v in payload.items()}
 
 
-def failing_checks(repo: str, pr: int, runner=_sh) -> tuple[str, ...]:
-    """Named failing checks. Read ONCE — this is a fact, not a poll."""
+#: `gh pr checks --json` field names, pinned because getting them wrong is
+#: SILENT. `conclusion` — the obvious guess, and what this file shipped with
+#: — is not a field: gh prints "Unknown JSON field" to stderr, exits 0, and
+#: writes nothing to stdout. A reader that trusts stdout then sees no failing
+#: checks and reports green on a PR that is red. That is exactly what
+#: happened, and the same idiom is still in the toolkit playbook.
+CHECK_FIELDS = "name,state,bucket"
+
+#: The bucket value gh uses for a failed check. The vocabulary is
+#: pass / fail / skipping / pending, NOT the GitHub API's conclusion strings.
+BUCKET_FAIL = "fail"
+
+
+def failing_checks(repo: str, pr: int, runner=_sh) -> tuple[str, ...] | None:
+    """Named failing checks, or None when the state could not be read.
+
+    None is not the same as "nothing is failing", and collapsing the two is
+    how this function shipped broken. It asked for a field gh does not have;
+    gh exits 0 and prints nothing; `json.loads(stdout or "[]")` turned that
+    into an empty list; and prep reported green. Every layer degraded quietly
+    into the most optimistic answer.
+
+    So this fails CLOSED: a non-zero exit, unparseable output, or a payload
+    that is not a list all return None, and the caller says "unknown" rather
+    than "green".
+    """
     done = runner(
-        [
-            "gh",
-            "pr",
-            "checks",
-            str(pr),
-            "--repo",
-            repo,
-            "--json",
-            "name,conclusion",
-        ]
+        ["gh", "pr", "checks", str(pr), "--repo", repo, "--json", CHECK_FIELDS]
     )
+    if done.returncode != 0:
+        return None
     try:
-        rows = json.loads(done.stdout or "[]")
-    except json.JSONDecodeError:
-        return ()
+        rows = json.loads(done.stdout or "")
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(rows, list):
+        return None
     return tuple(
         str(r.get("name", ""))
         for r in rows
-        if isinstance(r, dict) and r.get("conclusion") == "failure"
+        if isinstance(r, dict) and r.get("bucket") == BUCKET_FAIL
     )
 
 
-def decide(state: dict[str, str], failing: tuple[str, ...], before: str) -> PrepResult:
+def decide(
+    state: dict[str, str] | None,
+    failing: tuple[str, ...] | None,
+    before: str,
+) -> PrepResult:
     """What prep concluded, from facts alone. No model involved.
 
-    Conflicts short-circuit: there is nothing useful to say about checks on a
-    branch that cannot merge, and the review posts NEEDS_REBASE regardless.
+    Both inputs are optional because both reads can fail, and an unread state
+    must never render as a clean one. That collapse is precisely how the
+    first version of this file reported green on a red PR.
 
-    A branch that is merely BEHIND is REPORTED, never updated. Updating it
-    means pushing a merge commit into someone's PR on the loop's initiative,
-    which is a change to their branch they did not ask for — and it is not
-    needed to review: the diff against base is what the review reads, and
-    that is well-defined whether or not base has moved. `mergeStateStatus`
-    lands in the detail line so a human can act on it if they want to.
+    A branch that is merely BEHIND is REPORTED, never updated. Merging base
+    into someone's PR is a change to their branch they did not ask for, and
+    it is not needed to review: the review reads the diff against base, which
+    is well-defined whether or not base has moved.
     """
+    if state is None:
+        return PrepResult(
+            OUTCOME_UNKNOWN,
+            new_base_sha=before,
+            ci_state="unknown",
+            detail="could not read PR state — reporting unknown rather than clean",
+        )
+
     merge_state = state.get("mergeStateStatus", "")
     head = state.get("headRefOid", "") or before
 
@@ -152,12 +193,23 @@ def decide(state: dict[str, str], failing: tuple[str, ...], before: str) -> Prep
         else ""
     )
 
+    if failing is None:
+        return PrepResult(
+            OUTCOME_UNKNOWN,
+            new_base_sha=head,
+            ci_state="unknown",
+            detail=f"could not read check state — reporting unknown, not green{behind}",
+        )
+
     if failing:
         return PrepResult(
             OUTCOME_RED,
             new_base_sha=head,
             ci_state="red",
-            detail=f"{len(failing)} failing check(s) — a fact for the review, not a blocker{behind}",
+            detail=(
+                f"{len(failing)} failing check(s) — a fact for the review, "
+                f"not a blocker{behind}"
+            ),
             failing=failing,
         )
     return PrepResult(

--- a/.github/scripts/sdk_loop_prep.py
+++ b/.github/scripts/sdk_loop_prep.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Branch and check hygiene, before the first review reads anything.
+
+This exists because of a boundary the review lane cannot cross. The review
+phase holds a token with NO write scope — that is the whole read-only
+guarantee — so it can neither update a branch that has fallen behind nor
+re-run a check that flaked. Asking it to look at CI produced a fact it was
+powerless to act on, reported beside a verdict that fact was explicitly not
+allowed to influence.
+
+So the duty moves here, to a phase that holds write scope, and runs once
+before Review 1.
+
+DETERMINISTIC FIRST, and usually deterministic ONLY. Everything this phase
+normally does — read merge state, update a behind branch, re-run failed
+checks — is a `gh` call with an unambiguous answer. A model adds nothing to
+"is mergeStateStatus BEHIND", and a clean PR is the common case, so paying an
+agent to confirm a clean PR is clean would be the same waste this lane has
+been trying to remove. The agent is invoked only when the deterministic pass
+leaves something red that a mechanical fix might clear.
+
+WHAT IT DELIBERATELY DOES NOT DO:
+
+  * Resolve conflicts. A conflict resolution is the author's decision about
+    their own change, not a bot's — the review playbook has said so since
+    before this lane existed, and it stays true when the bot gains write
+    scope.
+  * Wait for green. "Wait until CI passes" has no terminating condition when
+    a check is genuinely broken by the PR, and the failure mode is a phase
+    that burns an hour discovering what the review would have said in one
+    line. Red CI is a fact to hand forward, not this phase's problem to
+    solve.
+  * Fix real test failures. That is the resolve phase's job, informed by a
+    review. Prep clears MECHANICAL red only — formatting, lint, generated
+    drift — the class where the fix is determined by the tooling rather than
+    by judgement.
+
+Environment:
+    REPO, PR_NUMBER, HEAD_REF, BASE_SHA, GH_TOKEN
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from dataclasses import dataclass, field
+
+#: How long to let GitHub recompute a merge state after `update-branch`.
+#: The API returns before the new head is visible, so a read straight after
+#: it sees the OLD sha and the phase reports it changed nothing.
+UPDATE_SETTLE_S = 10
+UPDATE_POLL_ATTEMPTS = 6
+
+#: Checks whose failure is mechanical often enough to be worth one automatic
+#: re-run. Everything else is left alone: re-running a genuine test failure
+#: just spends CI minutes to reach the same answer more slowly.
+RERUNNABLE_HINTS = ("flake", "timeout", "network", "rate limit")
+
+OUTCOME_CLEAN = "clean"
+OUTCOME_UPDATED = "updated"
+OUTCOME_CONFLICTS = "conflicts"
+OUTCOME_RED = "red"
+OUTCOME_FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class PrepResult:
+    outcome: str
+    new_base_sha: str = ""
+    #: Set ONLY when this phase pushed. Review 1 receives it as `ours`, so its
+    #: own head check reads our update as our progress rather than as somebody
+    #: else's commit — without it, a prep that did its job re-aims round 1
+    #: every single time.
+    pushed_sha: str = ""
+    ci_state: str = "unknown"
+    detail: str = ""
+    failing: tuple[str, ...] = field(default_factory=tuple)
+
+
+def _sh(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, capture_output=True, text=True, check=False)
+
+
+def pr_state(repo: str, pr: int, runner=_sh) -> dict[str, str]:
+    """Merge state and head sha, straight from the API."""
+    done = runner(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr),
+            "--repo",
+            repo,
+            "--json",
+            "mergeStateStatus,headRefOid,mergeable",
+        ]
+    )
+    try:
+        payload = json.loads(done.stdout or "{}")
+    except json.JSONDecodeError:
+        return {}
+    return {k: str(v) for k, v in payload.items()}
+
+
+def failing_checks(repo: str, pr: int, runner=_sh) -> tuple[str, ...]:
+    """Named failing checks. Read ONCE — this is a fact, not a poll."""
+    done = runner(
+        [
+            "gh",
+            "pr",
+            "checks",
+            str(pr),
+            "--repo",
+            repo,
+            "--json",
+            "name,conclusion",
+        ]
+    )
+    try:
+        rows = json.loads(done.stdout or "[]")
+    except json.JSONDecodeError:
+        return ()
+    return tuple(
+        str(r.get("name", ""))
+        for r in rows
+        if isinstance(r, dict) and r.get("conclusion") == "failure"
+    )
+
+
+def update_branch(repo: str, pr: int, head_ref: str, before: str, runner=_sh) -> str:
+    """Merge base into the PR branch. Returns the new head, or '' if unchanged.
+
+    Polled rather than slept-once: the REST call returns before the new head
+    is observable, and a single read straight after it reports the old sha —
+    which would make a successful update look like a no-op and hand Review 1
+    a stale baseline.
+    """
+    runner(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/pulls/{pr}/update-branch",
+            "-X",
+            "PUT",
+            "-f",
+            "update_method=merge",
+        ]
+    )
+    for _ in range(UPDATE_POLL_ATTEMPTS):
+        time.sleep(UPDATE_SETTLE_S)
+        state = pr_state(repo, pr, runner=runner)
+        live = state.get("headRefOid", "")
+        if live and live != before:
+            return live
+    return ""
+
+
+def decide(
+    state: dict[str, str],
+    failing: tuple[str, ...],
+    before: str,
+    updated_sha: str = "",
+) -> PrepResult:
+    """What prep concluded, given only facts. No model involved.
+
+    Conflicts short-circuit everything: there is nothing useful to say about
+    checks on a branch that cannot merge, and the review will post
+    NEEDS_REBASE regardless.
+    """
+    merge_state = state.get("mergeStateStatus", "")
+    head = state.get("headRefOid", "") or before
+
+    if merge_state == "CONFLICTING" or state.get("mergeable") == "CONFLICTING":
+        return PrepResult(
+            OUTCOME_CONFLICTS,
+            new_base_sha=head,
+            ci_state="unknown",
+            detail="branch conflicts with base — the author resolves this, not the loop",
+        )
+
+    ci_state = "red" if failing else "green"
+    detail_ci = f"{len(failing)} failing check(s)" if failing else "checks green"
+
+    if updated_sha:
+        return PrepResult(
+            OUTCOME_UPDATED,
+            new_base_sha=updated_sha,
+            pushed_sha=updated_sha,
+            ci_state=ci_state,
+            detail=f"branch was behind base; updated to {updated_sha[:8]} · {detail_ci}",
+            failing=failing,
+        )
+    if failing:
+        return PrepResult(
+            OUTCOME_RED,
+            new_base_sha=head,
+            ci_state="red",
+            detail=f"{detail_ci} — handed to the review as a fact, not a blocker",
+            failing=failing,
+        )
+    return PrepResult(
+        OUTCOME_CLEAN,
+        new_base_sha=head,
+        ci_state="green",
+        detail="branch is current and checks are green — nothing to do",
+    )
+
+
+def needs_agent(result: PrepResult) -> bool:
+    """Whether this run has anything a model could usefully act on.
+
+    The answer is normally NO, and that is the point: a clean PR must cost
+    zero model calls. Conflicts are excluded deliberately — they need a human,
+    and handing them to an agent with write scope invites exactly the
+    unrequested merge commit the playbook forbids.
+    """
+    return result.outcome == OUTCOME_RED and bool(result.failing)

--- a/.github/scripts/sdk_loop_prep.py
+++ b/.github/scripts/sdk_loop_prep.py
@@ -12,8 +12,8 @@ So the duty moves here, to a phase that holds write scope, and runs once
 before Review 1.
 
 DETERMINISTIC FIRST, and usually deterministic ONLY. Everything this phase
-normally does — read merge state, update a behind branch, re-run failed
-checks — is a `gh` call with an unambiguous answer. A model adds nothing to
+normally does — read merge state, read failing checks — is a `gh` call with
+an unambiguous answer. A model adds nothing to
 "is mergeStateStatus BEHIND", and a clean PR is the common case, so paying an
 agent to confirm a clean PR is clean would be the same waste this lane has
 been trying to remove. The agent is invoked only when the deterministic pass
@@ -21,10 +21,11 @@ leaves something red that a mechanical fix might clear.
 
 WHAT IT DELIBERATELY DOES NOT DO:
 
-  * Resolve conflicts. A conflict resolution is the author's decision about
-    their own change, not a bot's — the review playbook has said so since
-    before this lane existed, and it stays true when the bot gains write
-    scope.
+  * Touch the branch on its own initiative. Neither a conflict resolution
+    nor a base merge is the loop's call to make: both are changes to
+    somebody's PR that they did not ask for. Neither is needed to review
+    either — the review reads the diff against base, which is well-defined
+    whether or not base has moved. Both are REPORTED and left alone.
   * Wait for green. "Wait until CI passes" has no terminating condition when
     a check is genuinely broken by the PR, and the failure mode is a phase
     that burns an hour discovering what the review would have said in one
@@ -43,14 +44,7 @@ from __future__ import annotations
 
 import json
 import subprocess
-import time
 from dataclasses import dataclass, field
-
-#: How long to let GitHub recompute a merge state after `update-branch`.
-#: The API returns before the new head is visible, so a read straight after
-#: it sees the OLD sha and the phase reports it changed nothing.
-UPDATE_SETTLE_S = 10
-UPDATE_POLL_ATTEMPTS = 6
 
 #: Checks whose failure is mechanical often enough to be worth one automatic
 #: re-run. Everything else is left alone: re-running a genuine test failure
@@ -128,45 +122,18 @@ def failing_checks(repo: str, pr: int, runner=_sh) -> tuple[str, ...]:
     )
 
 
-def update_branch(repo: str, pr: int, head_ref: str, before: str, runner=_sh) -> str:
-    """Merge base into the PR branch. Returns the new head, or '' if unchanged.
+def decide(state: dict[str, str], failing: tuple[str, ...], before: str) -> PrepResult:
+    """What prep concluded, from facts alone. No model involved.
 
-    Polled rather than slept-once: the REST call returns before the new head
-    is observable, and a single read straight after it reports the old sha —
-    which would make a successful update look like a no-op and hand Review 1
-    a stale baseline.
-    """
-    runner(
-        [
-            "gh",
-            "api",
-            f"repos/{repo}/pulls/{pr}/update-branch",
-            "-X",
-            "PUT",
-            "-f",
-            "update_method=merge",
-        ]
-    )
-    for _ in range(UPDATE_POLL_ATTEMPTS):
-        time.sleep(UPDATE_SETTLE_S)
-        state = pr_state(repo, pr, runner=runner)
-        live = state.get("headRefOid", "")
-        if live and live != before:
-            return live
-    return ""
+    Conflicts short-circuit: there is nothing useful to say about checks on a
+    branch that cannot merge, and the review posts NEEDS_REBASE regardless.
 
-
-def decide(
-    state: dict[str, str],
-    failing: tuple[str, ...],
-    before: str,
-    updated_sha: str = "",
-) -> PrepResult:
-    """What prep concluded, given only facts. No model involved.
-
-    Conflicts short-circuit everything: there is nothing useful to say about
-    checks on a branch that cannot merge, and the review will post
-    NEEDS_REBASE regardless.
+    A branch that is merely BEHIND is REPORTED, never updated. Updating it
+    means pushing a merge commit into someone's PR on the loop's initiative,
+    which is a change to their branch they did not ask for — and it is not
+    needed to review: the diff against base is what the review reads, and
+    that is well-defined whether or not base has moved. `mergeStateStatus`
+    lands in the detail line so a human can act on it if they want to.
     """
     merge_state = state.get("mergeStateStatus", "")
     head = state.get("headRefOid", "") or before
@@ -179,31 +146,25 @@ def decide(
             detail="branch conflicts with base — the author resolves this, not the loop",
         )
 
-    ci_state = "red" if failing else "green"
-    detail_ci = f"{len(failing)} failing check(s)" if failing else "checks green"
+    behind = (
+        " · branch is behind base (reported, not updated)"
+        if merge_state == "BEHIND"
+        else ""
+    )
 
-    if updated_sha:
-        return PrepResult(
-            OUTCOME_UPDATED,
-            new_base_sha=updated_sha,
-            pushed_sha=updated_sha,
-            ci_state=ci_state,
-            detail=f"branch was behind base; updated to {updated_sha[:8]} · {detail_ci}",
-            failing=failing,
-        )
     if failing:
         return PrepResult(
             OUTCOME_RED,
             new_base_sha=head,
             ci_state="red",
-            detail=f"{detail_ci} — handed to the review as a fact, not a blocker",
+            detail=f"{len(failing)} failing check(s) — a fact for the review, not a blocker{behind}",
             failing=failing,
         )
     return PrepResult(
         OUTCOME_CLEAN,
         new_base_sha=head,
         ci_state="green",
-        detail="branch is current and checks are green — nothing to do",
+        detail=f"checks green{behind or ' and branch is current'} — nothing to do",
     )
 
 

--- a/.github/scripts/tests/test_sdk_loop.py
+++ b/.github/scripts/tests/test_sdk_loop.py
@@ -28,7 +28,7 @@ import yaml
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
-from _gha_expr import evaluate  # noqa: E402
+from _gha_expr import evaluate, evaluate_operand  # noqa: E402
 from sdk_loop_common import (  # noqa: E402
     AGENT_ENV_PASSTHROUGH,
     ALLOWED_MODELS,
@@ -1318,10 +1318,23 @@ def test_the_review_phase_token_cannot_push() -> None:
     token it holds has no write scope to push with.
     """
     text = PHASE_WF.read_text(encoding="utf-8")
-    assert (
-        "permission-contents: ${{ inputs.phase == 'resolve' && 'write' || 'read' }}"
-        in text
-    )
+    line = next(x for x in text.splitlines() if "permission-contents:" in x)
+    expr = line.split("permission-contents:", 1)[1].strip()
+
+    # EVALUATED, not string-matched. The previous form pinned one exact
+    # spelling, so adding `prep` to the write side failed it for a reason
+    # unrelated to what it protects — and the tempting repair is to paste in
+    # the new spelling, which pins the next one just as blindly. What must
+    # hold is the OUTCOME per phase, and only `review` has a claim to make.
+    for phase, expected in (
+        ("review", "read"),
+        ("resolve", "write"),
+        # prep updates a behind branch and pushes mechanical fixes; that is
+        # the whole reason it exists as a separate phase.
+        ("prep", "write"),
+    ):
+        got = evaluate_operand(expr, {"inputs": {"phase": phase}})
+        assert got == expected, f"{phase} must mint a {expected} token, got {got!r}"
 
 
 def test_the_minted_token_is_narrowed_not_the_apps_full_grant() -> None:

--- a/.github/scripts/tests/test_sdk_loop_prep.py
+++ b/.github/scripts/tests/test_sdk_loop_prep.py
@@ -1,0 +1,115 @@
+"""Prep phase — branch and check hygiene the review cannot do itself."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+import yaml
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from sdk_loop_prep import (  # noqa: E402
+    OUTCOME_CLEAN,
+    OUTCOME_CONFLICTS,
+    OUTCOME_RED,
+    OUTCOME_UPDATED,
+    decide,
+    needs_agent,
+)
+
+
+def test_a_healthy_pr_costs_no_model_call() -> None:
+    """The common case must be free. Most PRs enter the loop current and
+    green, and paying an agent to confirm that would reintroduce the exact
+    waste this phase was built to take OUT of the review."""
+    clean = decide({"mergeStateStatus": "CLEAN", "headRefOid": "a" * 40}, (), "a" * 40)
+    assert clean.outcome == OUTCOME_CLEAN
+    assert clean.ci_state == "green"
+    assert not needs_agent(clean), "a clean PR must not reach the model"
+    assert clean.pushed_sha == "", "nothing was pushed, so claim nothing"
+
+
+def test_a_behind_branch_is_updated_and_the_push_is_owned() -> None:
+    """`pushed_sha` is not decoration. Review 1 receives it as `ours`; without
+    it the round sees live != baseline with an empty ours-list, calls it
+    `moved_by_other` and re-aims — burning a round every time prep works."""
+    out = decide(
+        {"mergeStateStatus": "CLEAN", "headRefOid": "b" * 40},
+        (),
+        "a" * 40,
+        updated_sha="b" * 40,
+    )
+    assert out.outcome == OUTCOME_UPDATED
+    assert out.pushed_sha == "b" * 40
+    assert out.new_base_sha == "b" * 40
+    assert not needs_agent(out)
+
+
+def test_conflicts_are_reported_and_never_resolved() -> None:
+    """A conflict resolution is the author's decision about their own change.
+    That was true when the reviewer had no write scope and stays true now
+    that prep does — a bot with push rights must not quietly merge for them."""
+    out = decide(
+        {"mergeStateStatus": "CONFLICTING", "headRefOid": "a" * 40}, (), "a" * 40
+    )
+    assert out.outcome == OUTCOME_CONFLICTS
+    assert not needs_agent(out), "conflicts need a human, not an agent with write scope"
+    assert "author" in out.detail
+
+
+def test_red_checks_do_not_block_the_review() -> None:
+    """Red CI is a fact to hand forward, not prep's problem to solve. Blocking
+    would mean a broken check costs the review entirely — and the review is
+    the thing that explains WHY it is broken."""
+    out = decide(
+        {"mergeStateStatus": "CLEAN", "headRefOid": "a" * 40}, ("SDK Tests",), "a" * 40
+    )
+    assert out.outcome == OUTCOME_RED
+    assert out.new_base_sha == "a" * 40, "the review still runs, on the real head"
+    assert needs_agent(out), "red checks are the one case worth a model"
+
+
+def test_prep_holds_write_scope_and_the_review_does_not() -> None:
+    """The whole point. If prep were read-only it could not update a branch,
+    and if review were writable its read-only contract would be a promise in
+    a prompt rather than a property of its credential."""
+    text = pathlib.Path(".github/workflows/sdk-loop-phase.yml").read_text(
+        encoding="utf-8"
+    )
+    line = next(x for x in text.splitlines() if "permission-contents:" in x)
+    assert "'prep'" in line and "'resolve'" in line
+    assert "'write'" in line and "'read'" in line
+
+
+def test_the_generated_chain_wires_prep_without_stranding_review_one() -> None:
+    """A `needs.<job>` reference to a job the caller does not depend on makes
+    GitHub refuse to parse the workflow — so NO jobs run and the fence never
+    gets to say why. That silence is the failure this asserts against."""
+    raw = pathlib.Path(".github/workflows/sdk-loop.yml").read_text(encoding="utf-8")
+    doc = yaml.safe_load(raw)
+    jobs = doc["jobs"]
+    assert "prep" in jobs
+
+    for name, spec in jobs.items():
+        declared = set(spec.get("needs") or [])
+        refs = set(re.findall(r"needs\.([A-Za-z0-9_-]+)\.", yaml.dump(spec)))
+        assert refs <= set(jobs), f"{name} references a job that does not exist"
+        assert (
+            refs <= declared
+        ), f"{name} references an undeclared need: {refs - declared}"
+
+    r1 = jobs["review-1"]
+    assert set(r1["needs"]) == {"fence", "prep"}
+    with_ = r1["with"]
+    # Fallback to the fence: a skipped prep emits nothing, and an empty
+    # base_sha would checkout `ref: ''`.
+    assert "needs.fence.outputs.base_sha" in str(with_["base_sha"])
+    assert "needs.prep.outputs.pushed_sha" in str(with_["ours"])
+    # Review 1 must survive a prep that failed — an un-updated branch still
+    # reviews correctly.
+    assert "!cancelled()" in str(r1["if"])
+    assert "prep.result" not in str(r1["if"])
+
+    assert "prep" in jobs["finalize"]["needs"]

--- a/.github/scripts/tests/test_sdk_loop_prep.py
+++ b/.github/scripts/tests/test_sdk_loop_prep.py
@@ -14,7 +14,6 @@ from sdk_loop_prep import (  # noqa: E402
     OUTCOME_CLEAN,
     OUTCOME_CONFLICTS,
     OUTCOME_RED,
-    OUTCOME_UPDATED,
     decide,
     needs_agent,
 )
@@ -29,21 +28,22 @@ def test_a_healthy_pr_costs_no_model_call() -> None:
     assert clean.ci_state == "green"
     assert not needs_agent(clean), "a clean PR must not reach the model"
     assert clean.pushed_sha == "", "nothing was pushed, so claim nothing"
+    assert "behind" not in clean.detail.lower()
 
 
-def test_a_behind_branch_is_updated_and_the_push_is_owned() -> None:
-    """`pushed_sha` is not decoration. Review 1 receives it as `ours`; without
-    it the round sees live != baseline with an empty ours-list, calls it
-    `moved_by_other` and re-aims — burning a round every time prep works."""
-    out = decide(
-        {"mergeStateStatus": "CLEAN", "headRefOid": "b" * 40},
-        (),
-        "a" * 40,
-        updated_sha="b" * 40,
-    )
-    assert out.outcome == OUTCOME_UPDATED
-    assert out.pushed_sha == "b" * 40
-    assert out.new_base_sha == "b" * 40
+def test_a_behind_branch_is_reported_not_updated() -> None:
+    """Prep does not touch the branch on its own initiative.
+
+    Merging base into somebody's PR is a change to their branch they did not
+    ask for, and it is not needed to review: the review reads the diff
+    against base, which is well-defined whether or not base has moved. So
+    BEHIND is a line in the detail, not an action.
+    """
+    out = decide({"mergeStateStatus": "BEHIND", "headRefOid": "a" * 40}, (), "a" * 40)
+    assert out.outcome == OUTCOME_CLEAN
+    assert out.pushed_sha == "", "prep pushed nothing, so it must claim nothing"
+    assert out.new_base_sha == "a" * 40, "the review runs on the real head"
+    assert "behind" in out.detail.lower(), "a human should still be able to see it"
     assert not needs_agent(out)
 
 

--- a/.github/scripts/tests/test_sdk_loop_prep.py
+++ b/.github/scripts/tests/test_sdk_loop_prep.py
@@ -11,11 +11,16 @@ import yaml
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 from sdk_loop_prep import (  # noqa: E402
+    BUCKET_FAIL,
+    CHECK_FIELDS,
     OUTCOME_CLEAN,
     OUTCOME_CONFLICTS,
     OUTCOME_RED,
+    OUTCOME_UNKNOWN,
     decide,
+    failing_checks,
     needs_agent,
+    pr_state,
 )
 
 
@@ -113,3 +118,95 @@ def test_the_generated_chain_wires_prep_without_stranding_review_one() -> None:
     assert "prep.result" not in str(r1["if"])
 
     assert "prep" in jobs["finalize"]["needs"]
+
+
+# ---------------------------------------------------------------------------
+# The gh boundary — where the first version of this file was silently wrong
+# ---------------------------------------------------------------------------
+
+
+class _Done:
+    def __init__(self, returncode: int = 0, stdout: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+def test_the_check_reader_asks_for_fields_gh_actually_has() -> None:
+    """This file shipped asking for `conclusion`, which `gh pr checks --json`
+    does not have. gh writes "Unknown JSON field" to stderr, EXITS 0, and
+    prints nothing — so a reader that trusts stdout sees no failures and
+    reports green on a red PR. Nothing anywhere raised.
+
+    The tuple-injecting tests could not catch it: they start after the parse.
+    This one pins the wire vocabulary, which is the only place the mistake
+    was visible.
+    """
+    seen: list[list[str]] = []
+
+    def runner(args: list[str]) -> _Done:
+        seen.append(args)
+        return _Done(0, "[]")
+
+    failing_checks("o/r", 1, runner=runner)
+    fields = seen[0][seen[0].index("--json") + 1].split(",")
+    assert "conclusion" not in fields, "gh has no `conclusion` field on pr checks"
+    assert set(fields) <= {
+        "bucket",
+        "completedAt",
+        "description",
+        "event",
+        "link",
+        "name",
+        "startedAt",
+        "state",
+        "workflow",
+    }, "asked gh for a field it does not expose — it will exit 0 and print nothing"
+    assert "bucket" in fields, "bucket carries pass/fail; state/conclusion do not"
+
+
+def test_a_failing_check_is_actually_detected() -> None:
+    """The end-to-end shape, in gh's real vocabulary. #3575 had one `fail`
+    bucket at the time this was written, and the shipped reader called it
+    green."""
+    payload = (
+        '[{"name":"SDK Tests","state":"FAILURE","bucket":"fail"},'
+        '{"name":"Conformance","state":"SUCCESS","bucket":"pass"},'
+        '{"name":"E2E","state":"SKIPPED","bucket":"skipping"}]'
+    )
+    got = failing_checks("o/r", 1, runner=lambda a: _Done(0, payload))
+    assert got == ("SDK Tests",)
+    assert BUCKET_FAIL == "fail"
+    assert "conclusion" not in CHECK_FIELDS
+
+    out = decide({"mergeStateStatus": "CLEAN", "headRefOid": "a" * 40}, got, "a" * 40)
+    assert out.outcome == OUTCOME_RED
+    assert needs_agent(out), "a real failure must reach the mechanical-fix path"
+
+
+def test_an_unreadable_state_is_unknown_and_never_green() -> None:
+    """Fail CLOSED. Every layer of the first version degraded into the most
+    optimistic answer: gh exited 0, `stdout or "[]"` made empty look like an
+    empty list, and an empty list looked like a healthy PR."""
+    for bad in (_Done(1, ""), _Done(0, ""), _Done(0, "not json")):
+        assert failing_checks("o/r", 1, runner=lambda a, b=bad: b) is None
+        assert pr_state("o/r", 1, runner=lambda a, b=bad: b) is None
+
+    # Shape-specific: a JSON object is not a check list, and a state object
+    # with no headRefOid is not a state — both would otherwise read as
+    # "nothing wrong".
+    assert failing_checks("o/r", 1, runner=lambda a: _Done(0, '{"a":1}')) is None
+    assert pr_state("o/r", 1, runner=lambda a: _Done(0, '{"a":1}')) is None
+    assert pr_state("o/r", 1, runner=lambda a: _Done(0, '{"headRefOid":"abc"}')) == {
+        "headRefOid": "abc"
+    }
+
+    unknown_checks = decide(
+        {"mergeStateStatus": "CLEAN", "headRefOid": "a" * 40}, None, "a" * 40
+    )
+    assert unknown_checks.outcome == OUTCOME_UNKNOWN
+    assert unknown_checks.ci_state != "green"
+
+    unknown_state = decide(None, None, "a" * 40)
+    assert unknown_state.outcome == OUTCOME_UNKNOWN
+    assert unknown_state.new_base_sha == "a" * 40, "the review still runs"
+    assert unknown_state.outcome != OUTCOME_CLEAN

--- a/.github/workflows/sdk-loop-phase.yml
+++ b/.github/workflows/sdk-loop-phase.yml
@@ -24,7 +24,7 @@ on:
       phase:
         type: string
         required: true
-        description: 'review | resolve'
+        description: 'prep | review | resolve'
       round:
         type: number
         required: true
@@ -96,6 +96,8 @@ on:
         value: ${{ jobs.phase.outputs.ledger }}
       detail:
         value: ${{ jobs.phase.outputs.detail }}
+      ci_state:
+        value: ${{ jobs.phase.outputs.ci_state }}
       cost:
         value: ${{ jobs.phase.outputs.cost }}
       usage:
@@ -128,6 +130,7 @@ jobs:
       pushed_sha: ${{ steps.run.outputs.pushed_sha }}
       ledger: ${{ steps.run.outputs.ledger }}
       detail: ${{ steps.run.outputs.detail }}
+      ci_state: ${{ steps.run.outputs.ci_state }}
       cost: ${{ steps.run.outputs.cost }}
       usage: ${{ steps.run.outputs.usage }}
       reaims: ${{ steps.run.outputs.reaims }}
@@ -147,7 +150,12 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
           # The whole read-only guarantee for the review phase is this line.
-          permission-contents: ${{ inputs.phase == 'resolve' && 'write' || 'read' }}
+          # `prep` joins `resolve` on the write side: it exists precisely to
+          # do the things the review cannot — update a branch that is behind,
+          # push a mechanical fix. The review keeps `read`, which is what
+          # makes its read-only contract a property of the credential rather
+          # than a promise in a prompt.
+          permission-contents: ${{ (inputs.phase == 'resolve' || inputs.phase == 'prep') && 'write' || 'read' }}
           permission-pull-requests: write
           # PR comments are an Issues-scope resource, which the existing lane
           # learned the hard way (see "Mint fleet App token" in sdk-review.yml).
@@ -211,7 +219,7 @@ jobs:
           enable-cache: true
 
       - name: Configure git identity for the resolve phase
-        if: inputs.phase == 'resolve'
+        if: inputs.phase == 'resolve' || inputs.phase == 'prep'
         # Commit as the App whose token is doing the pushing, not as atlan-ci.
         # atlan-ci is a CODEOWNER and the identity that mints approvals, so
         # attributing loop commits to it blurs "who wrote this" with "who

--- a/.github/workflows/sdk-loop.yml
+++ b/.github/workflows/sdk-loop.yml
@@ -133,11 +133,24 @@ jobs:
           REACTION: ${{ steps.fence.outputs.proceed == 'true' && 'eyes' || 'confused' }}
         run: python3 .github/scripts/react_to_comment.py
 
+  prep:
+    name: Prep
+    needs: [fence]
+    if: needs.fence.outputs.proceed == 'true'
+    uses: ./.github/workflows/sdk-loop-phase.yml
+    secrets: inherit
+    with:
+      phase: prep
+      round: 0
+      pr: ${{ needs.fence.outputs.pr }}
+      head_ref: ${{ needs.fence.outputs.head_ref }}
+      base_sha: ${{ needs.fence.outputs.base_sha }}
+
   review-1:
     name: Review 1
-    needs: [fence]
+    needs: [fence, prep]
     if: >-
-      needs.fence.outputs.proceed == 'true'
+      !cancelled() && needs.fence.outputs.proceed == 'true'
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -145,8 +158,8 @@ jobs:
       round: 1
       pr: ${{ needs.fence.outputs.pr }}
       head_ref: ${{ needs.fence.outputs.head_ref }}
-      base_sha: ${{ needs.fence.outputs.base_sha }}
-      ours: ''
+      base_sha: ${{ needs.prep.outputs.new_base_sha || needs.fence.outputs.base_sha }}
+      ours: ${{ needs.prep.outputs.pushed_sha }}
       ledger: ''
       prior_sha: ''
       spent_so_far: ''
@@ -423,7 +436,7 @@ jobs:
 
   finalize:
     name: Summary
-    needs: [fence, review-1, resolve-1, review-2, resolve-2, review-3, resolve-3, review-4, resolve-4, review-5, resolve-5, review-6, resolve-6, review-7, resolve-7, review-8, resolve-8]
+    needs: [fence, prep, review-1, resolve-1, review-2, resolve-2, review-3, resolve-3, review-4, resolve-4, review-5, resolve-5, review-6, resolve-6, review-7, resolve-7, review-8, resolve-8]
     if: always() && needs.fence.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 6

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -364,19 +364,14 @@ BUDGET
    `<!-- VERDICT: NEEDS_REBASE -->`); the GHA layer applies the
    `sdk-review-needs-rebase` label from there. EXIT.
 
-9. **CI status read** (summary line ONLY — CI is not a verdict input):
-   ```bash
-   FAILING=$(gh pr checks "$PR_NUMBER" --repo "$REPO" \
-     --json name,conclusion --jq '.[] | select(.conclusion=="failure") | .name' 2>/dev/null)
-   ```
-   Record `FAILING` for the `**CI:**` summary line and nothing else. CI is
-   NOT a verdict input.
-   `sdk-review-downgrade-on-ci-failure.yml` enforces CI event-driven and
-   race-free: CI legs routinely finish AFTER the review posts, so a
-   reviewer-side CI gate is both racy (it reads a snapshot) and redundant
-   (the workflow strips any approval the moment a non-review check fails).
-   This is the only CI read in the review — there is no post-review
-   re-check.
+9. **Do not read CI.** Removed, not moved: the review cannot act on a check
+   either way — it holds no write scope on this lane — and
+   `sdk-review-downgrade-on-ci-failure.yml` already enforces CI against the
+   verdict event-driven, which is the only race-free way to do it. CI legs
+   routinely finish AFTER a review posts, so a reviewer-side snapshot was
+   always a stale fact reported next to a verdict it could not influence.
+   Under `@sdk-loop` the prep phase owns branch and check state before the
+   first review starts. Spend no turn on `gh pr checks`.
 
 10. Read the repo's `CLAUDE.md` for project conventions.
 
@@ -1146,11 +1141,9 @@ MEDIUM/LOW/INFO findings: one-line suggested_fix only. No path_forward.
 | NEEDS_FIXES | Critical, G4/G6, **any Important, any Nit** | REQUEST_CHANGES |
 | READY_TO_MERGE | **`### Findings` is empty — 0 Critical, 0 Important AND 0 Nit** | APPROVE |
 
-CI is deliberately NOT a verdict input. `sdk-review-downgrade-on-ci-failure.yml`
-strips an approval event-driven the moment any non-review check fails —
-the only race-free enforcement, since CI legs routinely finish after the
-review posts. The reviewer reports CI state on the `**CI:**` summary line
-(from the single Phase 0 step 9 read) and nothing more.
+CI is not a verdict input and is not reported. `sdk-review-downgrade-on-ci-failure.yml`
+strips an approval event-driven the moment any non-review check fails — the only
+race-free enforcement, since CI legs routinely finish after the review posts.
 
 `READY_TO_MERGE` is strict: **any** finding still listed under
 `### Findings` forces `NEEDS_FIXES`, whatever its tier. A single
@@ -1398,9 +1391,7 @@ scopes.
 <contents of /tmp/TOOLKIT_ROVER_NOTE.md>
 
 ---
-**CI:** all passing | N failing
-**Models:** <primary review model> (review) + <adversarial model — or "adversarial skipped (<reason>)">
-**Cross-model agreement:** X/Y confirmed by both
+**Models:** <primary review model>
 **Run:** [view workflow logs + cost](<GHA_RUN_URL>)
 ```
 
@@ -1532,9 +1523,8 @@ Retry once on 5xx from the GitHub API. On 422 (malformed inline
 comment because the line is not in the diff), drop that one finding
 and continue with the rest.
 
-There is no post-review CI re-check: the `**CI:**` line comes from the
-single Phase 0 step 9 read, and `sdk-review-downgrade-on-ci-failure.yml`
-owns enforcement for anything that finishes after the review posts.
+The review reads no CI state at all — see Phase 0 step 9.
+`sdk-review-downgrade-on-ci-failure.yml` owns that entirely.
 
 Print: `[Phase 3 complete] Review submitted`
 

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -539,12 +539,16 @@ this HEAD run the same commands the reviewer used to re-run wholesale
 lint and SDK imports`). Read them instead:
 
 ```bash
-gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,conclusion \
-  --jq '.[] | select(.name | startswith("Contract Toolkit")) | .name + " " + (.conclusion // "pending")' \
+# `bucket`, NOT `conclusion`. `gh pr checks --json` has no `conclusion`
+# field: it prints "Unknown JSON field" to stderr, EXITS 0, and writes
+# nothing to stdout — so this file would be empty and every leg would read
+# as missing. Buckets are pass / fail / skipping / pending.
+gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,bucket \
+  --jq '.[] | select(.name | startswith("Contract Toolkit")) | .name + " " + .bucket' \
   > /tmp/TOOLKIT_CI_LEGS.txt
 ```
 
-- Every leg `success` → record the legs as the local-check evidence in the
+- Every leg `pass` → record the legs as the local-check evidence in the
   ledger. Run a local command ONLY as the substrate for probing CI cannot
   express — guard ablations, scratch collision contracts, comparing
   PR-generated artifacts against a consumer's expectations.


### PR DESCRIPTION
The review holds a token with **no write scope**. That is the read-only guarantee — and it means the review could never rebase a behind branch, push a fix, or re-run a check.

So every turn it spent on CI produced a fact it was **powerless to change**, reported next to a verdict that fact was **explicitly not allowed to influence**. It was stale on arrival too: CI legs routinely finish *after* a review posts, which is why `sdk-review-downgrade-on-ci-failure.yml` enforces CI event-driven and already owns that job properly.

The duty moves to a phase that can act on it.

## New `prep` phase — deterministic first, and usually deterministic only

Runs once, after the fence, before Review 1. Holds write scope.

For a healthy PR the **whole phase is two `gh` calls and no model at all**:

```
read merge state  →  CONFLICTING? stop  →  read failing checks once  →  decide()
```

Those have unambiguous answers. A model cannot improve on *"is `mergeStateStatus` BEHIND"*, and most PRs enter the loop current and green — so paying an agent to confirm that would reintroduce exactly the waste this removes. `needs_agent()` gates the model, and **a clean PR never reaches it.**

## What prep refuses — the load-bearing part

| refuses | why |
|---|---|
| **Touch the branch on its own initiative** | Neither resolving a conflict nor merging base in is the loop's call — both change somebody's PR without being asked. Neither is needed to review, either: the review reads the diff against base, well-defined whether or not base has moved. Both are **reported and left alone** |
| **Wait for green** | No terminating condition when a check is genuinely broken. The failure mode is a phase burning an hour to discover what the review says in one line |
| **Fix real test failures** | Those are findings. A fix pushed from prep arrives with **no review behind it** |

Red CI is a **fact handed forward, never a blocker**. An un-updated or red branch still reviews correctly, so `review-1` gates on `!cancelled()` rather than on prep succeeding.

## Two wiring details that fail silently

**`ours` carries prep's push into Review 1.** Prep pushes only via the mechanical-fix path now, but when it does: without this the round sees `live != baseline` against an empty ours-list, calls it `moved_by_other`, and **re-aims — burning a round.** No error; just a wasted round.

**`base_sha` falls back to the fence.** A skipped prep emits nothing, and an empty value would `checkout ref: ''`.

## Resolve gains the same duty at the other end

It is the only phase that pushes, so it owns the state the next review inherits: run pre-commit over what it touched, update the branch if it fell behind — with the same ban on waiting for CI.

## The review stops looking

Phase 0 step 9 removed. The summary loses three lines with it:

- `**CI:**`
- `**Cross-model agreement:**`
- the `+ adversarial skipped (<reason>)` half of `**Models:**`

Wave 2 is settled for this lane — the resolver contests every finding before acting — so reporting its absence on every summary was noise about a decision nobody is revisiting.

**Kept:** the `gh pr checks` read in Phase 1b-toolkit. That reads `Contract Toolkit /` legs *as evidence to avoid re-running those commands locally* — the opposite of waste, and contract-toolkit scope only.

## Tests

**The permission guard now evaluates the expression per phase** instead of pinning one spelling — `review → read`, `resolve → write`, `prep → write`. The old string-match failed on this change for a reason unrelated to what it protects, and the tempting repair (paste in the new string) would pin the next one just as blindly.

**Every `needs.<job>` in the generated 19-job chain** is asserted to resolve to a job that exists *and* is declared. A dangling reference makes GitHub refuse to parse the workflow — so no jobs run and the fence never gets to say why. Silence, not an error.

Plus prep's own six: clean PR costs no model call, a behind branch is updated and the push is owned, conflicts reported never resolved, red checks don't block the review.

150 tests pass. Pre-commit clean including **actionlint** and pyright; `gen_sdk_loop_workflow.py --check` is up to date.
