### PR TITLE
chore(renovate): regenerate contracts that have one pkl root per entrypoint

### DIFF
--- a/.github/scripts/check_generated_freshness.py
+++ b/.github/scripts/check_generated_freshness.py
@@ -2,7 +2,7 @@
 """Generated-artifact freshness check driver (BLDX-1414).
 
 Invoked by ``.github/workflows/generated-freshness.yaml`` on app pull requests.
-Regenerates the contract artifacts from the *committed* ``contract/app.pkl`` +
+Regenerates the contract artifacts from the *committed* pkl root(s) +
 lock and fails if the working tree changed — i.e. the committed
 ``app/generated/**`` / ``atlan.yaml`` / ``app.yaml`` are stale or were
 hand-edited relative to what ``pkl eval`` produces today.
@@ -21,12 +21,12 @@ drift decision) and is unit-tested in
 
 Exit codes:
   * 0 — artifacts are fresh, OR the check is genuinely not-applicable (no
-        ``contract/app.pkl``, ``pkl`` not installed, or a ``git`` invocation
+        an evaluable pkl root, ``pkl`` not installed, or a ``git`` invocation
         failed — all infra/absence, not a broken contract), OR opted out
         (``--check-freshness false``).
   * 1 — the contract cannot be verified fresh: either drift (regeneration
         changed tracked files or produced untracked ones under the
-        generated-output paths) OR ``contract/app.pkl`` exists but ``pkl eval``
+        generated-output paths) OR an evaluable root exists but ``pkl eval``
         failed, so it does not regenerate at all. The latter used to degrade to
         exit 0, which silently shipped stale artifacts on every toolkit bump
         (the failure mode this gate exists to catch); it now fails red. The
@@ -49,7 +49,7 @@ from pathlib import Path
 # Reuse the exact regeneration primitive + output list the renovate sync uses,
 # so "regenerate" means the same thing in both places.
 sys.path.insert(0, str(Path(__file__).parent))
-from renovate_pkl_sync import OUTPUT_PATHS, regenerate  # noqa: E402
+from renovate_pkl_sync import OUTPUT_PATHS, eval_roots, regenerate  # noqa: E402
 
 
 def _changed_output_paths() -> list[str] | None:
@@ -100,14 +100,23 @@ def check_freshness(contract_dir: str = "contract") -> tuple[str, list[str]]:
     ``status`` is one of:
       * ``"clean"``       — regeneration produced no changes.
       * ``"drift"``       — regeneration changed/created output files (``changed_paths``).
-      * ``"eval_failed"`` — ``contract/app.pkl`` exists but ``pkl eval`` failed,
+      * ``"eval_failed"`` — an evaluable contract exists but ``pkl eval`` failed,
                             so it does not regenerate. A real breakage → fails red.
-      * ``"na"``          — genuinely nothing to check: no ``contract/app.pkl``,
+      * ``"na"``          — genuinely nothing to check: no evaluable pkl root,
                             ``pkl`` not installed (``OSError``), or a ``git``
                             invocation failed. Infra/absence, treated as pass.
     """
-    if not (Path(contract_dir) / "app.pkl").exists():
-        print(f"::notice::No {contract_dir}/app.pkl — no generated artifacts to check.")
+    # Ask for ROOTS, not for app.pkl. An app with one root per entrypoint
+    # (crawler.pkl + miner.pkl) has no app.pkl and used to return "na" here —
+    # a silent pass — before regenerate() was ever called. The skip has to be
+    # decided by the same discovery the regeneration uses, or the two disagree
+    # about what "nothing to generate" means.
+    roots = eval_roots(contract_dir)
+    if not roots:
+        print(
+            f"::notice::No evaluable pkl root in {contract_dir}/ — "
+            "no generated artifacts to check."
+        )
         return ("na", [])
 
     try:
@@ -123,7 +132,7 @@ def check_freshness(contract_dir: str = "contract") -> tuple[str, list[str]]:
         return ("na", [])
 
     if not regenerated:
-        # app.pkl exists (checked above) and regenerate() did not raise OSError
+        # a root exists (checked above) and regenerate() did not raise OSError
         # (pkl is runnable), so the only remaining reason it returned False is
         # that `pkl eval` itself failed — the committed contract does not
         # regenerate. That is the exact silent-degrade this gate must catch, not
@@ -144,7 +153,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--contract-dir",
         default="contract",
-        help="Directory containing PklProject and app.pkl (default: contract).",
+        help="Directory containing PklProject and the pkl root(s) (default: contract).",
     )
     parser.add_argument(
         "--check-freshness",
@@ -166,7 +175,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if status == "eval_failed":
         print(
-            "::error::contract/app.pkl exists but 'pkl eval' failed — the "
+            "::error::the contract has an evaluable pkl root but 'pkl eval' failed — the "
             "committed generated artifacts cannot be verified and are almost "
             "certainly stale (a toolkit bump merged without regenerating). Fix "
             "the contract so 'pkl eval -m . contract/app.pkl' (or "

--- a/.github/scripts/pkl_contract_layout.py
+++ b/.github/scripts/pkl_contract_layout.py
@@ -461,7 +461,24 @@ def export_contract_at(ref: str, contract_dir: str, dest: Path) -> bool:
     extract = subprocess.run(
         ["tar", "-x", "-C", str(dest)], input=archive.stdout, check=False
     )
-    return extract.returncode == 0 and (dest / contract_dir / "app.pkl").exists()
+    if extract.returncode != 0:
+        return False
+    # Validity is "the archive holds an evaluable contract", NOT "it holds
+    # app.pkl": an app with one root per entrypoint (crawler.pkl + miner.pkl)
+    # has no app.pkl and would otherwise never get a baseline, silently
+    # turning override detection off for exactly the apps whose generated
+    # trees are most likely to be post-processed.
+    exported = dest / contract_dir
+    if (exported / "app.pkl").exists():
+        return True
+    return any(
+        any(
+            ln.startswith("amends ")
+            for ln in f.read_text(encoding="utf-8").splitlines()
+        )
+        for f in sorted(exported.glob("*.pkl"))
+        if f.is_file()
+    )
 
 
 def run_post_generate(contract_dir: str = "contract") -> None:

--- a/.github/scripts/renovate_pkl_sync.py
+++ b/.github/scripts/renovate_pkl_sync.py
@@ -126,6 +126,95 @@ def resolve(contract_dir: str) -> None:
     run(["pkl", "project", "resolve", f"{contract_dir}/"], check=True)
 
 
+def eval_roots(contract_dir: str) -> list[Path]:
+    """The contract's pkl EVAL ROOTS, newest-convention first.
+
+    A root is a ``.pkl`` that ``amends`` a toolkit template — that is what
+    makes it evaluable on its own. Files the roots merely ``import``
+    (``credentials.pkl`` is the common one) are modules, not roots, and
+    evaluating them is meaningless.
+
+    ``app.pkl`` is returned alone when present: it is the single-root
+    convention and its outputs land at the generated dir itself.
+    """
+    d = Path(contract_dir)
+    if not d.is_dir():
+        return []
+    if (d / "app.pkl").is_file():
+        return [d / "app.pkl"]
+    roots: list[Path] = []
+    for f in sorted(d.glob("*.pkl")):
+        try:
+            text = f.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if any(ln.startswith("amends ") for ln in text.splitlines()):
+            roots.append(f)
+    return roots
+
+
+def _eval_root(root: Path, contract_dir: str, out: Path) -> bool:
+    """One `pkl eval -m` with the shared retry. True iff it produced output."""
+    cmd = ["pkl", "eval", "--project-dir", contract_dir, "-m", str(out), str(root)]
+    result = run(cmd)
+    attempt = 1
+    while result.returncode != 0 and attempt < EVAL_MAX_ATTEMPTS:
+        print(
+            f"::warning::pkl eval failed for {root.name} "
+            f"(attempt {attempt}/{EVAL_MAX_ATTEMPTS}); retrying in "
+            f"{EVAL_RETRY_SLEEP_S:g}s — a cold runner may still be fetching the "
+            "remote @app-contract-toolkit package."
+        )
+        time.sleep(EVAL_RETRY_SLEEP_S)
+        attempt += 1
+        result = run(cmd)
+    return result.returncode == 0
+
+
+def regenerate_multi_root(contract_dir: str, roots: list[Path]) -> bool:
+    """Regenerate an app whose contract has ONE ROOT PER ENTRYPOINT.
+
+    Some apps (synapse: ``crawler.pkl`` + ``miner.pkl``) have no single
+    ``app.pkl``; each root generates its own tree under
+    ``<generated>/<root stem>/``. They CANNOT share one ``pkl eval -m`` base:
+    every root emits the same unprefixed key names (``_input.py``,
+    ``manifest.json``, ``__init__.py``, the connectors JSON), so a shared base
+    silently lets the last root clobber the others — measured on synapse,
+    4 of 5 filenames collide. Each root therefore gets its own eval base and
+    its own swap target.
+
+    Root files (``atlan.yaml``/``app.yaml``) are deliberately NOT written from
+    here: no per-entrypoint root emits them, so anything at the repo root is
+    hand-authored and must survive (a prior incident clobbered exactly that).
+
+    Returns True iff at least one root regenerated. A root that fails eval or
+    whose swap refuses the layout is warned about and skipped — a partial
+    regeneration is still better than none, and the caller diffs the result.
+    """
+    placed = False
+    for root in roots:
+        tmp = Path(tempfile.mkdtemp())
+        try:
+            if not _eval_root(root, contract_dir, tmp):
+                print(
+                    f"::warning::pkl eval failed after {EVAL_MAX_ATTEMPTS} attempts "
+                    f"for {root.name} — its artifacts are left unchanged."
+                )
+                continue
+            target = f"{GENERATED_DIR}/{root.stem}"
+            if swap_outputs(tmp, generated_dir=target):
+                placed = True
+                print(f"Regenerated {target} from {root.name}.")
+            else:
+                print(f"::warning::swap refused the output layout for {root.name}.")
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+    if placed:
+        run_post_generate(contract_dir)
+        _format_generated()
+    return placed
+
+
 def regenerate(contract_dir: str) -> bool:
     """Regenerate contract artifacts; swap gated on eval+format success.
 
@@ -146,6 +235,13 @@ def regenerate(contract_dir: str) -> bool:
     """
     app_pkl = Path(contract_dir) / "app.pkl"
     if not app_pkl.exists():
+        roots = eval_roots(contract_dir)
+        if roots:
+            print(
+                f"::notice::No {app_pkl}; regenerating {len(roots)} per-entrypoint "
+                f"root(s): {', '.join(r.name for r in roots)}."
+            )
+            return regenerate_multi_root(contract_dir, roots)
         print(
             f"::notice::No {app_pkl} — skipping artifact regeneration (re-resolve only)."
         )

--- a/.github/scripts/renovate_pkl_sync.py
+++ b/.github/scripts/renovate_pkl_sync.py
@@ -194,6 +194,7 @@ def regenerate_multi_root(contract_dir: str, roots: list[Path]) -> bool:
     placed = False
     for root in roots:
         tmp = Path(tempfile.mkdtemp())
+        base_work: Path | None = None
         try:
             if not _eval_root(root, contract_dir, tmp):
                 print(
@@ -202,13 +203,16 @@ def regenerate_multi_root(contract_dir: str, roots: list[Path]) -> bool:
                 )
                 continue
             target = f"{GENERATED_DIR}/{root.stem}"
-            if swap_outputs(tmp, generated_dir=target):
+            base_out, base_work = _baseline_output_for_root(contract_dir, root.name)
+            if swap_outputs(tmp, generated_dir=target, baseline_dir=base_out):
                 placed = True
                 print(f"Regenerated {target} from {root.name}.")
             else:
                 print(f"::warning::swap refused the output layout for {root.name}.")
         finally:
             shutil.rmtree(tmp, ignore_errors=True)
+            if base_work is not None:
+                shutil.rmtree(base_work, ignore_errors=True)
     if placed:
         run_post_generate(contract_dir)
         _format_generated()
@@ -294,6 +298,56 @@ def regenerate(contract_dir: str) -> bool:
         shutil.rmtree(tmp, ignore_errors=True)
         if baseline_work is not None:
             shutil.rmtree(baseline_work, ignore_errors=True)
+
+
+def _baseline_output_for_root(
+    contract_dir: str, root_name: str
+) -> tuple[Path | None, Path | None]:
+    """``_baseline_output`` for ONE root of a multi-root contract.
+
+    Same contract and the same failure semantics: ``(eval_output, workdir)``,
+    output None whenever there is no baseline or producing one failed, never
+    raises. Without this the multi-root swap ran with ``baseline_dir=None``
+    and overwrote every app-maintained generated file on a toolkit bump —
+    the single-root path has protected those since it was written.
+    """
+    ref = baseline_contract_ref(contract_dir)
+    if ref is None:
+        return (None, None)  # no pin change in flight — nothing to protect
+    work = Path(tempfile.mkdtemp())
+    if not export_contract_at(ref, contract_dir, work):
+        print(
+            f"::warning::Could not export {contract_dir}/ at {ref[:12]} — "
+            f"app-maintained files under {GENERATED_DIR}/{Path(root_name).stem} "
+            "cannot be detected, so regeneration will overwrite them."
+        )
+        return (None, work)
+    base_root = work / contract_dir / root_name
+    if not base_root.exists():
+        # The root is new in this revision: nothing committed came from it, so
+        # there is nothing to preserve. Not a failure.
+        return (None, work)
+    out = work / "out"
+    out.mkdir()
+    result = run(
+        [
+            "pkl",
+            "eval",
+            "--project-dir",
+            str(work / contract_dir),
+            "-m",
+            str(out),
+            str(base_root),
+        ]
+    )
+    if result.returncode != 0:
+        print(
+            f"::warning::Baseline pkl eval (pre-bump toolkit pin) failed for "
+            f"{root_name} — app-maintained generated files cannot be detected, "
+            "so regeneration will overwrite them."
+        )
+        return (None, work)
+    return (out, work)
 
 
 def _baseline_output(contract_dir: str) -> tuple[Path | None, Path | None]:

--- a/.github/scripts/tests/test_check_generated_freshness.py
+++ b/.github/scripts/tests/test_check_generated_freshness.py
@@ -208,3 +208,38 @@ def test_untracked_output_ignored_by_gitignore_still_caught(repo, monkeypatch):
 
     monkeypatch.setattr(sync, "run", fake_run)
     assert mod.main([]) == 1
+
+
+# ── multi-root contracts reach the gate ──────────────────────────────────────
+
+
+def test_multi_root_app_is_checked_not_skipped(repo, monkeypatch):
+    """A one-root-per-entrypoint app (crawler.pkl + miner.pkl) has no app.pkl.
+    The gate used to return "na" on that — a silent pass — before regenerate()
+    was ever called, which is the exact failure this check exists to catch.
+    """
+    (repo / "contract" / "app.pkl").unlink()
+    (repo / "contract" / "crawler.pkl").write_text(
+        'amends "@app-contract-toolkit/NativeApp.pkl"\n'
+    )
+    called: list[str] = []
+
+    def fake_regenerate(contract_dir):
+        called.append(contract_dir)
+        (repo / "app" / "generated" / "crawler").mkdir(parents=True, exist_ok=True)
+        (repo / "app" / "generated" / "crawler" / "_input.py").write_text("drifted\n")
+        return True
+
+    monkeypatch.setattr(mod, "regenerate", fake_regenerate)
+    status, changed = mod.check_freshness("contract")
+    assert called == ["contract"]  # regenerate() actually ran
+    assert status == "drift"
+    assert any("crawler" in c for c in changed)
+
+
+def test_no_evaluable_root_is_still_na(repo, monkeypatch):
+    """An imported module is not a root: nothing to generate, still a pass."""
+    (repo / "contract" / "app.pkl").unlink()
+    (repo / "contract" / "credentials.pkl").write_text('name = "creds"\n')
+    monkeypatch.setattr(mod, "regenerate", lambda d: pytest.fail("must not regenerate"))
+    assert mod.check_freshness("contract") == ("na", [])

--- a/.github/scripts/tests/test_pkl_contract_layout.py
+++ b/.github/scripts/tests/test_pkl_contract_layout.py
@@ -456,8 +456,6 @@ def test_export_contract_at_accepts_a_multi_root_archive(tmp_path, monkeypatch):
     app.pkl". Requiring app.pkl meant a one-root-per-entrypoint app never got
     a baseline, silently disabling override detection for exactly the apps
     whose generated trees are most likely to be post-processed."""
-    import subprocess as sp
-
     src = tmp_path / "src"
     (src / "contract").mkdir(parents=True)
     (src / "contract" / "crawler.pkl").write_text(
@@ -471,7 +469,7 @@ def test_export_contract_at_accepts_a_multi_root_archive(tmp_path, monkeypatch):
         ["add", "-A"],
         ["commit", "-qm", "c"],
     ):
-        sp.run(["git", *args], cwd=src, check=True, capture_output=True)
+        subprocess.run(["git", *args], cwd=src, check=True, capture_output=True)
 
     monkeypatch.chdir(src)
     dest = tmp_path / "dest"
@@ -488,6 +486,6 @@ def test_export_contract_at_accepts_a_multi_root_archive(tmp_path, monkeypatch):
         ["add", "-A"],
         ["commit", "-qm", "c"],
     ):
-        sp.run(["git", *args], cwd=src2, check=True, capture_output=True)
+        subprocess.run(["git", *args], cwd=src2, check=True, capture_output=True)
     monkeypatch.chdir(src2)
     assert mod.export_contract_at("HEAD", "contract", tmp_path / "dest2") is False

--- a/.github/scripts/tests/test_pkl_contract_layout.py
+++ b/.github/scripts/tests/test_pkl_contract_layout.py
@@ -449,3 +449,45 @@ def test_export_contract_at_returns_false_for_a_bad_ref(tree):
     _commit(tree, "init")
 
     assert mod.export_contract_at("nope-not-a-ref", "contract", tree / "e") is False
+
+
+def test_export_contract_at_accepts_a_multi_root_archive(tmp_path, monkeypatch):
+    """Validity is "the archive holds an evaluable contract", not "it holds
+    app.pkl". Requiring app.pkl meant a one-root-per-entrypoint app never got
+    a baseline, silently disabling override detection for exactly the apps
+    whose generated trees are most likely to be post-processed."""
+    import subprocess as sp
+
+    src = tmp_path / "src"
+    (src / "contract").mkdir(parents=True)
+    (src / "contract" / "crawler.pkl").write_text(
+        'amends "@app-contract-toolkit/NativeApp.pkl"\n'
+    )
+    (src / "contract" / "credentials.pkl").write_text('name = "creds"\n')
+    for args in (
+        ["init", "-q"],
+        ["config", "user.email", "t@t"],
+        ["config", "user.name", "t"],
+        ["add", "-A"],
+        ["commit", "-qm", "c"],
+    ):
+        sp.run(["git", *args], cwd=src, check=True, capture_output=True)
+
+    monkeypatch.chdir(src)
+    dest = tmp_path / "dest"
+    assert mod.export_contract_at("HEAD", "contract", dest) is True
+
+    # an archive with only imported modules is NOT evaluable
+    src2 = tmp_path / "src2"
+    (src2 / "contract").mkdir(parents=True)
+    (src2 / "contract" / "credentials.pkl").write_text('name = "creds"\n')
+    for args in (
+        ["init", "-q"],
+        ["config", "user.email", "t@t"],
+        ["config", "user.name", "t"],
+        ["add", "-A"],
+        ["commit", "-qm", "c"],
+    ):
+        sp.run(["git", *args], cwd=src2, check=True, capture_output=True)
+    monkeypatch.chdir(src2)
+    assert mod.export_contract_at("HEAD", "contract", tmp_path / "dest2") is False

--- a/.github/scripts/tests/test_renovate_pkl_sync.py
+++ b/.github/scripts/tests/test_renovate_pkl_sync.py
@@ -833,3 +833,44 @@ def test_no_roots_at_all_is_still_a_skip(repo):
     (repo / "contract" / "credentials.pkl").write_text('name = "creds"\n')
     assert mod.eval_roots("contract") == []
     assert mod.regenerate("contract") is False
+
+
+def test_multi_root_swap_gets_a_per_root_baseline(repo, monkeypatch):
+    """Without a baseline the swap overwrites every app-maintained generated
+    file on a toolkit bump — protection the single-root path has always had.
+    Each root's baseline must be its OWN pre-bump eval, not app.pkl's."""
+    _multi_root_contract(repo)
+    seen: list[tuple[str, object]] = []
+
+    def fake_baseline(contract_dir, root_name):
+        return (Path("/tmp/base") / Path(root_name).stem, None)
+
+    def fake_swap(out_dir, generated_dir=mod.GENERATED_DIR, baseline_dir=None):
+        seen.append((generated_dir, baseline_dir))
+        return True
+
+    monkeypatch.setattr(mod, "_baseline_output_for_root", fake_baseline)
+    monkeypatch.setattr(mod, "swap_outputs", fake_swap)
+    monkeypatch.setattr(
+        mod,
+        "run",
+        lambda cmd, *, check=False: subprocess.CompletedProcess(cmd, 0, "", ""),
+    )
+    monkeypatch.setattr(mod, "run_post_generate", lambda d: None)
+    monkeypatch.setattr(mod, "_format_generated", lambda: None)
+
+    assert mod.regenerate("contract") is True
+    assert seen == [
+        ("app/generated/crawler", Path("/tmp/base/crawler")),
+        ("app/generated/miner", Path("/tmp/base/miner")),
+    ]  # per-root target AND per-root baseline
+
+
+def test_multi_root_baseline_absent_root_is_not_a_failure(repo, monkeypatch):
+    """A root that is new in this revision has nothing committed from it, so
+    there is nothing to preserve — None baseline, no warning-worthy failure."""
+    _multi_root_contract(repo)
+    monkeypatch.setattr(mod, "baseline_contract_ref", lambda d: "abc123")
+    monkeypatch.setattr(mod, "export_contract_at", lambda ref, d, dest: True)
+    out, work = mod._baseline_output_for_root("contract", "crawler.pkl")
+    assert out is None and work is not None  # workdir returned for cleanup

--- a/.github/scripts/tests/test_renovate_pkl_sync.py
+++ b/.github/scripts/tests/test_renovate_pkl_sync.py
@@ -720,3 +720,116 @@ def test_resolve_failure_is_fatal(repo, monkeypatch):
 
     with pytest.raises(subprocess.CalledProcessError):
         mod.main(["--regenerate", "false"])
+
+
+# ── multi-root contracts: one pkl root per entrypoint ────────────────────────
+
+
+def _multi_root_contract(repo: Path) -> None:
+    """synapse's shape: no app.pkl, one amending root per entrypoint, plus an
+    imported (non-root) module."""
+    (repo / "contract" / "app.pkl").unlink(missing_ok=True)
+    (repo / "contract" / "crawler.pkl").write_text(
+        'amends "@app-contract-toolkit/NativeApp.pkl"\nimport "./credentials.pkl"\n'
+    )
+    (repo / "contract" / "miner.pkl").write_text(
+        'amends "@app-contract-toolkit/NativeApp.pkl"\n'
+    )
+    # imported, never evaluated on its own
+    (repo / "contract" / "credentials.pkl").write_text('name = "creds"\n')
+
+
+def test_eval_roots_finds_amending_roots_not_imported_modules(repo):
+    _multi_root_contract(repo)
+    assert [r.name for r in mod.eval_roots("contract")] == [
+        "crawler.pkl",
+        "miner.pkl",
+    ]  # credentials.pkl imports nothing and amends nothing — not a root
+
+
+def test_eval_roots_prefers_app_pkl_alone(repo):
+    """The single-root convention wins outright: app.pkl's outputs land at the
+    generated dir itself, never in a per-root subdir."""
+    (repo / "contract" / "extra.pkl").write_text(
+        'amends "@app-contract-toolkit/NativeApp.pkl"\n'
+    )
+    assert [r.name for r in mod.eval_roots("contract")] == ["app.pkl"]
+
+
+def test_multi_root_gives_each_root_its_own_eval_base(repo, monkeypatch):
+    """Every root emits the SAME unprefixed key names, so a shared `pkl eval
+    -m` base lets the last root clobber the others (measured on synapse: 4 of
+    5 filenames collide). Each root must get its own base and its own target.
+    """
+    _multi_root_contract(repo)
+    bases: list[str] = []
+
+    def fake_run(cmd, *, check=False):
+        if cmd[0] == "pkl" and cmd[1] == "eval":
+            out = Path(cmd[cmd.index("-m") + 1])
+            bases.append(str(out))
+            root = Path(cmd[-1]).stem
+            out.mkdir(parents=True, exist_ok=True)
+            # identical key names from both roots — the collision under test
+            (out / "_input.py").write_text(f"# {root}\n")
+            (out / "manifest.json").write_text(f'{{"entrypoint": "{root}"}}\n')
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    assert mod.regenerate("contract") is True
+    assert len(bases) == 2 and len(set(bases)) == 2  # never a shared base
+
+    crawler = repo / "app" / "generated" / "crawler"
+    miner = repo / "app" / "generated" / "miner"
+    assert "crawler" in (crawler / "_input.py").read_text()
+    assert "miner" in (miner / "_input.py").read_text()  # not clobbered
+
+
+def test_multi_root_never_writes_repo_root_files(repo, monkeypatch):
+    """No per-entrypoint root emits atlan.yaml/app.yaml, so anything at the
+    repo root is hand-authored and must survive (a prior incident clobbered
+    exactly that)."""
+    _multi_root_contract(repo)
+    (repo / "atlan.yaml").write_text("hand: authored\n")
+
+    def fake_run(cmd, *, check=False):
+        if cmd[0] == "pkl" and cmd[1] == "eval":
+            out = Path(cmd[cmd.index("-m") + 1])
+            out.mkdir(parents=True, exist_ok=True)
+            (out / "_input.py").write_text("x = 1\n")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    assert mod.regenerate("contract") is True
+    assert (repo / "atlan.yaml").read_text() == "hand: authored\n"
+
+
+def test_multi_root_one_bad_root_does_not_sink_the_others(repo, monkeypatch):
+    """A partial regeneration beats none: the caller diffs the result."""
+    _multi_root_contract(repo)
+
+    def fake_run(cmd, *, check=False):
+        if cmd[0] == "pkl" and cmd[1] == "eval":
+            if Path(cmd[-1]).stem == "miner":
+                return subprocess.CompletedProcess(cmd, 1, "", "boom")
+            out = Path(cmd[cmd.index("-m") + 1])
+            out.mkdir(parents=True, exist_ok=True)
+            (out / "_input.py").write_text("ok = 1\n")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod.time, "sleep", lambda _s: None)
+    assert mod.regenerate("contract") is True
+    assert (repo / "app" / "generated" / "crawler" / "_input.py").exists()
+    assert not (repo / "app" / "generated" / "miner").exists()
+
+
+def test_no_roots_at_all_is_still_a_skip(repo):
+    """An app with a PklProject but no evaluable root regenerates nothing."""
+    (repo / "contract" / "app.pkl").unlink(missing_ok=True)
+    (repo / "contract" / "credentials.pkl").write_text('name = "creds"\n')
+    assert mod.eval_roots("contract") == []
+    assert mod.regenerate("contract") is False


### PR DESCRIPTION
An app with no `contract/app.pkl` was treated as having nothing to generate:

```python
if not app_pkl.exists():
    print(f"::notice::No {app_pkl} — skipping artifact regeneration (re-resolve only).")
    return False
```

But some apps have no single root. `atlan-synapse-app` ships `crawler.pkl` + `miner.pkl` (plus an imported `credentials.pkl`) and generates one tree per entrypoint under `app/generated/<entrypoint>/`. For those, `regenerate()` returned False — so **the freshness gate silently checked nothing**, and every consumer of this primitive (the Renovate pkl sync, and the conformance remediation lane) could not regenerate them at all.

## Why they cannot share one eval base

Measured on synapse — each root evaluated alone:

| | crawler.pkl | miner.pkl |
|---|---|---|
| `_input.py` | ✅ | ✅ |
| `manifest.json` | ✅ | ✅ |
| `__init__.py` | ✅ | ✅ |
| `atlan-connectors-synapse.json` | ✅ | ✅ |
| entrypoint JSON | `synapse-crawler.json` | `synapse-miner.json` |

The keys are **unprefixed**, so **4 of 5 filenames collide**: one shared `pkl eval -m` base means the last root silently clobbers the first. Each root therefore gets its own eval base and its own swap target (`app/generated/<root stem>`), reusing the existing layout-aware `swap_outputs`.

Root files are deliberately **not** written from this path — no per-entrypoint root emits `atlan.yaml`/`app.yaml`, so anything at the repo root is hand-authored and must survive (a prior incident clobbered exactly that).

A root is identified by `amends` (that is what makes it evaluable); imported modules like `credentials.pkl` are correctly not roots, and `app.pkl` still wins outright when present, so **single-root behaviour is unchanged**.

## Verified against the real repo

Ran the new path against a fresh clone of `atlan-synapse-app`:

- both roots regenerate, and the committed tree is reproduced **byte-identically**;
- `atlan.yaml` untouched;
- one delta — `app/generated/miner/atlan-connectors-synapse.json`, a generated file the app is genuinely **missing**. That is real drift this gate previously could not see.

## Tests

`pytest tests/test_renovate_pkl_sync.py -q` → **30 passed**. New: roots are the amending files (not imported modules); `app.pkl` still wins alone; each root gets its own base and neither clobbers the other; repo-root files are never written; one failing root does not sink the others; an app with no evaluable root is still a skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)