### PR TITLE
ci(fix): build the renovate manifest from the scan, not from an s3 ls

### DIFF
--- a/.github/scripts/renovate_dashboard_stage.py
+++ b/.github/scripts/renovate_dashboard_stage.py
@@ -18,12 +18,23 @@ Layout produced under --stage-dir, mirroring s3://<bucket>/renovate-dashboard/:
     repos/<slug>.json       every per-repo summary the scanner emitted
     history/<slug>.jsonl    existing history + this run's rows, deduplicated
     fleet.json              full-fleet runs only
+    repos.json              full-fleet runs only — the manifest, built from the
+                            staged repo files rather than from an `aws s3 ls`
 
-Single-repo mode writes no fleet.json and no fleet history: the scanner only has
-data for one repo, so publishing either would overwrite the real fleet aggregate
-with a partial view. That decision lives here rather than in the workflow because
-`docs/standards/ci.md` keeps branching logic out of YAML, where it cannot be
-regression-tested.
+Single-repo mode writes no fleet.json, no fleet history and no manifest: the
+scanner only has data for one repo, so publishing any of them would overwrite a
+fleet-wide artifact with a partial view. That decision lives here rather than in
+the workflow because `docs/standards/ci.md` keeps branching logic out of YAML,
+where it cannot be regression-tested.
+
+The manifest is built from what this run staged, replacing an `aws s3 ls` of the
+prefix in the workflow. Listing the bucket cannot express fleet membership: the
+prefix is deliberately additive (no `--delete`, so a partial run can never drop
+another run's files), so every repo that has EVER published stays listed. On
+2026-08-31 that left 619 entries against a real consumer fleet of 80 — 452 of
+them repos that were never consumers, written while discovery was broken, and
+frozen ever since. Nothing deletes them, and nothing needs to: a manifest built
+from the scan simply stops naming them. FND-960.
 
 Usage:
     renovate_dashboard_stage.py --output-dir /tmp/renovate-output \\
@@ -34,6 +45,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import shutil
 import sys
 from pathlib import Path
@@ -91,7 +103,17 @@ def stage(
         merged += 1
 
     fleet_written = 0
+    manifest_written = 0
     if not single_repo:
+        if not repo_files:
+            # Same fail-closed reasoning as the missing aggregate below, and the
+            # same rule publish_fleet_dashboard.py applies: a manifest built from
+            # nothing empties every panel at once, which reads as a catastrophic
+            # regression rather than as the failed scan it is.
+            raise RuntimeError(
+                f"no per-repo files in {output_dir / 'repos'} on a full-fleet run "
+                "— refusing to stage a manifest that would empty the dashboard"
+            )
         fleet_json = output_dir / "fleet.json"
         if not fleet_json.is_file():
             # Fail closed, matching publish_fleet_dashboard.py. Staging the
@@ -112,10 +134,22 @@ def stage(
                 merge_history(existing, fleet_history), encoding="utf-8"
             )
 
+        # The manifest names exactly what this run staged. Deliberately NO
+        # fraction-based rail on how far it may shrink: the first run after a
+        # broken discovery legitimately drops the manifest from 619 to 80, which
+        # any such cap would block — and #3516 removed that class of heuristic
+        # from this scan for the same reason. The emptiness guard above is the
+        # rail; a shrink is visible in the log line either way.
+        (stage_dir / "repos.json").write_text(
+            json.dumps(sorted(path.name for path in repo_files)), encoding="utf-8"
+        )
+        manifest_written = 1
+
     return {
         "repos": len(repo_files),
         "histories": merged,
         "fleet_json": fleet_written,
+        "manifest": manifest_written,
     }
 
 
@@ -147,7 +181,9 @@ def main(argv: Optional[list[str]] = None) -> int:
         return 1
     print(
         f"staged {counts['repos']} repo files, {counts['histories']} histories, "
-        f"fleet.json={'yes' if counts['fleet_json'] else 'no'}"
+        f"fleet.json={'yes' if counts['fleet_json'] else 'no'}, "
+        f"manifest={'yes' if counts['manifest'] else 'no'} "
+        f"({counts['repos']} repos)"
     )
     return 0
 

--- a/.github/scripts/tests/test_renovate_dashboard_stage.py
+++ b/.github/scripts/tests/test_renovate_dashboard_stage.py
@@ -12,6 +12,8 @@ import json
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__))))
 
 import renovate_dashboard_stage as stage  # noqa: E402
@@ -48,7 +50,9 @@ def test_every_repo_summary_is_staged(tmp_path):
 
 
 def test_history_merges_existing_with_new(tmp_path):
-    out = _scanner_output(tmp_path, histories={"atlanhq_a": ['{"d":"2026-08-29"}']})
+    out = _scanner_output(
+        tmp_path, repos=["atlanhq_a"], histories={"atlanhq_a": ['{"d":"2026-08-29"}']}
+    )
     existing = _existing(tmp_path, {"atlanhq_a": ['{"d":"2026-08-28"}']})
 
     stage.stage(out, existing, tmp_path / "stage")
@@ -60,7 +64,7 @@ def test_history_merges_existing_with_new(tmp_path):
 def test_history_is_idempotent_across_reruns(tmp_path):
     # Two runs the same day emit an identical row; it must not accumulate.
     row = '{"d":"2026-08-29","open":5}'
-    out = _scanner_output(tmp_path, histories={"atlanhq_a": [row]})
+    out = _scanner_output(tmp_path, repos=["atlanhq_a"], histories={"atlanhq_a": [row]})
     existing = _existing(tmp_path, {"atlanhq_a": [row]})
 
     stage.stage(out, existing, tmp_path / "stage")
@@ -72,7 +76,11 @@ def test_history_is_idempotent_across_reruns(tmp_path):
 
 def test_history_survives_a_repo_with_no_published_history(tmp_path):
     # First time a repo is seen: no existing file, and that is not an error.
-    out = _scanner_output(tmp_path, histories={"atlanhq_new": ['{"d":"2026-08-29"}']})
+    out = _scanner_output(
+        tmp_path,
+        repos=["atlanhq_new"],
+        histories={"atlanhq_new": ['{"d":"2026-08-29"}']},
+    )
 
     stage.stage(out, _existing(tmp_path), tmp_path / "stage")
 
@@ -82,7 +90,9 @@ def test_history_survives_a_repo_with_no_published_history(tmp_path):
 
 
 def test_full_fleet_run_stages_fleet_aggregates(tmp_path):
-    out = _scanner_output(tmp_path, histories={"fleet": ['{"d":"2026-08-29"}']})
+    out = _scanner_output(
+        tmp_path, repos=["atlanhq_a"], histories={"fleet": ['{"d":"2026-08-29"}']}
+    )
     existing = _existing(tmp_path, {"fleet": ['{"d":"2026-08-28"}']})
 
     counts = stage.stage(out, existing, tmp_path / "stage", single_repo="")
@@ -99,7 +109,9 @@ def test_full_fleet_run_stages_fleet_aggregates(tmp_path):
 def test_single_repo_run_never_stages_fleet_aggregates(tmp_path):
     # The scanner only has one repo's data; publishing either would overwrite the
     # real fleet view with a partial one.
-    out = _scanner_output(tmp_path, histories={"fleet": ['{"d":"2026-08-29"}']})
+    out = _scanner_output(
+        tmp_path, repos=["atlanhq_a"], histories={"fleet": ['{"d":"2026-08-29"}']}
+    )
 
     counts = stage.stage(
         out, _existing(tmp_path), tmp_path / "stage", single_repo="atlanhq/a"
@@ -123,7 +135,9 @@ def test_fleet_history_is_never_staged_as_a_repo(tmp_path):
 
 
 def test_blank_lines_are_dropped(tmp_path):
-    out = _scanner_output(tmp_path, histories={"atlanhq_a": ['{"d":"1"}', "", "  "]})
+    out = _scanner_output(
+        tmp_path, repos=["atlanhq_a"], histories={"atlanhq_a": ['{"d":"1"}', "", "  "]}
+    )
 
     stage.stage(out, _existing(tmp_path), tmp_path / "stage")
 
@@ -213,3 +227,71 @@ def test_main_stages_end_to_end(tmp_path, capsys):
 
     assert rc == 0
     assert "staged 1 repo files, 1 histories, fleet.json=yes" in capsys.readouterr().out
+
+
+# ── the manifest (FND-960) ───────────────────────────────────────────────────
+
+
+def test_full_fleet_run_stages_a_manifest_of_what_it_scanned(tmp_path):
+    out = _scanner_output(tmp_path, repos=["atlanhq_a", "atlanhq_b"])
+    counts = stage.stage(out, _existing(tmp_path), tmp_path / "stage")
+
+    manifest = json.loads((tmp_path / "stage" / "repos.json").read_text())
+    assert manifest == ["atlanhq_a.json", "atlanhq_b.json"]
+    assert counts["manifest"] == 1
+
+
+def test_the_manifest_names_only_this_run_not_what_the_bucket_holds(tmp_path):
+    """The prefix is additive, so every repo that ever published stays stored.
+
+    Building the manifest from an `aws s3 ls` therefore listed 619 repos against
+    a fleet of 80 — 452 of them never consumers, written while discovery was
+    broken and frozen since. A manifest built from the scan stops naming them
+    without deleting anything.
+    """
+    out = _scanner_output(tmp_path, repos=["atlanhq_still-a-consumer"])
+    stage_dir = tmp_path / "stage"
+    (stage_dir / "repos").mkdir(parents=True)
+    # A leftover from an earlier, broken run, already staged/stored.
+    (stage_dir / "repos" / "atlanhq_CARAT.json").write_text("[]")
+
+    stage.stage(out, _existing(tmp_path), stage_dir)
+
+    manifest = json.loads((stage_dir / "repos.json").read_text())
+    assert manifest == ["atlanhq_still-a-consumer.json"]
+    # Not deleted — the sync is additive; it is simply no longer named.
+    assert (stage_dir / "repos" / "atlanhq_CARAT.json").is_file()
+
+
+def test_single_repo_run_never_stages_a_manifest(tmp_path):
+    """One repo must not be allowed to redefine fleet membership."""
+    out = _scanner_output(tmp_path, repos=["atlanhq_a"], fleet=False)
+    counts = stage.stage(
+        out, _existing(tmp_path), tmp_path / "stage", single_repo="atlanhq/a"
+    )
+    assert not (tmp_path / "stage" / "repos.json").exists()
+    assert counts["manifest"] == 0
+
+
+def test_full_fleet_run_refuses_to_stage_an_empty_manifest(tmp_path):
+    """A scan that produced nothing would empty every panel at once."""
+    out = _scanner_output(tmp_path, repos=[])
+    with pytest.raises(RuntimeError, match="refusing to stage a manifest"):
+        stage.stage(out, _existing(tmp_path), tmp_path / "stage")
+
+
+def test_no_fractional_shrink_rail_blocks_the_first_corrected_run(tmp_path):
+    """619 -> 80 is the fix working, not a fault to guard against.
+
+    Any percentage-based cap would refuse exactly this run. #3516 removed that
+    class of heuristic from this scan for the same reason.
+    """
+    out = _scanner_output(tmp_path, repos=[f"atlanhq_app-{i}" for i in range(80)])
+    stage_dir = tmp_path / "stage"
+    (stage_dir / "repos").mkdir(parents=True)
+    for i in range(619):
+        (stage_dir / "repos" / f"atlanhq_stale-{i}.json").write_text("[]")
+
+    stage.stage(out, _existing(tmp_path), stage_dir)
+
+    assert len(json.loads((stage_dir / "repos.json").read_text())) == 80

--- a/.github/workflows/renovate-dashboard.yaml
+++ b/.github/workflows/renovate-dashboard.yaml
@@ -198,17 +198,16 @@ jobs:
             --stage-dir /tmp/renovate-stage \
             --single-repo "${SINGLE_REPO:-}"
 
-          # Up in one pass. No --delete: this prefix is additive, and a partial
-          # run must never remove another run's repo files.
+          # Up in one pass, manifest included. No --delete: this prefix is
+          # additive, and a partial run must never remove another run's repo
+          # files.
+          #
+          # repos.json is staged by the script above (full-fleet runs only) and
+          # rides along in this sync. It used to be rebuilt here from an
+          # `aws s3 ls` of the prefix, which cannot express fleet membership on
+          # an additive prefix: every repo that ever published stayed listed
+          # forever. That left 619 entries against a fleet of 80 (FND-960).
           aws s3 sync /tmp/renovate-stage/ "s3://kryptonite-store/${PREFIX}/"
-
-          # Regenerate manifest of all repo files present in S3.
-          aws s3 ls "s3://kryptonite-store/${PREFIX}/repos/" \
-            | grep '\.json$' | awk '{print $4}' \
-            | python3 -c "import json,sys; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))" \
-            > /tmp/renovate-output/repos.json
-          aws s3 cp /tmp/renovate-output/repos.json \
-            "s3://kryptonite-store/${PREFIX}/repos.json"
 
           echo "Renovate dashboard updated: https://k.atlan.dev/${PREFIX}/"
 


### PR DESCRIPTION
@cmgrote — last piece of the renovate-dashboard thread, on top of #3524. Deliberately built **inside** your staging model rather than replacing it (see "What I did not do"). Not merging it myself.

## The problem

The deploy syncs **without `--delete`** — by design, so a partial run can never drop another run's repo files. Rebuilding `repos.json` from an `aws s3 ls` of that same prefix therefore cannot express fleet membership: **every repo that has ever published stays listed, forever.**

#3524 fixed the write side (discovery went from `Discovered 1 consumer repos` to `Discovered 80 fleet repos`). It could not retract what was already written. Measured today:

| | |
|---|---|
| Manifest entries | **619** |
| Real consumer fleet | **80** |
| Never consumers | **452** (`AI-taskforce`, `Atlan11`, `CARAT`, `Claude-Agent-Fleet`…) |

And they are provably frozen, not being rewritten:

| Document | `collectedAt` |
|---|---|
| `atlanhq_CARAT` | 2026-08-31T**12:26**:16Z |
| `atlanhq_AI-taskforce` | 2026-08-31T**12:26**:16Z |
| `atlanhq_atlan-workday-prism-analytics-app` *(archived)* | 2026-08-31T**12:26**:16Z |
| `atlanhq_atlan-mysql-app` *(real consumer)* | 2026-09-01T**04:14**:47Z |

12:26Z was the last run before #3524 merged at 16:15Z. Two full-fleet runs have happened since and touched none of them. They cannot leave a list built by listing the bucket.

## The change

`renovate_dashboard_stage.py` now stages `repos.json` from the repo files this run produced, and the workflow's `aws s3 ls` rebuild is deleted. The manifest rides along in the existing `aws s3 sync` — no extra S3 call.

**Full-fleet runs only.** A single-repo run has data for one repo and must not redefine fleet membership — the same rule, in the same place, as the `fleet.json` and fleet-history decisions the script already owns.

**Nothing is deleted.** The stale objects stay in the bucket, consistent with the additive-prefix invariant. They are merely no longer *named*, and the dashboard self-corrects 619 → 80 on the next full-fleet run.

## What I did not do

My first instinct was to route this through `publish_fleet_dashboard.py`, which has exactly this bounding logic (merged in #3480, proven on gate-enforcement going 168 → 167). **That would have reverted #3512**: it is the per-file `cp` model whose ~1,644 CLI invocations took 39m18s and overran the 45-minute ceiling. Building inside your staging script keeps the sync model intact.

I also did **not** add a fraction-based shrink rail. The first corrected run legitimately drops 619 → 80, so any such cap would block the fix itself — and #3516 removed that class of heuristic from this scan for the same reason. The rail here is an emptiness guard: a full-fleet run that staged no repo files raises rather than publishing a manifest that would empty every panel, matching `publish_fleet_dashboard.py`'s "no per-repo documents" refusal.

## Also closes an FND-960 leak

The archived `atlan-workday-prism-analytics-app` is in that 619. It was pruned on 27 Aug and reappeared on the 31st because the org-wide search re-created its document. #3524's `--no-archived` stops new writes; this stops the old one being listed.

## Verification

- `pytest .github/scripts/tests/test_renovate_dashboard_stage.py` — 13 → **18 passed**.
- `pre-commit` clean, **including `actionlint`** on the workflow edit.
- New cases: manifest names only this run; a leftover staged file is excluded but **not deleted**; single-repo stages no manifest; empty full-fleet run refuses; and one pinning that a 619 → 80 shrink is allowed through.

**Heads-up on existing tests:** five staged history on a full-fleet run with **zero** repo summaries — an input the module now refuses. They isolate history/aggregate behaviour, so each gained a summary. No assertion changed, and I'd rather flag that than have you find it in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)