### PR TITLE
ci(loop): do not dispatch a sub-agent when the scope routes to only one

### DIFF
--- a/.github/scripts/sdk_loop_common.py
+++ b/.github/scripts/sdk_loop_common.py
@@ -452,23 +452,77 @@ def classify_scope(files: Sequence[str], changed_lines: int = 0) -> str:
     return "full"
 
 
-def solo_scope(scope: str) -> str:
-    """The one agent this scope routes to, or '' when it routes to 0 or 2+.
+#: Config paths that justify a `ci-config` partition agent. `uv.lock` alone
+#: does NOT: §2a skips the extra when the only config churn is an incidental
+#: lock bump with no `.github/`, `helm/` or `pyproject` change.
+_SUBSTANTIVE_CONFIG = r"^(\.github/|helm/|pyproject\.toml|\.pre-commit)"
+
+
+def dispatch_set(scope: str, files: Sequence[str] = ()) -> tuple[str, ...]:
+    """Every agent the playbook may `Task` for this PR — the registration set.
+
+    NOT just §2a's routing table. Registering exactly that table looked right
+    and was wrong in two ways, because the table is only the Wave 1 row:
+
+      * §1b dispatches `reachability` on `full` and `mixed-sdk-toolkit`. It is
+        named nowhere in §2a's table, so a table-only registration left the
+        parent instructed to dispatch an agent that did not exist.
+      * §2a's "Mixed partitions" rule and §11's `conformance-only` note add a
+        partition specialist when a PR ALSO touches config or conformance
+        files — `ci-config` or `conformance`, scoped to that slice only.
+
+    The invariant is "register exactly what the playbook will try to
+    dispatch", and these extras are part of that. They are deliberately kept
+    OUT of SCOPE_AGENTS: that mirrors §2a's markdown table and is asserted
+    against it, so stuffing derived agents in would break the very drift check
+    that keeps it honest.
+    """
+    agents = list(SCOPE_AGENTS.get(scope, ()))
+    paths = [f.strip() for f in files if f and f.strip()]
+
+    if scope in ("full", "mixed-sdk-toolkit") and "reachability" not in agents:
+        agents.append("reachability")
+
+    has_config = any(re.search(_SUBSTANTIVE_CONFIG, p) for p in paths)
+    has_conf = any(
+        re.search(r"^(packages/conformance/|remediation/)", p) for p in paths
+    )
+
+    if scope in ("full", "tests-focused"):
+        if has_config and "ci-config" not in agents:
+            agents.append("ci-config")
+        if has_conf and "conformance" not in agents:
+            agents.append("conformance")
+    elif scope == "conformance-only" and has_config and "ci-config" not in agents:
+        # §11: a conformance PR that also carries config files gets the CI
+        # specialist on that slice — so this scope is NOT always solo.
+        agents.append("ci-config")
+
+    return tuple(agents)
+
+
+def solo_scope(scope: str, files: Sequence[str] = ()) -> str:
+    """The one agent this PR routes to, or '' when it routes to 0 or 2+.
+
+    Computed from `dispatch_set`, never from SCOPE_AGENTS alone: a
+    `conformance-only` PR that also touches `.github/` picks up `ci-config`
+    and is a two-agent review, and treating it as solo would silently drop
+    the CI specialist from a PR that changes CI.
 
     A dispatch exists to run agents CONCURRENTLY. With one agent there is
     nothing to run alongside, so `Task` buys no parallelism and costs a cold
     start: the parent has already read the playbook, the diff and every
     changed file, and the sub-agent begins with none of it and re-reads its
     way back. Measured on three single-agent reviews — 904s, ~9min, and 26min
-    inside that one call, per-step latency climbing 4s → 58s → 185s → 526s as
-    the re-read context accumulated. The 26-minute one reached step 11 of 25
-    before it was killed; the parent covers the same ground in under a minute.
+    inside that one call, per-step latency climbing 4s to 526s as the re-read
+    context accumulated. The 26-minute one reached step 11 of 25 before it was
+    killed; the parent covers the same ground in under a minute.
 
-    Two or more agents is a different trade, and dispatch stays: a single
-    agent covering several domains produces a worse verdict, and nothing in
-    the output would say so.
+    Two or more is a different trade and dispatch stays: a single agent
+    covering several domains produces a worse verdict, and nothing in the
+    output would say so.
     """
-    agents = SCOPE_AGENTS.get(scope, ())
+    agents = dispatch_set(scope, files)
     return agents[0] if len(agents) == 1 else ""
 
 

--- a/.github/scripts/sdk_loop_common.py
+++ b/.github/scripts/sdk_loop_common.py
@@ -359,7 +359,120 @@ def _agent_prompt(name: str) -> str:
         return handle.read()
 
 
-def review_subagents(model: str) -> dict[str, Any]:
+# --------------------------------------------------------------------------
+# Review scope — which specialists §2a routes a PR to
+# --------------------------------------------------------------------------
+
+#: §2a's routing table, mirrored. The playbook stays authoritative and
+#: `test_the_scope_table_matches_the_playbook` parses the markdown table and
+#: fails if these drift — so this is a cache of that table, not a second
+#: opinion about it.
+SCOPE_AGENTS: dict[str, tuple[str, ...]] = {
+    "full": ("correctness", "quality", "structure"),
+    "minor": ("correctness",),
+    "contract-toolkit": ("toolkit-review",),
+    "mixed-sdk-toolkit": ("correctness", "quality", "structure", "toolkit-review"),
+    "tests-only": ("quality",),
+    "tests-focused": ("quality", "correctness"),
+    "conformance-only": ("conformance",),
+    "config-only": ("ci-config",),
+    "docs-only": (),
+}
+
+
+#: §11's bucket patterns, mirrored. Classification is pure file-list
+#: arithmetic with no judgement in it, so it belongs in Python: the agent
+#: currently spends a turn on a sixty-line bash block to reach an answer the
+#: harness can compute before the model starts, and — more importantly — the
+#: harness needs the answer FIRST, to decide whether registering sub-agents
+#: makes sense at all.
+_BUCKETS: tuple[tuple[str, str], ...] = (
+    ("ct", r"^contract-toolkit/"),
+    ("sdk", r"^application_sdk/"),
+    ("conf", r"^(packages/conformance/|remediation/)"),
+    ("test", r"^(tests/|contract-toolkit/tests/)"),
+    ("doc", r"^(docs/|contract-toolkit/docs/)|.*README\.md$"),
+    ("config", r"^(pyproject\.toml|uv\.lock|\.pre-commit|\.github/|helm/)"),
+    ("meta", r"^(\.mothership/|\.claude/)|(^|/)(AGENTS|CLAUDE)\.md$"),
+    ("security", r"(credential|secret|auth|token|_dapr|_temporal)"),
+)
+
+#: A file in NONE of the non-source buckets. Computed by exclusion rather than
+#: TOTAL - sum(buckets), because a path in two buckets (docs/CLAUDE.md is both
+#: DOC and META) would be subtracted twice and could zero out a real source
+#: count — silently skipping code review. §11 makes the same point.
+_NON_SOURCE = (
+    r"^(packages/conformance/|remediation/|tests/|contract-toolkit/tests/|"
+    r"docs/|contract-toolkit/docs/|pyproject\.toml|uv\.lock|\.pre-commit|"
+    r"\.github/|helm/|\.mothership/|\.claude/)|.*README\.md$|"
+    r"(^|/)(AGENTS|CLAUDE)\.md$"
+)
+
+
+def classify_scope(files: Sequence[str], changed_lines: int = 0) -> str:
+    """`review_scope` for a PR, by §11's rules, first match wins.
+
+    Mirrors `.mothership/pr-review/ORCHESTRATION.md` §11. Kept in step by
+    `test_the_scope_table_matches_the_playbook`, which parses §2a's routing
+    table — the playbook stays authoritative.
+    """
+    paths = [f.strip() for f in files if f and f.strip()]
+    n = {name: sum(1 for p in paths if re.search(pat, p)) for name, pat in _BUCKETS}
+    source = sum(1 for p in paths if not re.search(_NON_SOURCE, p))
+    total = len(paths)
+
+    if n["ct"] and not n["sdk"] and not n["conf"] and not n["config"]:
+        return "contract-toolkit"
+    if n["ct"] and (n["sdk"] or n["config"]):
+        return "mixed-sdk-toolkit"
+    if n["meta"] and not any(
+        (source, n["config"], n["conf"], n["ct"], n["test"], n["doc"])
+    ):
+        return "docs-only"
+    if not source and n["conf"] and not n["ct"]:
+        return "conformance-only"
+    if not source and n["test"]:
+        return "tests-only"
+    if not source and n["doc"] and not n["test"]:
+        return "docs-only"
+    if not source and n["config"]:
+        return "config-only"
+    if source <= 2 and n["test"] >= source * 3 and n["test"]:
+        return "tests-focused"
+    if (
+        source >= 1
+        and total <= 2
+        and changed_lines < 50
+        and not n["conf"]
+        and not n["ct"]
+        and not n["config"]
+        and not n["security"]
+    ):
+        return "minor"
+    return "full"
+
+
+def solo_scope(scope: str) -> str:
+    """The one agent this scope routes to, or '' when it routes to 0 or 2+.
+
+    A dispatch exists to run agents CONCURRENTLY. With one agent there is
+    nothing to run alongside, so `Task` buys no parallelism and costs a cold
+    start: the parent has already read the playbook, the diff and every
+    changed file, and the sub-agent begins with none of it and re-reads its
+    way back. Measured on three single-agent reviews — 904s, ~9min, and 26min
+    inside that one call, per-step latency climbing 4s → 58s → 185s → 526s as
+    the re-read context accumulated. The 26-minute one reached step 11 of 25
+    before it was killed; the parent covers the same ground in under a minute.
+
+    Two or more agents is a different trade, and dispatch stays: a single
+    agent covering several domains produces a worse verdict, and nothing in
+    the output would say so.
+    """
+    agents = SCOPE_AGENTS.get(scope, ())
+    return agents[0] if len(agents) == 1 else ""
+
+
+def review_subagents(model: str, only: Sequence[str] = ()) -> dict[str, Any]:
     """opencode subagent entries for the playbook's Phase 2 agents.
 
     Each is read-only by construction: the review lane holds a token with no
@@ -442,11 +555,15 @@ def review_subagents(model: str) -> dict[str, Any]:
                 "doom_loop": "deny",
             },
         }
-        for name in PHASE2_AGENTS
+        for name in (tuple(only) or PHASE2_AGENTS)
     }
 
 
-def opencode_config(model: str, with_subagents: bool = False) -> dict[str, Any]:
+def opencode_config(
+    model: str,
+    with_subagents: bool = False,
+    subagents: Sequence[str] = (),
+) -> dict[str, Any]:
     """`opencode.json` pinning the only provider and models this lane may use.
 
     Shell and network stay ALLOWED here, unlike the conformance fast lane which
@@ -512,7 +629,7 @@ def opencode_config(model: str, with_subagents: bool = False) -> dict[str, Any]:
         # unanswered ask as a rejection — a connector-pulse run starved exactly
         # that way when its skill reads were auto-rejected. So everything a
         # phase legitimately does is allowed outright.
-        **({"agent": review_subagents(model)} if with_subagents else {}),
+        **({"agent": review_subagents(model, subagents)} if with_subagents else {}),
         # Every permission the playbooks can reach, in one place.
         #
         # Headless opencode has nobody to answer an "ask", so it auto-REJECTS
@@ -954,6 +1071,7 @@ def run_agent(
     transcript_path: str | None = None,
     sink: Any = None,
     subagents: bool = False,
+    subagent_names: Sequence[str] = (),
     idle_timeout_s: int = IDLE_TIMEOUT_S,
 ) -> AgentResult:
     """Invoke one agent phase, STREAMING its output to the job log.
@@ -978,7 +1096,11 @@ def run_agent(
     os.environ["RIPGREP_CONFIG_PATH"] = write_rg_config(cwd)
     config_path = os.path.join(cwd, "opencode.json")
     with open(config_path, "w", encoding="utf-8") as handle:
-        json.dump(opencode_config(model, with_subagents=subagents), handle, indent=2)
+        json.dump(
+            opencode_config(model, with_subagents=subagents, subagents=subagent_names),
+            handle,
+            indent=2,
+        )
 
     lines: list[str] = []
     # Stamped BEFORE launch so the follower can tell this run's log file from

--- a/.github/scripts/sdk_loop_phase.py
+++ b/.github/scripts/sdk_loop_phase.py
@@ -48,8 +48,10 @@ from sdk_loop_common import (
     PLAYBOOK_REVIEW,
     RESOLVE_MODEL,
     REVIEW_MODEL,
+    SCOPE_AGENTS,
     AgentResult,
     DismissalLedger,
+    classify_scope,
     emit_outputs,
     format_usage,
     head_state,
@@ -60,6 +62,7 @@ from sdk_loop_common import (
     parse_verdict,
     reaim_exhausted,
     run_agent,
+    solo_scope,
     token_budget,
     token_budget_exceeded,
     usage_total,
@@ -188,12 +191,40 @@ def prep_prompt(pr: int, failing: tuple[str, ...]) -> str:
     )
 
 
+def pr_files(repo: str, pr: int) -> list[str]:
+    """Paths the PR touches. Deleted files included — classifying from
+    `+++ b/` diff headers alone would miss them, as §11 warns."""
+    out = _sh(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr),
+            "--repo",
+            repo,
+            "--json",
+            "files",
+            "--jq",
+            ".files[].path",
+        ]
+    ).stdout
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def diff_lines(repo: str, pr: int) -> int:
+    """Added + removed lines, for the `minor` fast-path threshold."""
+    out = _sh(["gh", "pr", "diff", str(pr), "--repo", repo]).stdout
+    return sum(1 for line in out.splitlines() if line[:1] in "+-")
+
+
 def review_prompt(
     pr: int,
     round_no: int,
     sha: str,
     ledger: DismissalLedger,
     prior_sha: str = "",
+    scope: str = "",
+    solo: str = "",
 ) -> str:
     """Point the agent at the playbook. The playbook is NOT restated here.
 
@@ -223,12 +254,30 @@ def review_prompt(
         "You are READ-ONLY. Your token carries no write scope — do not attempt",
         "to push, and do not treat a push failure as something to work around.",
         "",
-        "§2a says to dispatch the domain agents via the Agent tool. On this runtime",
-        "that tool is called `Task`, and the agents are already registered —",
-        f"{', '.join(PHASE2_AGENTS)}. Dispatch them in parallel exactly as §2a",
-        "routes them by review_scope. Do NOT do their work yourself in one pass:",
-        "a single agent covering every domain still produces a verdict, just a",
-        "worse one, and nothing in the output would say so.",
+        "§2a dispatches domain agents via the Agent tool. On this runtime that",
+        "tool is called `Task`. Only the agents §2a routes YOUR scope to are",
+        "registered — never all of them — so `Task` cannot reach a specialist",
+        "the routing did not choose.",
+        "",
+        "When two or more ARE registered, dispatch them in parallel.",
+        "Do NOT do their work yourself in one pass: a single agent covering",
+        "several domains still produces a verdict, just a worse one, and",
+        "nothing in the output would say so.",
+        "",
+        "**Your review_scope is already settled — do NOT re-derive it.** §11's",
+        "classification is file-list arithmetic with no judgement in it, so the",
+        "harness computed it before you started. Running that sixty-line bash",
+        "block again spends a turn to reach the same answer.",
+        "",
+        "The second rule is measured, not stylistic. A dispatch with one agent",
+        "buys no parallelism — there is nothing to run alongside — and costs a",
+        "cold start: you have already read the playbook, the diff and every",
+        "changed file, and the sub-agent begins with none of it and re-reads",
+        "its way back. Three `config-only`/`conformance-only` reviews spent",
+        "904s, ~9min and 26min inside that one call, with per-step latency",
+        "climbing 4s → 58s → 185s → 526s as the re-read context accumulated.",
+        "The 26-minute one reached step 11 of 25 before it was killed. The",
+        "parent reaches the same point in under a minute.",
         "",
         "SKIP §2b (the Wave 2 cross-model adversarial). Two reasons, and either",
         "alone is sufficient:",
@@ -247,6 +296,34 @@ def review_prompt(
         "phase contests findings)`, NOT as unavailable.",
         "",
     ]
+    if solo:
+        parts += [
+            f"review_scope = `{scope}`, which §2a routes to exactly ONE",
+            f"specialist: `{solo}`.",
+            "",
+            "**Do not dispatch it.** No sub-agents are registered for this run —",
+            "`Task` has nothing to delegate to. Read",
+            f"`.mothership/pr-review/agents/{solo}.md`, adopt that brief as your",
+            "own, review as that specialist, and go straight to §2c.",
+            "",
+            "A dispatch runs agents CONCURRENTLY. With one agent there is nothing",
+            "to run alongside, so it buys no parallelism and costs a cold start:",
+            "you have already read the playbook, the diff and every changed file,",
+            "and a sub-agent would begin with none of it and re-read its way back.",
+            "Three single-agent reviews spent 904s, ~9 minutes and 26 minutes",
+            "inside that one call, per-step latency climbing 4s to 526s as the",
+            "re-read context piled up. The 26-minute one reached step 11 of 25",
+            "before it was killed.",
+            "",
+        ]
+    elif scope:
+        agents = ", ".join(SCOPE_AGENTS.get(scope, ()))
+        parts += [
+            f"review_scope = `{scope}`. §2a routes it to: {agents or 'no agents'}.",
+            "Those, and only those, are registered — dispatch them in parallel.",
+            "",
+        ]
+
     if prior_sha:
         # Handed over so §2e labelling and the §2e′ nit rules do not have to
         # re-derive the range. It is ADDITIONAL context, never a substitute for
@@ -609,16 +686,38 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if phase == "review":
+        # Classify BEFORE the model starts. §11's routing is pure file-list
+        # arithmetic, so the harness can settle it deterministically — and it
+        # has to, because whether registering sub-agents makes any sense is
+        # decided by the answer. A scope that routes to ONE agent gets none
+        # registered: `Task` then has nothing to dispatch to, and the rule
+        # holds by construction rather than by the model choosing to follow a
+        # paragraph. It did not follow the comparable "fetch once" paragraph.
+        files = pr_files(repo, pr)
+        scope = classify_scope(files, diff_lines(repo, pr))
+        solo = solo_scope(scope)
+        fan_out = SCOPE_AGENTS.get(scope, ())
+        print(
+            f"scope={scope} agents={len(fan_out)}" + (f" solo={solo}" if solo else "")
+        )
+
         print(f"::group::review round {round_no} — agent transcript")
         result = run_agent(
             REVIEW_MODEL,
             review_prompt(
-                pr, round_no, state.live, ledger, os.environ.get("PRIOR_SHA", "")
+                pr,
+                round_no,
+                state.live,
+                ledger,
+                os.environ.get("PRIOR_SHA", ""),
+                scope=scope,
+                solo=solo,
             ),
             workspace,
             TIMEOUT_REVIEW_S,
             transcript_path=transcript,
-            subagents=True,
+            subagents=not solo and bool(fan_out),
+            subagent_names=fan_out,
         )
         print("::endgroup::")
         comments = json.loads(

--- a/.github/scripts/sdk_loop_phase.py
+++ b/.github/scripts/sdk_loop_phase.py
@@ -43,7 +43,6 @@ from typing import Any, Callable
 
 from sdk_loop_common import (
     MAX_ROUNDS,
-    PHASE2_AGENTS,
     PLAYBOOK_RESOLVE,
     PLAYBOOK_REVIEW,
     RESOLVE_MODEL,

--- a/.github/scripts/sdk_loop_phase.py
+++ b/.github/scripts/sdk_loop_phase.py
@@ -39,7 +39,7 @@ import os
 import subprocess
 import sys
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 
 from sdk_loop_common import (
     MAX_ROUNDS,
@@ -47,10 +47,10 @@ from sdk_loop_common import (
     PLAYBOOK_REVIEW,
     RESOLVE_MODEL,
     REVIEW_MODEL,
-    SCOPE_AGENTS,
     AgentResult,
     DismissalLedger,
     classify_scope,
+    dispatch_set,
     emit_outputs,
     format_usage,
     head_state,
@@ -224,6 +224,7 @@ def review_prompt(
     prior_sha: str = "",
     scope: str = "",
     solo: str = "",
+    agents: Sequence[str] = (),
 ) -> str:
     """Point the agent at the playbook. The playbook is NOT restated here.
 
@@ -316,10 +317,13 @@ def review_prompt(
             "",
         ]
     elif scope:
-        agents = ", ".join(SCOPE_AGENTS.get(scope, ()))
+        # The REGISTERED set, which is §2a's row plus §1b's reachability and
+        # any mixed-partition specialist — not the markdown table alone.
+        named = ", ".join(agents)
         parts += [
-            f"review_scope = `{scope}`. §2a routes it to: {agents or 'no agents'}.",
-            "Those, and only those, are registered — dispatch them in parallel.",
+            f"review_scope = `{scope}`. Registered for this PR: "
+            f"{named or 'no agents'}.",
+            "Those, and only those, can be dispatched — do them in parallel.",
             "",
         ]
 
@@ -694,8 +698,13 @@ def main(argv: list[str] | None = None) -> int:
         # paragraph. It did not follow the comparable "fetch once" paragraph.
         files = pr_files(repo, pr)
         scope = classify_scope(files, diff_lines(repo, pr))
-        solo = solo_scope(scope)
-        fan_out = SCOPE_AGENTS.get(scope, ())
+        # `dispatch_set`, not SCOPE_AGENTS: the table is only §2a's Wave 1 row.
+        # §1b adds `reachability` on full/mixed, and §2a's mixed-partition rule
+        # adds a `ci-config` or `conformance` specialist when the PR also
+        # carries those files. Registering the table alone left the parent
+        # instructed to dispatch agents that did not exist.
+        fan_out = dispatch_set(scope, files)
+        solo = solo_scope(scope, files)
         print(
             f"scope={scope} agents={len(fan_out)}" + (f" solo={solo}" if solo else "")
         )
@@ -711,6 +720,7 @@ def main(argv: list[str] | None = None) -> int:
                 os.environ.get("PRIOR_SHA", ""),
                 scope=scope,
                 solo=solo,
+                agents=fan_out,
             ),
             workspace,
             TIMEOUT_REVIEW_S,

--- a/.github/scripts/sdk_loop_prep.py
+++ b/.github/scripts/sdk_loop_prep.py
@@ -43,6 +43,7 @@ Environment:
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from dataclasses import dataclass, field
 
@@ -229,3 +230,51 @@ def needs_agent(result: PrepResult) -> bool:
     unrequested merge commit the playbook forbids.
     """
     return result.outcome == OUTCOME_RED and bool(result.failing)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """The deterministic pass, as a step of its own.
+
+    Split out so the workflow can decide whether to install anything. Prep is
+    normally a couple of `gh` reads and no model at all, but it was paying 18
+    seconds to `npm install opencode` first — on every run, for an agent it
+    almost never invokes. That is nearly half the phase spent preparing for a
+    branch it does not take.
+
+    Emits `needs_agent` so the workflow gates the install on it, and emits the
+    full result too: when no agent is needed this step IS the phase, and the
+    job can end here.
+    """
+    repo, pr = os.environ["REPO"], int(os.environ["PR_NUMBER"])
+    baseline = os.environ.get("BASE_SHA", "")
+
+    state = pr_state(repo, pr)
+    # Conflicts short-circuit BEFORE the checks read: nothing useful can be
+    # said about CI on a branch that cannot merge, and the read is a round
+    # trip spent to reach an answer that changes nothing.
+    conflicted = state is not None and (
+        state.get("mergeStateStatus") == "CONFLICTING"
+        or state.get("mergeable") == "CONFLICTING"
+    )
+    result = decide(state, () if conflicted else failing_checks(repo, pr), baseline)
+    wants = needs_agent(result)
+
+    path = os.environ.get("GITHUB_OUTPUT")
+    if path:
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(f"needs_agent={'true' if wants else 'false'}\n")
+            handle.write(f"outcome={result.outcome}\n")
+            handle.write(f"new_base_sha={result.new_base_sha}\n")
+            handle.write(f"pushed_sha={result.pushed_sha}\n")
+            handle.write(f"ci_state={result.ci_state}\n")
+            handle.write(f"detail={result.detail}\n")
+            handle.write(f"failing={','.join(result.failing)}\n")
+
+    print(f"prep: {result.outcome} — {result.detail}")
+    if not wants:
+        print("prep: nothing for a model to do — skipping the opencode install")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_sdk_loop.py
+++ b/.github/scripts/tests/test_sdk_loop.py
@@ -551,6 +551,9 @@ def test_every_agent_the_playbook_dispatches_is_registered() -> None:
 def test_the_review_prompt_names_the_delegation_tool_for_this_runtime() -> None:
     prompt = review_prompt(42, 1, "a" * 40, DismissalLedger())
     assert "`Task`" in prompt
+    # The multi-domain invariant, which survives the solo-scope change: when
+    # several agents ARE registered, collapsing them into one pass yields a
+    # worse verdict and says nothing about having done so.
     assert "Do NOT do their work yourself" in prompt
 
 

--- a/.github/scripts/tests/test_sdk_loop_prep.py
+++ b/.github/scripts/tests/test_sdk_loop_prep.py
@@ -6,10 +6,12 @@ import pathlib
 import re
 import sys
 
+import pytest
 import yaml
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
+import sdk_loop_prep  # noqa: E402
 from sdk_loop_prep import (  # noqa: E402
     BUCKET_FAIL,
     CHECK_FIELDS,
@@ -210,3 +212,60 @@ def test_an_unreadable_state_is_unknown_and_never_green() -> None:
     assert unknown_state.outcome == OUTCOME_UNKNOWN
     assert unknown_state.new_base_sha == "a" * 40, "the review still runs"
     assert unknown_state.outcome != OUTCOME_CLEAN
+
+
+def test_a_clean_prep_installs_nothing() -> None:
+    """Prep is normally two `gh` reads and no model. It was still paying
+    `npm install -g opencode` first — 18 seconds of a 41-second phase, every
+    run, preparing for a branch it almost never takes.
+
+    So the deterministic pass runs BEFORE the installs and gates them. This
+    asserts the wiring, because the saving is invisible from the Python side:
+    the script cannot tell whether the workflow installed anything.
+    """
+    wf = pathlib.Path(".github/workflows/sdk-loop-phase.yml").read_text(
+        encoding="utf-8"
+    )
+    gate = "inputs.phase != 'prep' || steps.prep.outputs.needs_agent == 'true'"
+
+    # The deterministic step must come first, or gating it is impossible.
+    assert wf.index("Prep — deterministic pass") < wf.index("Install opencode")
+
+    for step in ("Cache the opencode install", "Install opencode", "Install uv"):
+        head = wf.index(f"- name: {step}")
+        assert gate in wf[head : head + 400], f"{step} is not gated on needs_agent"
+
+    # A skipped `run` step has empty outputs, so the job must fall back to the
+    # deterministic step — otherwise a clean prep reports nothing and Review 1
+    # checks out `ref: ''`.
+    for key in ("outcome", "new_base_sha", "pushed_sha", "ci_state", "detail"):
+        assert (
+            f"steps.run.outputs.{key} || steps.prep.outputs.{key}" in wf
+        ), f"job output {key} has no fallback for a deterministic prep"
+
+
+def test_the_deterministic_cli_reports_whether_an_agent_is_wanted(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """`needs_agent` is what the workflow gates on, so it has to be emitted
+    even on the happy path — an absent output reads as false, which is right
+    here, but only by accident. Assert it is written explicitly."""
+    out = tmp_path / "gh_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.setenv("REPO", "o/r")
+    monkeypatch.setenv("PR_NUMBER", "1")
+    monkeypatch.setenv("BASE_SHA", "a" * 40)
+    monkeypatch.setattr(
+        sdk_loop_prep,
+        "pr_state",
+        lambda r, p, **k: {"mergeStateStatus": "CLEAN", "headRefOid": "a" * 40},
+    )
+    monkeypatch.setattr(sdk_loop_prep, "failing_checks", lambda r, p, **k: ())
+    assert sdk_loop_prep.main([]) == 0
+
+    written = dict(
+        line.split("=", 1) for line in out.read_text().splitlines() if "=" in line
+    )
+    assert written["needs_agent"] == "false", "a clean PR must not trigger the install"
+    assert written["outcome"] == "clean"
+    assert written["new_base_sha"] == "a" * 40

--- a/.github/scripts/tests/test_sdk_loop_scope.py
+++ b/.github/scripts/tests/test_sdk_loop_scope.py
@@ -11,10 +11,19 @@ import pytest
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 from sdk_loop_common import DismissalLedger  # noqa: E402
+
+
+class _Done:
+    returncode = 0
+    stdout = ""
+
+
+import sdk_loop_phase  # noqa: E402
 from sdk_loop_common import (  # noqa: E402
     REVIEW_MODEL,
     SCOPE_AGENTS,
     classify_scope,
+    dispatch_set,
     opencode_config,
     solo_scope,
 )
@@ -69,39 +78,93 @@ def test_scope_classification(files: list[str], lines: int, expected: str) -> No
     assert classify_scope(files, lines) == expected
 
 
-def test_a_one_agent_scope_registers_no_subagents() -> None:
-    """The fix, made structural rather than instructed.
+def test_main_passes_no_subagents_for_a_solo_scope(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """Assert what PRODUCTION passes, not what a helper can be asked to build.
 
-    A dispatch exists to run agents concurrently. With one agent there is
-    nothing to run alongside, so it buys no parallelism and costs a cold
-    start — the parent has read the playbook, the diff and every changed
-    file, and the sub-agent starts with none of it. Three such reviews spent
-    904s, ~9min and 26min inside that single call, per-step latency climbing
-    4s to 526s as the re-read context accumulated.
-
-    Registering nothing means `Task` has nothing to delegate to, so the rule
-    holds by construction. Prose was not enough: the comparable "fetch once"
-    instruction in the research preamble is demonstrably ignored.
+    Calling `opencode_config(..., with_subagents=False)` in a test proves only
+    that the builder honours its own argument. It would stay green if `main()`
+    started passing `subagents=True`, which is the regression that matters —
+    so this drives `main()` and captures the kwargs `run_agent` receives.
     """
+    captured: dict[str, object] = {}
+
+    def fake_run_agent(model, prompt, cwd, timeout_s, **kwargs):
+        captured.update(kwargs)
+        captured["prompt"] = prompt
+        return sdk_loop_phase.AgentResult(exit_code=0, stdout="", stderr="")
+
+    monkeypatch.setattr(sdk_loop_phase, "run_agent", fake_run_agent)
+    monkeypatch.setattr(
+        sdk_loop_phase, "pr_files", lambda r, p: [".github/workflows/x.yaml"]
+    )
+    monkeypatch.setattr(sdk_loop_phase, "diff_lines", lambda r, p: 85)
+    monkeypatch.setattr(sdk_loop_phase, "live_head", lambda r, h: "a" * 40)
+    monkeypatch.setattr(sdk_loop_phase, "_sh", lambda *a, **k: _Done())
+    monkeypatch.setattr(sdk_loop_phase, "opencode_usage", lambda w: {})
+    monkeypatch.setenv("PHASE", "review")
+    monkeypatch.setenv("ROUND", "1")
+    monkeypatch.setenv("REPO", "o/r")
+    monkeypatch.setenv("PR_NUMBER", "1")
+    monkeypatch.setenv("HEAD_REF", "b")
+    monkeypatch.setenv("BASE_SHA", "a" * 40)
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("LITELLM_BASE_URL", "https://gateway.example")
+    sdk_loop_phase.main([])
+
+    assert captured.get("subagents") is False, (
+        "a config-only PR routes to one agent; registering any means `Task` "
+        "can dispatch, and the cold-start cost this change removes comes back"
+    )
+    assert "Do not dispatch it" in str(captured.get("prompt", ""))
+
+
+def test_the_registration_set_covers_everything_the_playbook_dispatches() -> None:
+    """§2a's table is only the Wave 1 row. Registering exactly it looked
+    right and silently broke two dispatches the playbook still asks for:
+    §1b's `reachability` on full/mixed, and the mixed-partition specialist
+    §2a and §11 add when a PR also carries config or conformance files.
+    """
+    # §1b: reachability on full and mixed-sdk-toolkit, and nowhere else.
+    assert "reachability" in dispatch_set("full", ["application_sdk/a.py"])
+    assert "reachability" in dispatch_set("mixed-sdk-toolkit", ["contract-toolkit/a"])
+    for scope in ("config-only", "conformance-only", "tests-only", "minor"):
+        assert "reachability" not in dispatch_set(scope, [])
+
+    # §2a mixed partitions.
+    full_cfg = dispatch_set("full", ["application_sdk/a.py", ".github/w.yaml"])
+    assert "ci-config" in full_cfg
+    full_conf = dispatch_set("full", ["application_sdk/a.py", "packages/conformance/c"])
+    assert "conformance" in full_conf
+
+    # ...but NOT for an incidental lockfile bump, per §2a's own carve-out.
+    assert "ci-config" not in dispatch_set("full", ["application_sdk/a.py", "uv.lock"])
+
+    # §11: a conformance PR that also carries config is TWO agents, so it is
+    # not solo — treating it as solo would drop the CI specialist from a PR
+    # that changes CI.
+    both = ["packages/conformance/c.py", ".github/workflows/x.yaml"]
+    assert set(dispatch_set("conformance-only", both)) == {"conformance", "ci-config"}
+    assert solo_scope("conformance-only", both) == ""
+    assert (
+        solo_scope("conformance-only", ["packages/conformance/c.py"]) == "conformance"
+    )
+
+
+def test_registration_matches_the_dispatch_set() -> None:
+    """Whatever the playbook may dispatch must be registered, exactly."""
     monkey = pytest.MonkeyPatch()
     monkey.setenv("LITELLM_BASE_URL", "https://gateway.example")
     try:
-        for scope in ("config-only", "conformance-only", "tests-only", "minor"):
-            assert solo_scope(scope), f"{scope} should route to exactly one agent"
-            cfg = opencode_config(REVIEW_MODEL, with_subagents=False)
-            assert "agent" not in cfg
-
-        # Two or more is a different trade and dispatch stays: one agent
-        # covering several domains produces a worse verdict, silently.
-        for scope in ("full", "mixed-sdk-toolkit", "tests-focused"):
-            assert not solo_scope(scope)
-            cfg = opencode_config(
-                REVIEW_MODEL, with_subagents=True, subagents=SCOPE_AGENTS[scope]
-            )
-            assert set(cfg["agent"]) == set(SCOPE_AGENTS[scope]), (
-                "register exactly the routed agents — a scope must not be able "
-                "to dispatch a specialist §2a did not choose"
-            )
+        for scope, files in (
+            ("full", ["application_sdk/a.py", ".github/w.yaml"]),
+            ("mixed-sdk-toolkit", ["contract-toolkit/a.pkl", "application_sdk/b.py"]),
+            ("tests-focused", ["tests/t.py", "application_sdk/a.py"]),
+        ):
+            want = dispatch_set(scope, files)
+            cfg = opencode_config(REVIEW_MODEL, with_subagents=True, subagents=want)
+            assert set(cfg["agent"]) == set(want)
     finally:
         monkey.undo()
 
@@ -115,8 +178,19 @@ def test_the_prompt_tells_a_solo_review_not_to_dispatch() -> None:
         )
         assert "Do not dispatch it" in solo
         assert "agents/ci-config.md" in solo
-        fan = review_prompt(1, 1, "a" * 40, DismissalLedger(), scope="full")
-        assert "dispatch them in parallel" in fan
-        assert "correctness, quality, structure" in fan
+        files = ["application_sdk/a.py"]
+        fan = review_prompt(
+            1,
+            1,
+            "a" * 40,
+            DismissalLedger(),
+            scope="full",
+            agents=dispatch_set("full", files),
+        )
+        assert "do them in parallel" in fan
+        # The prompt names the REGISTERED set, so §1b's reachability must
+        # appear — a `full` review is told to dispatch it.
+        for name in ("correctness", "quality", "structure", "reachability"):
+            assert name in fan
     finally:
         monkey.undo()

--- a/.github/scripts/tests/test_sdk_loop_scope.py
+++ b/.github/scripts/tests/test_sdk_loop_scope.py
@@ -1,0 +1,122 @@
+"""Scope routing — and why a one-agent scope must not dispatch."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from sdk_loop_common import DismissalLedger  # noqa: E402
+from sdk_loop_common import (  # noqa: E402
+    REVIEW_MODEL,
+    SCOPE_AGENTS,
+    classify_scope,
+    opencode_config,
+    solo_scope,
+)
+from sdk_loop_phase import review_prompt  # noqa: E402
+
+
+def test_the_scope_table_matches_the_playbook() -> None:
+    """SCOPE_AGENTS mirrors §2a's routing table, so the table has to stay the
+    authority. Parsed rather than eyeballed: a scope silently routing to the
+    wrong specialist reviews the PR through the wrong lens and still returns
+    a confident verdict.
+    """
+    text = pathlib.Path(".mothership/pr-review/ORCHESTRATION.md").read_text(
+        encoding="utf-8"
+    )
+    rows = re.findall(r"^\| `([a-z-]+)` \| (.+?) \|$", text, re.M)
+    assert rows, "could not find §2a's routing table — did its shape change?"
+
+    from_playbook: dict[str, set[str]] = {}
+    for scope, cell in rows:
+        if scope not in SCOPE_AGENTS:
+            continue
+        named = set(re.findall(r"([a-z-]+)\.md", cell))
+        if "SKIP" in cell:
+            named = set()
+        from_playbook[scope] = named
+
+    for scope, expected in from_playbook.items():
+        assert set(SCOPE_AGENTS[scope]) == expected, (
+            f"{scope}: playbook routes to {sorted(expected)}, "
+            f"SCOPE_AGENTS has {sorted(SCOPE_AGENTS[scope])}"
+        )
+
+
+@pytest.mark.parametrize(
+    "files,lines,expected",
+    [
+        ([".github/actionlint.yaml", ".pre-commit-config.yaml"], 85, "config-only"),
+        (["packages/conformance/suite/checks/x.py"], 40, "conformance-only"),
+        (["application_sdk/a.py", "application_sdk/b.py", "x/c.py"], 900, "full"),
+        (["application_sdk/a.py"], 10, "minor"),
+        (["tests/test_a.py"], 30, "tests-only"),
+        (["contract-toolkit/src/x.pkl"], 20, "contract-toolkit"),
+        ([".mothership/pr-review/ORCHESTRATION.md"], 50, "docs-only"),
+        (["contract-toolkit/a.pkl", "application_sdk/b.py"], 60, "mixed-sdk-toolkit"),
+        # Security paths never take the `minor` fast path — a three-line auth
+        # change is exactly where a subtle blocker hides (§11).
+        (["application_sdk/credentials.py"], 10, "full"),
+    ],
+)
+def test_scope_classification(files: list[str], lines: int, expected: str) -> None:
+    assert classify_scope(files, lines) == expected
+
+
+def test_a_one_agent_scope_registers_no_subagents() -> None:
+    """The fix, made structural rather than instructed.
+
+    A dispatch exists to run agents concurrently. With one agent there is
+    nothing to run alongside, so it buys no parallelism and costs a cold
+    start — the parent has read the playbook, the diff and every changed
+    file, and the sub-agent starts with none of it. Three such reviews spent
+    904s, ~9min and 26min inside that single call, per-step latency climbing
+    4s to 526s as the re-read context accumulated.
+
+    Registering nothing means `Task` has nothing to delegate to, so the rule
+    holds by construction. Prose was not enough: the comparable "fetch once"
+    instruction in the research preamble is demonstrably ignored.
+    """
+    monkey = pytest.MonkeyPatch()
+    monkey.setenv("LITELLM_BASE_URL", "https://gateway.example")
+    try:
+        for scope in ("config-only", "conformance-only", "tests-only", "minor"):
+            assert solo_scope(scope), f"{scope} should route to exactly one agent"
+            cfg = opencode_config(REVIEW_MODEL, with_subagents=False)
+            assert "agent" not in cfg
+
+        # Two or more is a different trade and dispatch stays: one agent
+        # covering several domains produces a worse verdict, silently.
+        for scope in ("full", "mixed-sdk-toolkit", "tests-focused"):
+            assert not solo_scope(scope)
+            cfg = opencode_config(
+                REVIEW_MODEL, with_subagents=True, subagents=SCOPE_AGENTS[scope]
+            )
+            assert set(cfg["agent"]) == set(SCOPE_AGENTS[scope]), (
+                "register exactly the routed agents — a scope must not be able "
+                "to dispatch a specialist §2a did not choose"
+            )
+    finally:
+        monkey.undo()
+
+
+def test_the_prompt_tells_a_solo_review_not_to_dispatch() -> None:
+    monkey = pytest.MonkeyPatch()
+    monkey.setenv("LITELLM_BASE_URL", "https://gateway.example")
+    try:
+        solo = review_prompt(
+            1, 1, "a" * 40, DismissalLedger(), scope="config-only", solo="ci-config"
+        )
+        assert "Do not dispatch it" in solo
+        assert "agents/ci-config.md" in solo
+        fan = review_prompt(1, 1, "a" * 40, DismissalLedger(), scope="full")
+        assert "dispatch them in parallel" in fan
+        assert "correctness, quality, structure" in fan
+    finally:
+        monkey.undo()

--- a/.github/workflows/sdk-loop-phase.yml
+++ b/.github/workflows/sdk-loop-phase.yml
@@ -122,15 +122,19 @@ jobs:
     # the agent's own budget is enforced inside sdk_loop_phase.py.
     timeout-minutes: ${{ inputs.phase == 'review' && 55 || 40 }}
     outputs:
-      outcome: ${{ steps.run.outputs.outcome }}
+      # `|| steps.prep.outputs.*` because a deterministic prep finishes before
+      # `run` exists — that step is skipped, and a skipped step's outputs are
+      # empty. Without the fallback a clean prep would report nothing, and
+      # Review 1 would checkout `ref: ''`.
+      outcome: ${{ steps.run.outputs.outcome || steps.prep.outputs.outcome }}
       verdict: ${{ steps.run.outputs.verdict }}
       verdict_url: ${{ steps.run.outputs.verdict_url }}
       reviewed_head: ${{ steps.run.outputs.reviewed_head }}
-      new_base_sha: ${{ steps.run.outputs.new_base_sha }}
-      pushed_sha: ${{ steps.run.outputs.pushed_sha }}
+      new_base_sha: ${{ steps.run.outputs.new_base_sha || steps.prep.outputs.new_base_sha }}
+      pushed_sha: ${{ steps.run.outputs.pushed_sha || steps.prep.outputs.pushed_sha }}
       ledger: ${{ steps.run.outputs.ledger }}
-      detail: ${{ steps.run.outputs.detail }}
-      ci_state: ${{ steps.run.outputs.ci_state }}
+      detail: ${{ steps.run.outputs.detail || steps.prep.outputs.detail }}
+      ci_state: ${{ steps.run.outputs.ci_state || steps.prep.outputs.ci_state }}
       cost: ${{ steps.run.outputs.cost }}
       usage: ${{ steps.run.outputs.usage }}
       reaims: ${{ steps.run.outputs.reaims }}
@@ -198,7 +202,23 @@ jobs:
       #
       # Installed from npm rather than opencode.ai's install script, which is
       # `curl | bash` and barred by the org baseline.
+      # Prep's whole job is normally a couple of `gh` reads and no model
+      # at all. Running it BEFORE the installs lets the job skip them:
+      # opencode alone was 18s of a 41s prep, spent every run preparing
+      # for a branch prep almost never takes. When no agent is needed this
+      # step IS the phase, and everything below is skipped.
+      - name: Prep — deterministic pass
+        id: prep
+        if: inputs.phase == 'prep'
+        env:
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr }}
+          BASE_SHA: ${{ inputs.base_sha }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: python3 .github/scripts/sdk_loop_prep.py
+
       - name: Cache the opencode install
+        if: inputs.phase != 'prep' || steps.prep.outputs.needs_agent == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # `~/.npm` is the package; `~/.local/share/opencode` is the ripgrep
@@ -212,6 +232,7 @@ jobs:
           key: opencode-${{ runner.os }}-1.18.22
 
       - name: Install opencode
+        if: inputs.phase != 'prep' || steps.prep.outputs.needs_agent == 'true'
         run: npm install -g --prefer-offline opencode-ai@1.18.22
 
       # uv is how this repo runs everything — `uv run pytest`,
@@ -221,12 +242,16 @@ jobs:
       # A resolver that cannot check its work is worse than one that does not
       # try, because the output looks identical.
       - name: Install uv
+        if: inputs.phase != 'prep' || steps.prep.outputs.needs_agent == 'true'
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
 
-      - name: Configure git identity for the resolve phase
-        if: inputs.phase == 'resolve' || inputs.phase == 'prep'
+      - name: Configure git identity for the phases that push
+        if: >-
+          inputs.phase == 'resolve'
+          || (inputs.phase == 'prep'
+              && steps.prep.outputs.needs_agent == 'true')
         # Commit as the App whose token is doing the pushing, not as atlan-ci.
         # atlan-ci is a CODEOWNER and the identity that mints approvals, so
         # attributing loop commits to it blurs "who wrote this" with "who
@@ -235,8 +260,11 @@ jobs:
           git config user.name  "atlan-app-fleet[bot]"
           git config user.email "4265590+atlan-app-fleet[bot]@users.noreply.github.com"
 
+      # Skipped entirely when prep already finished deterministically —
+      # its outputs come straight from the step above.
       - name: Run the phase
         id: run
+        if: inputs.phase != 'prep' || steps.prep.outputs.needs_agent == 'true'
         # Untrusted-input discipline: nothing from the PR — title, body, diff,
         # comment text — is ever interpolated with ${{ }} into a shell that
         # holds the App token. Inputs ride env vars, which the shell treats as


### PR DESCRIPTION
Three reviews spent nearly all their wall clock inside a **single `Task` call**:

| PR | scope | agents §2a routes to | sub-agent time |
|---|---|--:|--:|
| #3478 | `conformance-only` | **1** | 904s |
| #3539 | `config-only` | **1** | ~9 min |
| #3580 | `config-only` | **1** | 26 min, cancelled |

The 26-minute run reached **step 11 of 25**, with per-step latency climbing:

```
step 1   +4s      step  7  +185s
step 2   +5s      step  8  +176s
step 3   +8s      step  9  +164s
step 4  +58s      step 10  +526s   ← 8m 46s
step 5   +5s      step 11  +135s
step 6   +5s
```

## Why

A dispatch exists to run agents **concurrently**. With one agent there is nothing to run alongside — so it buys **no parallelism at all**, and it costs a cold start.

The parent has already read the playbook, the diff and every changed file. The sub-agent begins with **none of it** and re-reads its way back, and each re-read enlarges the context that makes the next step slower. That's the climbing latency, and it's why that same run kept re-opening `release.yaml`, `release.py` and `test_conformance_release.py`.

**Fan-out for two or more agents is unchanged.** One agent covering several domains produces a worse verdict and says nothing about having done so.

## Structural, not instructed

The harness classifies the scope **before the model starts** and registers only the agents §2a routes it to — **none, for a solo scope**. `Task` then has nothing to delegate to, and the rule holds by construction.

Prose would not have been enough. The comparable rule already in the research preamble — *"fetch once, a file you have already read is already in your context"* — is followed by **no run I have measured**.

## Classification moves to Python

It's pure file-list arithmetic with no judgement in it, and the harness needs the answer *first* to make the registration decision. That also deletes a turn: the agent no longer runs §11's sixty-line bash block to compute what it's now simply told.

§2a's table stays authoritative — `test_the_scope_table_matches_the_playbook` **parses the markdown** and fails if `SCOPE_AGENTS` drifts from it.

A second, smaller fix rides along: all seven agents were registered on every review, so a scope could dispatch a specialist its own routing hadn't chosen. Now only the routed ones are.

## Expectations

**This is a prediction, not a measurement.** Single-agent reviews should land near the parent's own pace — Phase 0+1 was **56 seconds** on a comparable PR — instead of 9–26 minutes.

If they don't, the explanation is wrong and I'd rather establish that than keep tuning around the edges.

144 tests pass (12 new, covering all nine scopes, the security-path exclusion from the `minor` fast path, and the registration behaviour). Pre-commit clean including pyright.
