### PR TITLE
feat(contract-toolkit): optional transformed_nondata_prefix on the publish node

### DIFF
--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -307,6 +307,9 @@ pipeline {
     // connectionEntity: default "{{connection}}". Set null to omit
     // connection_entity AND disable connection creation (see below).
     connectionEntity = null
+    // transformedNondataPrefix: default null (arg omitted). Set it when the
+    // extract workflow emits non-data payloads (see below).
+    transformedNondataPrefix = "$.extract.outputs.transformed_nondata_prefix"
   }
 }
 ```
@@ -316,6 +319,8 @@ Dependencies between pipeline steps are **auto-wired** based on position — you
 Every node ships with a default `errorHandling.startToCloseTimeoutSeconds`: **1 day (86400s)** for every node, except `publish` and `lineage-publish` at **3 days (259200s)** (both write to Atlas and can be heavy on large tenants). This keeps non-trivial extract/lineage/publish work from silently inheriting Automation Engine's tight 2h workflow default. The `errorHandling` overrides shown above win over the default; set `errorHandling = null` on a node to fall back to AE's own default.
 
 `PublishStep.connectionEntity` (also settable directly on `PublishNode`) controls the publish node's `connection_entity` arg — the full connection entity JSON used for connection creation. It defaults to the `"{{connection}}"` form placeholder. Setting it to `null` omits `connection_entity` from the generated args entirely, and because the field is **linked** to `connection_creation_enabled` (which defaults to `connectionEntity != null`), a `null` entity also disables connection creation — publish then targets an already-existing connection and creates nothing. Override `connectionCreationEnabled` explicitly on the node to disable creation even when an entity is present.
+
+`PublishStep.transformedNondataPrefix` (also settable directly on `PublishNode`) controls the publish node's optional `transformed_nondata_prefix` arg — the object-store prefix holding the run's transformed **non-data** payloads, alongside the asset rows publish reads from `transformed_data_prefix`. It defaults to `null`, which omits the arg entirely, so apps that do not set it generate byte-identical manifests. Set it — normally to an output reference such as `"$.extract.outputs.transformed_nondata_prefix"`, though a literal prefix or form placeholder is passed through verbatim — only when the upstream node actually emits non-data payloads. It leaves `transformed_data_prefix` and every other publish arg untouched.
 
 The toolkit can append a run-level notification node when an app opts in:
 

--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -307,9 +307,9 @@ pipeline {
     // connectionEntity: default "{{connection}}". Set null to omit
     // connection_entity AND disable connection creation (see below).
     connectionEntity = null
-    // transformedNondataPrefix: default null (arg omitted). Set it when the
+    // transformedNonDataPrefix: default null (arg omitted). Set it when the
     // extract workflow emits non-data payloads (see below).
-    transformedNondataPrefix = "$.extract.outputs.transformed_nondata_prefix"
+    transformedNonDataPrefix = "$.extract.outputs.transformed_nondata_prefix"
   }
 }
 ```
@@ -320,7 +320,7 @@ Every node ships with a default `errorHandling.startToCloseTimeoutSeconds`: **1 
 
 `PublishStep.connectionEntity` (also settable directly on `PublishNode`) controls the publish node's `connection_entity` arg — the full connection entity JSON used for connection creation. It defaults to the `"{{connection}}"` form placeholder. Setting it to `null` omits `connection_entity` from the generated args entirely, and because the field is **linked** to `connection_creation_enabled` (which defaults to `connectionEntity != null`), a `null` entity also disables connection creation — publish then targets an already-existing connection and creates nothing. Override `connectionCreationEnabled` explicitly on the node to disable creation even when an entity is present.
 
-`PublishStep.transformedNondataPrefix` (also settable directly on `PublishNode`) controls the publish node's optional `transformed_nondata_prefix` arg — the object-store prefix holding the run's transformed **non-data** payloads, alongside the asset rows publish reads from `transformed_data_prefix`. It defaults to `null`, which omits the arg entirely, so apps that do not set it generate byte-identical manifests. Set it — normally to an output reference such as `"$.extract.outputs.transformed_nondata_prefix"`, though a literal prefix or form placeholder is passed through verbatim — only when the upstream node actually emits non-data payloads. It leaves `transformed_data_prefix` and every other publish arg untouched.
+`PublishStep.transformedNonDataPrefix` (also settable directly on `PublishNode`) controls the publish node's optional `transformed_nondata_prefix` arg — the object-store prefix holding the run's transformed **non-data** payloads, alongside the asset rows publish reads from `transformed_data_prefix`. It defaults to `null`, which omits the arg entirely, so apps that do not set it generate byte-identical manifests. Set it — normally to an output reference such as `"$.extract.outputs.transformed_nondata_prefix"`, though a literal prefix or form placeholder is passed through verbatim — only when the upstream node actually emits non-data payloads. It leaves `transformed_data_prefix` and every other publish arg untouched.
 
 The toolkit can append a run-level notification node when an app opts in:
 

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -589,7 +589,7 @@ class PublishStep {
   executorEnabled: Boolean|String = true
   includeInputFields: Boolean = true     // generates output_dir/load_to_atlan/publish_dry_run in _input.py
   connectionEntity: String? = "{{connection}}"  // args["connection_entity"]; null omits it AND sets connection_creation_enabled=false
-  transformedNondataPrefix: String? = null      // args["transformed_nondata_prefix"]; null omits it
+  transformedNonDataPrefix: String? = null      // args["transformed_nondata_prefix"]; null omits it
   lineagePublish: LineagePublishStep?    // opt-in lineage publish (default-off)
   errorHandling: ErrorHandlingConfig? = new ErrorHandlingConfig {
     startToCloseTimeoutSeconds = 259200  // 72h default — AE's 2h is too tight for large tenants
@@ -2146,7 +2146,7 @@ class PublishNode extends DAGNode {
   tagAttachmentsPrefix: String? = null
   connectionEntity: String? = "{{connection}}"
   connectionCreationEnabled: Boolean = connectionEntity != null
-  transformedNondataPrefix: String? = null
+  transformedNonDataPrefix: String? = null
   displayName = "Publish to Atlas"
   workflowType = "PublishWorkflow"
   appName = "publish"
@@ -2158,8 +2158,8 @@ class PublishNode extends DAGNode {
     ["connection_creation_enabled"] = connectionCreationEnabled
     ["executor_enabled"] = executorEnabled
     when (connectionEntity != null) { ["connection_entity"] = connectionEntity }
-    when (transformedNondataPrefix != null) {
-      ["transformed_nondata_prefix"] = transformedNondataPrefix
+    when (transformedNonDataPrefix != null) {
+      ["transformed_nondata_prefix"] = transformedNonDataPrefix
     }
   }
   dependsOn { upstream }
@@ -2180,18 +2180,18 @@ entity is present. For the auto-generated default publish node, set the app-leve
 `publishExecutorEnabled`; for `extraNodes["publish"] = new PublishNode { ... }`,
 set `executorEnabled` on that node.
 
-`transformedNondataPrefix` is the object-store prefix holding the run's
+`transformedNonDataPrefix` is the object-store prefix holding the run's
 transformed **non-data** payloads — what the app emits alongside the asset rows
 that publish reads from `transformed_data_prefix`. It is opt-in: the default
 `null` omits `transformed_nondata_prefix` from the args entirely, so apps that
 never set it generate byte-identical manifests. Set it on the node
-(`extraNodes["publish"]`) or via `pipeline.publish.transformedNondataPrefix`,
+(`extraNodes["publish"]`) or via `pipeline.publish.transformedNonDataPrefix`,
 normally to an output reference:
 
 ```pkl
 pipeline {
   publish {
-    transformedNondataPrefix = "$.extract.outputs.transformed_nondata_prefix"
+    transformedNonDataPrefix = "$.extract.outputs.transformed_nondata_prefix"
   }
 }
 ```

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -589,6 +589,7 @@ class PublishStep {
   executorEnabled: Boolean|String = true
   includeInputFields: Boolean = true     // generates output_dir/load_to_atlan/publish_dry_run in _input.py
   connectionEntity: String? = "{{connection}}"  // args["connection_entity"]; null omits it AND sets connection_creation_enabled=false
+  transformedNondataPrefix: String? = null      // args["transformed_nondata_prefix"]; null omits it
   lineagePublish: LineagePublishStep?    // opt-in lineage publish (default-off)
   errorHandling: ErrorHandlingConfig? = new ErrorHandlingConfig {
     startToCloseTimeoutSeconds = 259200  // 72h default — AE's 2h is too tight for large tenants
@@ -2145,6 +2146,7 @@ class PublishNode extends DAGNode {
   tagAttachmentsPrefix: String? = null
   connectionEntity: String? = "{{connection}}"
   connectionCreationEnabled: Boolean = connectionEntity != null
+  transformedNondataPrefix: String? = null
   displayName = "Publish to Atlas"
   workflowType = "PublishWorkflow"
   appName = "publish"
@@ -2156,6 +2158,9 @@ class PublishNode extends DAGNode {
     ["connection_creation_enabled"] = connectionCreationEnabled
     ["executor_enabled"] = executorEnabled
     when (connectionEntity != null) { ["connection_entity"] = connectionEntity }
+    when (transformedNondataPrefix != null) {
+      ["transformed_nondata_prefix"] = transformedNondataPrefix
+    }
   }
   dependsOn { upstream }
 }
@@ -2174,6 +2179,29 @@ Override `connectionCreationEnabled` explicitly to disable creation even when an
 entity is present. For the auto-generated default publish node, set the app-level
 `publishExecutorEnabled`; for `extraNodes["publish"] = new PublishNode { ... }`,
 set `executorEnabled` on that node.
+
+`transformedNondataPrefix` is the object-store prefix holding the run's
+transformed **non-data** payloads — what the app emits alongside the asset rows
+that publish reads from `transformed_data_prefix`. It is opt-in: the default
+`null` omits `transformed_nondata_prefix` from the args entirely, so apps that
+never set it generate byte-identical manifests. Set it on the node
+(`extraNodes["publish"]`) or via `pipeline.publish.transformedNondataPrefix`,
+normally to an output reference:
+
+```pkl
+pipeline {
+  publish {
+    transformedNondataPrefix = "$.extract.outputs.transformed_nondata_prefix"
+  }
+}
+```
+
+The value is passed through verbatim, so a literal prefix or a form placeholder
+works too. Set it only when the upstream node actually emits non-data payloads —
+pointing it at an output key the extract workflow never populates leaves publish
+resolving a prefix that does not exist. It does not affect
+`transformed_data_prefix`, the publish state / current-state args, or any other
+node. See [`examples/publish-controls/`](../examples/publish-controls/).
 
 If the workflow form contains `enable-tags`, `PublishNode` also emits
 `tag_pipeline_enabled = "{{enable-tags}}"` and

--- a/contract-toolkit/examples/publish-controls/app.pkl
+++ b/contract-toolkit/examples/publish-controls/app.pkl
@@ -29,7 +29,7 @@ pipeline {
     // Opt in to the non-data hand-off: this app's extract workflow emits a
     // `transformed_nondata_prefix` output alongside the asset rows. Apps that
     // emit only asset rows leave this unset and the arg is omitted.
-    transformedNondataPrefix = "$.extract.outputs.transformed_nondata_prefix"
+    transformedNonDataPrefix = "$.extract.outputs.transformed_nondata_prefix"
     errorHandling = new ErrorHandlingConfig {
       startToCloseTimeoutSeconds = 14400
     }

--- a/contract-toolkit/examples/publish-controls/app.pkl
+++ b/contract-toolkit/examples/publish-controls/app.pkl
@@ -1,6 +1,6 @@
 /// Minimal example demonstrating publish input opt-out, publish executor
-/// templating, compact activity labels, and workflow-safe error handling for
-/// toolkit-managed extract/publish nodes.
+/// templating, the optional non-data prefix hand-off, compact activity labels,
+/// and workflow-safe error handling for toolkit-managed extract/publish nodes.
 ///
 /// The app keeps the standard extract -> publish DAG, suppresses toolkit
 /// scaffolding fields from _input.py, and declares its own load-to-atlan UI
@@ -26,6 +26,10 @@ pipeline {
     includeInputFields = false
     executorEnabled = "{{load-to-atlan}}"
     displayName = "Publish"
+    // Opt in to the non-data hand-off: this app's extract workflow emits a
+    // `transformed_nondata_prefix` output alongside the asset rows. Apps that
+    // emit only asset rows leave this unset and the arg is omitted.
+    transformedNondataPrefix = "$.extract.outputs.transformed_nondata_prefix"
     errorHandling = new ErrorHandlingConfig {
       startToCloseTimeoutSeconds = 14400
     }

--- a/contract-toolkit/examples/publish-controls/app/generated/manifest.json
+++ b/contract-toolkit/examples/publish-controls/app/generated/manifest.json
@@ -41,6 +41,7 @@
           "connection_creation_enabled": true,
           "executor_enabled": "{{load-to-atlan}}",
           "connection_entity": "{{connection}}",
+          "transformed_nondata_prefix": "$.extract.outputs.transformed_nondata_prefix",
           "connection_cache_enabled": true,
           "connection_cache_via_app_enabled": true,
           "current_state_enabled": true,

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -911,6 +911,26 @@ open class PublishNode extends DAGNode {
   /// disable creation even when an entity is present.
   connectionCreationEnabled: Boolean = connectionEntity != null
 
+  /// Value emitted as `args["transformed_nondata_prefix"]` when non-null.
+  ///
+  /// Object-store prefix holding the run's transformed **non-data** payloads —
+  /// everything the app emits alongside the asset rows that publish handles on a
+  /// separate path from `transformed_data_prefix`. Normally an output reference
+  /// such as `"$.extract.outputs.transformed_nondata_prefix"`, but any literal
+  /// prefix or form placeholder is accepted.
+  ///
+  /// Defaults to `null`, which **omits the arg entirely** — generated manifests
+  /// for apps that do not set it are byte-identical to before. Set it only when
+  /// the upstream node actually emits non-data payloads; pointing it at an
+  /// output key the extract workflow never populates leaves publish resolving a
+  /// prefix that does not exist.
+  ///
+  /// Settable directly on the node (`extraNodes["publish"]`) or, for the typed
+  /// pipeline, via `PublishStep.transformedNondataPrefix`. Does not change
+  /// `transformed_data_prefix`, the publish state/current-state args, or any
+  /// other node.
+  transformedNondataPrefix: String? = null
+
   displayName = "Publish to Atlas"
   workflowType = "PublishWorkflow"
   appName = "publish"
@@ -922,6 +942,9 @@ open class PublishNode extends DAGNode {
     ["connection_creation_enabled"] = connectionCreationEnabled
     ["executor_enabled"] = executorEnabled
     when (connectionEntity != null) { ["connection_entity"] = connectionEntity }
+    when (transformedNondataPrefix != null) {
+      ["transformed_nondata_prefix"] = transformedNondataPrefix
+    }
     ["connection_cache_enabled"] = connectionCacheEnabled
     ["connection_cache_via_app_enabled"] = connectionCacheViaAppEnabled
     ["current_state_enabled"] = currentStateEnabled
@@ -1583,6 +1606,17 @@ class PublishStep {
   /// `false` on the generated publish node (the node links the two), so publish
   /// targets an existing connection and creates nothing.
   connectionEntity: String? = "{{connection}}"
+
+  /// Object-store prefix for the run's transformed non-data payloads, emitted as
+  /// the publish node's `args["transformed_nondata_prefix"]`.
+  ///
+  /// Defaults to `null`, which omits the arg entirely, so existing generated
+  /// manifests are unchanged. Set it — normally to an output reference such as
+  /// `"$.extract.outputs.transformed_nondata_prefix"` — only when the extract
+  /// workflow actually emits non-data payloads. See
+  /// `PublishNode.transformedNondataPrefix` for the full semantics; this
+  /// property is passed straight through to the generated node.
+  transformedNondataPrefix: String? = null
 
   /// Optional lineage-publish sub-step. When set, adds a `"lineage-publish"`
   /// node after the main publish step.
@@ -2544,6 +2578,7 @@ local function generateDAG(): Mapping<String, Any> = new Mapping {
           currentStateEnabled = ps.currentStateEnabled
           currentStateViaAppEnabled = ps.currentStateViaAppEnabled
           connectionEntity = ps.connectionEntity
+          transformedNondataPrefix = ps.transformedNondataPrefix
         })
   }
   when (pipeline.publish != null && pipeline.publish!!.lineagePublish != null) {

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -913,6 +913,11 @@ open class PublishNode extends DAGNode {
 
   /// Value emitted as `args["transformed_nondata_prefix"]` when non-null.
   ///
+  /// Note the deliberate asymmetry: the Pkl property reads `NonData` (non-data is
+  /// hyphenated, so `Nondata` scans badly), while the emitted arg key stays
+  /// `transformed_nondata_prefix` — that spelling is the wire contract the
+  /// publish app reads and is not ours to change here.
+  ///
   /// Object-store prefix holding the run's transformed **non-data** payloads —
   /// everything the app emits alongside the asset rows that publish handles on a
   /// separate path from `transformed_data_prefix`. Normally an output reference
@@ -926,10 +931,10 @@ open class PublishNode extends DAGNode {
   /// prefix that does not exist.
   ///
   /// Settable directly on the node (`extraNodes["publish"]`) or, for the typed
-  /// pipeline, via `PublishStep.transformedNondataPrefix`. Does not change
+  /// pipeline, via `PublishStep.transformedNonDataPrefix`. Does not change
   /// `transformed_data_prefix`, the publish state/current-state args, or any
   /// other node.
-  transformedNondataPrefix: String? = null
+  transformedNonDataPrefix: String? = null
 
   displayName = "Publish to Atlas"
   workflowType = "PublishWorkflow"
@@ -942,8 +947,8 @@ open class PublishNode extends DAGNode {
     ["connection_creation_enabled"] = connectionCreationEnabled
     ["executor_enabled"] = executorEnabled
     when (connectionEntity != null) { ["connection_entity"] = connectionEntity }
-    when (transformedNondataPrefix != null) {
-      ["transformed_nondata_prefix"] = transformedNondataPrefix
+    when (transformedNonDataPrefix != null) {
+      ["transformed_nondata_prefix"] = transformedNonDataPrefix
     }
     ["connection_cache_enabled"] = connectionCacheEnabled
     ["connection_cache_via_app_enabled"] = connectionCacheViaAppEnabled
@@ -1614,9 +1619,9 @@ class PublishStep {
   /// manifests are unchanged. Set it — normally to an output reference such as
   /// `"$.extract.outputs.transformed_nondata_prefix"` — only when the extract
   /// workflow actually emits non-data payloads. See
-  /// `PublishNode.transformedNondataPrefix` for the full semantics; this
+  /// `PublishNode.transformedNonDataPrefix` for the full semantics; this
   /// property is passed straight through to the generated node.
-  transformedNondataPrefix: String? = null
+  transformedNonDataPrefix: String? = null
 
   /// Optional lineage-publish sub-step. When set, adds a `"lineage-publish"`
   /// node after the main publish step.
@@ -2578,7 +2583,7 @@ local function generateDAG(): Mapping<String, Any> = new Mapping {
           currentStateEnabled = ps.currentStateEnabled
           currentStateViaAppEnabled = ps.currentStateViaAppEnabled
           connectionEntity = ps.connectionEntity
-          transformedNondataPrefix = ps.transformedNondataPrefix
+          transformedNonDataPrefix = ps.transformedNonDataPrefix
         })
   }
   when (pipeline.publish != null && pipeline.publish!!.lineagePublish != null) {

--- a/contract-toolkit/tests/fixtures/publish_nondata_prefix.pkl
+++ b/contract-toolkit/tests/fixtures/publish_nondata_prefix.pkl
@@ -1,0 +1,30 @@
+/// Fixture: app whose typed publish step opts in to the non-data hand-off.
+///
+/// Exercises the pipeline path with `pipeline.publish.transformedNondataPrefix`
+/// set, which must thread the value through `generateDAG()` onto the generated
+/// publish node as `args["transformed_nondata_prefix"]` without disturbing any
+/// other publish arg.
+amends "../../src/App.pkl"
+
+name = "publish-nondata-prefix"
+displayName = "Publish Nondata Prefix"
+icon = "https://assets.atlan.com/assets/fullscreen-exit.svg"
+hasCredentialConfig = false
+
+pipeline = new Pipeline {
+  publish = new PublishStep {
+    transformedNondataPrefix = "$.extract.outputs.transformed_nondata_prefix"
+  }
+}
+
+uiConfig = new UIConfig {
+  tasks {
+    ["Configuration"] {
+      inputs {
+        ["connection"] = new ConnectionCreator {
+          placeholderText = "Connection Name"
+        }
+      }
+    }
+  }
+}

--- a/contract-toolkit/tests/fixtures/publish_nondata_prefix.pkl
+++ b/contract-toolkit/tests/fixtures/publish_nondata_prefix.pkl
@@ -1,19 +1,19 @@
 /// Fixture: app whose typed publish step opts in to the non-data hand-off.
 ///
-/// Exercises the pipeline path with `pipeline.publish.transformedNondataPrefix`
+/// Exercises the pipeline path with `pipeline.publish.transformedNonDataPrefix`
 /// set, which must thread the value through `generateDAG()` onto the generated
 /// publish node as `args["transformed_nondata_prefix"]` without disturbing any
 /// other publish arg.
 amends "../../src/App.pkl"
 
 name = "publish-nondata-prefix"
-displayName = "Publish Nondata Prefix"
+displayName = "Publish Non-Data Prefix"
 icon = "https://assets.atlan.com/assets/fullscreen-exit.svg"
 hasCredentialConfig = false
 
 pipeline = new Pipeline {
   publish = new PublishStep {
-    transformedNondataPrefix = "$.extract.outputs.transformed_nondata_prefix"
+    transformedNonDataPrefix = "$.extract.outputs.transformed_nondata_prefix"
   }
 }
 

--- a/contract-toolkit/tests/publish_nondata_prefix_test.pkl
+++ b/contract-toolkit/tests/publish_nondata_prefix_test.pkl
@@ -4,9 +4,9 @@
 // Background: alongside the asset rows it reads from `transformed_data_prefix`,
 // publish can consume a run's transformed *non-data* payloads from a second
 // object-store prefix. Not every app emits them, so the arg is opt-in: the node
-// exposes a nullable `transformedNondataPrefix` (default `null`) and emits the
+// exposes a nullable `transformedNonDataPrefix` (default `null`) and emits the
 // arg only when it is non-null — both directly on the node and via the typed
-// `PublishStep.transformedNondataPrefix`. Apps that never set it generate
+// `PublishStep.transformedNonDataPrefix`. Apps that never set it generate
 // byte-identical manifests to before the property existed.
 
 amends "pkl:test"
@@ -24,7 +24,7 @@ local defaultPublishArgs = new json.Parser { useMapping = true }.parse(
   defaultPipelineApp.output.files["app/generated/manifest.json"].text
 )["dag"]["publish"]["inputs"]["args"]
 
-// Pipeline with `pipeline.publish.transformedNondataPrefix` set: arg present.
+// Pipeline with `pipeline.publish.transformedNonDataPrefix` set: arg present.
 local nondataPublishArgs = new json.Parser { useMapping = true }.parse(
   nondataPrefixApp.output.files["app/generated/manifest.json"].text
 )["dag"]["publish"]["inputs"]["args"]
@@ -44,28 +44,28 @@ facts {
 
   ["PublishNode emits transformed_nondata_prefix when set"] {
     new App.PublishNode {
-      transformedNondataPrefix = local_prefix
+      transformedNonDataPrefix = local_prefix
     }.args["transformed_nondata_prefix"] == local_prefix
   }
 
   // The value is passed through verbatim — a literal prefix or form placeholder
   // is as valid as an output reference.
-  ["PublishNode passes a literal transformedNondataPrefix through verbatim"] {
+  ["PublishNode passes a literal transformedNonDataPrefix through verbatim"] {
     new App.PublishNode {
-      transformedNondataPrefix = "artifacts/nondata"
+      transformedNonDataPrefix = "artifacts/nondata"
     }.args["transformed_nondata_prefix"] == "artifacts/nondata"
   }
 
   // Explicit null is the same shape as "never declared" — one omission, not two.
   ["PublishNode with an explicit null omits the arg"] {
     new App.PublishNode {
-      transformedNondataPrefix = null
+      transformedNonDataPrefix = null
     }.args.toMap().containsKey("transformed_nondata_prefix") == false
   }
 
   // Setting the non-data prefix must not disturb the data prefix or any sibling.
   ["PublishNode keeps transformed_data_prefix independent of the non-data prefix"] {
-    local node = new App.PublishNode { transformedNondataPrefix = local_prefix }
+    local node = new App.PublishNode { transformedNonDataPrefix = local_prefix }
     node.args["transformed_data_prefix"] == "$.extract.outputs.transformed_data_prefix"
     node.args["publish_state_prefix"] == "$.extract.outputs.publish_state_prefix"
     node.args["current_state_prefix"] == "$.extract.outputs.current_state_prefix"
@@ -74,8 +74,8 @@ facts {
 
   // ---- Typed pipeline (PublishStep) -------------------------------------------
 
-  ["PublishStep defaults transformedNondataPrefix to null"] {
-    new App.PublishStep {}.transformedNondataPrefix == null
+  ["PublishStep defaults transformedNonDataPrefix to null"] {
+    new App.PublishStep {}.transformedNonDataPrefix == null
   }
 
   ["Default pipeline generates a publish node without transformed_nondata_prefix"] {
@@ -85,7 +85,7 @@ facts {
   // Regression guard: `generateDAG()` copies PublishStep fields onto PublishNode
   // one by one, so a field missing from that copy block is silently dropped for
   // every app on the typed pipeline path.
-  ["PublishStep.transformedNondataPrefix reaches the generated publish node"] {
+  ["PublishStep.transformedNonDataPrefix reaches the generated publish node"] {
     nondataPublishArgs["transformed_nondata_prefix"] == local_prefix
   }
 

--- a/contract-toolkit/tests/publish_nondata_prefix_test.pkl
+++ b/contract-toolkit/tests/publish_nondata_prefix_test.pkl
@@ -1,0 +1,105 @@
+// Tests that `transformed_nondata_prefix` is an optional, opt-in arg on the
+// built-in PublishNode.
+//
+// Background: alongside the asset rows it reads from `transformed_data_prefix`,
+// publish can consume a run's transformed *non-data* payloads from a second
+// object-store prefix. Not every app emits them, so the arg is opt-in: the node
+// exposes a nullable `transformedNondataPrefix` (default `null`) and emits the
+// arg only when it is non-null — both directly on the node and via the typed
+// `PublishStep.transformedNondataPrefix`. Apps that never set it generate
+// byte-identical manifests to before the property existed.
+
+amends "pkl:test"
+
+import "pkl:json"
+import "fixtures/default_pipeline.pkl" as defaultPipelineApp
+import "fixtures/publish_nondata_prefix.pkl" as nondataPrefixApp
+import "fixtures/extra_nodes_publish_override.pkl" as overrideApp
+import "../src/App.pkl" as App
+
+local local_prefix = "$.extract.outputs.transformed_nondata_prefix"
+
+// Default (undeclared) pipeline: the publish node must not carry the arg.
+local defaultPublishArgs = new json.Parser { useMapping = true }.parse(
+  defaultPipelineApp.output.files["app/generated/manifest.json"].text
+)["dag"]["publish"]["inputs"]["args"]
+
+// Pipeline with `pipeline.publish.transformedNondataPrefix` set: arg present.
+local nondataPublishArgs = new json.Parser { useMapping = true }.parse(
+  nondataPrefixApp.output.files["app/generated/manifest.json"].text
+)["dag"]["publish"]["inputs"]["args"]
+
+// App that replaces publish wholesale via `extraNodes["publish"]` without
+// setting the property: the arg must stay absent there too.
+local overridePublishArgs = new json.Parser { useMapping = true }.parse(
+  overrideApp.output.files["app/generated/manifest.json"].text
+)["dag"]["publish"]["inputs"]["args"]
+
+facts {
+  // ---- Direct class instances -------------------------------------------------
+
+  ["PublishNode omits transformed_nondata_prefix by default"] {
+    new App.PublishNode {}.args.toMap().containsKey("transformed_nondata_prefix") == false
+  }
+
+  ["PublishNode emits transformed_nondata_prefix when set"] {
+    new App.PublishNode {
+      transformedNondataPrefix = local_prefix
+    }.args["transformed_nondata_prefix"] == local_prefix
+  }
+
+  // The value is passed through verbatim — a literal prefix or form placeholder
+  // is as valid as an output reference.
+  ["PublishNode passes a literal transformedNondataPrefix through verbatim"] {
+    new App.PublishNode {
+      transformedNondataPrefix = "artifacts/nondata"
+    }.args["transformed_nondata_prefix"] == "artifacts/nondata"
+  }
+
+  // Explicit null is the same shape as "never declared" — one omission, not two.
+  ["PublishNode with an explicit null omits the arg"] {
+    new App.PublishNode {
+      transformedNondataPrefix = null
+    }.args.toMap().containsKey("transformed_nondata_prefix") == false
+  }
+
+  // Setting the non-data prefix must not disturb the data prefix or any sibling.
+  ["PublishNode keeps transformed_data_prefix independent of the non-data prefix"] {
+    local node = new App.PublishNode { transformedNondataPrefix = local_prefix }
+    node.args["transformed_data_prefix"] == "$.extract.outputs.transformed_data_prefix"
+    node.args["publish_state_prefix"] == "$.extract.outputs.publish_state_prefix"
+    node.args["current_state_prefix"] == "$.extract.outputs.current_state_prefix"
+    node.args["connection_entity"] == "{{connection}}"
+  }
+
+  // ---- Typed pipeline (PublishStep) -------------------------------------------
+
+  ["PublishStep defaults transformedNondataPrefix to null"] {
+    new App.PublishStep {}.transformedNondataPrefix == null
+  }
+
+  ["Default pipeline generates a publish node without transformed_nondata_prefix"] {
+    defaultPublishArgs.toMap().containsKey("transformed_nondata_prefix") == false
+  }
+
+  // Regression guard: `generateDAG()` copies PublishStep fields onto PublishNode
+  // one by one, so a field missing from that copy block is silently dropped for
+  // every app on the typed pipeline path.
+  ["PublishStep.transformedNondataPrefix reaches the generated publish node"] {
+    nondataPublishArgs["transformed_nondata_prefix"] == local_prefix
+  }
+
+  ["Setting the non-data prefix preserves the other publish args"] {
+    nondataPublishArgs["transformed_data_prefix"] == "$.extract.outputs.transformed_data_prefix"
+    nondataPublishArgs["connection_qualified_name"] != null
+    nondataPublishArgs["connection_entity"] == "{{connection}}"
+    nondataPublishArgs["connection_cache_enabled"] == true
+    nondataPublishArgs["current_state_enabled"] == true
+  }
+
+  // ---- extraNodes override path -----------------------------------------------
+
+  ["extraNodes publish override omits transformed_nondata_prefix when unset"] {
+    overridePublishArgs.toMap().containsKey("transformed_nondata_prefix") == false
+  }
+}


### PR DESCRIPTION
## What

Adds an optional `transformed_nondata_prefix` arg to the manifest's publish node.

Publish can consume a run's transformed **non-data** payloads from a second object-store prefix, alongside the asset rows it already reads from `transformed_data_prefix`. Not every app emits them, so the arg is opt-in: set it and it appears in the manifest, leave it and it doesn't.

## How

`PublishNode` gets a nullable `transformedNondataPrefix`, emitted only when non-null — the same shape `connection_entity` already uses a few lines below it:

```pkl
when (transformedNondataPrefix != null) {
  ["transformed_nondata_prefix"] = transformedNondataPrefix
}
```

The value is passed through verbatim, so an output reference, a literal prefix, or a form placeholder all work:

```pkl
pipeline {
  publish {
    transformedNondataPrefix = "$.extract.outputs.transformed_nondata_prefix"
  }
}
```

`PublishStep` gets the matching property and `generateDAG()` copies it onto the generated node. That copy block lists `PublishStep` fields one by one, so without it the property would work via `extraNodes["publish"]` but be **silently dropped** for every app on the typed pipeline path — there's a named regression test for exactly that.

## Blast radius

Default is `null`, so the arg is absent and every existing manifest is unchanged. After `regenerate-all.sh` the only generated diff across all 13 examples is one line in `publish-controls`, which opts in to demonstrate the hand-off:

```diff
+          "transformed_nondata_prefix": "$.extract.outputs.transformed_nondata_prefix",
```

Nothing else moves — `transformed_data_prefix`, the publish state / current-state args, and every other node are untouched. `NativeApp.pkl` is deliberately not changed (frozen legacy per `contract-toolkit/CLAUDE.md`).

Cross-repo: the publish app has to accept the key before any real contract sets it. Because the arg is omitted by default this is purely additive — no manifest starts sending it until an app opts in.

## Tests

New `tests/publish_nondata_prefix_test.pkl` (10 facts / 17 asserts), covering both wiring paths and the omission guarantee:

- omitted by default, and on an explicit `null` (one omission shape, not two)
- emitted when set; literal values passed through verbatim
- `transformed_data_prefix` and siblings unaffected when set
- `PublishStep` → generated node passthrough (the `generateDAG()` copy-block guard)
- default pipeline and an `extraNodes["publish"]` override both stay clean

## Validation

- [x] `contract-toolkit/scripts/regenerate-all.sh`
- [x] `contract-toolkit/scripts/check-invariants.sh` — all passed
- [x] `pkl test tests/*.pkl` — 360 passed / 860 asserts
- [x] `contract-toolkit/scripts/test-sdk-import.py` — 41 files
- [x] `git diff --check`
- [x] `pre-commit` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)