### PR TITLE
ci(loop): stop re-downloading ripgrep, and forward the run vars the agent asks for

### DIFF
--- a/.github/scripts/sdk_loop_common.py
+++ b/.github/scripts/sdk_loop_common.py
@@ -748,6 +748,12 @@ AGENT_ENV_PASSTHROUGH = (
     "RIPGREP_CONFIG_PATH",
     "GH_TOKEN",
     "GITHUB_REPOSITORY",
+    # The agent reaches for these BEFORE the GHA_RUN_URL below — a live
+    # transcript shows it printing `GITHUB_RUN_ID=` and `GITHUB_SERVER_URL=`
+    # empty and spending a turn on it. They cost nothing to forward and the
+    # runner already has them.
+    "GITHUB_RUN_ID",
+    "GITHUB_SERVER_URL",
     # The playbook's own variables. Their absence was VISIBLE in a live
     # transcript — the agent's very first shell block printed `REPO env:
     # unset`, `PR_NUMBER env: unset`, `GHA_RUN_URL env: unset` and four more,

--- a/.github/workflows/sdk-loop-phase.yml
+++ b/.github/workflows/sdk-loop-phase.yml
@@ -201,7 +201,14 @@ jobs:
       - name: Cache the opencode install
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/.npm
+          # `~/.npm` is the package; `~/.local/share/opencode` is the ripgrep
+          # binary opencode downloads from GitHub Releases the first time an
+          # agent uses Glob or Grep. That download happened on EVERY job — up
+          # to 18 per run — and it is a network fetch on the critical path of
+          # the first search the reviewer makes.
+          path: |
+            ~/.npm
+            ~/.local/share/opencode/bin
           key: opencode-${{ runner.os }}-1.18.22
 
       - name: Install opencode


### PR DESCRIPTION
Two small costs, both visible in a live `@sdk-loop` transcript.

## ripgrep was re-downloaded on every job

```
[oc] message="downloading ripgrep" url=https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/...
```

opencode fetches its own ripgrep binary the first time an agent uses `Glob` or `Grep`. The cache step covered `~/.npm` but not `~/.local/share/opencode/bin`, so that fetch happened on **every job — up to 19 in a full loop** — and it lands on the critical path of the reviewer's first search.

## The agent probed for run vars that were empty

```
GITHUB_RUN_ID=
GITHUB_SERVER_URL=
```

It reaches for these *before* falling back to the `GHA_RUN_URL` this lane already passes, and `agent_env`'s allowlist didn't forward them. The runner has them; a turn was spent discovering they were missing.

## Scope

Neither is the runtime problem. That's still the sub-agent, whose step latency climbs as it re-reads files already in its context — observed at 90s/77s/96s and again at 185s in a later run, with `release.yaml`, `release.py` and `test_conformance_release.py` each read twice just before the slow step. `doom_loop: deny` does **not** catch that pattern; I'll correct #3562's claim separately.

These two are free, so they're worth taking on their own.

132 tests pass; pre-commit clean including actionlint and pyright.
