### PR TITLE
ci(release): guard every release opener against re-minting a published version (FND-1168)

### DIFF
--- a/.github/scripts/conformance_release.py
+++ b/.github/scripts/conformance_release.py
@@ -24,6 +24,8 @@ import subprocess
 import sys
 from datetime import date
 
+import release_guard
+
 REPO = os.environ.get("GITHUB_REPOSITORY", "atlanhq/application-sdk")
 PYPROJECT = "packages/conformance/pyproject.toml"
 VERSION_PY = "packages/conformance/conformance/__init__.py"
@@ -270,6 +272,18 @@ def main():
     bump = compute_bump(subjects, bodies)
     new_version = bump_version(current, bump)
     new_tag = f"{TAG_PREFIX}{new_version}"
+
+    # This run may be looking at a frozen merge ref that predates an already
+    # merged-and-published release, in which case `current` is stale and we are
+    # about to mint a version that already exists. See release_guard for the
+    # incident (application-sdk#3570) and for why the check reads the version on
+    # origin/main rather than testing whether new_tag exists. Must run before
+    # any file is touched.
+    skip, main_version = release_guard.already_released(PYPROJECT, new_version)
+    if skip:
+        print(release_guard.skip_message(PYPROJECT, new_version, main_version))
+        _set_output("skip", "true")
+        return
 
     print(f"Version: {current} -> {new_version} ({bump} bump)")
 

--- a/.github/scripts/contract_toolkit_release.py
+++ b/.github/scripts/contract_toolkit_release.py
@@ -23,6 +23,8 @@ import subprocess
 import sys
 from datetime import date
 
+import release_guard
+
 REPO = os.environ.get("GITHUB_REPOSITORY", "atlanhq/application-sdk")
 PKLPROJECT = "contract-toolkit/src/PklProject"
 CHANGELOG = "contract-toolkit/CHANGELOG.md"
@@ -244,6 +246,18 @@ def main():
     bump = compute_bump(subjects, bodies)
     new_version = bump_version(current, bump)
     new_tag = f"{TAG_PREFIX}{new_version}"
+
+    # This run may be looking at a frozen merge ref that predates an already
+    # merged-and-published release, in which case `current` is stale and we are
+    # about to mint a version that already exists. See release_guard for the
+    # incident (application-sdk#3570) and for why the check reads the version on
+    # origin/main rather than testing whether new_tag exists. Must run before
+    # any file is touched.
+    skip, main_version = release_guard.already_released(PKLPROJECT, new_version)
+    if skip:
+        print(release_guard.skip_message(PKLPROJECT, new_version, main_version))
+        _set_output("skip", "true")
+        return
 
     print(f"Version: {current} -> {new_version} ({bump} bump)")
 

--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -1,10 +1,28 @@
 import argparse
 import logging
+import os
 import re
 import subprocess
 import sys
 
+import release_guard
 import semver
+
+PYPROJECT = "pyproject.toml"
+
+
+def _set_output(key, value):
+    """Write a step output for the calling workflow.
+
+    Falls back to stdout for local runs, where GITHUB_OUTPUT is unset.
+    """
+    gho = os.environ.get("GITHUB_OUTPUT")
+    if gho:
+        with open(gho, "a") as f:
+            f.write(f"{key}={value}\n")
+    else:
+        logging.info(f"OUTPUT: {key}={value}")
+
 
 # Commits scoped to sub-packages that manage their own versioning are dropped
 # from the SDK bump walk. Path-only exclusion in git log doesn't cover mixed
@@ -311,6 +329,30 @@ def main():
         has_release_tag=last_release_tag() is not None,
     )
 
+    # This job may be running against a frozen `pull_request` merge ref that
+    # predates an already merged-and-published release, in which case
+    # `current_version` is stale and `new_version` is one that already shipped.
+    # See release_guard for the incident (application-sdk#3570) and for why the
+    # check reads the version on the target branch rather than testing for a
+    # tag. Must run before pyproject.toml is touched.
+    #
+    # Callers gate their changelog and commit steps on this output. A caller
+    # pinned to an older sdk_scripts_ref never sets it, and an unset output
+    # reads as empty, so those steps simply run as they always did.
+    skip, remote_version = release_guard.already_released(
+        PYPROJECT, new_version, branch=current_branch
+    )
+    if skip:
+        logging.warning(
+            release_guard.skip_message(
+                PYPROJECT, new_version, remote_version, branch=current_branch
+            )
+        )
+        _set_output("skip", "true")
+        return
+
+    _set_output("skip", "false")
+    _set_output("new", new_version)
     update_pyproject_version(new_version=new_version)
 
 

--- a/.github/scripts/release_guard.py
+++ b/.github/scripts/release_guard.py
@@ -1,0 +1,144 @@
+"""
+release_guard.py
+----------------
+Shared guard against a release opener minting a version that has *already*
+been released.
+
+Why this exists
+===============
+Every release lane in this repo fires on ``pull_request: closed`` and checks
+out the PR's merge ref. That ref is **frozen** at the moment GitHub computed
+it, so a run triggered by PR *B* can be looking at a tree that predates the
+merge of release PR *A* — even though *A* landed on main seconds earlier and
+its package was already published.
+
+Observed on 2026-08-31 (application-sdk#3570):
+
+===================  =========================================================
+22:25:15             ``c532fd16`` — the v0.25.0 release PR (#3443) lands on main
+22:27:55             Publish run starts for v0.25.0
+22:27:56             Release opener starts for a *sibling* PR (#3569)
+22:28:02–07          Checks out ``refs/pull/3569/merge`` — parent ``da1ed376``,
+                     i.e. main **before** the release merge
+22:28:10             Reads version 0.24.0, mints 0.25.0 a second time
+22:28:17             Force-pushes the shared bump branch, opens a duplicate PR
+22:28:19             Publish creates tag ``conformance-v0.25.0``
+===================  =========================================================
+
+Merging that duplicate would have attempted a second PyPI upload of 0.25.0 and
+a second ``conformance-v0.25.0`` tag.
+
+Why the check is version-based and not tag-based
+================================================
+The obvious guard — "skip if the tag for the version I computed already
+exists" — **does not work**, and the timeline above is the proof: the tag was
+created at 22:28:19, nine seconds *after* the opener read the repo at
+22:28:10. At the only moment the guard could have run, the tag did not exist.
+
+What *was* already true at 22:28:10 is that ``origin/main`` carried version
+0.25.0 (merged at 22:25:15). So the reliable signal is the version on the
+target branch, read fresh from the remote rather than from the frozen
+checkout. Please do not "simplify" this into a tag-existence check.
+
+Fail-open by design
+===================
+Every failure to determine the remote version — no network, no token scope,
+missing file, a version string this module cannot parse — returns "not already
+released" and lets the release proceed. A lane that goes red because it could
+not reach origin would be a worse defect than the duplicate PR this prevents.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+
+VERSION_RE = re.compile(r'^version\s*=\s*"([^"]+)"', re.MULTILINE)
+TRIPLE_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+def parse_version(text):
+    """Return the ``version = "..."`` value in *text*, or None.
+
+    Matches both ``pyproject.toml`` and Pkl ``PklProject`` files, which
+    happen to share this spelling.
+    """
+    m = VERSION_RE.search(text or "")
+    return m.group(1) if m else None
+
+
+def version_tuple(version):
+    """Return (major, minor, patch) for a plain X.Y.Z string, else None.
+
+    Anything with a pre-release or build suffix returns None, which makes the
+    caller fail open. That is deliberate: ordering ``1.0.0-rc1`` against
+    ``1.0.0`` correctly needs full PEP 440 / semver semantics, and this module
+    is stdlib-only so it can run in every lane (the conformance and
+    contract-toolkit openers install no extra packages).
+    """
+    m = TRIPLE_RE.match(version or "")
+    return tuple(int(x) for x in m.groups()) if m else None
+
+
+def version_on_branch(path, branch="main", remote="origin"):
+    """Version of *path* as it exists on ``<remote>/<branch>``, or None.
+
+    Fetches the branch first so the answer reflects the remote *now*, not the
+    frozen merge-ref checkout the job started from.
+    """
+    # Fetch into the remote-tracking ref explicitly. Reading FETCH_HEAD instead
+    # would be wrong: it is mutable global state in the checkout, so any other
+    # git fetch earlier in the job (the private-dependency auth steps in the
+    # app lane do run git commands) leaves its own value behind.
+    fetched = subprocess.run(
+        ["git", "fetch", "--quiet", remote, f"{branch}:refs/remotes/{remote}/{branch}"],
+        capture_output=True,
+        text=True,
+    )
+    if fetched.returncode != 0:
+        # A non-fast-forward update of the tracking ref is fine to ignore; the
+        # plain fetch below still refreshes it in the common case.
+        subprocess.run(
+            ["git", "fetch", "--quiet", remote, branch],
+            capture_output=True,
+            text=True,
+        )
+
+    for ref in (f"{remote}/{branch}", "FETCH_HEAD"):
+        shown = subprocess.run(
+            ["git", "show", f"{ref}:{path}"], capture_output=True, text=True
+        )
+        if shown.returncode == 0:
+            parsed = parse_version(shown.stdout)
+            if parsed:
+                return parsed
+    return None
+
+
+def already_released(path, new_version, branch="main", remote="origin"):
+    """Return ``(skip, remote_version)`` for the release about to be minted.
+
+    *skip* is True when ``<remote>/<branch>`` already carries *new_version* or
+    newer — meaning some other run has already opened and merged this release,
+    so minting it again would duplicate a published version.
+
+    Returns ``(False, ...)`` — let the release proceed — whenever the remote
+    version cannot be determined or compared. *remote_version* is returned
+    alongside so the caller can log the evidence without a second fetch.
+    """
+    remote_version = version_on_branch(path, branch=branch, remote=remote)
+    remote_t = version_tuple(remote_version)
+    new_t = version_tuple(new_version)
+    if remote_t is None or new_t is None:
+        return False, remote_version
+    return remote_t >= new_t, remote_version
+
+
+def skip_message(path, new_version, remote_version, branch="main"):
+    """Human-readable reason, for the run log."""
+    return (
+        f"{path} on origin/{branch} is already at {remote_version!r}, which is "
+        f">= the computed {new_version!r}. This release has already been "
+        f"published — most likely this run checked out a frozen merge ref that "
+        f"predates it. Skipping instead of opening a duplicate release PR."
+    )

--- a/.github/scripts/release_guard.py
+++ b/.github/scripts/release_guard.py
@@ -53,7 +53,7 @@ from __future__ import annotations
 import re
 import subprocess
 
-VERSION_RE = re.compile(r'^version\s*=\s*"([^"]+)"', re.MULTILINE)
+VERSION_RE = re.compile(r'^\s*version\s*=\s*"([^"]+)"', re.MULTILINE)
 TRIPLE_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 
 

--- a/.github/scripts/tests/test_conformance_release.py
+++ b/.github/scripts/tests/test_conformance_release.py
@@ -365,6 +365,15 @@ class TestMainBootstrap:
         monkeypatch.setattr(conformance_release, "VERSION_PY", str(version_py))
         monkeypatch.setattr(conformance_release, "CHANGELOG", str(changelog))
         monkeypatch.setattr(conformance_release, "RELEASE_NOTES_FILE", str(relnotes))
+        # Keep main() hermetic. The already-released guard would otherwise run a
+        # real `git fetch` against origin on every one of these tests. The guard
+        # itself is covered by test_release_guard.py; its wiring into main() is
+        # covered by TestAlreadyReleasedGuard below.
+        monkeypatch.setattr(
+            conformance_release.release_guard,
+            "already_released",
+            lambda *_a, **_k: (False, None),
+        )
         return pyproject, version_py, changelog, relnotes
 
     def test_first_release_falls_back_to_initial_commit(
@@ -451,6 +460,15 @@ class TestMainExistingTag:
         monkeypatch.setattr(conformance_release, "VERSION_PY", str(version_py))
         monkeypatch.setattr(conformance_release, "CHANGELOG", str(changelog))
         monkeypatch.setattr(conformance_release, "RELEASE_NOTES_FILE", str(relnotes))
+        # Keep main() hermetic. The already-released guard would otherwise run a
+        # real `git fetch` against origin on every one of these tests. The guard
+        # itself is covered by test_release_guard.py; its wiring into main() is
+        # covered by TestAlreadyReleasedGuard below.
+        monkeypatch.setattr(
+            conformance_release.release_guard,
+            "already_released",
+            lambda *_a, **_k: (False, None),
+        )
         return pyproject, version_py, changelog, relnotes
 
     def test_no_commits_sets_skip_true(
@@ -533,6 +551,104 @@ class TestMainExistingTag:
 
         assert outputs["new"] == "0.3.0"  # minor bump from 0.2.0
         assert 'version = "0.3.0"' in pyproject.read_text()
+
+
+class TestAlreadyReleasedGuard:
+    """main() must not mint a version origin/main already carries.
+
+    Reproduces application-sdk#3570: a run whose checkout is a frozen merge ref
+    predating the release merge reads a stale current version, recomputes the
+    version that was just published, and opens a duplicate release PR.
+    """
+
+    def _setup(
+        self, version: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple:
+        pyproject = _pyproject(version, tmp_path)
+        version_py = _version_py(version, tmp_path)
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("# Changelog\n")
+        relnotes = tmp_path / "release-notes.md"
+
+        monkeypatch.setattr(conformance_release, "PYPROJECT", str(pyproject))
+        monkeypatch.setattr(conformance_release, "VERSION_PY", str(version_py))
+        monkeypatch.setattr(conformance_release, "CHANGELOG", str(changelog))
+        monkeypatch.setattr(conformance_release, "RELEASE_NOTES_FILE", str(relnotes))
+
+        def fake_run(cmd, **_kw):
+            if "--format=%s" in cmd:
+                return "feat: add new check"
+            if "--format=%B" in cmd:
+                return ""
+            if any("--format=%H" in str(c) for c in cmd):
+                return "abc9999\x00feat: add new check\x00\x1e"
+            return ""
+
+        monkeypatch.setattr(conformance_release, "tag_exists", lambda _tag: True)
+        monkeypatch.setattr(conformance_release, "_run", fake_run)
+        return pyproject, version_py, changelog, relnotes
+
+    def test_skips_and_leaves_every_file_untouched(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        # Stale checkout says 0.24.0, so main() computes 0.25.0 — but origin/main
+        # is already at 0.25.0 because the release PR merged moments ago.
+        pyproject, version_py, changelog, relnotes = self._setup(
+            "0.24.0", tmp_path, monkeypatch
+        )
+        before = (pyproject.read_text(), version_py.read_text(), changelog.read_text())
+
+        monkeypatch.setattr(
+            conformance_release.release_guard,
+            "already_released",
+            lambda *_a, **_k: (True, "0.25.0"),
+        )
+
+        outputs: dict = {}
+        monkeypatch.setattr(
+            conformance_release, "_set_output", lambda k, v: outputs.update({k: v})
+        )
+
+        conformance_release.main()
+
+        # The workflow gates every downstream step on skip != 'true', so this
+        # single output is what prevents the push and the duplicate PR.
+        assert outputs.get("skip") == "true"
+        assert "new" not in outputs
+        # Nothing may be mutated: the guard runs before any file is written.
+        assert (
+            pyproject.read_text(),
+            version_py.read_text(),
+            changelog.read_text(),
+        ) == before
+        assert not relnotes.exists()
+        assert "already been published" in capsys.readouterr().out
+
+    def test_guard_is_asked_about_the_computed_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The guard must be handed the *new* version, not the current one."""
+        self._setup("0.24.0", tmp_path, monkeypatch)
+
+        seen: dict = {}
+
+        def fake_guard(path, new_version, **_kw):
+            seen["path"] = path
+            seen["new_version"] = new_version
+            return False, None
+
+        monkeypatch.setattr(
+            conformance_release.release_guard, "already_released", fake_guard
+        )
+        monkeypatch.setattr(conformance_release, "_set_output", lambda _k, _v: None)
+
+        conformance_release.main()
+
+        assert seen["new_version"] == "0.25.0"
+        assert seen["path"] == conformance_release.PYPROJECT
 
 
 # ---------------------------------------------------------------------------

--- a/.github/scripts/tests/test_release.py
+++ b/.github/scripts/tests/test_release.py
@@ -397,3 +397,81 @@ class TestApplyFirstReleaseFloor:
             )
             == "0.2.0"
         )
+
+
+class TestMainAlreadyReleasedGuard:
+    """release.main() must not bump to a version the target branch already has.
+
+    Reproduces application-sdk#3570 in the lane shared by the SDK's own release
+    and all app repos: a run whose checkout is a frozen merge ref predating the
+    release merge recomputes the version that just shipped.
+    """
+
+    def _wire(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        guard_result: tuple,
+        branch: str = "main",
+        new_version: str = "1.3.0",
+    ) -> tuple[list, dict, dict]:
+        monkeypatch.setattr(sys, "argv", ["release.py", branch, "1.2.0"])
+        monkeypatch.setattr(release, "get_commits_since_last_tag", lambda: ["feat: x"])
+        monkeypatch.setattr(release, "last_release_tag", lambda: "v1.2.0")
+        monkeypatch.setattr(release, "calculate_version_bump", lambda **_k: new_version)
+
+        written: list = []
+        monkeypatch.setattr(
+            release,
+            "update_pyproject_version",
+            lambda **kw: written.append(kw["new_version"]),
+        )
+
+        outputs: dict = {}
+        monkeypatch.setattr(release, "_set_output", lambda k, v: outputs.update({k: v}))
+
+        seen: dict = {}
+
+        def fake_guard(path, version, **kwargs):
+            seen["path"] = path
+            seen["version"] = version
+            seen["branch"] = kwargs.get("branch")
+            return guard_result
+
+        monkeypatch.setattr(release.release_guard, "already_released", fake_guard)
+        return written, outputs, seen
+
+    def test_skips_without_writing_pyproject(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        written, outputs, _ = self._wire(monkeypatch, guard_result=(True, "1.3.0"))
+
+        release.main()
+
+        # The callers gate their changelog and commit steps on this output.
+        assert outputs["skip"] == "true"
+        assert "new" not in outputs
+        assert written == []
+
+    def test_normal_release_proceeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        written, outputs, _ = self._wire(monkeypatch, guard_result=(False, "1.2.0"))
+
+        release.main()
+
+        assert outputs["skip"] == "false"
+        assert outputs["new"] == "1.3.0"
+        assert written == ["1.3.0"]
+
+    def test_guard_is_asked_about_the_target_branch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """App repos may release off a branch other than main."""
+        _w, _o, seen = self._wire(
+            monkeypatch, guard_result=(False, None), branch="release-2.x"
+        )
+
+        release.main()
+
+        assert seen["branch"] == "release-2.x"
+        assert seen["version"] == "1.3.0"
+        assert seen["path"] == "pyproject.toml"

--- a/.github/scripts/tests/test_release_guard.py
+++ b/.github/scripts/tests/test_release_guard.py
@@ -20,6 +20,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 import release_guard
 
 PYPROJECT = "packages/conformance/pyproject.toml"
+PKLPROJECT = "contract-toolkit/src/PklProject"
+PKLPROJECT_VERSION = 'package {\n  version = "0.23.0"\n}\n'
 
 
 def _fake_git(monkeypatch, *, show: dict[str, str] | None = None, fetch_rc: int = 0):
@@ -50,6 +52,16 @@ def _fake_git(monkeypatch, *, show: dict[str, str] | None = None, fetch_rc: int 
 
 
 class TestGuardFires:
+    def test_indented_pklproject_version_is_already_released(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _fake_git(monkeypatch, show={f"origin/main:{PKLPROJECT}": PKLPROJECT_VERSION})
+
+        skip, remote = release_guard.already_released(PKLPROJECT, "0.23.0")
+
+        assert skip is True
+        assert remote == "0.23.0"
+
     def test_equal_version_is_already_released(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -247,7 +259,8 @@ class TestParsing:
             ('version = "1.2.3"', "1.2.3"),
             ("version = '1.2.3'", None),  # single quotes are not the spelling used
             ('name = "x"\nversion = "0.1.0"\n', "0.1.0"),
-            ('amends "../App.pkl"\nversion = "9.9.9"\n', "9.9.9"),  # PklProject
+            ('amends "../App.pkl"\n  version = "9.9.9"\n', "9.9.9"),  # PklProject
+            (PKLPROJECT_VERSION, "0.23.0"),
             ("no version at all", None),
             ("", None),
         ],

--- a/.github/scripts/tests/test_release_guard.py
+++ b/.github/scripts/tests/test_release_guard.py
@@ -1,0 +1,281 @@
+"""Tests for .github/scripts/release_guard.py.
+
+The guard fails open on every error path, so a test suite that only checked
+"nothing breaks" would pass even if the guard never fired at all. The tests
+below therefore assert the *positive* case first and hardest: given a remote
+branch that is already at or beyond the computed version, the guard must say
+skip.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import release_guard
+
+PYPROJECT = "packages/conformance/pyproject.toml"
+
+
+def _fake_git(monkeypatch, *, show: dict[str, str] | None = None, fetch_rc: int = 0):
+    """Stub subprocess.run for git fetch/show.
+
+    ``show`` maps a ref-qualified path (``"origin/main:some/path"``) to the file
+    content git should return; anything absent exits non-zero, as git does for
+    an unknown ref or path.
+    """
+    show = show or {}
+
+    def fake_run(cmd, **_kwargs):
+        if cmd[:2] == ["git", "fetch"]:
+            return subprocess.CompletedProcess(cmd, fetch_rc, "", "")
+        if cmd[:2] == ["git", "show"]:
+            key = cmd[2]
+            if key in show:
+                return subprocess.CompletedProcess(cmd, 0, show[key], "")
+            return subprocess.CompletedProcess(cmd, 128, "", "fatal: invalid object")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(release_guard.subprocess, "run", fake_run)
+
+
+# ---------------------------------------------------------------------------
+# The guard fires — the case the incident needed
+# ---------------------------------------------------------------------------
+
+
+class TestGuardFires:
+    def test_equal_version_is_already_released(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The exact application-sdk#3570 shape.
+
+        A frozen checkout read 0.24.0 and computed 0.25.0, while origin/main was
+        already at 0.25.0 from the release that had just merged.
+        """
+        _fake_git(
+            monkeypatch, show={f"origin/main:{PYPROJECT}": 'version = "0.25.0"\n'}
+        )
+
+        skip, remote = release_guard.already_released(PYPROJECT, "0.25.0")
+
+        assert skip is True
+        assert remote == "0.25.0"
+
+    def test_remote_ahead_is_already_released(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _fake_git(
+            monkeypatch, show={f"origin/main:{PYPROJECT}": 'version = "0.26.0"\n'}
+        )
+
+        skip, _ = release_guard.already_released(PYPROJECT, "0.25.0")
+
+        assert skip is True
+
+    def test_patch_race_against_a_newer_minor(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """String comparison would get this wrong; tuple comparison must not.
+
+        A fix-only sibling computes 0.24.1 while main has already moved to
+        0.25.0. ``"0.25.0" >= "0.24.1"`` happens to hold as strings here, but
+        the 0.9.0/0.10.0 case below is where string ordering breaks.
+        """
+        _fake_git(
+            monkeypatch, show={f"origin/main:{PYPROJECT}": 'version = "0.25.0"\n'}
+        )
+
+        skip, _ = release_guard.already_released(PYPROJECT, "0.24.1")
+
+        assert skip is True
+
+    def test_double_digit_minor_beats_string_ordering(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``"0.9.0" > "0.10.0"`` as strings — the guard must not be fooled."""
+        _fake_git(
+            monkeypatch, show={f"origin/main:{PYPROJECT}": 'version = "0.10.0"\n'}
+        )
+
+        skip, _ = release_guard.already_released(PYPROJECT, "0.9.0")
+
+        assert skip is True
+
+
+# ---------------------------------------------------------------------------
+# The guard stays out of the way — normal releases must not be blocked
+# ---------------------------------------------------------------------------
+
+
+class TestGuardAllowsRealRelease:
+    def test_remote_behind_proceeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The ordinary case: main is at the version we are bumping *from*."""
+        _fake_git(
+            monkeypatch, show={f"origin/main:{PYPROJECT}": 'version = "0.24.0"\n'}
+        )
+
+        skip, remote = release_guard.already_released(PYPROJECT, "0.25.0")
+
+        assert skip is False
+        assert remote == "0.24.0"
+
+    def test_double_digit_minor_proceeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_git(monkeypatch, show={f"origin/main:{PYPROJECT}": 'version = "0.9.0"\n'})
+
+        skip, _ = release_guard.already_released(PYPROJECT, "0.10.0")
+
+        assert skip is False
+
+
+# ---------------------------------------------------------------------------
+# Fail-open paths — never block a release because the check itself failed
+# ---------------------------------------------------------------------------
+
+
+class TestFailsOpen:
+    def test_unreadable_path_proceeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_git(monkeypatch, show={})
+
+        skip, remote = release_guard.already_released(PYPROJECT, "0.25.0")
+
+        assert skip is False
+        assert remote is None
+
+    def test_fetch_failure_proceeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No network / no token scope must not turn into a red release lane."""
+        _fake_git(monkeypatch, show={}, fetch_rc=128)
+
+        skip, _ = release_guard.already_released(PYPROJECT, "0.25.0")
+
+        assert skip is False
+
+    def test_unparseable_remote_version_proceeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _fake_git(
+            monkeypatch, show={f"origin/main:{PYPROJECT}": "name = 'no version here'\n"}
+        )
+
+        skip, _ = release_guard.already_released(PYPROJECT, "0.25.0")
+
+        assert skip is False
+
+    def test_prerelease_computed_version_proceeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ordering a pre-release needs full semver; fail open rather than guess."""
+        _fake_git(monkeypatch, show={f"origin/main:{PYPROJECT}": 'version = "1.0.0"\n'})
+
+        skip, _ = release_guard.already_released(PYPROJECT, "1.0.0-rc1")
+
+        assert skip is False
+
+    def test_prerelease_remote_version_proceeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _fake_git(
+            monkeypatch, show={f"origin/main:{PYPROJECT}": 'version = "1.0.0-rc1"\n'}
+        )
+
+        skip, _ = release_guard.already_released(PYPROJECT, "1.0.0")
+
+        assert skip is False
+
+
+# ---------------------------------------------------------------------------
+# Ref selection
+# ---------------------------------------------------------------------------
+
+
+class TestRefHandling:
+    def test_reads_remote_tracking_ref_not_fetch_head(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FETCH_HEAD is mutable global state; the tracking ref must win.
+
+        Both refs are readable here and they disagree — the guard must report
+        the remote-tracking one.
+        """
+        _fake_git(
+            monkeypatch,
+            show={
+                f"origin/main:{PYPROJECT}": 'version = "0.25.0"\n',
+                f"FETCH_HEAD:{PYPROJECT}": 'version = "0.11.0"\n',
+            },
+        )
+
+        assert release_guard.version_on_branch(PYPROJECT) == "0.25.0"
+
+    def test_falls_back_to_fetch_head(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A checkout with no remote-tracking ref still gets an answer."""
+        _fake_git(monkeypatch, show={f"FETCH_HEAD:{PYPROJECT}": 'version = "0.25.0"\n'})
+
+        assert release_guard.version_on_branch(PYPROJECT) == "0.25.0"
+
+    def test_honours_non_main_target_branch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """App repos pass target_branch; the guard must read that branch."""
+        _fake_git(
+            monkeypatch,
+            show={f"origin/release-2.x:{PYPROJECT}": 'version = "2.4.0"\n'},
+        )
+
+        skip, remote = release_guard.already_released(
+            PYPROJECT, "2.4.0", branch="release-2.x"
+        )
+
+        assert skip is True
+        assert remote == "2.4.0"
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+class TestParsing:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ('version = "1.2.3"', "1.2.3"),
+            ("version = '1.2.3'", None),  # single quotes are not the spelling used
+            ('name = "x"\nversion = "0.1.0"\n', "0.1.0"),
+            ('amends "../App.pkl"\nversion = "9.9.9"\n', "9.9.9"),  # PklProject
+            ("no version at all", None),
+            ("", None),
+        ],
+    )
+    def test_parse_version(self, text: str, expected: str | None) -> None:
+        assert release_guard.parse_version(text) == expected
+
+    @pytest.mark.parametrize(
+        "version,expected",
+        [
+            ("1.2.3", (1, 2, 3)),
+            ("0.10.0", (0, 10, 0)),
+            ("10.0.0", (10, 0, 0)),
+            ("1.0.0-rc1", None),
+            ("1.0", None),
+            ("1.2.3.4", None),
+            ("", None),
+            (None, None),
+        ],
+    )
+    def test_version_tuple(self, version: str | None, expected) -> None:
+        assert release_guard.version_tuple(version) == expected
+
+
+class TestSkipMessage:
+    def test_names_both_versions_and_the_path(self) -> None:
+        msg = release_guard.skip_message(PYPROJECT, "0.25.0", "0.25.0")
+
+        assert PYPROJECT in msg
+        assert "0.25.0" in msg
+        assert "origin/main" in msg

--- a/.github/workflows/release-version-bump.yaml
+++ b/.github/workflows/release-version-bump.yaml
@@ -164,7 +164,16 @@ jobs:
           NEW=$(uvx --from=toml-cli toml get --toml-path=pyproject.toml project.version)
           echo "new=${NEW}" >> "$GITHUB_OUTPUT"
 
+      # release.py sets skip=true when the target branch already carries the
+      # version it computed — this run is looking at a frozen merge ref that
+      # predates a release which has already merged and published, so bumping
+      # again would open a duplicate release PR (application-sdk#3570).
+      # Guarding the two mutating steps is enough: `uv lock` above is a no-op
+      # when the version did not change, and the job then ends green having
+      # done nothing. A caller pinned to an older sdk_scripts_ref never sets
+      # this output, and an unset output is empty, so it behaves as before.
       - name: Generate changelog
+        if: steps.bump.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -177,6 +186,7 @@ jobs:
         run: git config --global --unset-all url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf
 
       - name: Commit and open PR
+        if: steps.bump.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
           TARGET_BRANCH: ${{ inputs.target_branch }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,6 +59,12 @@ jobs:
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
 
       - name: Update version.py
+        # release.py sets skip=true when main already carries the version it
+        # computed — this run is looking at a frozen merge ref that predates a
+        # release which has already merged and published, so bumping again
+        # would open a duplicate release PR (application-sdk#3570). Guarding
+        # the mutating steps leaves the job green having done nothing.
+        if: steps.version_update.outputs.skip != 'true'
         # In-place edit the ``__version__`` line only. The previous block
         # truncated the file and re-emitted a fixed 5-line template, which
         # wiped out anything else living alongside ``__version__`` (the
@@ -92,11 +98,13 @@ jobs:
 
       - name: Generate changelog
         id: changelog
+        if: steps.version_update.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: python .github/scripts/update_changelog.py "${{ env.CURRENT_VERSION }}" "${{ env.NEW_VERSION }}"
 
       - name: Commit version bump and changelog
+        if: steps.version_update.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TARGET_BRANCH: ${{ github.ref_name }}


### PR DESCRIPTION
Closes FND-1168.

## What happened

Conformance v0.25.0 was published, tagged and merged — and 26 seconds later a second release PR appeared for the same version, in conflict. #3570 was a phantom: the release it proposed had already happened. It is now closed.

**Nothing mis-shipped, and nothing was lost.** PyPI has 0.25.0, `conformance-v0.25.0` → `c532fd16`, and the published wheel contains every merged commit including #3569. The one changelog line that differed between the phantom branch and main is documentation-only and belongs to the SDK side (`BaseE2ETest.dag_runs`), not the conformance package — so no changelog patch is needed. Merging #3570 *would* have attempted a second PyPI upload and a second tag.

## Root cause

Every release opener fires on `pull_request: closed` and checks out the PR's **merge ref**, which GitHub freezes when it computes it. A run triggered by PR *B* can therefore be looking at a tree that predates the merge of release PR *A*.

| Time (UTC) | Event |
| --- | --- |
| 22:25:15 | `c532fd16` — the v0.25.0 release PR (#3443) lands on main |
| 22:27:55 | Publish run starts; the opener run for the release PR *itself* is correctly **skipped** by the `head.ref` guard |
| 22:27:56 | Opener run starts for a **sibling** PR (#3569) |
| 22:28:02–07 | Checks out `refs/pull/3569/merge` — parent `da1ed376`, i.e. main **before** the release merge |
| 22:28:10 | Reads version 0.24.0, sees tag `conformance-v0.24.0`, recomputes **0.25.0** |
| 22:28:17 | Force-pushes the shared bump branch, opening #3570 |
| 22:28:19 | Publish creates tag `conformance-v0.25.0` — two seconds too late to have helped |

Both existing defences miss it. The `if` guard only skips a run whose **own** head ref is the bump branch, so it cannot see a sibling PR's run. The `concurrency` group serialises runs, but the stale snapshot is frozen at merge-ref time — waiting its turn never refreshes it.

## Why the guard is version-based and not tag-based

The intuitive fix — *skip if the tag for the computed version already exists* — **provably could not have fired**. The tag was created at 22:28:19, nine seconds after the opener read the repo at 22:28:10.

What *was* already true at 22:28:10 is that `origin/main` carried 0.25.0 (merged at 22:25:15). So the reliable signal is the version on the target branch, fetched fresh rather than read from the frozen checkout. `release_guard`'s module docstring records this timeline specifically so the check is not later "simplified" into the version that cannot work.

Fails open on every error path — no network, no token scope, missing file, unparseable version. A release lane going red because it could not reach origin would be a worse defect than the duplicate PR.

## The two commits, and why they are split

**1. `stop a stale opener re-minting a published version`** — the shared `release_guard`, wired into the conformance and contract-toolkit openers. This is where the race actually occurred. Both lanes already gate every downstream step on `steps.versions.outputs.skip != 'true'`, so **no workflow change was needed**.

**2. `extend the already-released guard to the SDK and app lanes`** — **preventive, not corrective, and separable if you disagree with it.** The SDK's own bump and the reusable workflow all 81 app repos call share `release.py` and have the identical shape. But a scan of every open bump PR across the app fleet found **67 open, zero phantoms** — all with a head version strictly ahead of their default branch. The SDK monorepo's merge concurrency is what makes the race reachable; a single app repo rarely merges two release-relevant PRs seconds apart.

Because these callers have no skip plumbing and the reusable workflow is consumed at `@main` by 81 repos, this commit is deliberately minimal:

- `release.py` reads `origin/<target_branch>`, so an app releasing off a non-main branch is checked against its own branch.
- Only the **two mutating steps** are gated. `uv lock` is a no-op when the version did not change, so no step needed splitting and the job simply ends green having done nothing.
- A caller pinned to an older `sdk_scripts_ref` never sets the output, and an unset output reads as empty — so those repos behave exactly as before.
- Verified both workflows end at the guarded commit step; there is no trailing unconditional step that would fire on a no-op run.

## Testing

- `release_guard`: 29 unit tests. These assert the guard **fires** (equal version, remote ahead, and the `0.9.0`/`0.10.0` case where string ordering would give the wrong answer) as well as that it fails open — a guard that always failed open would pass a suite that only checked for crashes.
- `conformance_release`: a test reproducing the #3570 shape end-to-end through `main()`, asserting `skip=true` and that **no file is mutated**, plus one asserting the guard is handed the *computed* version rather than the current one.
- `release`: guard wiring, the normal-release path, and non-main `target_branch` handling.
- 136 passed across the three affected test modules.
- `pre-commit` clean. `actionlint` adds no new findings — the two `SC2086` infos in `release.yaml` are pre-existing on `main` (verified against `origin/main`).

## Not a regression of FND-934

FND-934 fixed a different defect in the same fixed-bump-branch design — PR title and body frozen at the first run's version. This is a distinct race: duplicate PR *creation*, not stale metadata on an existing PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
