### PR TITLE
ci(config-validator): validate workerPools against infra ceilings (ARUN-1041)

### DIFF
--- a/.github/scripts/config_validator.py
+++ b/.github/scripts/config_validator.py
@@ -26,6 +26,17 @@ Rules enforced:
      it in CI. resources.limits.cpu (schema allows integer|string) and the
      serverResources/workerResources blocks (partly unconstrained) are
      deliberately excluded to avoid false positives.
+ 11. len(workerPools)       <= 10. Each pool renders its own TWD plus an
+     on-demand mirror variant, so per-app tiers cost Temporal twice their
+     count in worker deployments and don't scale across the fleet.
+ 12. Per pool: rules 2-8 again, against the pool's own `resources` and `vpa`
+     blocks, resolved through the chart's PER-POOL fallback chains — which
+     differ from the app-level ones (see _check_worker_pools).
+ 13. Per pool: rule 9 again, against the pool's own `keda` block.
+ 14. Every pool has a `name`; `name` and `taskQueue` are unique across pools.
+ 15. Declared workerPools require splitDeploymentEnabled=true AND
+     temporalWorkerDeployment.enabled=true — the chart drops the whole block
+     otherwise, so activities routed to a pool queue sit unpolled.
 
 Rules 4-7 hit `resources` always; `serverResources`/`workerResources` only when
 `splitDeploymentEnabled=true` (chart ignores them otherwise).
@@ -53,6 +64,20 @@ MAX_VPA_MEMORY_BYTES: int = 27 * 1024**3
 # VPA actually enforces in cluster.
 DEFAULT_VPA_MAX_CPU_MILLI: int = 2_000
 DEFAULT_VPA_MAX_MEMORY_BYTES: int = 18 * 1024**3
+
+# Cap on dedicated worker pools per app. Every pool TWD also declares an
+# on-demand (-od) mirror variant, so N pools cost Temporal 2N worker-deployment
+# children on top of the main worker. Fleet-wide (100+ apps) an unbounded
+# per-app tier count is what makes TWD reconciliation unmanageable. Change
+# requires PR + platform-team review.
+MAX_WORKER_POOLS: int = 10
+
+# Chart-shipped per-pool vpa.maxAllowed fallback, used when neither the pool nor
+# the app declares one. Deliberately separate from DEFAULT_VPA_MAX_* above: the
+# per-pool chain is pool.vpa.maxAllowed -> vpa.maxAllowed -> this, and Helm's
+# `default` swaps the WHOLE dict at each step rather than merging keys.
+DEFAULT_POOL_VPA_MAX_CPU_MILLI: int = 2_000
+DEFAULT_POOL_VPA_MAX_MEMORY_BYTES: int = 6 * 1024**3
 
 # Binary (Ki/Mi/Gi/...) use 1024; decimal (k/K/M/G/...) use 1000. Not interchangeable.
 _MEM_SUFFIXES = {
@@ -277,9 +302,13 @@ def _check_twc_sdk_floor(
 
 def _parse_vpa(
     cfg: dict,
+    label: str = "vpa",
 ) -> tuple[dict[tuple[str, str], int | None], list[Violation]]:
     """Parse vpa.{minAllowed,maxAllowed} once. Shared by _check_vpa and
-    _resolve_effective_vpa_max to avoid duplicate invalid_quantity violations."""
+    _resolve_effective_vpa_max to avoid duplicate invalid_quantity violations.
+
+    *label* prefixes the reported field path; per-pool callers pass
+    `workerPools[i].vpa`."""
     vpa = cfg.get("vpa") or {}
     mn = vpa.get("minAllowed") or {}
     mx = vpa.get("maxAllowed") or {}
@@ -292,12 +321,16 @@ def _parse_vpa(
         ):
             if resource in src:
                 parsed[(resource, kind)] = parser(
-                    src[resource], f"vpa.{kind}.{resource}", errs
+                    src[resource], f"{label}.{kind}.{resource}", errs
                 )
     return parsed, errs
 
 
-def _check_vpa(cfg: dict, parsed: dict[tuple[str, str], int | None]) -> list[Violation]:
+def _check_vpa(
+    cfg: dict,
+    parsed: dict[tuple[str, str], int | None],
+    label: str = "vpa",
+) -> list[Violation]:
     vpa = cfg.get("vpa") or {}
     mn = vpa.get("minAllowed") or {}
     mx = vpa.get("maxAllowed") or {}
@@ -307,11 +340,11 @@ def _check_vpa(cfg: dict, parsed: dict[tuple[str, str], int | None]) -> list[Vio
     if cpu_max is not None and cpu_max > MAX_VPA_CPU_MILLI:
         errs.append(
             Violation(
-                field="vpa.maxAllowed.cpu",
+                field=f"{label}.maxAllowed.cpu",
                 actual=mx.get("cpu"),
                 expected=f"<= 7 cores ({MAX_VPA_CPU_MILLI}m)",
                 rule="vpa_max_cpu_ceiling",
-                fix="Lower vpa.maxAllowed.cpu to 7 cores or less.",
+                fix=f"Lower {label}.maxAllowed.cpu to 7 cores or less.",
             )
         )
 
@@ -319,11 +352,11 @@ def _check_vpa(cfg: dict, parsed: dict[tuple[str, str], int | None]) -> list[Vio
     if mem_max is not None and mem_max > MAX_VPA_MEMORY_BYTES:
         errs.append(
             Violation(
-                field="vpa.maxAllowed.memory",
+                field=f"{label}.maxAllowed.memory",
                 actual=mx.get("memory"),
                 expected="<= 27Gi",
                 rule="vpa_max_memory_ceiling",
-                fix="Lower vpa.maxAllowed.memory to 27Gi or less.",
+                fix=f"Lower {label}.maxAllowed.memory to 27Gi or less.",
             )
         )
 
@@ -335,14 +368,35 @@ def _check_vpa(cfg: dict, parsed: dict[tuple[str, str], int | None]) -> list[Vio
         if a > b:
             errs.append(
                 Violation(
-                    field=f"vpa.minAllowed.{resource}",
+                    field=f"{label}.minAllowed.{resource}",
                     actual=mn[resource],
-                    expected=f"<= vpa.maxAllowed.{resource} ({mx[resource]})",
+                    expected=f"<= {label}.maxAllowed.{resource} ({mx[resource]})",
                     rule="vpa_min_le_max",
-                    fix=f"Lower vpa.minAllowed.{resource} or raise vpa.maxAllowed.{resource}.",
+                    fix=(
+                        f"Lower {label}.minAllowed.{resource} or raise "
+                        f"{label}.maxAllowed.{resource}."
+                    ),
                 )
             )
     return errs
+
+
+def _vpa_update_mode_is_off(update_mode: Any) -> bool:
+    """True when this updateMode leaves initial requests unclamped.
+
+    VPA clamps requests only in `Initial`, `Recreate`, or `Auto`. In `Off` it
+    emits recommendations without applying them, so requests above maxAllowed
+    deploy as-is.
+
+    Matches the enum case-insensitively. K8s VPA accepts only the canonical
+    casings, but app owners typing `off` should not get a misleading clamp
+    violation — the chart's schema rejects bad casings later anyway. Also
+    accepts bool False: PyYAML's YAML 1.1 loader coerces unquoted `off` / `no`
+    to False (Helm's YAML 1.2 loader keeps the string), a common gotcha.
+    """
+    return update_mode is False or (
+        isinstance(update_mode, str) and update_mode.strip().lower() == "off"
+    )
 
 
 def _resolve_effective_vpa_max(
@@ -363,16 +417,7 @@ def _resolve_effective_vpa_max(
     if vpa_enabled is not True:
         return None, None
     vpa = cfg.get("vpa") or {}
-    # Match VPA enum case-insensitively. K8s VPA accepts only the canonical
-    # casings (Off/Initial/Recreate/Auto), but app owners typing `off` should
-    # not get a misleading clamp violation — the chart's schema rejects bad
-    # casings later anyway. Also accept bool False: PyYAML's YAML 1.1 loader
-    # coerces unquoted `off` / `no` to False — common gotcha.
-    update_mode = vpa.get("updateMode")
-    is_off = update_mode is False or (
-        isinstance(update_mode, str) and update_mode.strip().lower() == "off"
-    )
-    if is_off:
+    if _vpa_update_mode_is_off(vpa.get("updateMode")):
         return None, None
     max_allowed = vpa.get("maxAllowed") or {}
     cpu_milli: int | None = (
@@ -393,9 +438,17 @@ def _check_resource_block(
     key: str,
     vpa_max_cpu_milli: int | None = None,
     vpa_max_memory_bytes: int | None = None,
+    label: str | None = None,
+    vpa_label: str = "vpa",
 ) -> list[Violation]:
     """Validate resources / serverResources / workerResources.
-    None vpa_max_* skips the requests<=vpa.maxAllowed rule (vpa disabled)."""
+    None vpa_max_* skips the requests<=vpa.maxAllowed rule (vpa disabled).
+
+    *label* overrides the reported field path when *cfg* is not the config root;
+    per-pool callers pass the pool dict with `workerPools[i].resources`.
+    *vpa_label* names the VPA block that clamps this one — a pool is clamped by
+    its own, so the fix text points at the knob that actually moves."""
+    label = label or key
     block = cfg.get(key) or {}
     if not block:
         return []
@@ -413,7 +466,7 @@ def _check_resource_block(
         ):
             if resource in src:
                 parsed[(resource, kind)] = parser(
-                    src[resource], f"{key}.{kind}.{resource}", errs
+                    src[resource], f"{label}.{kind}.{resource}", errs
                 )
 
     # Even without VPA, raw request above infra guarantee fails to schedule.
@@ -421,22 +474,22 @@ def _check_resource_block(
     if cpu_req is not None and cpu_req > MAX_VPA_CPU_MILLI:
         errs.append(
             Violation(
-                field=f"{key}.requests.cpu",
+                field=f"{label}.requests.cpu",
                 actual=requests.get("cpu"),
                 expected=f"<= 7 cores ({MAX_VPA_CPU_MILLI}m)",
                 rule="requests_cpu_ceiling",
-                fix=f"Lower {key}.requests.cpu to 7 cores or less.",
+                fix=f"Lower {label}.requests.cpu to 7 cores or less.",
             )
         )
     mem_req = parsed.get(("memory", "requests"))
     if mem_req is not None and mem_req > MAX_VPA_MEMORY_BYTES:
         errs.append(
             Violation(
-                field=f"{key}.requests.memory",
+                field=f"{label}.requests.memory",
                 actual=requests.get("memory"),
                 expected="<= 27Gi",
                 rule="requests_memory_ceiling",
-                fix=f"Lower {key}.requests.memory to 27Gi or less.",
+                fix=f"Lower {label}.requests.memory to 27Gi or less.",
             )
         )
 
@@ -449,11 +502,14 @@ def _check_resource_block(
     ):
         errs.append(
             Violation(
-                field=f"{key}.requests.cpu",
+                field=f"{label}.requests.cpu",
                 actual=requests.get("cpu"),
-                expected=f"<= vpa.maxAllowed.cpu ({vpa_max_cpu_milli}m)",
+                expected=f"<= {vpa_label}.maxAllowed.cpu ({vpa_max_cpu_milli}m)",
                 rule="requests_exceeds_vpa_max_cpu",
-                fix=f"Lower {key}.requests.cpu, raise vpa.maxAllowed.cpu, or disable vpa.enabled.",
+                fix=(
+                    f"Lower {label}.requests.cpu, raise {vpa_label}.maxAllowed.cpu, "
+                    f"or disable {vpa_label}.enabled."
+                ),
             )
         )
     if (
@@ -463,11 +519,14 @@ def _check_resource_block(
     ):
         errs.append(
             Violation(
-                field=f"{key}.requests.memory",
+                field=f"{label}.requests.memory",
                 actual=requests.get("memory"),
-                expected=f"<= vpa.maxAllowed.memory ({vpa_max_memory_bytes} bytes)",
+                expected=f"<= {vpa_label}.maxAllowed.memory ({vpa_max_memory_bytes} bytes)",
                 rule="requests_exceeds_vpa_max_memory",
-                fix=f"Lower {key}.requests.memory, raise vpa.maxAllowed.memory, or disable vpa.enabled.",
+                fix=(
+                    f"Lower {label}.requests.memory, raise "
+                    f"{vpa_label}.maxAllowed.memory, or disable {vpa_label}.enabled."
+                ),
             )
         )
 
@@ -481,11 +540,11 @@ def _check_resource_block(
         if req > lim:
             errs.append(
                 Violation(
-                    field=f"{key}.requests.{resource}",
+                    field=f"{label}.requests.{resource}",
                     actual=requests[resource],
-                    expected=f"<= {key}.limits.{resource} ({limits[resource]})",
+                    expected=f"<= {label}.limits.{resource} ({limits[resource]})",
                     rule="requests_le_limits",
-                    fix=f"Ensure {key}.requests.{resource} is not greater than {key}.limits.{resource}.",
+                    fix=f"Ensure {label}.requests.{resource} is not greater than {label}.limits.{resource}.",
                 )
             )
 
@@ -507,10 +566,12 @@ def _check_resources(
     return errs
 
 
-def _check_keda(cfg: dict) -> list[Violation]:
+def _check_keda(cfg: dict, label: str = "keda") -> list[Violation]:
     """keda.minReplicaCount <= keda.maxReplicaCount (when both set).
 
     Non-int / bool replica counts silently skip — chart schema handles type errors.
+    *label* prefixes the reported field path; per-pool callers pass
+    `workerPools[i].keda`.
     """
     keda = cfg.get("keda") or {}
     mn = keda.get("minReplicaCount")
@@ -524,11 +585,14 @@ def _check_keda(cfg: dict) -> list[Violation]:
     if mn > mx:
         return [
             Violation(
-                field="keda.minReplicaCount",
+                field=f"{label}.minReplicaCount",
                 actual=mn,
-                expected=f"<= keda.maxReplicaCount ({mx})",
+                expected=f"<= {label}.maxReplicaCount ({mx})",
                 rule="keda_min_le_max",
-                fix="Lower keda.minReplicaCount or raise keda.maxReplicaCount.",
+                fix=(
+                    f"Lower {label}.minReplicaCount or raise "
+                    f"{label}.maxReplicaCount."
+                ),
             )
         ]
     return []
@@ -616,6 +680,248 @@ def _check_scalar_types(cfg: dict) -> list[Violation]:
     return errs
 
 
+def _resolve_pool_vpa_max(
+    cfg: dict,
+    pool: dict,
+    pool_parsed: dict[tuple[str, str], int | None],
+    app_parsed: dict[tuple[str, str], int | None],
+) -> tuple[int | None, int | None]:
+    """Effective per-pool vpa.maxAllowed (cpu_milli, mem_bytes). None per
+    resource means the pool's VPA does not clamp that resource at admission.
+
+    Three ways the chart's per-pool chain differs from the app-level one:
+      - The pool VPA is gated on the POOL's own `vpa.enabled`; it does not
+        inherit the app-level flag, so a pool without it is never clamped.
+      - updateMode falls back pool.vpa.updateMode -> vpa.updateMode -> "Auto",
+        so an undeclared updateMode still clamps.
+      - maxAllowed swaps the whole dict at each fallback step, so a pool
+        declaring only `memory` leaves cpu uncapped — hence a per-resource None
+        rather than reaching for a chart default one key at a time.
+    """
+    pool_vpa = pool.get("vpa") or {}
+    if pool_vpa.get("enabled") is not True:
+        return None, None
+    app_vpa = cfg.get("vpa") or {}
+    update_mode = (
+        pool_vpa["updateMode"]
+        if "updateMode" in pool_vpa
+        else app_vpa.get("updateMode")
+    )
+    if _vpa_update_mode_is_off(update_mode):
+        return None, None
+
+    declared = pool_vpa.get("maxAllowed") or {}
+    parsed = pool_parsed
+    if not declared:
+        declared, parsed = app_vpa.get("maxAllowed") or {}, app_parsed
+    if not declared:
+        return DEFAULT_POOL_VPA_MAX_CPU_MILLI, DEFAULT_POOL_VPA_MAX_MEMORY_BYTES
+    return (
+        parsed.get(("cpu", "maxAllowed")) if "cpu" in declared else None,
+        parsed.get(("memory", "maxAllowed")) if "memory" in declared else None,
+    )
+
+
+def _check_pool_identity(pools: list) -> list[Violation]:
+    """Every pool needs a `name`; `name` and `taskQueue` must be unique.
+
+    A duplicate name is a hard Helm failure, not a soft one: deployment.yaml
+    keys pools as `pool:<name>` and looks the entry back up by name, so two
+    entries sharing a name render two objects with the same metadata.name. A
+    missing name renders a nameless TWD. Two pools on one taskQueue both poll
+    it, so routed activities land on whichever worker grabs the task first and
+    the tiers stop separating work.
+    """
+    errs: list[Violation] = []
+    seen_names: dict[str, int] = {}
+    seen_queues: dict[str, int] = {}
+    for i, pool in enumerate(pools):
+        if not isinstance(pool, dict):
+            continue
+        name = pool.get("name")
+        if not isinstance(name, str) or not name.strip():
+            errs.append(
+                Violation(
+                    field=f"workerPools[{i}].name",
+                    actual=name,
+                    expected="non-empty string",
+                    rule="worker_pool_name_required",
+                    fix=(
+                        "Give every workerPools entry a name. The chart derives "
+                        "the pool's TemporalWorkerDeployment name and its default "
+                        "task queue from it."
+                    ),
+                )
+            )
+        elif name in seen_names:
+            errs.append(
+                Violation(
+                    field=f"workerPools[{i}].name",
+                    actual=name,
+                    expected=(
+                        "unique across workerPools (already used by "
+                        f"workerPools[{seen_names[name]}])"
+                    ),
+                    rule="worker_pool_name_duplicate",
+                    fix=(
+                        "Rename this pool. The chart derives each pool's TWD name "
+                        "from it, so two pools sharing a name render two objects "
+                        "with the same metadata.name and the Helm apply fails."
+                    ),
+                )
+            )
+        else:
+            seen_names[name] = i
+
+        queue = pool.get("taskQueue")
+        if not isinstance(queue, str) or not queue.strip():
+            continue
+        if queue in seen_queues:
+            errs.append(
+                Violation(
+                    field=f"workerPools[{i}].taskQueue",
+                    actual=queue,
+                    expected=(
+                        "unique across workerPools (already used by "
+                        f"workerPools[{seen_queues[queue]}])"
+                    ),
+                    rule="worker_pool_task_queue_duplicate",
+                    fix=(
+                        "Give each pool its own taskQueue. Two pools polling one "
+                        "queue both receive its activities, so routed work lands "
+                        "on whichever worker grabs it first and the pools stop "
+                        "separating load."
+                    ),
+                )
+            )
+        else:
+            seen_queues[queue] = i
+    return errs
+
+
+def _check_worker_pools_rendered(bools: dict[str, bool | None]) -> list[Violation]:
+    """Declared pools require splitDeploymentEnabled + temporalWorkerDeployment.
+
+    Both chart defaults are false, so a missing flag drops the block exactly as
+    an explicit false does — hence `is not True` rather than the
+    explicit-false-only test _check_split_requires_twc uses (there, absent means
+    the safe default; here it means the pools vanish). The CI driver runs SDK
+    flag injection first, which sets both true for SDK >= 2.7.4, so this fires
+    on apps that opt out explicitly or sit below the TWC floor — the cases where
+    the app routes activities to a queue no worker polls and the workflow hangs.
+    """
+    unmet = [
+        field
+        for field in ("splitDeploymentEnabled", "temporalWorkerDeployment.enabled")
+        if bools.get(field) is not True
+    ]
+    if not unmet:
+        return []
+    return [
+        Violation(
+            field="workerPools",
+            actual=unmet,
+            expected=(
+                "splitDeploymentEnabled: true and "
+                "temporalWorkerDeployment.enabled: true"
+            ),
+            rule="worker_pools_require_split_twc",
+            fix=(
+                "Set the listed flags to true, or remove the workerPools block. "
+                "The chart renders pool deployments only under split + TWC and "
+                "drops the block silently otherwise, so activities routed to a "
+                "pool's task queue sit unpolled and the workflow hangs."
+            ),
+        )
+    ]
+
+
+def _check_worker_pools(
+    cfg: dict,
+    bools: dict[str, bool | None],
+    app_vpa_parsed: dict[tuple[str, str], int | None],
+) -> list[Violation]:
+    """Validate `workerPools` — the extra dedicated worker pools (rules 11-15).
+
+    Each entry renders its own TemporalWorkerDeployment + KEDA ScaledObject
+    (+ optional VPA) polling its own task queue. The magnitude rules are the
+    app-level ones re-pointed at the pool's blocks, but the chart resolves a
+    pool's values through different fallback chains:
+      - `pool.resources` REPLACES workerResources/resources wholesale (no key
+        merge), so a pool declaring only requests has no limits at all — the
+        requests<=limits rule simply has nothing to compare.
+      - pool VPA: see _resolve_pool_vpa_max.
+      - pool KEDA targetQueueSize is flat, not nested under `temporal`.
+    """
+    pools = cfg.get("workerPools")
+    if pools is None:
+        return []
+    if not isinstance(pools, list):
+        return [
+            Violation(
+                field="workerPools",
+                actual=pools,
+                expected="list of pool mappings",
+                rule="invalid_type",
+                fix=(
+                    f"Make workerPools a YAML list (got {type(pools).__name__}). "
+                    "The chart ranges over it; a non-list fails at render."
+                ),
+            )
+        ]
+    if not pools:
+        return []
+
+    errs = _check_worker_pools_rendered(bools)
+    if len(pools) > MAX_WORKER_POOLS:
+        errs.append(
+            Violation(
+                field="workerPools",
+                actual=len(pools),
+                expected=f"<= {MAX_WORKER_POOLS} pools",
+                rule="worker_pool_count_ceiling",
+                fix=(
+                    f"Reduce workerPools to {MAX_WORKER_POOLS} or fewer. Each pool "
+                    "renders its own TemporalWorkerDeployment plus an on-demand "
+                    "mirror variant, so Temporal-side worker deployments grow at "
+                    "twice the tier count per app."
+                ),
+            )
+        )
+    errs += _check_pool_identity(pools)
+
+    for i, pool in enumerate(pools):
+        prefix = f"workerPools[{i}]"
+        if not isinstance(pool, dict):
+            errs.append(
+                Violation(
+                    field=prefix,
+                    actual=pool,
+                    expected="mapping",
+                    rule="invalid_type",
+                    fix=(
+                        f"Make each workerPools entry a mapping (got "
+                        f"{type(pool).__name__})."
+                    ),
+                )
+            )
+            continue
+        pool_parsed, parse_errs = _parse_vpa(pool, label=f"{prefix}.vpa")
+        errs += parse_errs
+        errs += _check_vpa(pool, pool_parsed, label=f"{prefix}.vpa")
+        cpu_max, mem_max = _resolve_pool_vpa_max(cfg, pool, pool_parsed, app_vpa_parsed)
+        errs += _check_resource_block(
+            pool,
+            "resources",
+            cpu_max,
+            mem_max,
+            label=f"{prefix}.resources",
+            vpa_label=f"{prefix}.vpa",
+        )
+        errs += _check_keda(pool, label=f"{prefix}.keda")
+    return errs
+
+
 def validate_config(config_yaml: Any, sdk_version: str | None = None) -> None:
     """Run all guardrail rules. Accepts YAML string or already-parsed dict.
 
@@ -665,6 +971,7 @@ def validate_config(config_yaml: Any, sdk_version: str | None = None) -> None:
     errs += _check_vpa(cfg, vpa_parsed)
     errs += _check_resources(cfg, vpa_parsed, bools)
     errs += _check_keda(cfg)
+    errs += _check_worker_pools(cfg, bools, vpa_parsed)
 
     if errs:
         raise ConfigValidationError(errs)

--- a/.github/scripts/tests/test_config_validator.py
+++ b/.github/scripts/tests/test_config_validator.py
@@ -800,3 +800,563 @@ vpa:
 """)
         types = {(v.rule, v.field) for v in exc.value.violations}
         assert ("invalid_type", "vpa.maxAllowed.cpu") in types
+
+
+# ---------------------------------------------------------------------------
+# Rule: workerPools — count ceiling
+# ---------------------------------------------------------------------------
+
+# Pools only render under split + TWC; every pass-case config below needs both
+# or the inert-block rule fires instead.
+_SPLIT_TWC = "splitDeploymentEnabled: true\ntemporalWorkerDeployment: {enabled: true}\n"
+
+
+def _pools_yaml(count: int) -> str:
+    entries = "".join(f"  - name: tier{i}\n" for i in range(count))
+    return f"{_SPLIT_TWC}workerPools:\n{entries}"
+
+
+class TestWorkerPoolCount:
+    def test_absent_pools_passes(self):
+        validate_config(_SPLIT_TWC)
+
+    def test_empty_pool_list_passes(self):
+        validate_config(_SPLIT_TWC + "workerPools: []\n")
+
+    def test_ten_pools_passes(self):
+        validate_config(_pools_yaml(10))
+
+    def test_eleven_pools_fails(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(_pools_yaml(11))
+        assert any(
+            v.rule == "worker_pool_count_ceiling" and v.actual == 11
+            for v in exc.value.violations
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rule: workerPools — infra ceilings per pool
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerPoolCeilings:
+    def test_memory_request_above_ceiling_fails(self):
+        # The ARUN-1041 example: 40Gi is not schedulable on current infra.
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(
+                _SPLIT_TWC
+                + """
+workerPools:
+  - name: heavy
+    resources:
+      requests: {cpu: 250m, memory: 40Gi}
+      limits:   {cpu: 1,    memory: 40Gi}
+"""
+            )
+        assert any(
+            v.rule == "requests_memory_ceiling"
+            and v.field == "workerPools[0].resources.requests.memory"
+            for v in exc.value.violations
+        )
+
+    def test_cpu_request_above_ceiling_fails(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(
+                _SPLIT_TWC
+                + """
+workerPools:
+  - name: heavy
+    resources:
+      requests: {cpu: 8, memory: 1Gi}
+      limits:   {cpu: 8, memory: 2Gi}
+"""
+            )
+        assert any(
+            v.rule == "requests_cpu_ceiling"
+            and v.field == "workerPools[0].resources.requests.cpu"
+            for v in exc.value.violations
+        )
+
+    def test_vpa_max_above_ceiling_fails(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(
+                _SPLIT_TWC
+                + """
+workerPools:
+  - name: heavy
+    vpa:
+      enabled: true
+      maxAllowed: {cpu: 8, memory: 40Gi}
+"""
+            )
+        fields = {(v.rule, v.field) for v in exc.value.violations}
+        assert ("vpa_max_cpu_ceiling", "workerPools[0].vpa.maxAllowed.cpu") in fields
+        assert (
+            "vpa_max_memory_ceiling",
+            "workerPools[0].vpa.maxAllowed.memory",
+        ) in fields
+
+    def test_at_ceiling_passes(self):
+        validate_config(
+            _SPLIT_TWC
+            + """
+workerPools:
+  - name: heavy
+    vpa:
+      enabled: true
+      maxAllowed: {cpu: "7", memory: 27Gi}
+    resources:
+      requests: {cpu: "7", memory: 27Gi}
+      limits:   {cpu: "7", memory: 27Gi}
+"""
+        )
+
+    def test_violation_field_carries_pool_index(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(
+                _SPLIT_TWC
+                + """
+workerPools:
+  - name: light
+    resources:
+      requests: {cpu: 100m, memory: 1Gi}
+  - name: heavy
+    resources:
+      requests: {cpu: 100m, memory: 40Gi}
+"""
+            )
+        assert [v.field for v in exc.value.violations] == [
+            "workerPools[1].resources.requests.memory"
+        ]
+
+    def test_invalid_quantity_reports_pool_path(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(
+                _SPLIT_TWC
+                + """
+workerPools:
+  - name: heavy
+    resources:
+      requests: {memory: 4GB}
+"""
+            )
+        assert any(
+            v.rule == "invalid_quantity"
+            and v.field == "workerPools[0].resources.requests.memory"
+            for v in exc.value.violations
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rule: workerPools — requests <= the pool's effective vpa.maxAllowed
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerPoolVpaClamp:
+    def test_chart_default_max_applies_when_nothing_declared(self):
+        # Pool VPA on with no maxAllowed anywhere → chart default 6Gi clamps.
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(
+                _SPLIT_TWC
+                + """
+workerPools:
+  - name: heavy
+    vpa: {enabled: true}
+    resources:
+      requests: {cpu: 250m, memory: 8Gi}
+"""
+            )
+        assert any(
+            v.rule == "requests_exceeds_vpa_max_memory" for v in exc.value.violations
+        )
+
+    def test_inherits_app_level_max_allowed(self):
+        validate_config(
+            _SPLIT_TWC
+            + """
+vpa:
+  enabled: true
+  maxAllowed: {cpu: "2", memory: 16Gi}
+workerPools:
+  - name: heavy
+    vpa: {enabled: true}
+    resources:
+      requests: {cpu: 250m, memory: 8Gi}
+"""
+        )
+
+    def test_pool_max_allowed_overrides_app_level(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(
+                _SPLIT_TWC
+                + """
+vpa:
+  enabled: true
+  maxAllowed: {cpu: "2", memory: 16Gi}
+workerPools:
+  - name: heavy
+    vpa:
+      enabled: true
+      maxAllowed: {memory: 4Gi}
+    resources:
+      requests: {cpu: 250m, memory: 8Gi}
+"""
+            )
+        assert any(
+            v.rule == "requests_exceeds_vpa_max_memory" for v in exc.value.violations
+        )
+
+    def test_partial_pool_max_allowed_leaves_other_resource_unclamped(self):
+        # Helm's `default` swaps the whole maxAllowed dict, so declaring only
+        # memory means VPA never bounds cpu — a 6-core request must not trip
+        # the clamp rule (the 7-core infra ceiling still applies).
+        validate_config(
+            _SPLIT_TWC
+            + """
+workerPools:
+  - name: heavy
+    vpa:
+      enabled: true
+      maxAllowed: {memory: 16Gi}
+    resources:
+      requests: {cpu: 6, memory: 8Gi}
+"""
+        )
+
+    def test_pool_does_not_inherit_app_vpa_enabled(self):
+        # The chart gates the pool VPA on the pool's own vpa.enabled, so an
+        # app-level enable must not clamp a pool that never opted in.
+        validate_config(
+            _SPLIT_TWC
+            + """
+vpa:
+  enabled: true
+  maxAllowed: {memory: 4Gi}
+workerPools:
+  - name: heavy
+    resources:
+      requests: {cpu: 250m, memory: 8Gi}
+"""
+        )
+
+    def test_pool_update_mode_off_skips_clamp(self):
+        validate_config(
+            _SPLIT_TWC
+            + """
+workerPools:
+  - name: heavy
+    vpa:
+      enabled: true
+      updateMode: "Off"
+      maxAllowed: {memory: 4Gi}
+    resources:
+      requests: {cpu: 250m, memory: 8Gi}
+"""
+        )
+
+    def test_pool_inherits_app_update_mode_off(self):
+        validate_config(
+            _SPLIT_TWC
+            + """
+vpa:
+  enabled: true
+  updateMode: "Off"
+workerPools:
+  - name: heavy
+    vpa:
+      enabled: true
+      maxAllowed: {memory: 4Gi}
+    resources:
+      requests: {cpu: 250m, memory: 8Gi}
+"""
+        )
+
+    def test_pool_update_mode_overrides_app_off(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(
+                _SPLIT_TWC
+                + """
+vpa:
+  enabled: true
+  updateMode: "Off"
+workerPools:
+  - name: heavy
+    vpa:
+      enabled: true
+      updateMode: Auto
+      maxAllowed: {memory: 4Gi}
+    resources:
+      requests: {cpu: 250m, memory: 8Gi}
+"""
+            )
+        assert any(
+            v.rule == "requests_exceeds_vpa_max_memory" for v in exc.value.violations
+        )
+
+    def test_unquoted_off_loads_as_bool_and_still_skips_clamp(self):
+        # PyYAML's YAML 1.1 loader coerces unquoted `off` to False.
+        validate_config(
+            _SPLIT_TWC
+            + """
+workerPools:
+  - name: heavy
+    vpa:
+      enabled: true
+      updateMode: off
+      maxAllowed: {memory: 4Gi}
+    resources:
+      requests: {cpu: 250m, memory: 8Gi}
+"""
+        )
+
+    def test_clamp_fix_points_at_the_pool_vpa(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(
+                _SPLIT_TWC
+                + """
+workerPools:
+  - name: heavy
+    vpa:
+      enabled: true
+      maxAllowed: {memory: 4Gi}
+    resources:
+      requests: {memory: 8Gi}
+"""
+            )
+        clamp = next(
+            v
+            for v in exc.value.violations
+            if v.rule == "requests_exceeds_vpa_max_memory"
+        )
+        assert "workerPools[0].vpa.maxAllowed.memory" in clamp.fix
+
+
+# ---------------------------------------------------------------------------
+# Rule: workerPools — relational rules per pool
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerPoolRelational:
+    def test_requests_above_limits_fails(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(
+                _SPLIT_TWC
+                + """
+workerPools:
+  - name: heavy
+    resources:
+      requests: {memory: 8Gi}
+      limits:   {memory: 4Gi}
+"""
+            )
+        assert any(
+            v.rule == "requests_le_limits"
+            and v.field == "workerPools[0].resources.requests.memory"
+            for v in exc.value.violations
+        )
+
+    def test_vpa_min_above_max_fails(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(
+                _SPLIT_TWC
+                + """
+workerPools:
+  - name: heavy
+    vpa:
+      enabled: true
+      minAllowed: {memory: 8Gi}
+      maxAllowed: {memory: 4Gi}
+"""
+            )
+        assert any(
+            v.rule == "vpa_min_le_max"
+            and v.field == "workerPools[0].vpa.minAllowed.memory"
+            for v in exc.value.violations
+        )
+
+    def test_keda_min_above_max_fails(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(
+                _SPLIT_TWC
+                + """
+workerPools:
+  - name: heavy
+    keda: {minReplicaCount: 4, maxReplicaCount: 2}
+"""
+            )
+        assert any(
+            v.rule == "keda_min_le_max"
+            and v.field == "workerPools[0].keda.minReplicaCount"
+            for v in exc.value.violations
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rule: workerPools — name / taskQueue identity
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerPoolIdentity:
+    def test_missing_name_fails(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(_SPLIT_TWC + "workerPools:\n  - taskQueue: q\n")
+        assert any(
+            v.rule == "worker_pool_name_required" and v.field == "workerPools[0].name"
+            for v in exc.value.violations
+        )
+
+    def test_blank_name_fails(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(_SPLIT_TWC + 'workerPools:\n  - name: "  "\n')
+        assert any(v.rule == "worker_pool_name_required" for v in exc.value.violations)
+
+    def test_duplicate_name_fails_on_the_later_entry(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(
+                _SPLIT_TWC + "workerPools:\n  - name: heavy\n  - name: heavy\n"
+            )
+        dupes = [
+            v for v in exc.value.violations if v.rule == "worker_pool_name_duplicate"
+        ]
+        assert [v.field for v in dupes] == ["workerPools[1].name"]
+        assert "workerPools[0]" in dupes[0].expected
+
+    def test_duplicate_task_queue_fails(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(
+                _SPLIT_TWC
+                + """
+workerPools:
+  - name: light
+    taskQueue: shared-q
+  - name: heavy
+    taskQueue: shared-q
+"""
+            )
+        assert any(
+            v.rule == "worker_pool_task_queue_duplicate"
+            and v.field == "workerPools[1].taskQueue"
+            for v in exc.value.violations
+        )
+
+    def test_distinct_names_and_queues_pass(self):
+        validate_config(
+            _SPLIT_TWC
+            + """
+workerPools:
+  - name: light
+    taskQueue: light-q
+  - name: heavy
+    taskQueue: heavy-q
+"""
+        )
+
+    def test_omitted_task_queues_are_not_duplicates(self):
+        # taskQueue defaults per-pool from the pool name, so several pools
+        # leaving it unset is normal, not a collision.
+        validate_config(_SPLIT_TWC + "workerPools:\n  - name: light\n  - name: heavy\n")
+
+
+# ---------------------------------------------------------------------------
+# Rule: declared workerPools require split + TWC
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerPoolsRequireSplitTwc:
+    def test_split_disabled_fails(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(
+                "splitDeploymentEnabled: false\n"
+                "temporalWorkerDeployment: {enabled: true}\n"
+                "workerPools:\n  - name: heavy\n"
+            )
+        inert = next(
+            v
+            for v in exc.value.violations
+            if v.rule == "worker_pools_require_split_twc"
+        )
+        assert inert.actual == ["splitDeploymentEnabled"]
+
+    def test_twc_disabled_fails(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(
+                "splitDeploymentEnabled: true\n"
+                "temporalWorkerDeployment: {enabled: false}\n"
+                "workerPools:\n  - name: heavy\n"
+            )
+        inert = next(
+            v
+            for v in exc.value.violations
+            if v.rule == "worker_pools_require_split_twc"
+        )
+        assert inert.actual == ["temporalWorkerDeployment.enabled"]
+
+    def test_both_absent_lists_both_flags(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config("workerPools:\n  - name: heavy\n")
+        inert = next(
+            v
+            for v in exc.value.violations
+            if v.rule == "worker_pools_require_split_twc"
+        )
+        assert inert.actual == [
+            "splitDeploymentEnabled",
+            "temporalWorkerDeployment.enabled",
+        ]
+
+    def test_both_enabled_passes(self):
+        validate_config(_SPLIT_TWC + "workerPools:\n  - name: heavy\n")
+
+    def test_magnitude_rules_still_run_when_inert(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(
+                """
+workerPools:
+  - name: heavy
+    resources:
+      requests: {memory: 40Gi}
+"""
+            )
+        rules = {v.rule for v in exc.value.violations}
+        assert "worker_pools_require_split_twc" in rules
+        assert "requests_memory_ceiling" in rules
+
+
+# ---------------------------------------------------------------------------
+# workerPools shape
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerPoolShape:
+    def test_mapping_instead_of_list_fails(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(_SPLIT_TWC + "workerPools:\n  heavy:\n    name: heavy\n")
+        assert any(
+            v.rule == "invalid_type" and v.field == "workerPools"
+            for v in exc.value.violations
+        )
+
+    def test_non_mapping_entry_fails(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(_SPLIT_TWC + "workerPools:\n  - heavy\n")
+        assert any(
+            v.rule == "invalid_type" and v.field == "workerPools[0]"
+            for v in exc.value.violations
+        )
+
+    def test_non_mapping_entry_does_not_mask_valid_siblings(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config(
+                _SPLIT_TWC
+                + """
+workerPools:
+  - heavy
+  - name: light
+    resources:
+      requests: {memory: 40Gi}
+"""
+            )
+        fields = {v.field for v in exc.value.violations}
+        assert "workerPools[0]" in fields
+        assert "workerPools[1].resources.requests.memory" in fields

--- a/application_sdk/app/registry.py
+++ b/application_sdk/app/registry.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 
 from application_sdk.app.entrypoint import build_workflow_type_index
+from application_sdk.common.task_queue import task_queue_from_env
 from application_sdk.contracts.base import validate_is_contract
 from application_sdk.errors import (
     APP_ALREADY_REGISTERED,
@@ -529,7 +530,20 @@ def resolve_pool_queue(pool: str) -> str | None:
        name are normalised to underscores so ``"cold-tier"`` looks up
        ``ATLAN_POOL_COLD_TIER_QUEUE``.
     2. ``{ATLAN_TASK_QUEUE}-{pool}`` derived from the app's base queue.
-    3. ``None`` — neither env var is set; the caller must handle this.
+    3. ``{atlan-<app>-<deployment>}-{pool}`` derived the same way the worker's
+       own base queue is, via :func:`task_queue_from_env`.
+    4. ``None`` — nothing in the environment names a queue; the caller must
+       handle this.
+
+    Step 3 exists because the ``atlan-app`` chart sets neither env var in steps
+    1-2. It sets ``ATLAN_APPLICATION_NAME`` + ``ATLAN_DEPLOYMENT_NAME`` (and, on
+    a pool's own pods, ``ATLAN_APP_TASK_QUEUE``), so without it every
+    chart-deployed ``@task(pool=...)`` resolved to ``None`` and its activities
+    silently ran on the workflow's default queue — the dedicated pool sat idle
+    while the main worker absorbed the load it was created to offload. Deriving
+    through :func:`task_queue_from_env` reproduces the chart's own
+    ``atlan-<app>-<deploymentName>-<pool>`` byte-for-byte, so the routing target
+    and the pool worker's poll target agree with no env plumbing.
 
     Args:
         pool: Validated lowercase kebab-case pool name
@@ -551,5 +565,5 @@ def resolve_pool_queue(pool: str) -> str | None:
     explicit = os.environ.get(env_key)
     if explicit:
         return explicit
-    base_queue = os.environ.get("ATLAN_TASK_QUEUE", "")
+    base_queue = os.environ.get("ATLAN_TASK_QUEUE", "") or (task_queue_from_env() or "")
     return f"{base_queue}-{pool}" if base_queue else None

--- a/contract-toolkit/CLAUDE.md
+++ b/contract-toolkit/CLAUDE.md
@@ -25,7 +25,7 @@ Contracts generate — from one `pkl eval -m . contract/app.pkl` at repo root:
 
 - `src/App.pkl`: **canonical template** for all new native app contracts.
 - `src/Widgets.pkl`: widget catalog re-exported from `App.pkl`.
-- `src/Deployment.pkl`: deployment classes (`DeployConfig`, `Pool`, `KedaConfig`, `DaprComponents`, `ResourceConfig`) re-exported from `App.pkl`.
+- `src/Deployment.pkl`: deployment classes (`DeployConfig`, `Pool`, `KedaConfig`, `DaprComponents`, `ResourceConfig`, `VpaConfig`) re-exported from `App.pkl`.
 - `src/Connectors.pkl`: connector type registry (still imported explicitly by consumers).
 - Legacy modules (reference only, not for new apps):
   - `src/NativeApp.pkl`, `src/NativeAppBundle.pkl`, `src/AgentConfig.pkl`

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -650,9 +650,28 @@ The auth-type radio's `ui.hidden` is auto-derived from `credentialAuthOptions.le
 
 `deploy: DeployConfig? = null` — leave unset (null, the default) to let Heracles apply platform defaults. Set to `new DeployConfig { … }` to emit a `deploy:` block (and `pools:` when pools are configured) in `atlan.yaml`.
 
-Singleton fields (`executionMode`, `splitDeployment`, `dapr`) apply to the whole deployment. Per-pool scaling (KEDA, resources, env) goes inside `deploy.pools`.
+Singleton fields (`executionMode`, `splitDeployment`, `dapr`) apply to the whole deployment. Per-pool scaling (KEDA, resources, VPA, env) goes inside `deploy.pools`.
 
-All deployment classes (`DeployConfig`, `Pool`, `DaprComponents`, `KedaConfig`, `KedaTemporalConfig`, `ResourceConfig`) are defined in `Deployment.pkl` and re-exported by `App.pkl` — amending contracts do not need a supplemental import.
+All deployment classes (`DeployConfig`, `Pool`, `DaprComponents`, `KedaConfig`, `KedaTemporalConfig`, `ResourceConfig`, `VpaConfig`) are defined in `Deployment.pkl` and re-exported by `App.pkl` — amending contracts do not need a supplemental import.
+
+#### What `deploy.pools` generates
+
+`pools` is a mapping, but the `atlan-app` Helm chart reads a **list** of dedicated pools under `deploy.workerPools`, with a **flat** `keda` block. The toolkit owns that translation — a contract never writes `workerPools` by hand:
+
+| Contract | Generated `atlan.yaml` | Read by |
+|---|---|---|
+| the **first** `pools` key | `deploy:` — `keda`, `resources`, `vpa`, `env` synthesised from it | chart, as the app's main worker |
+| **every key after the first** | one `deploy.workerPools[]` entry, `name` = the pool key | chart, as a dedicated pool: its own TemporalWorkerDeployment, ScaledObject, VPA, task queue |
+| the whole map | top-level `pools:` mirror | tooling reading the contract shape directly |
+
+Two consequences worth knowing:
+
+- **The first pool is the main worker, not an extra one.** A single-pool contract emits no `workerPools` at all. Order therefore matters: putting a scale-to-zero pool first synthesises a scale-to-zero `deploy:` block.
+- **The pool key is the only source of the pool's task queue.** No `taskQueue` is ever generated. The chart renders `atlan-<app>-<deploymentName>-<key>` and `application_sdk`'s `resolve_pool_queue()` derives the same string from `ATLAN_APPLICATION_NAME` + `ATLAN_DEPLOYMENT_NAME`, so the routing target and the pool worker's poll target cannot drift. `ATLAN_POOL_<POOL>_QUEUE` remains an explicit override for local dev.
+
+`replicaCount`, `env`, `envOverrides`, and `keda.enabled` are generated into `workerPools[]` entries but **not yet honored per-pool by the chart**, which reads only `name`, `taskQueue`, `resources`, `keda`, `vpa`, `capacityType`, `maxConcurrentActivities`, and `terminationGracePeriodSeconds`. They are emitted rather than dropped so the contract stays the declaration of intent and the gap is visible in the generated manifest. Tracked in ARUN-1041.
+
+Generated `deploy` blocks are validated in CI against the platform's infra ceilings (`.github/scripts/config_validator.py`), including per-pool resources, VPA, and KEDA bounds.
 
 | Property | Type | Default | Description |
 |---|---|---|---|
@@ -666,7 +685,7 @@ All deployment classes (`DeployConfig`, `Pool`, `DaprComponents`, `KedaConfig`, 
 | `deploy.splitDeployment` | Boolean | `true` | Emitted as `splitDeploymentEnabled`. |
 | `deploy.dapr` | DaprComponents | `new DaprComponents {}` | Dapr sidecar toggles — app-wide, not per-pool. Emitted under `dapr:` when any component is enabled. |
 | `deploy.overrides` | Mapping<String, Any> | `{}` | Global escape hatch. Deep-merged on top of the rendered `deploy:` block after first-pool `overrides`. |
-| `deploy.pools` | Mapping<KebabCase, Pool> | `{}` | Named worker-pool map. Pool keys must be lowercase kebab-case and match `@task(pool="…")` in Python. When non-empty, emits `deploy:` (synthesised from the first pool's keda/resources/env) and `pools:`. |
+| `deploy.pools` | Mapping<KebabCase, Pool> | `{}` | Named worker-pool map. Pool keys must be lowercase kebab-case and match `@task(pool="…")` in Python. When non-empty, emits `deploy:` (synthesised from the first pool), one `deploy.workerPools[]` entry per pool after the first, and the top-level `pools:` mirror. See [What `deploy.pools` generates](#what-deploypools-generates). |
 
 **Pool class:**
 
@@ -675,11 +694,14 @@ class Pool {
   replicaCount: Int? = null     // static replica count (ignored when keda.enabled = true)
   keda: KedaConfig = new KedaConfig {}
   resources: ResourceConfig? = null
+  vpa: VpaConfig? = null        // per-pool VPA; the chart gates a pool's VPA on THIS block alone
   env: Mapping<String, String> = new Mapping {}
   envOverrides: Mapping<String, Mapping<String, String>> = new Mapping {}
   overrides: Mapping<String, Any> = new Mapping {}  // deep-merged last (escape hatch)
 }
 ```
+
+There is deliberately no `taskQueue` field — see [What `deploy.pools` generates](#what-deploypools-generates).
 
 **DaprComponents:**
 
@@ -702,13 +724,14 @@ class DaprComponents {
 class KedaConfig {
   enabled: Boolean = true
   minReplicaCount: Int = 0
+  maxReplicaCount: Int? = null  // replica ceiling; omit to inherit the chart's chain
   cooldownPeriod: Int? = null  // seconds to wait after queue drains before scaling to zero
   temporal: KedaTemporalConfig = new { targetQueueSize = 5 }
 }
 class KedaTemporalConfig { targetQueueSize: Int }
 ```
 
-`targetQueueSize` must be set via `keda.temporal.targetQueueSize`. `cooldownPeriod` is omitted from the rendered output when not set (Helm chart default applies).
+`targetQueueSize` must be set via `keda.temporal.targetQueueSize` — in a generated `workerPools[]` entry it lands flat, as `keda.targetQueueSize`, because that is the shape the chart reads. `cooldownPeriod` and `maxReplicaCount` are omitted from the rendered output when not set (Helm chart defaults apply).
 
 **ResourceConfig:**
 
@@ -719,7 +742,25 @@ class ResourceConfig {
 }
 ```
 
-Example — two pools, hot always-on + cold scale-to-zero:
+**VpaConfig:**
+
+```pkl
+class VpaConfig {
+  enabled: Boolean = false
+  updateMode: String? = null   // "Off" | "Initial" | "Recreate" | "Auto"
+  minAllowed: Mapping<String, String>
+  maxAllowed: Mapping<String, String>
+}
+```
+
+`updateMode` is constrained to the four casings the Kubernetes VPA accepts, so a contract cannot emit the lowercase `off` that YAML 1.1 loaders coerce to boolean `false`.
+
+Two chart behaviours to know when setting this on a `Pool`:
+
+- A pool's VPA is gated on **its own** `enabled`. The chart does not fall back to an app-level VPA flag, so a pool that omits this block is never clamped.
+- `maxAllowed` is swapped as a **whole dict** at each chart fallback step, not merged key-by-key. Declaring only `memory` leaves cpu on the chart default (`2000m`), not on any app-level value.
+
+Example — two pools, hot always-on + cold scale-to-zero. `hot` is first, so it is the app's main worker; `cold` becomes a dedicated `workerPools[]` entry:
 
 ```pkl
 deploy = new DeployConfig {
@@ -728,13 +769,18 @@ deploy = new DeployConfig {
       keda { minReplicaCount = 1; cooldownPeriod = 300 }
     }
     ["cold"] = new Pool {
-      keda { minReplicaCount = 0; cooldownPeriod = 30 }
+      keda { minReplicaCount = 0; maxReplicaCount = 4; cooldownPeriod = 30 }
+      vpa = new VpaConfig {
+        enabled = true
+        updateMode = "Auto"
+        maxAllowed { ["cpu"] = "2"; ["memory"] = "4Gi" }
+      }
     }
   }
 }
 ```
 
-Example — single pool with Dapr sidecars and a VPA override:
+Example — single pool with Dapr sidecars and a VPA:
 
 ```pkl
 deploy = new DeployConfig {
@@ -746,14 +792,14 @@ deploy = new DeployConfig {
         requests { ["cpu"] = "500m"; ["memory"] = "1Gi" }
         limits { ["cpu"] = "2"; ["memory"] = "4Gi" }
       }
+      vpa = new VpaConfig { enabled = true; updateMode = "Auto" }
       env { ["LOG_LEVEL"] = "INFO" }
-      overrides {
-        ["verticalPodAutoscaler"] = new Mapping { ["enabled"] = true; ["updateMode"] = "Auto" }
-      }
     }
   }
 }
 ```
+
+Use the typed `vpa` field rather than `overrides`: the chart key is `vpa`, and an `overrides` entry naming anything else is silently ignored at render.
 
 For the single-pool case use key `"default"`. See `examples/deploy/` for the full single-pool example and `examples/pools/` for the two-pool example.
 

--- a/contract-toolkit/examples/pools/app.pkl
+++ b/contract-toolkit/examples/pools/app.pkl
@@ -1,15 +1,21 @@
 /// Multi-pool deployment example — two named worker pools with per-pool
-/// KEDA, resources, cooldownPeriod, and env.
+/// KEDA, resources, VPA, cooldownPeriod, and env.
 ///
 /// Two pools:
 ///   "hot"  — always-on (minReplicaCount=1), lenient cooldown (300 s)
-///             so warm workers survive bursts.
+///             so warm workers survive bursts. FIRST key, so this pool is the
+///             app's main worker: its config synthesises the `deploy:` block.
 ///   "cold" — scale-to-zero (minReplicaCount=0), aggressive cooldown
-///             (30 s) to reclaim resources fast.
+///             (30 s) to reclaim resources fast. A key after the first, so it
+///             renders as a dedicated `deploy.workerPools[]` entry with its own
+///             TemporalWorkerDeployment, ScaledObject, VPA, and task queue.
 ///
-/// Pool keys here must match the strings used in @task(pool="…")
-/// in Python. The runtime resolves them to task queues via
-/// ATLAN_POOL_<POOL>_QUEUE env vars.
+/// Pool keys here must match the strings used in @task(pool="…") in Python.
+/// Nothing carries the queue name between the chart and the runtime: the chart
+/// renders `atlan-<app>-<deploymentName>-<key>` and the SDK's
+/// resolve_pool_queue() derives the same string from ATLAN_APPLICATION_NAME +
+/// ATLAN_DEPLOYMENT_NAME. ATLAN_POOL_<POOL>_QUEUE stays available as an explicit
+/// override for local dev and for queues the chart does not own.
 amends "../../src/App.pkl"
 
 name = "pools-example"
@@ -46,6 +52,7 @@ deploy = new DeployConfig {
       keda {
         enabled = true
         minReplicaCount = 0
+        maxReplicaCount = 4
         cooldownPeriod = 30
         temporal {
           targetQueueSize = 5
@@ -55,6 +62,16 @@ deploy = new DeployConfig {
         requests {
           ["cpu"] = "100m"
           ["memory"] = "256Mi"
+        }
+      }
+      // A pool's VPA is gated on its OWN `enabled` — the chart never falls back
+      // to an app-level flag, so a pool that omits this block is never clamped.
+      vpa = new VpaConfig {
+        enabled = true
+        updateMode = "Auto"
+        maxAllowed {
+          ["cpu"] = "2"
+          ["memory"] = "4Gi"
         }
       }
       env {

--- a/contract-toolkit/examples/pools/atlan.yaml
+++ b/contract-toolkit/examples/pools/atlan.yaml
@@ -33,6 +33,26 @@ deploy:
       memory: 4Gi
   env:
     WORKER_TYPE: hot
+  workerPools:
+  - name: cold
+    keda:
+      enabled: true
+      minReplicaCount: 0
+      maxReplicaCount: 4
+      cooldownPeriod: 30
+      targetQueueSize: 5
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    vpa:
+      enabled: true
+      updateMode: Auto
+      maxAllowed:
+        cpu: '2'
+        memory: 4Gi
+    env:
+      WORKER_TYPE: cold
 pools:
   hot:
     keda:
@@ -54,6 +74,7 @@ pools:
     keda:
       enabled: true
       minReplicaCount: 0
+      maxReplicaCount: 4
       cooldownPeriod: 30
       temporal:
         targetQueueSize: 5
@@ -61,5 +82,11 @@ pools:
       requests:
         cpu: 100m
         memory: 256Mi
+    vpa:
+      enabled: true
+      updateMode: Auto
+      maxAllowed:
+        cpu: '2'
+        memory: 4Gi
     env:
       WORKER_TYPE: cold

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -105,6 +105,7 @@ typealias DaprComponents = DeploymentPkg.DaprComponents
 typealias KedaTemporalConfig = DeploymentPkg.KedaTemporalConfig
 typealias KedaConfig = DeploymentPkg.KedaConfig
 typealias ResourceConfig = DeploymentPkg.ResourceConfig
+typealias VpaConfig = DeploymentPkg.VpaConfig
 typealias DeployConfig = DeploymentPkg.DeployConfig
 typealias Pool = DeploymentPkg.Pool
 
@@ -3766,6 +3767,7 @@ local function renderKedaConfig(k: KedaConfig): Mapping<String, Any> = new Mappi
   ["enabled"] = k.enabled
   when (k.enabled) {
     ["minReplicaCount"] = k.minReplicaCount
+    when (k.maxReplicaCount != null) { ["maxReplicaCount"] = k.maxReplicaCount }
     when (k.cooldownPeriod != null) { ["cooldownPeriod"] = k.cooldownPeriod }
     ["temporal"] = new Mapping {
       ["targetQueueSize"] = k.temporal.targetQueueSize
@@ -3773,15 +3775,61 @@ local function renderKedaConfig(k: KedaConfig): Mapping<String, Any> = new Mappi
   }
 }
 
+local function renderResourceConfig(r: ResourceConfig): Mapping<String, Any> = new Mapping {
+  when (!r.requests.isEmpty) { ["requests"] = r.requests }
+  when (!r.limits.isEmpty) { ["limits"] = r.limits }
+}
+
+local function renderVpaConfig(v: VpaConfig): Mapping<String, Any> = new Mapping {
+  ["enabled"] = v.enabled
+  when (v.updateMode != null) { ["updateMode"] = v.updateMode }
+  when (!v.minAllowed.isEmpty) { ["minAllowed"] = v.minAllowed }
+  when (!v.maxAllowed.isEmpty) { ["maxAllowed"] = v.maxAllowed }
+}
+
+/// Contract-shape `pools:` entry — the mirror of the whole `pools` map that
+/// `atlan.yaml` carries at top level for tooling reading the contract directly.
 local function renderPool(p: Pool): Mapping<String, Any> = new Mapping {
   when (p.replicaCount != null) { ["replicaCount"] = p.replicaCount }
   ["keda"] = renderKedaConfig(p.keda)
-  when (p.resources != null) {
-    ["resources"] = new Mapping {
-      when (!p.resources!!.requests.isEmpty) { ["requests"] = p.resources!!.requests }
-      when (!p.resources!!.limits.isEmpty) { ["limits"] = p.resources!!.limits }
-    }
+  when (p.resources != null) { ["resources"] = renderResourceConfig(p.resources!!) }
+  when (p.vpa != null) { ["vpa"] = renderVpaConfig(p.vpa!!) }
+  when (!p.env.isEmpty) { ["env"] = p.env }
+  when (!p.envOverrides.isEmpty) { ["envOverrides"] = p.envOverrides }
+}
+
+/// Chart-shape `deploy.workerPools[]` entry for one dedicated pool.
+///
+/// The `atlan-app` chart reads a LIST keyed by `name` with a FLAT `keda` block —
+/// not the contract's `pools:` mapping with `keda.temporal.targetQueueSize` and
+/// `keda.enabled`. This function owns that translation so no app has to
+/// hand-write it, and so the pool key stays the single source of the pool's
+/// identity.
+///
+/// `taskQueue` is deliberately never emitted: the chart derives
+/// `atlan-<app>-<deploymentName>-<name>` and `application_sdk`'s
+/// `resolve_pool_queue()` derives the same string, so emitting one would create
+/// a second source that can drift from the routing side.
+///
+/// `keda.enabled`, `replicaCount`, `env`, and `envOverrides` are emitted but NOT
+/// yet honored per-pool by the chart (`subcharts/atlan-app` reads only `name`,
+/// `taskQueue`, `resources`, `keda`, `vpa`, `capacityType`,
+/// `maxConcurrentActivities`, `terminationGracePeriodSeconds`). They are emitted
+/// rather than dropped so the contract stays the declaration of intent and the
+/// chart gap is visible in the generated manifest instead of silently vanishing
+/// at render time. Tracked in ARUN-1041.
+local function renderWorkerPool(poolName: String, p: Pool): Mapping<String, Any> = new Mapping {
+  ["name"] = poolName
+  when (p.replicaCount != null) { ["replicaCount"] = p.replicaCount }
+  ["keda"] = new Mapping {
+    ["enabled"] = p.keda.enabled
+    ["minReplicaCount"] = p.keda.minReplicaCount
+    when (p.keda.maxReplicaCount != null) { ["maxReplicaCount"] = p.keda.maxReplicaCount }
+    when (p.keda.cooldownPeriod != null) { ["cooldownPeriod"] = p.keda.cooldownPeriod }
+    ["targetQueueSize"] = p.keda.temporal.targetQueueSize
   }
+  when (p.resources != null) { ["resources"] = renderResourceConfig(p.resources!!) }
+  when (p.vpa != null) { ["vpa"] = renderVpaConfig(p.vpa!!) }
   when (!p.env.isEmpty) { ["env"] = p.env }
   when (!p.envOverrides.isEmpty) { ["envOverrides"] = p.envOverrides }
 }
@@ -3812,17 +3860,26 @@ local function renderDeployYaml(d: DeployConfig): Mapping<String, Any> =
     deepMergeMapping(globalFields, d.overrides)
   else
     let (firstPool: Pool = (new Listing<Pool> { for (_, p in d.pools) { p } }).first)
+    let (firstPoolName: String = (new Listing<String> { for (k, _ in d.pools) { k } }).first)
+    // Pools after the first render as chart-shape `workerPools[]` entries. The
+    // first pool IS the app's main worker (its config synthesises the `deploy:`
+    // block below), so emitting it here too would render a duplicate
+    // TemporalWorkerDeployment polling a second queue.
+    let (extraPools: Listing<Mapping<String, Any>> = new Listing {
+      for (pName, p in d.pools) {
+        when (pName != firstPoolName) {
+          deepMergeMapping(renderWorkerPool(pName, p), p.overrides)
+        }
+      }
+    })
     let (poolFields: Mapping<String, Any> = new Mapping {
       when (firstPool.replicaCount != null) { ["replicaCount"] = firstPool.replicaCount }
       ["keda"] = renderKedaConfig(firstPool.keda)
-      when (firstPool.resources != null) {
-        ["resources"] = new Mapping {
-          when (!firstPool.resources!!.requests.isEmpty) { ["requests"] = firstPool.resources!!.requests }
-          when (!firstPool.resources!!.limits.isEmpty) { ["limits"] = firstPool.resources!!.limits }
-        }
-      }
+      when (firstPool.resources != null) { ["resources"] = renderResourceConfig(firstPool.resources!!) }
+      when (firstPool.vpa != null) { ["vpa"] = renderVpaConfig(firstPool.vpa!!) }
       when (!firstPool.env.isEmpty) { ["env"] = firstPool.env }
       when (!firstPool.envOverrides.isEmpty) { ["envOverrides"] = firstPool.envOverrides }
+      when (!extraPools.isEmpty) { ["workerPools"] = extraPools }
     })
     deepMergeMapping(
       deepMergeMapping(globalFields, poolFields),

--- a/contract-toolkit/src/Deployment.pkl
+++ b/contract-toolkit/src/Deployment.pkl
@@ -21,6 +21,10 @@ class KedaTemporalConfig {
 class KedaConfig {
   enabled: Boolean = true
   minReplicaCount: Int = 0
+  /// Replica ceiling. Omit to inherit the chart's fallback chain (chart-wide
+  /// `keda.maxReplicaCount`, then the platform's `maxWorkerReplicaCount`,
+  /// then 10).
+  maxReplicaCount: Int? = null
   /// Seconds KEDA waits after the queue drains before scaling to zero.
   /// Omit to use the Helm chart default.
   cooldownPeriod: Int? = null
@@ -32,6 +36,25 @@ class ResourceConfig {
   limits: Mapping<String, String> = new Mapping {}
 }
 
+/// Vertical Pod Autoscaler settings.
+///
+/// `updateMode` is constrained to the four casings the Kubernetes VPA actually
+/// accepts, so a contract cannot emit the lowercase `off` that YAML 1.1 loaders
+/// coerce to boolean `false`.
+///
+/// On a `Pool`, this block alone decides whether the pool is clamped: the chart
+/// does not fall back to an app-level VPA flag, so a pool that never sets
+/// `enabled = true` is never clamped. `maxAllowed` is swapped as a WHOLE dict at
+/// each chart fallback step rather than merged key-by-key, so declaring only
+/// `memory` leaves cpu on the chart default (`2000m`) rather than on any
+/// app-level value.
+class VpaConfig {
+  enabled: Boolean = false
+  updateMode: String?(this == null || List("Off", "Initial", "Recreate", "Auto").contains(this)) = null
+  minAllowed: Mapping<String, String> = new Mapping {}
+  maxAllowed: Mapping<String, String> = new Mapping {}
+}
+
 /// Per-pool deployment configuration. The pool key must be lowercase kebab-case
 /// and exactly match the string passed to `@task(pool="…")` in Python — the
 /// runtime routes activities to the corresponding task queue via that name.
@@ -39,6 +62,13 @@ class ResourceConfig {
 /// Until conformance rule P016 (BLDX-1485) ships, the pool-key / `@task(pool=…)`
 /// alignment is enforced only by reading. A typo silently routes activities to an
 /// unstaffed queue and they hang until `start_to_close_timeout`.
+///
+/// The pool key is the ONLY source of the pool's task queue. Both sides derive it
+/// from the key and nothing carries it between them: the chart renders
+/// `atlan-<app>-<deploymentName>-<key>`, and `application_sdk`'s
+/// `resolve_pool_queue()` derives the same string from `ATLAN_APPLICATION_NAME` +
+/// `ATLAN_DEPLOYMENT_NAME`. There is deliberately no `taskQueue` field here —
+/// declaring one would let the poll target and the routing target drift.
 ///
 /// ```pkl
 /// deploy = new DeployConfig {
@@ -57,6 +87,10 @@ class Pool {
   replicaCount: Int? = null
   keda: KedaConfig = new KedaConfig {}
   resources: ResourceConfig? = null
+  /// Per-pool VPA. Independent of any app-level VPA setting — the chart gates a
+  /// pool's VPA on this block alone, so omitting it (the default) means this
+  /// pool's requests are never clamped.
+  vpa: VpaConfig? = null
   env: Mapping<String, String> = new Mapping {}
   envOverrides: Mapping<String, Mapping<String, String>> = new Mapping {}
   /// Per-pool escape hatch for `atlan.yaml` keys not yet modelled as typed fields.
@@ -96,10 +130,17 @@ class DeployConfig {
   /// `overrides` from the first pool are applied.
   overrides: Mapping<String, Any> = new Mapping {}
   /// Named worker-pool map. Pool keys must be lowercase kebab-case.
-  /// An empty map (the default) emits no `pools:` block in `atlan.yaml`.
-  /// Order matters: the first key in insertion order drives the synthesised
-  /// top-level `deploy:` block (keda, resources, env). Put the primary
-  /// always-on pool first; placing a scale-to-zero pool first will silently
-  /// synthesise a scale-to-zero `deploy:` block.
+  /// An empty map (the default) emits no pool config in `atlan.yaml`.
+  ///
+  /// Order matters. The FIRST key in insertion order is the app's main worker:
+  /// its keda/resources/env drive the synthesised top-level `deploy:` block.
+  /// Put the primary always-on pool first; placing a scale-to-zero pool first
+  /// will silently synthesise a scale-to-zero `deploy:` block.
+  ///
+  /// Every key AFTER the first renders a dedicated worker pool as a
+  /// `deploy.workerPools[]` entry — the shape the `atlan-app` chart reads. Those
+  /// pools each get their own TemporalWorkerDeployment, KEDA ScaledObject, and
+  /// task queue. `atlan.yaml` also carries a top-level `pools:` mirror of the
+  /// whole map for tooling that reads the contract shape directly.
   pools: Mapping<KebabCase, Pool> = new Mapping {}
 }

--- a/contract-toolkit/tests/worker_pools_render_test.pkl
+++ b/contract-toolkit/tests/worker_pools_render_test.pkl
@@ -1,0 +1,213 @@
+/// `deploy.workerPools` rendering — the chart-shape projection of the contract's
+/// `pools:` map.
+///
+/// The `atlan-app` chart reads a LIST keyed by `name` with a FLAT `keda` block.
+/// The contract declares a MAPPING keyed by pool name with
+/// `keda.temporal.targetQueueSize`. These tests pin that translation, plus the
+/// first-pool-is-the-main-worker rule that keeps single-pool apps byte-identical.
+///
+/// Assertions read the rendered `atlan.yaml` VALUE rather than its text: the
+/// point of the projection is its structure, and a text match cannot tell a flat
+/// `keda.targetQueueSize` from the nested one in the `pools:` mirror.
+amends "pkl:test"
+
+import "../src/App.pkl" as App
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+local function appWith(deployCfg: App.DeployConfig?) = (App) {
+  name = "wp-test"
+  displayName = "Worker Pools Test"
+  icon = "https://assets.atlan.com/assets/dummy.svg"
+  hasCredentialConfig = false
+  pipeline { publish = null }
+  deploy = deployCfg
+  uiConfig = new App.UIConfig {
+    tasks {
+      ["Settings"] {
+        inputs {
+          ["target"] = new App.TextInput { title = "Target" }
+        }
+      }
+    }
+  }
+}
+
+local function atlanYaml(a) = a.output.files["atlan.yaml"].value
+local function deployOf(a) = atlanYaml(a)["deploy"]
+
+local singlePool = appWith(new App.DeployConfig {
+  pools {
+    ["default"] = new App.Pool {
+      keda { minReplicaCount = 1 }
+    }
+  }
+})
+
+local threePools = appWith(new App.DeployConfig {
+  pools {
+    ["main"] = new App.Pool {
+      keda { minReplicaCount = 1; cooldownPeriod = 300; temporal { targetQueueSize = 10 } }
+      resources = new App.ResourceConfig {
+        requests { ["cpu"] = "500m"; ["memory"] = "1Gi" }
+      }
+      env { ["WORKER_TYPE"] = "main" }
+    }
+    ["heavy"] = new App.Pool {
+      keda {
+        minReplicaCount = 0
+        maxReplicaCount = 4
+        cooldownPeriod = 30
+        temporal { targetQueueSize = 1 }
+      }
+      resources = new App.ResourceConfig {
+        requests { ["cpu"] = "250m"; ["memory"] = "4Gi" }
+        limits { ["cpu"] = "2"; ["memory"] = "16Gi" }
+      }
+      vpa = new App.VpaConfig {
+        enabled = true
+        updateMode = "Auto"
+        maxAllowed { ["cpu"] = "2"; ["memory"] = "16Gi" }
+      }
+      env { ["WORKER_TYPE"] = "heavy" }
+    }
+    ["cold-tier"] = new App.Pool {
+      keda { minReplicaCount = 0 }
+    }
+  }
+})
+
+local noPools = appWith(new App.DeployConfig {})
+local noDeploy = appWith(null)
+
+local threeWorkerPools = deployOf(threePools)["workerPools"].toList()
+local heavy = threeWorkerPools.findOrNull((p) -> p["name"] == "heavy")
+local coldTier = threeWorkerPools.findOrNull((p) -> p["name"] == "cold-tier")
+
+facts {
+  // ── First pool is the main worker, not a workerPools entry ────────────────
+
+  ["a single pool emits NO workerPools block — it IS the app's main worker"] {
+    !deployOf(singlePool).containsKey("workerPools")
+  }
+
+  ["a single pool still drives the synthesised deploy: block"] {
+    deployOf(singlePool)["keda"]["minReplicaCount"] == 1
+  }
+
+  ["an empty pools map emits no workerPools block"] {
+    !deployOf(noPools).containsKey("workerPools")
+  }
+
+  ["no deploy block at all emits no deploy and no pools"] {
+    !atlanYaml(noDeploy).containsKey("deploy") && !atlanYaml(noDeploy).containsKey("pools")
+  }
+
+  ["three pools render exactly two workerPools entries"] {
+    threeWorkerPools.length == 2
+  }
+
+  ["the first pool never appears as a workerPools entry"] {
+    threeWorkerPools.every((p) -> p["name"] != "main")
+  }
+
+  ["every pool after the first does appear, keyed by its contract key"] {
+    heavy != null && coldTier != null
+  }
+
+  ["the first pool still drives deploy:, so its config is not lost"] {
+    deployOf(threePools)["keda"]["temporal"]["targetQueueSize"] == 10 &&
+      deployOf(threePools)["env"]["WORKER_TYPE"] == "main"
+  }
+
+  // ── keda: nested contract shape → flat chart shape ────────────────────────
+
+  ["a workerPools entry carries targetQueueSize FLAT"] {
+    heavy["keda"]["targetQueueSize"] == 1
+  }
+
+  ["a workerPools entry has NO nested temporal block"] {
+    !heavy["keda"].containsKey("temporal")
+  }
+
+  ["the contract's pools: mirror keeps the NESTED temporal shape"] {
+    atlanYaml(threePools)["pools"]["heavy"]["keda"]["temporal"]["targetQueueSize"] == 1
+  }
+
+  ["minReplicaCount, maxReplicaCount and cooldownPeriod reach the entry"] {
+    heavy["keda"]["minReplicaCount"] == 0 &&
+      heavy["keda"]["maxReplicaCount"] == 4 &&
+      heavy["keda"]["cooldownPeriod"] == 30
+  }
+
+  ["an undeclared maxReplicaCount is omitted rather than guessed"] {
+    !coldTier["keda"].containsKey("maxReplicaCount")
+  }
+
+  // ── taskQueue is never emitted: the pool key is the only source ───────────
+
+  ["no workerPools entry declares a taskQueue"] {
+    // The chart derives atlan-<app>-<deploymentName>-<pool>, and
+    // application_sdk's resolve_pool_queue() derives the same string. A
+    // generated taskQueue would be a second source that can drift from it.
+    threeWorkerPools.every((p) -> !p.containsKey("taskQueue"))
+  }
+
+  // ── resources / vpa ───────────────────────────────────────────────────────
+
+  ["a pool's resources reach its entry, requests and limits both"] {
+    heavy["resources"]["requests"]["memory"] == "4Gi" &&
+      heavy["resources"]["limits"]["memory"] == "16Gi"
+  }
+
+  ["a pool declaring no resources emits no resources key"] {
+    !coldTier.containsKey("resources")
+  }
+
+  ["a pool's VPA reaches its entry"] {
+    heavy["vpa"]["enabled"] == true &&
+      heavy["vpa"]["updateMode"] == "Auto" &&
+      heavy["vpa"]["maxAllowed"]["memory"] == "16Gi"
+  }
+
+  ["a pool that declares no VPA emits no vpa key — the chart then never clamps it"] {
+    !coldTier.containsKey("vpa")
+  }
+
+  // ── Emitted-but-not-yet-honored keys (ARUN-1041) ──────────────────────────
+
+  ["per-pool env is emitted rather than silently dropped"] {
+    // The chart does not read workerPools[].env yet. Emitting it keeps the
+    // contract the declaration of intent and makes the gap visible in the
+    // generated manifest instead of vanishing at render time.
+    heavy["env"]["WORKER_TYPE"] == "heavy"
+  }
+
+  // ── VpaConfig constrains updateMode to the K8s casings ────────────────────
+
+  ["VpaConfig rejects the lowercase off that YAML 1.1 coerces to false"] {
+    module.catch(() -> (new App.VpaConfig { updateMode = "off" }).updateMode) != null
+  }
+
+  ["VpaConfig accepts each canonical K8s casing"] {
+    (new App.VpaConfig { updateMode = "Off" }).updateMode == "Off" &&
+      (new App.VpaConfig { updateMode = "Initial" }).updateMode == "Initial" &&
+      (new App.VpaConfig { updateMode = "Recreate" }).updateMode == "Recreate" &&
+      (new App.VpaConfig { updateMode = "Auto" }).updateMode == "Auto"
+  }
+
+  ["VpaConfig defaults to disabled with no updateMode"] {
+    (new App.VpaConfig {}).enabled == false && (new App.VpaConfig {}).updateMode == null
+  }
+
+  // ── pool keys stay kebab-case, so derived queue names stay valid ──────────
+
+  ["a non-kebab-case pool key is rejected — the chart builds metadata.name from it"] {
+    module.catch(() -> appWith(new App.DeployConfig {
+      pools {
+        ["main"] = new App.Pool {}
+        ["Heavy_Pool"] = new App.Pool {}
+      }
+    }).output.files["atlan.yaml"].value) != null
+  }
+}

--- a/docs/adr/0016-multi-pool-worker-routing.md
+++ b/docs/adr/0016-multi-pool-worker-routing.md
@@ -314,9 +314,35 @@ Implemented in **PR #2351** (application-sdk), which covers:
 - **Phase 4** (BLDX-1375): `@task(pool=...)` decorator; `ATLAN_POOL_<POOL>_QUEUE`
   resolution in `_create_task_activity_wrapper`.
 
+- **Phase 5** (ARUN-1041): wired the contract to the chart. The Helm prerequisite
+  below had landed out-of-repo under a different shape than this ADR assumed —
+  `deploy.workerPools`, a **list** keyed by `name` with a **flat** `keda` block,
+  rather than the contract's `pools:` mapping with `keda.temporal.targetQueueSize`.
+  Nothing read `pools:`. Consequences, all now closed:
+  - Pools after the first were emitted only into the ignored `pools:` block, so a
+    second declared pool was **never staffed** — the failure this ADR set out to
+    prevent. `App.pkl` now renders every pool after the first as a
+    `deploy.workerPools[]` entry and owns the mapping→list and
+    nested→flat-`keda` translation.
+  - `resolve_pool_queue()` read `ATLAN_TASK_QUEUE`, which the chart does not set,
+    so on a chart deployment every `@task(pool=...)` resolved to `None` and its
+    activities silently ran on the workflow's default queue. It now falls back to
+    `task_queue_from_env()`, reproducing the chart's own
+    `atlan-<app>-<deploymentName>-<pool>` byte-for-byte. No `taskQueue` is
+    generated: the pool key stays the single source, derived independently and
+    identically on both sides.
+  - `Pool.vpa` (typed `VpaConfig`) and `KedaConfig.maxReplicaCount` added, so the
+    per-pool knobs CI validates are expressible in the contract instead of
+    reached for through the untyped `overrides` escape hatch.
+
 Tracking:
 - **BLDX-1485** — P016 `PoolKeyMismatch` conformance rule (not yet implemented).
-- Helm chart update (out-of-repo) — hard prerequisite before any production pool is staffed.
+- **ARUN-1041** — chart does not yet honor `workerPools[].env`, `envOverrides`, or
+  `replicaCount`; the toolkit emits them so the gap is visible rather than
+  silently dropped. Also open: `capacityType`,
+  `maxConcurrentActivities`, and `terminationGracePeriodSeconds` are chart-side
+  pool knobs with no typed contract field yet, and app-level `vpa` /
+  `workerResources` still reach `atlan.yaml` only via `deploy.overrides`.
 - Option 3 escalation backstop — separate lower-priority follow-up.
 
 ---

--- a/tests/unit/app/test_task.py
+++ b/tests/unit/app/test_task.py
@@ -768,3 +768,144 @@ class TestTaskPool:
             asyncio.run(wrapper(MagicMock()))
 
         assert mock_exec.call_args.kwargs["task_queue"] == "explicit-cold-queue"
+
+
+class TestTaskPoolChartEnv:
+    """Pool routing under the env the `atlan-app` chart actually sets.
+
+    The chart sets neither ``ATLAN_POOL_<POOL>_QUEUE`` nor ``ATLAN_TASK_QUEUE``.
+    It sets ``ATLAN_APPLICATION_NAME`` + ``ATLAN_DEPLOYMENT_NAME``, and renders a
+    pool's queue as ``atlan-<app>-<deployment>-<pool>``. Before the
+    ``task_queue_from_env`` fallback, every chart-deployed ``@task(pool=...)``
+    resolved to ``None`` and its activities silently ran on the workflow's
+    default queue — the dedicated pool idle while the main worker absorbed the
+    load it existed to offload.
+    """
+
+    @staticmethod
+    def _chart_env(monkeypatch: pytest.MonkeyPatch) -> None:
+        """Exactly the queue-relevant env a chart-deployed pool pod receives."""
+        monkeypatch.delenv("ATLAN_POOL_HEAVY_QUEUE", raising=False)
+        monkeypatch.delenv("ATLAN_TASK_QUEUE", raising=False)
+        monkeypatch.setenv("ATLAN_APPLICATION_NAME", "automation-engine")
+        monkeypatch.setenv("ATLAN_DEPLOYMENT_NAME", "default")
+
+    def test_pool_queue_matches_the_chart_derivation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Derived queue is byte-identical to the chart's own formula.
+
+        The chart renders ``atlan-%s-%s-%s`` from name/deploymentName/pool
+        (``subcharts/atlan-app/templates/deployment.yaml``). Pinning the literal
+        here is the point: if either side's formula changes, routed activities
+        land on a queue no worker polls, and that is invisible at deploy time.
+        """
+        from application_sdk.app.registry import resolve_pool_queue
+
+        self._chart_env(monkeypatch)
+        assert resolve_pool_queue("heavy") == "atlan-automation-engine-default-heavy"
+
+    def test_hyphenated_pool_name_survives_derivation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A kebab-case pool key is appended verbatim, not underscore-normalised.
+
+        Underscore normalisation applies only to the env-var KEY lookup; the
+        queue itself keeps the hyphen so it matches the chart, which interpolates
+        the pool name straight into the queue string.
+        """
+        from application_sdk.app.registry import resolve_pool_queue
+
+        self._chart_env(monkeypatch)
+        monkeypatch.delenv("ATLAN_POOL_COLD_TIER_QUEUE", raising=False)
+        assert (
+            resolve_pool_queue("cold-tier")
+            == "atlan-automation-engine-default-cold-tier"
+        )
+
+    def test_explicit_env_still_outranks_the_chart_derivation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The new fallback is last, so it cannot shadow an explicit override."""
+        from application_sdk.app.registry import resolve_pool_queue
+
+        self._chart_env(monkeypatch)
+        monkeypatch.setenv("ATLAN_POOL_HEAVY_QUEUE", "operator-pinned-queue")
+        assert resolve_pool_queue("heavy") == "operator-pinned-queue"
+
+    def test_atlan_task_queue_still_outranks_the_chart_derivation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicit base queue keeps winning over the derived one."""
+        from application_sdk.app.registry import resolve_pool_queue
+
+        self._chart_env(monkeypatch)
+        monkeypatch.setenv("ATLAN_TASK_QUEUE", "local-dev-queue")
+        assert resolve_pool_queue("heavy") == "local-dev-queue-heavy"
+
+    def test_no_app_name_still_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Nothing nameable in the env → None, not a manufactured queue.
+
+        ``derive_task_queue`` refuses to invent a queue without an app name, and
+        the fallback must not paper over that with a bare ``-heavy``.
+        """
+        from application_sdk.app.registry import resolve_pool_queue
+
+        monkeypatch.delenv("ATLAN_POOL_HEAVY_QUEUE", raising=False)
+        monkeypatch.delenv("ATLAN_TASK_QUEUE", raising=False)
+        monkeypatch.delenv("ATLAN_APPLICATION_NAME", raising=False)
+        monkeypatch.delenv("ATLAN_DEPLOYMENT_NAME", raising=False)
+        assert resolve_pool_queue("heavy") is None
+
+    def test_app_name_without_deployment_drops_the_prefix(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """App name alone derives the bare ``{app}`` base, per derive_task_queue."""
+        from application_sdk.app.registry import resolve_pool_queue
+
+        monkeypatch.delenv("ATLAN_POOL_HEAVY_QUEUE", raising=False)
+        monkeypatch.delenv("ATLAN_TASK_QUEUE", raising=False)
+        monkeypatch.delenv("ATLAN_DEPLOYMENT_NAME", raising=False)
+        monkeypatch.setenv("ATLAN_APPLICATION_NAME", "automation-engine")
+        assert resolve_pool_queue("heavy") == "automation-engine-heavy"
+
+    def test_dispatch_path_routes_to_the_chart_queue(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End-to-end through the real wrapper, not just the resolver.
+
+        Calls _create_task_activity_wrapper so closure capture and kwarg
+        threading are covered too — the resolver being right is not the same as
+        the dispatched activity carrying the right queue.
+        """
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from application_sdk.app.base import _create_task_activity_wrapper
+
+        self._chart_env(monkeypatch)
+
+        with patch(
+            "application_sdk.execution._temporal.eviction_retry.execute_activity_with_eviction_retry",
+            new_callable=AsyncMock,
+        ) as mock_exec:
+            mock_exec.return_value = MagicMock()
+            wrapper = _create_task_activity_wrapper(
+                app_name="automation-engine",
+                task_name="analyse-heavy",
+                timeout_seconds=600,
+                retry_max_attempts=3,
+                retry_max_interval_seconds=30,
+                output_type=SimpleOutput,
+                context_data={"run_id": "r1", "correlation_id": "c1"},
+                pool="heavy",
+            )
+            import asyncio
+
+            asyncio.run(wrapper(MagicMock()))
+
+        assert (
+            mock_exec.call_args.kwargs["task_queue"]
+            == "atlan-automation-engine-default-heavy"
+        )


### PR DESCRIPTION
`workerPools` entries in `atlan.yaml` were unvalidated, so sizes the infra cannot honour reached Helm apply - the 40Gi pool memory request in ARUN-1041 among them. This adds rules 11-15 to `config_validator`, applying the existing infra ceilings per pool plus a 10-pool cap and identity checks. 134 tests pass (97 existing, 37 new); the live `atlan-publish-app` pool config validates clean.

Linear: [ARUN-1041](https://linear.app/atlan-epd/issue/ARUN-1041/add-validation-for-workerpool-taskqueues-in-atlanyaml)

## Rules added

| # | Rule | Rule id |
|---|---|---|
| 11 | `len(workerPools) <= 10` | `worker_pool_count_ceiling` |
| 12 | Per pool: rules 2-8 against the pool's own `resources` / `vpa` | existing ids, pool-prefixed fields |
| 13 | Per pool: rule 9 against the pool's own `keda` | `keda_min_le_max` |
| 14 | `name` present; `name` and `taskQueue` unique across pools | `worker_pool_name_required`, `worker_pool_name_duplicate`, `worker_pool_task_queue_duplicate` |
| 15 | Declared pools require split + TWC | `worker_pools_require_split_twc` |

Violations report indexed paths, e.g. `workerPools[1].resources.requests.memory`.

## Why the pool rules are not just the app-level rules re-pointed

Three fallback chains differ in the chart (`atlanhq/atlan` `subcharts/atlan-app`), and getting them wrong produces false positives in a blocking CI gate:

- **`pool.resources` replaces, not merges.** `deployment.yaml` renders `toYaml $pool.resources`, so a pool declaring only `requests` inherits no limits from `workerResources`/`resources`.
- **Pool VPA is gated on the pool's own `vpa.enabled`.** `vpa.yaml` does not fall back to the app-level flag, so a pool that never opted in is never clamped. Its `updateMode` does fall back (pool -> app -> `"Auto"`), so an undeclared mode still clamps. Its `maxAllowed` falls back as a whole dict (pool -> app -> `{cpu: 2000m, memory: 6Gi}`), so a pool declaring only `memory` leaves cpu uncapped.
- **Pool `keda.targetQueueSize` is flat**, not nested under `temporal` (`deployment.yaml:149`).

The shared helpers (`_parse_vpa`, `_check_vpa`, `_check_keda`, `_check_resource_block`) now take a field-path label so app-level and per-pool checks stay one implementation rather than a parallel copy.

## Rule 11: why 10, and why it is 2x worse than it looks

Every pool TWD also declares an on-demand (`-od`) mirror variant, so N pools cost Temporal 2N worker-deployment children on top of the main worker. At 100+ apps an unbounded per-app tier count is what makes TWD reconciliation unmanageable.

## Rule 15: gating choice

Pools render only under `splitDeploymentEnabled && temporalWorkerDeployment.enabled` (`deployment.yaml:22`); both chart defaults are `false`. The magnitude rules run regardless, and rule 15 additionally flags the block as inert - the same reasoning as rule 1b, and the failure mode ARUN-1041 raises: activities routed to a queue no worker polls hang the workflow rather than failing.

This uses `is not True` rather than the explicit-false-only test rule 1 uses, because here a missing flag drops the block just as an explicit `false` does. The CI driver runs SDK flag injection first (both true for SDK >= 2.7.4), so this fires on apps that opt out explicitly or sit below the TWC floor.

## Verification

- `uv run pytest .github/scripts/tests/test_config_validator.py` - 134 passed (97 existing, 37 new). Test file is append-only (560 insertions, 0 deletions).
- Mutation-checked: reverting `MAX_WORKER_POOLS` to 100 and the pool VPA default to 18Gi fails the two tests that pin them, so the new tests bite.
- `uv run pre-commit run --files ...` - ruff, ruff-format, isort, pyright all pass.

### Against live app configs

Run through the real CI path - `deploy:` block extracted as `parse_atlan_yaml` does it, SDK version read from each app's own `uv.lock`, then `inject_sdk_version_flags` before `validate_config`:

| App | SDK | Pools | Result |
|---|---|---|---|
| `atlan-publish-app` | 3.11.0 | 1 (`metastore-od`, pool VPA off) | PASS |
| `atlan-automation-engine-app` | 3.19.0 | 1 (`heavy`, pool VPA on, maxAllowed 16Gi) | PASS |
| `atlan-redshift-app` | 3.28.2 | 0 | PASS |

### Fleet-wide: every `-app` repo in the org

All 170 non-archived `atlanhq/*-app` repos, same real CI path (SDK pin read from each repo's own `uv.lock`):

| | Count |
|---|---|
| `-app` repos (non-archived) | 170 |
| no root `atlan.yaml` - CI never validates these | 25 |
| **with a `deploy:` block** | **145** |
| validate clean | 144 |
| skipped, no SDK pin in `uv.lock` (driver skips these too) | 1 |
| **violations, any rule, existing or new** | **0** |

**No app in the fleet regresses.** Zero violations from the new rules, and zero from the existing rules 1-10 as a side observation.

Only 4 of 145 apps declare `workerPools` today, so this gate is preventive rather than remedial:

| App | SDK | Pools | Result |
|---|---|---|---|
| `atlan-automation-engine-app` | 3.19.0 | 1 (`heavy`) | PASS |
| `atlan-publish-app` | 3.11.0 | 1 (`metastore-od`) | PASS |
| `atlan-query-intelligence-app` | 2.8.7 | 1 (`heavy`) | PASS |
| `atlan-system-workflows-app` | 3.28.3 | 1 (`sqe`) | PASS |

Two notes from that sweep:

- `atlan-system-workflows-app` declares a pool with `splitDeploymentEnabled: true` but **no `temporalWorkerDeployment` block at all**. It passes only because it is on SDK 3.28.3, where flag injection supplies `temporalWorkerDeployment.enabled: true`. On an SDK below the 2.7.4 TWC floor the same file would trip rule 15 - correctly, since the chart would drop the pool.
- `atlan-data-product-score-app` is the one skip: no `atlan-application-sdk` pin in its `uv.lock`, so the driver skips validation before reaching any rule. Probed against hypothetical 3.28.3 and 2.7.4 pins it would pass either way, so the skip hides nothing.

The sweep harness was itself checked by seeding 11 pools at 40Gi into one app's config: it reported `worker_pool_count_ceiling` plus 11 `requests_memory_ceiling` violations, so the clean fleet result is a real pass, not a silent no-op.

No false positives. To confirm the pass is not vacuous, each rule was then fired by perturbing those same configs:

| Perturbation | Rules raised |
|---|---|
| AE `heavy` request -> 40Gi (the ARUN-1041 example) | `requests_memory_ceiling`, `requests_exceeds_vpa_max_memory`, `requests_le_limits` |
| AE `heavy` `vpa.maxAllowed.memory` -> 40Gi | `vpa_max_memory_ceiling` |
| AE `heavy` request 20Gi, above its own 16Gi maxAllowed | `requests_exceeds_vpa_max_memory` |
| AE fanned out to 11 tiers | `worker_pool_count_ceiling` |
| AE `heavy` declared twice | `worker_pool_name_duplicate`, `worker_pool_task_queue_duplicate` |
| publish with `splitDeploymentEnabled: false` | `worker_pools_require_split_twc` |
| publish with `temporalWorkerDeployment.enabled: false` | `worker_pools_require_split_twc` (+ the existing `twc_required_for_split`) |

## Out of scope, needs a decision

`DEFAULT_VPA_MAX_MEMORY_BYTES` is `18Gi`, but the chart's app-level `vpa.maxAllowed` default is `6Gi` (`vpa.yaml:104`; cpu `2000m` matches). Rule 6 is therefore ~3x too lenient today for apps that enable VPA without declaring `maxAllowed`. Not touched here: correcting it would newly fail configs that pass on `main`, which is a behaviour change beyond this ticket. The new pool constant uses the chart-accurate `6Gi`, hence two separate default constants with a comment explaining why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
