### PR TITLE
ci(loop): load the review playbook by lane and scope, not all of it every time

### DIFF
--- a/.github/scripts/tests/test_review_playbook_sections.py
+++ b/.github/scripts/tests/test_review_playbook_sections.py
@@ -127,3 +127,28 @@ def test_the_context_budget_binds_whoever_reviews() -> None:
         "§1c must keep the measured reasons for the ceiling — without them the "
         "next reader raises it to the model's context window"
     )
+
+
+def test_the_conflicting_rule_stays_in_the_router() -> None:
+    """`NEEDS_REBASE` is a terminal verdict on the LOOP lane —
+    `VERDICTS_TERMINAL` in sdk_loop_common.py, acted on in sdk_loop_phase.py.
+    An early draft of the split filed all of step 8 behind a "mothership only"
+    pointer, which would have left the loop lane with no instruction to emit
+    that verdict: a conflicted PR would draw ordinary findings, no
+    `sdk-review-needs-rebase` label, and the loop would spend rounds on a
+    branch no resolve phase can move. Only the sandbox-only BEHIND update
+    belongs in a section file.
+    """
+    router = _router()
+    step8 = router[router.index("8. **Branch freshness") :][:2600]
+    assert "NEEDS_REBASE" in step8, (
+        "the CONFLICTING -> NEEDS_REBASE rule must stay inline: both lanes need "
+        "it and the loop lane's terminal-verdict handling depends on it"
+    )
+    assert "BOTH LANES" in step8
+    section = (SECTIONS / "branch-freshness.md").read_text(encoding="utf-8")
+    assert "update-branch" in section, "the BEHIND update belongs in the section"
+    assert "CONFLICTING" not in section.split("NOTE")[0].split("\n8.")[1], (
+        "the CONFLICTING path must not be duplicated into the section file — "
+        "two copies of a verdict rule drift"
+    )

--- a/.github/scripts/tests/test_review_playbook_sections.py
+++ b/.github/scripts/tests/test_review_playbook_sections.py
@@ -191,9 +191,9 @@ def test_the_toolkit_section_is_gated_on_lane_not_just_scope() -> None:
     router = _router()
     idx = router.index("sections/toolkit-consumer-setup.md")
     stanza = router[max(0, idx - 400) : idx + 1800]
-    assert "mothership sandbox" in stanza, (
-        "the 1b-toolkit pointer no longer restricts consumer cloning to the "
-        "sandbox lane"
+    assert "requires: clone-private" in stanza, (
+        "the 1b-toolkit pointer no longer restricts consumer cloning to lanes "
+        "that can actually clone private repos"
     )
     assert "TOOLKIT_ROVER_NOTE" in stanza, (
         "the loop lane lost its fallback — without the Rover note, a toolkit "
@@ -202,3 +202,75 @@ def test_the_toolkit_section_is_gated_on_lane_not_just_scope() -> None:
     )
     section = (SECTIONS / "toolkit-consumer-setup.md").read_text(encoding="utf-8")
     assert "mothership sandbox only" in section
+
+
+#: Every capability the Runtime table defines. A step may only cite one of
+#: these — a typo'd capability resolves to nothing and the step runs everywhere.
+CAPABILITIES = {
+    "write-branch",
+    "clone-private",
+    "reach-proxy",
+    "given-scope",
+    "given-delta",
+    "needs-run-guards",
+}
+
+#: Steps that were lane-conditional before the redesign, by a stable anchor in
+#: their text. Each must still resolve against the Runtime table. Losing an
+#: annotation is silent: the step simply runs on a lane that cannot perform it,
+#: which is run 33500595871 exactly.
+LANE_CONDITIONAL_STEPS = {
+    "4b–5. **Run guards**": "needs-run-guards",
+    "6b/6c. **Prior review": "given-delta",
+    "**If `BEHIND`:**": "write-branch",
+    "11. **Smart agent routing.**": "given-scope",
+    "### 1b-toolkit.": "clone-private",
+    "### 2b. Wave 2": "reach-proxy",
+}
+
+
+def test_the_runtime_table_defines_every_capability() -> None:
+    """The matrix is the single axis every lane-conditional step resolves
+    against. A step citing a capability the table does not define resolves to
+    nothing, and "resolves to nothing" reads exactly like "no condition"."""
+    runtime = _router().split("## Runtime")[1].split("## Time Budgets")[0]
+    for cap in CAPABILITIES:
+        assert f"`{cap}`" in runtime, f"Runtime table does not define {cap}"
+    assert "mothership sandbox" in runtime and "sdk-loop" in runtime
+
+
+def test_every_lane_conditional_step_still_names_a_capability() -> None:
+    """The redesign's real risk. Before it, lane differences were spelled out
+    inline at each step; after it they are one word that has to be there. Two
+    bugs found today came from a step gated on the wrong axis — CONFLICTING
+    gated on lane when it needed neither, toolkit cloning gated on scope when
+    the credential decides. This asserts the mapping the matrix replaced."""
+    router = _router()
+    for anchor, capability in LANE_CONDITIONAL_STEPS.items():
+        assert anchor in router, f"step anchor vanished: {anchor!r}"
+        idx = router.index(anchor)
+        window = router[idx : idx + 1200]
+        assert capability in window, (
+            f"step {anchor!r} no longer names `{capability}` — it will run on "
+            "a lane that cannot perform it"
+        )
+
+
+def test_no_step_cites_an_undefined_capability() -> None:
+    """A typo'd tag is worse than a missing one: it looks gated and is not."""
+    cited = set(re.findall(r"(?:requires|given): ([a-z-]+)", _router()))
+    unknown = cited - CAPABILITIES
+    assert not unknown, f"steps cite capabilities the Runtime table lacks: {unknown}"
+
+
+def test_rationale_lives_outside_the_agent_context() -> None:
+    """DESIGN.md is maintainer-facing and must never enter a review's context:
+    it is not in Phase 0 step 6's read list and nothing may point the agent at
+    it. Rationale in the playbook is paid for on every turn after the read."""
+    design = (PLAYBOOK_DIR / "DESIGN.md").read_text(encoding="utf-8")
+    assert "The agent never reads this file" in design
+    router = _router()
+    step6 = router[router.index("6. **Read in-repo") : router.index("6b/6c.")]
+    assert "DESIGN.md" not in step6, "DESIGN.md must not be in the read list"
+    claude = (PLAYBOOK_DIR / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "DESIGN.md" not in claude

--- a/.github/scripts/tests/test_review_playbook_sections.py
+++ b/.github/scripts/tests/test_review_playbook_sections.py
@@ -177,3 +177,28 @@ def test_the_mandatory_read_list_stays_deduplicated() -> None:
     # And CLAUDE.md must not resurrect its blanket references/*.md read.
     claude = (PLAYBOOK_DIR / "CLAUDE.md").read_text(encoding="utf-8")
     assert "4. `.mothership/pr-review/references/*.md`" not in claude
+
+
+def test_the_toolkit_section_is_gated_on_lane_not_just_scope() -> None:
+    """Run 33500595871 (a contract-toolkit PR on @sdk-loop) followed 1b-toolkit
+    into cloning five private consumer repos. The lane's App token is scoped to
+    this repository, git has no other credential helper on the runner, so all
+    five died with `could not read Username` — and the phase was later killed
+    by the idle watchdog with no verdict. A scope-only gate re-creates that run
+    on the next toolkit PR; the pointer must also gate on lane and hand the
+    loop lane its fallback.
+    """
+    router = _router()
+    idx = router.index("sections/toolkit-consumer-setup.md")
+    stanza = router[max(0, idx - 400) : idx + 1800]
+    assert "mothership sandbox" in stanza, (
+        "the 1b-toolkit pointer no longer restricts consumer cloning to the "
+        "sandbox lane"
+    )
+    assert "TOOLKIT_ROVER_NOTE" in stanza, (
+        "the loop lane lost its fallback — without the Rover note, a toolkit "
+        "PR on @sdk-loop either dies cloning or approves without saying the "
+        "cross-repo validation never ran"
+    )
+    section = (SECTIONS / "toolkit-consumer-setup.md").read_text(encoding="utf-8")
+    assert "mothership sandbox only" in section

--- a/.github/scripts/tests/test_review_playbook_sections.py
+++ b/.github/scripts/tests/test_review_playbook_sections.py
@@ -103,3 +103,27 @@ def test_the_sections_index_lists_every_section() -> None:
             f"{name} is missing from the 'Conditional sections' index at the top "
             "of ORCHESTRATION.md"
         )
+
+
+def test_the_context_budget_binds_whoever_reviews() -> None:
+    """§1c's ceiling was written as "per agent call", from when every review
+    fanned out. §2a now routes a single-specialist scope to the primary agent,
+    and on twelve of fourteen measured @sdk-loop runs nothing was dispatched at
+    all — so the only input cap in the playbook governed a code path those
+    reviews never took and the primary's context went unbounded.
+
+    That matters twice over, and both are measured: turn latency on the review
+    model climbs from ~10s to 75-90s by turn 12 as context accumulates, and
+    xai/grok-4.6 doubles its per-token rate above a 200K context.
+    """
+    router = _router()
+    budget = router[router.index("### 1c.") : router.index("## Phase 2")]
+    assert (
+        "dispatched agent or not" in budget
+    ), "§1c's budget must bind the inline reviewer, not only a dispatched agent"
+    # The ceiling exists because of latency and price, not because of the
+    # model's window. Losing that reasoning is how it gets raised to the window.
+    assert "200K" in budget and "75-90s" in budget, (
+        "§1c must keep the measured reasons for the ceiling — without them the "
+        "next reader raises it to the model's context window"
+    )

--- a/.github/scripts/tests/test_review_playbook_sections.py
+++ b/.github/scripts/tests/test_review_playbook_sections.py
@@ -152,3 +152,28 @@ def test_the_conflicting_rule_stays_in_the_router() -> None:
         "the CONFLICTING path must not be duplicated into the section file — "
         "two copies of a verdict rule drift"
     )
+
+
+def test_the_mandatory_read_list_stays_deduplicated() -> None:
+    """Round 2 of the trim removed two whole-file reads from Phase 0 step 6:
+    review-policy.md (merged into retro-log.md, which CLAUDE.md declares the
+    ONLY do-not-flag list) and review.yaml (a paraphrase of the rubric and
+    CLAUDE.md). Each was a tool call plus ~750 tokens on every review. The
+    regression this guards is the quiet re-add — one line in a read list looks
+    harmless, and nothing else would fail.
+    """
+    router = _router()
+    step6 = router[router.index("6. **Read in-repo") : router.index("6b/6c.")]
+    assert "- `.mothership/review-policy.md`" not in step6
+    assert "- `.mothership/review.yaml`" not in step6
+    # The merge target must actually carry the merged content, or the
+    # by-design patterns silently stop protecting anything.
+    retro = (PLAYBOOK_DIR / "references" / "retro-log.md").read_text(encoding="utf-8")
+    assert "By-design patterns" in retro
+    assert "ThreadPoolExecutor" in retro, (
+        "review-policy.md's patterns are gone from retro-log.md — the "
+        "do-not-flag merge has been undone without a replacement"
+    )
+    # And CLAUDE.md must not resurrect its blanket references/*.md read.
+    claude = (PLAYBOOK_DIR / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "4. `.mothership/pr-review/references/*.md`" not in claude

--- a/.github/scripts/tests/test_review_playbook_sections.py
+++ b/.github/scripts/tests/test_review_playbook_sections.py
@@ -1,0 +1,105 @@
+"""The review playbook is split into a router plus conditional sections.
+
+An orphaned section is SILENT. Nothing errors, no check goes red — the agent
+simply never reads it, the review quietly loses whatever that file governed,
+and the verdict comes back as confident as ever. That is the same failure shape
+`review_subagents` already refuses to trust for `{file:...}` templates, and it
+is why these invariants are asserted rather than assumed.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+PLAYBOOK_DIR = pathlib.Path(__file__).resolve().parents[3] / ".mothership/pr-review"
+ROUTER = PLAYBOOK_DIR / "ORCHESTRATION.md"
+SECTIONS = PLAYBOOK_DIR / "sections"
+
+#: Chars per token, near enough for a budget guard. The point of the number is
+#: to fail when someone re-inlines a large block, not to be exact.
+CHARS_PER_TOKEN = 4
+
+#: What the router may cost before it stops being a router. Set above today's
+#: measured size with room to grow, and far below the 20.6K it replaced.
+ROUTER_TOKEN_CEILING = 16_000
+
+
+def _router() -> str:
+    return ROUTER.read_text(encoding="utf-8")
+
+
+def _section_files() -> set[str]:
+    return {p.name for p in SECTIONS.iterdir() if p.suffix == ".md"}
+
+
+def _referenced() -> set[str]:
+    return set(re.findall(r"sections/([a-z0-9-]+\.md)", _router()))
+
+
+def test_every_section_is_reachable_from_the_router() -> None:
+    """A section nobody points at is dead text that still has to be maintained,
+    and its absence from a review is invisible."""
+    orphaned = _section_files() - _referenced()
+    assert not orphaned, (
+        f"section file(s) not referenced from ORCHESTRATION.md: {sorted(orphaned)}. "
+        "Add a pointer, or delete the file."
+    )
+
+
+def test_every_pointer_resolves_to_a_file() -> None:
+    """A pointer to a missing file sends the agent to read nothing, and the
+    Read simply fails mid-phase — after the turn has been paid for."""
+    dangling = _referenced() - _section_files()
+    assert (
+        not dangling
+    ), f"ORCHESTRATION.md points at missing section(s): {sorted(dangling)}"
+
+
+def test_every_pointer_states_its_condition() -> None:
+    """The whole saving is conditional loading. A pointer that does not say
+    WHEN to read the file gets read every time, which is the state this split
+    exists to leave — so each one must carry a condition the agent can evaluate.
+    """
+    # Everything before "## Runtime" is the index, which states conditions in
+    # its own table. The pointers under test are the ones at the STEP that owns
+    # each section — those are what the agent hits mid-phase, and those are the
+    # ones that have to carry the condition.
+    body = _router().split("## Runtime", 1)[1]
+    for name in sorted(_referenced()):
+        assert f"sections/{name}" in body, (
+            f"{name} is only referenced from the index, not from the step that "
+            "owns it — the agent reaching that step would not know to read it"
+        )
+        idx = body.index(f"sections/{name}")
+        stanza = body[max(0, idx - 700) : idx + 400]
+        # One literal phrase, not a vocabulary of near-synonyms. A regex that
+        # accepts several phrasings drifts into accepting prose that states no
+        # condition at all, which is precisely the thing being guarded.
+        assert (
+            "read only when:" in stanza.lower()
+        ), f"the pointer to {name} carries no `Read only when:` condition"
+
+
+def test_the_router_stays_a_router() -> None:
+    """The failure this guards is re-inlining: someone moves a section back for
+    convenience and the loaded prompt silently returns to its old size. The
+    playbook was ~20.6K tokens before the split and every review paid all of
+    it, on both lanes, regardless of scope."""
+    size = len(_router()) // CHARS_PER_TOKEN
+    assert size < ROUTER_TOKEN_CEILING, (
+        f"ORCHESTRATION.md is ~{size} tokens, over the {ROUTER_TOKEN_CEILING} "
+        "ceiling. Move a conditional block into sections/ rather than raising it."
+    )
+
+
+def test_the_sections_index_lists_every_section() -> None:
+    """The index is what a reader scans to decide what to skip. One missing row
+    means a section that is only discoverable by reading to the step that owns
+    it — which defeats reading less."""
+    index = _router().split("## Runtime")[0]
+    for name in sorted(_section_files()):
+        assert name in index, (
+            f"{name} is missing from the 'Conditional sections' index at the top "
+            "of ORCHESTRATION.md"
+        )

--- a/.mothership/pr-review/CLAUDE.md
+++ b/.mothership/pr-review/CLAUDE.md
@@ -10,11 +10,18 @@ COMMENTER_INTENT, etc.). Follow
 
 ## Critical Files to Read First
 
-1. `.mothership/pr-review/ORCHESTRATION.md` — your playbook (MANDATORY)
-2. `.mothership/pr-review/severity-rubric.yaml` — pattern → severity map + severity calibration and confidence floors (single source for both)
-3. `.mothership/pr-review/references/retro-log.md` — **MANDATORY: do-not-flag list.** Every candidate finding MUST be checked against the patterns here; matches are withdrawn silently with no inline comment or auto-fix. This is the ONLY do-not-flag list — no other file may carry one.
-4. `.mothership/pr-review/references/*.md` + `agents/*.md`
-5. For `contract-toolkit/**` PRs: `contract-toolkit/AGENTS.md`, `.mothership/pr-review/agents/toolkit-review.md`, and `.mothership/pr-review/references/toolkit-consumer-registry.md`
+1. `.mothership/pr-review/ORCHESTRATION.md` — your playbook (MANDATORY).
+   Its Phase 0 step 6 is the ONLY read list; this file does not keep a
+   competing one. (An earlier revision here said to read `references/*.md`
+   and every agent brief — directly against §6d, which defers references to
+   whoever reviews that domain, and worth ~125 KB of context per review.)
+2. `.mothership/pr-review/severity-rubric.yaml` — pattern → severity map +
+   severity calibration and confidence floors (single source for both)
+3. `.mothership/pr-review/references/retro-log.md` — **the ONLY do-not-flag
+   list** (by-design patterns included). Whoever raises findings — a
+   dispatched specialist, or you when reviewing a domain inline — MUST check
+   candidates against it and withdraw matches silently. No other file may
+   carry a do-not-flag list.
 
 PR metadata and the authoritative diff are fetched in Phase 0 via
 `gh pr view` / `gh pr diff` and written to `/tmp/PR.json` and

--- a/.mothership/pr-review/DESIGN.md
+++ b/.mothership/pr-review/DESIGN.md
@@ -1,0 +1,126 @@
+# SDK Review — Design rationale (maintainers only)
+
+**The agent never reads this file.** It is not in Phase 0 step 6's read list
+and must not be added to it. ORCHESTRATION.md is the agent-facing contract:
+every rule, command, table, template and marker — and nothing else. The *why*
+behind each rule lives here, because rationale in the playbook is paid for at
+runtime on every review, on every turn after the read, and the 2026-09-01
+measurements put that price at 75-90s per turn once context accumulates.
+
+If you change a rule in ORCHESTRATION.md, record the reasoning here, not
+there. If a rule looks arbitrary, this file says which incident made it.
+
+## Why the playbook is terse
+
+Three rounds of measured trimming (FND-1232):
+
+1. Six conditional blocks moved to `sections/` behind lane/scope gates
+   (~7.7K tokens off a conformance review).
+2. Satellite reads collapsed: `review-policy.md` merged into `retro-log.md`
+   (one do-not-flag list, as CLAUDE.md always claimed); `review.yaml`
+   delisted (paraphrase of the rubric + CLAUDE.md).
+3. This file: rationale out of agent context. External calibration:
+   PR-Agent's whole rendered `/review` prompt is ~1,428 tokens.
+
+## Incident index — what taught each rule
+
+- **Lane marker (`LANE: sdk-loop`), Runtime**: an agent spent a paid turn on
+  `ls -la /workspace/application-sdk || echo NO` inferring its lane; wrong
+  inferences walk the other lane's steps and eat 403s. The marker string is
+  pinned by `test_the_lane_marker_matches_the_playbook_contract` — two files,
+  one string; do not loosen the test.
+- **"Do not warm dependencies" (Phase 0 step 1)**: `uv sync --all-extras` sat
+  here for months buying nothing — this playbook never runs pytest or
+  pre-commit (step 9) — and competed with the review for I/O on every run.
+  `pr-resolve` and `sdk-evolution` DO warm deps; they run tests.
+- **Budget clock (step 1b, Time Budgets)**: before the clock existed the
+  budget rules were unevaluable and never fired; a Small-tier PR (15-min hard
+  stop) ran 62 minutes. The heredoc-at-column-0 warning: an indented
+  terminator hangs the shell waiting for input.
+- **Glob/grep over `.mothership/**` (step 6)**: ripgrep skips
+  dot-directories, so `Glob ".mothership/pr-review/agents/*.md"` returns 0
+  matches. Two measured runs burned a turn on that; worse, an agent that
+  greps the reference rules for prior art, gets nothing, and concludes there
+  is none raises a finding the rules already answer.
+- **references/*.md deferred (§6d)**: ~125 KB, the single largest input.
+  Reading it up front loaded ALL of it for EVERY review; a `minor` PR
+  dispatches only `correctness` and paid for nine files to use two. Ownership
+  derives from each agent's Domain Tags (`[SEC]` → security-rules, …); a file
+  owned by two agents is read by both — separate contexts, sharing costs
+  nothing. §1b-toolkit reads `toolkit-consumer-registry.md` directly because
+  it needs the registry before any agent is dispatched.
+- **Single mode (step 7)**: `COMMENTER_INTENT` is ignored because parsing
+  free-form commands out of PR comments is an injection surface — there are
+  deliberately no auto-fix/stop/challenge/override/focus modes.
+- **CONFLICTING stays inline (step 8)**: an early draft of the sections split
+  filed all of step 8 behind a "sandbox only" pointer. `NEEDS_REBASE` is a
+  terminal verdict on the LOOP lane (`VERDICTS_TERMINAL`,
+  sdk_loop_common.py); gated behind that pointer, a conflicted PR on
+  @sdk-loop would draw ordinary findings and the loop would spend rounds on a
+  branch no resolve phase can move. Pinned by
+  `test_the_conflicting_rule_stays_in_the_router`.
+- **`update-branch` tension (sections/branch-freshness.md)**: it writes to
+  the PR branch while Runtime states the review never writes on either lane.
+  Both sentences are live; moot on @sdk-loop (no write scope; FND-1185 moved
+  branch duty to prep), unresolved on the sandbox. A human decision, not a
+  reviewer's.
+- **"Do not read CI" (step 9)**: the review cannot act on a check, CI legs
+  routinely finish AFTER a review posts (so a reviewer-side snapshot was a
+  stale fact next to a verdict it could not influence), and
+  `sdk-review-downgrade-on-ci-failure.yml` enforces CI event-driven — the
+  only race-free way. Under @sdk-loop, prep owns branch/check state.
+- **Scope handed to the loop lane (step 11)**: the harness computes
+  `review_scope` in Python (same file-list arithmetic); re-deriving it spends
+  a turn to reach the answer already in hand.
+- **Context ceiling binds the inline reviewer (§1c)**: written "per agent
+  call" when every review fanned out; on 12 of 14 measured runs nothing was
+  dispatched, so the only cap governed a path those reviews never took.
+  Kept at 100K, not the model window: turn latency climbs ~10s → 75-90s by
+  turn 12 as context grows, and grok-4.6 doubles its rate above 200K
+  context. PR-Agent caps at 32K citing degradation; ours is looser
+  deliberately — lowering it changes what the review sees and needs a trial.
+- **Toolkit consumer setup gated on lane (1b-toolkit)**: run 33500595871
+  (PR #3594) followed it into cloning five private repos on @sdk-loop; the
+  scoped App token cannot, all five died with `could not read Username`, and
+  the idle watchdog killed the phase with no verdict. Scope said "toolkit"
+  but feasibility is decided by the credential — a lane property.
+- **Last decision point before dispatch (§2a)**: a dispatch cannot be
+  interrupted; 43 minutes elapsed inside a single dispatch against a 15-min
+  hard stop, and the budget's `OVER HARD STOP` printed to nobody who could
+  act. Hence: measure BEFORE dispatching, degrade by percentage.
+- **Class sweep (§2d)**: a single revert-scope bug cost five review rounds
+  because each round fixed the one reported instance, never the class.
+  Reviewer-only: the conformance remediation loop's per-site independence is
+  a feature — clustering fixes there trades robustness for a round-count
+  problem that loop doesn't have. `class:` stays prose-only because the
+  Phase 3a schema 422s on unknown fields.
+- **Nit convergence (§2e′) and the strict verdict (§2h)**: the resolver loops
+  until `### Findings` is empty, nits included. A reviewer that mines fresh
+  pre-existing nits each pass — or lists observations with no action — makes
+  that loop non-terminating and withholds approval indefinitely. Approving
+  over an open nit made the reviewer the looser bar of the two and left the
+  resolver working on a stamped PR. Downgrading an Important to a Nit no
+  longer buys an approval, so an accepted finding is dropped with a reason,
+  not demoted.
+- **Toolkit inline bodies staged to files (3b, 3f)**: the redaction gate
+  scans staged files; a body posted from memory bypasses it. The gate exempts
+  hex control markers because it once rewrote `<!-- REVIEWED_HEAD -->` to
+  `[private sha]`, sdk_review_approve.py read "no marker", skipped every
+  label and the approval, and exited 0 — a green run on an unapproved PR.
+- **Summary posted LAST (3f)**: it is the completion signal —
+  `sdk-review-approve-on-verdict.yml` fires on it, the soft-success check
+  treats it as "delivered", the §6b replay guard reads its footer. Posted
+  first, all three read a partial submission as a complete one.
+- **ANSWERS_TRIGGER (3e, 3f)**: two reviews can be outstanding on one PR
+  (sandbox runs up to 2h; resolver waits 40 min per round; humans re-tag
+  mid-review), so a verdict's timestamp cannot say which request it answers.
+  The resolver's push guard reads the marker; an EMPTY marker is worse than
+  none (reads as "names a round, not yours" and holds the push for the full
+  stale window) — hence stamp-then-delete-if-blank.
+- **REVIEWED_HEAD sed net (3f)**: repairs only the literal `<HEAD_SHA>`
+  placeholder. It runs after the redaction gate on purpose — a marker damaged
+  by the gate no longer matches the pattern, which is why the gate exempts
+  markers rather than relying on this repair.
+- **Model names in the summary footer**: filled from the models that actually
+  ran; a stale hardcoded name erodes trust in everything else the summary
+  claims.

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -4,6 +4,30 @@ Follow these phases EXACTLY. Do not skip phases. Do not reorder.
 Print `[Phase N complete]` after each phase, followed by `bash /tmp/budget.sh`
 (see Time Budgets — the elapsed number is measured, never estimated).
 
+## Conditional sections — read only what your lane and scope select
+
+Six blocks of this playbook live under `sections/` instead of inline, and each
+is pointed to from the step that owns it, with the condition for reading it.
+**Do not read a section whose condition you do not meet.**
+
+| `sections/…` | Read it when |
+|---|---|
+| `sandbox-guards.md` | mothership sandbox lane |
+| `adversarial-wave-2.md` | mothership sandbox lane |
+| `prior-review-and-delta.md` | your lane computes its own prior review + delta |
+| `branch-freshness.md` | your lane holds a write scope |
+| `scope-classification.md` | your lane must derive `review_scope` itself |
+| `toolkit-consumer-setup.md` | `review_scope` is `contract-toolkit` or `mixed-sdk-toolkit` |
+
+This is not tidying. Everything you read stays in context for every turn that
+follows, and measured turn latency on the review model climbs from ~10s early
+in a phase to 75-90s by turn 12 as that context grows — so a section you load
+and never use is charged to every remaining turn of the review. On a
+conformance-only `@sdk-loop` review all six conditions are false, which is
+~7.7K tokens not carried. Nothing has been deleted: each file holds its
+original text verbatim, and a test asserts every one of them is still reachable
+from a pointer here.
+
 ## Runtime
 
 Two lanes run this playbook, and they differ in what the SURROUNDING system
@@ -199,90 +223,13 @@ BUDGET
    (§2a). Reading it up front pays for it twice, and pays for it at all on
    reviews where no agent ever runs. Defer it to §6d.
 
-6b. **Load prior review into context (re-review continuity)** — if a
-    previous `<!-- SDK_REVIEW -->` summary comment exists on this
-    PR, read its full body and write it to `/tmp/PRIOR_REVIEW.md`. The
-    body becomes **input** to Phase 2 reasoning (not just a labeling
-    reference for §2e at the end): it tells the agents what was flagged
-    before, what the author said in response, and what should be
-    carried forward, downgraded, or re-checked given the current HEAD.
+6b/6c. **Prior review and the re-review delta.**
 
-    ```bash
-    # S5: use --paginate --slurp and pipe into standalone jq. The naive
-    # --paginate --jq idiom runs the jq filter once PER PAGE, so `last`
-    # picks the last match on the FIRST page, not the last match across all
-    # pages. On PRs with many comments spanning multiple API pages this
-    # would silently load an older review. --slurp collapses pages into one
-    # outer array; `.[][]` flattens into a single stream before `last`.
-    PRIOR_REVIEW=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-      --paginate --slurp 2>/dev/null \
-      | jq -r '[.[][] | select(.body | contains("<!-- SDK_REVIEW -->"))] | last | .body // ""')
-
-    if [ -n "$PRIOR_REVIEW" ]; then
-      printf '%s\n' "$PRIOR_REVIEW" > /tmp/PRIOR_REVIEW.md
-      echo "[bootstrap] prior sdk-review summary found — loaded into /tmp/PRIOR_REVIEW.md"
-    else
-      : > /tmp/PRIOR_REVIEW.md
-      echo "[bootstrap] no prior sdk-review summary — fresh review"
-    fi
-    ```
-
-    **CRITICAL — jq idiom:** two mistakes to avoid:
-    - `--jq '.[] | select(...) | .body' | head -1` collapses the raw
-      multiline body to its first line (the `<!-- SDK_REVIEW -->`
-      HTML marker) and silently drops the entire review content.
-    - `--paginate --jq '[.[] | select(...)] | last'` runs the jq filter
-      ONCE PER PAGE, so `last` picks the final match on page 1, not
-      across all pages. On a PR with enough comments to span pages,
-      this returns a stale older review. Always use `--paginate --slurp`
-      and pipe into standalone `jq -r '[.[][] | select(...)] | last'`.
-
-    Every subsequent phase that reasons about the PR (Phase 2 agents,
-    cross-model debias, verdict determination) should treat
-    `/tmp/PRIOR_REVIEW.md` as additional context when non-empty —
-    not because it's authoritative, but because it captures both the
-    prior bot's reasoning and (often, in author replies on inline
-    threads) the human's response, which materially changes what
-    counts as a "new" finding vs a known-and-discussed one.
-
-    **Replay and duplicate-trigger guards are sandbox-only** — Appendix A.
-    They exist because mothership recovers a dropped stream by re-running
-    this prompt from the top in the SAME sandbox, and because a bot can
-    re-trigger a review of a HEAD already reviewed. `@sdk-loop` has neither
-    shape: opencode is invoked once per job, and its Fence job decides
-    duplicate triggers before any model runs.
-
-6c. **Compute the re-review delta (scope-cutter).** Each review summary
-    stamps the HEAD it reviewed as `<!-- REVIEWED_HEAD: <sha> -->` (§3e).
-    On a re-review, use it to scope Phase 1–2 to what actually changed —
-    re-deriving conclusions about unchanged hunks is the single largest
-    waste in multi-round reviews. If step 8 updates the branch (BEHIND),
-    re-run this computation after it — the HEAD changes.
-
-    ```bash
-    PRIOR_HEAD=$(grep -oE '<!-- REVIEWED_HEAD: [0-9a-f]{40} -->' /tmp/PRIOR_REVIEW.md \
-      | grep -oE '[0-9a-f]{40}' || true)
-
-    DELTA_KNOWN=0
-    : > /tmp/DELTA.patch
-    : > /tmp/DELTA_FILES.txt
-    if [ -n "$PRIOR_HEAD" ] && git cat-file -e "$PRIOR_HEAD" 2>/dev/null; then
-      DELTA_KNOWN=1
-      # Restrict to the PR's own files so base-branch merges between rounds
-      # don't inflate the delta. A PR file also touched by a base merge shows
-      # base churn — acceptable: it errs toward MORE review, never less.
-      gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[].path' > /tmp/PR_FILES.txt
-      git diff "$PRIOR_HEAD".."$HEAD_SHA" -- $(cat /tmp/PR_FILES.txt) > /tmp/DELTA.patch || true
-      git diff --name-only "$PRIOR_HEAD".."$HEAD_SHA" -- $(cat /tmp/PR_FILES.txt) > /tmp/DELTA_FILES.txt || true
-    fi
-    DELTA_LINES=$(grep -cE '^[+-]' /tmp/DELTA.patch 2>/dev/null || echo 0)
-    ```
-
-    `DELTA_KNOWN=0` (no prior review, a pre-rollout summary without the
-    marker, or an unfetchable `PRIOR_HEAD`) means **unknown**, not "nothing
-    changed" — skip delta scoping and run the full review. Only
-    `DELTA_KNOWN=1` activates step 11b.
-
+    * `LANE: sdk-loop` — both are **handed to you in the dispatch prompt**: the
+      prior verdict, and the incremental range as `git diff <prior>..<head>`.
+      Verify them; do not recompute them.
+    * mothership sandbox — **read only when:** you are on that lane; then
+      follow 6b, 6c and 11b in `sections/prior-review-and-delta.md`.
 6d. **Do NOT read `references/*.md`. The agents that use them read them.**
 
     Each Phase 2 agent now names the reference files it owns, at the top of
@@ -332,38 +279,13 @@ BUDGET
    is cut to that delta per step 11b — the continuity rules are unchanged.
 
 
-8. **Branch freshness + conflict resolution** (before reviewing):
-   ```bash
-   MERGE_STATUS=$(jq -r '.mergeStateStatus' /tmp/PR.json)
-   ```
+8. **Branch freshness + conflict resolution.**
 
-   If `BEHIND` — **sandbox only.** `update-branch` writes to the PR branch and
-   needs `contents: write`; the `@sdk-loop` review phase holds a token without
-   it, so this 403s. On that lane, review the branch as it is and note it in
-   the summary — a base merge cannot introduce a finding in the PR's own
-   hunks, which is what the review is about. Do not retry, and do not report
-   the 403 as a defect.
-
-   ```bash
-   # Tier 1: GitHub-side update (merges base into the PR branch)
-   gh api "repos/$REPO/pulls/$PR_NUMBER/update-branch" \
-     -X PUT -f update_method=merge 2>/dev/null
-   sleep 10
-   # Re-fetch — SHA changed after merge
-   git fetch origin "$HEAD_REF" && git reset --hard "origin/$HEAD_REF"
-   # Re-fetch authoritative PR metadata and diff after the update
-   gh pr view "$PR_NUMBER" --repo "$REPO" --json number,state,isDraft,mergeable,mergeStateStatus,headRefName,baseRefName,headRefOid,title,body,labels > /tmp/PR.json
-   gh pr diff "$PR_NUMBER" --repo "$REPO" > /tmp/DIFF.patch
-   ```
-
-   If `CONFLICTING`: do NOT attempt a local merge or push — the review is
-   read-only (see Runtime). A conflict-resolution merge is the author's
-   decision, not the reviewer's. Submit minimal review: "PR has merge conflicts. Please
-   rebase or comment `@sdk-review` after resolving conflicts." Set the
-   verdict in §3e to `NEEDS_REBASE` (the structured marker is
-   `<!-- VERDICT: NEEDS_REBASE -->`); the GHA layer applies the
-   `sdk-review-needs-rebase` label from there. EXIT.
-
+    * `LANE: sdk-loop` — your token carries no write scope. **Report a behind
+      or conflicted branch as a finding and attempt nothing.** A push fails
+      with a 403 after the turn has already been paid for.
+    * mothership sandbox — **read only when:** you are on that lane; then
+      follow `sections/branch-freshness.md`.
 9. **Do not read CI.** Removed, not moved: the review cannot act on a check
    either way — it holds no write scope on this lane — and
    `sdk-review-downgrade-on-ci-failure.yml` already enforces CI against the
@@ -375,102 +297,21 @@ BUDGET
 
 10. Read the repo's `CLAUDE.md` for project conventions.
 
-11. **Smart agent routing** — classify the PR by which area it touches, and
-    dispatch only the matching specialist(s):
-    ```bash
-    gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[].path' > /tmp/PR_FILES.txt
-    TOTAL_FILES=$(wc -l < /tmp/PR_FILES.txt)
-    CT_FILES=$(grep -cE '^contract-toolkit/' /tmp/PR_FILES.txt || true)
-    SDK_FILES=$(grep -cE '^application_sdk/' /tmp/PR_FILES.txt || true)
-    CONF_FILES=$(grep -cE '^(packages/conformance/|remediation/)' /tmp/PR_FILES.txt || true)
-    TEST_FILES=$(grep -cE '^(tests/|contract-toolkit/tests/)' /tmp/PR_FILES.txt || true)
-    DOC_FILES=$(grep -cE '^(docs/|contract-toolkit/docs/|.*README\.md$)' /tmp/PR_FILES.txt || true)
-    CONFIG_FILES=$(grep -cE '^(pyproject\.toml|uv\.lock|\.pre-commit|\.github/|helm/)' /tmp/PR_FILES.txt || true)
-    # Agent-prompt / operational-meta files with NO Temporal/Dapr code surface:
-    # the mothership review+resolve playbooks, Claude Code config, and
-    # AGENTS/CLAUDE instruction files. Excluded from SOURCE_FILES below so a
-    # prompt-only PR is never routed into the full 3-agent SDK panel (the SDK
-    # correctness/quality/structure agents have no rules for reviewing prompts).
-    META_FILES=$(grep -cE '^(\.mothership/|\.claude/)|(^|/)(AGENTS|CLAUDE)\.md$' /tmp/PR_FILES.txt || true)
-    # SOURCE_FILES = files in NONE of the non-source buckets (conformance, tests,
-    # docs, config, meta). Computed by exclusion (grep -vc) rather than
-    # TOTAL - sum(buckets): a file matching two buckets (e.g. docs/CLAUDE.md is
-    # both DOC and META) would be subtracted twice by the arithmetic and could
-    # zero out a real source count, silently skipping code review. Mirrors the
-    # bucket patterns above (contract-toolkit is intentionally NOT excluded — CT
-    # PRs are routed by the first two rules before SOURCE_FILES is consulted).
-    SOURCE_FILES=$(grep -vcE '^(packages/conformance/|remediation/|tests/|contract-toolkit/tests/|docs/|contract-toolkit/docs/|pyproject\.toml|uv\.lock|\.pre-commit|\.github/|helm/|\.mothership/|\.claude/)|.*README\.md$|(^|/)(AGENTS|CLAUDE)\.md$' /tmp/PR_FILES.txt || true)
-    CHANGED_LINES=$(grep -cE '^[+-]' /tmp/DIFF.patch 2>/dev/null || echo 0)
-    # Security-sensitive paths NEVER take the fast path (a 3-line auth/secret
-    # change is exactly where a subtle blocker hides).
-    SECURITY_PATHS=$(grep -cE '(credential|secret|auth|token|_dapr|_temporal)' /tmp/PR_FILES.txt || true)
-    ```
-   This file-list based classification includes deleted files; do not classify
-   only from `+++ b/` diff headers. Apply in order; **first match wins**:
-   - If `CT_FILES > 0 && SDK_FILES == 0 && CONF_FILES == 0 && CONFIG_FILES == 0` → `review_scope=contract-toolkit`
-     (toolkit-review.md only; mandatory private consumer validation based on affected surface)
-   - If `CT_FILES > 0 && (SDK_FILES > 0 || CONFIG_FILES > 0)` → `review_scope=mixed-sdk-toolkit`
-     (standard SDK review agents + toolkit-review.md)
-   - If `META_FILES > 0 && SOURCE_FILES == 0 && CONFIG_FILES == 0 && CONF_FILES == 0
-     && CT_FILES == 0 && TEST_FILES == 0 && DOC_FILES == 0` → `review_scope=docs-only`
-     (agent-prompt / operational-meta files only — `.mothership/**`, `.claude/**`,
-     `AGENTS.md`, `CLAUDE.md` — carry no Temporal/Dapr code surface, so the SDK
-     domain agents have nothing to review. Take the docs-only skip path: submit
-     APPROVE, no Phase 2. Because META is excluded from `SOURCE_FILES`, a PR that
-     ALSO touches code routes on the real code — `config-only`, `full`, etc. — so
-     the meta files never drag prompt/markdown into the SDK correctness agents,
-     and code is never skipped just because prompts changed alongside it.)
-   - If `SOURCE_FILES == 0 && CONF_FILES > 0 && CT_FILES == 0` → `review_scope=conformance-only`
-     (`conformance.md` agent only — the conformance-suite specialist for
-     `packages/conformance/**` + `remediation/**`: SARIF detector correctness,
-     rule-catalog consistency, rule scope (sdk/app/both), the two CI gates, and
-     the paired remediation program in the SAME PR. NOT the SDK CORRECTNESS
-     agent — conformance code is AST/rule logic, not Temporal/Dapr runtime.
-     If `CONFIG_FILES > 0` too, also dispatch `ci-config.md` on the config slice.)
-   - If `SOURCE_FILES == 0 && TEST_FILES > 0` → `review_scope=tests-only`
-     (QUALITY agent only — focused on test patterns, coverage, assertions)
-   - If `SOURCE_FILES == 0 && DOC_FILES > 0 && TEST_FILES == 0` → `review_scope=docs-only`
-     (Skip Phase 2 — submit APPROVE with "Docs/meta-only PR, no code review needed")
-   - If `SOURCE_FILES == 0 && CONFIG_FILES > 0` → `review_scope=config-only`
-     (`ci-config.md` agent only — the CI/workflow/deps/infra specialist, NOT
-     the SDK CORRECTNESS agent. Reviews GHA injection/permissions/pinning,
-     shell robustness, dependency/supply-chain, and `helm/**`.)
-   - If `SOURCE_FILES <= 2 && TEST_FILES >= SOURCE_FILES * 3` → `review_scope=tests-focused`
-     (QUALITY agent + lightweight CORRECTNESS — mostly tests with a few source changes)
-   - If `SOURCE_FILES >= 1 && TOTAL_FILES <= 2 && CHANGED_LINES < 50 && CONF_FILES == 0
-     && CT_FILES == 0 && CONFIG_FILES == 0 && SECURITY_PATHS == 0` → `review_scope=minor`
-     (**fast path** for a tiny source change: CORRECTNESS agent only — it always
-     keeps guardrail coverage G1-G5 — skipping the heavier QUALITY/STRUCTURE
-     waves and the adversarial Wave 2, on the Small time budget. NEVER matches
-     credential/secret/auth or `_dapr`/`_temporal` seam paths; those fall through
-     to `full`.)
-   - Otherwise → `review_scope=full` (correctness + quality + structure)
+11. **Smart agent routing.** `review_scope` decides which specialists §2a
+    dispatches.
 
-11b. **Re-review delta scoping** (only when `DELTA_KNOWN=1` from step 6c).
-    Step 11 decides *which* specialists could run; on a re-review the delta
-    decides *how much work actually remains*:
+    * `LANE: sdk-loop` — **you are told your scope. Do NOT derive it.** The
+      harness computed it in Python before the phase started, from the same
+      file-list arithmetic, and re-running that classification spends a turn to
+      reach the answer you already have.
+    * mothership sandbox — **read only when:** you are on that lane; then
+      follow `sections/scope-classification.md` to derive `review_scope`.
 
-    - `DELTA_LINES == 0` (re-trigger on the same HEAD, or only base merges
-      since the prior round) → **verification-only re-review**: skip Wave 1
-      and Wave 2 discovery entirely. Phase 2 reduces to §2e labeling of the
-      prior findings against the current HEAD plus the §2h verdict — no new
-      hunks means no new findings can exist.
-    - `0 < DELTA_LINES < 2000` → **delta-scoped re-review**: re-run the
-      step 11 bucket classification over `/tmp/DELTA_FILES.txt` (not the
-      full PR file list) and dispatch only the matching specialists. Agents
-      receive `/tmp/DELTA.patch` as the diff, `/tmp/PRIOR_REVIEW.md`, and
-      full file contents for delta files only. Prior findings on unchanged
-      hunks carry forward per §2e without re-deriving them; prior findings
-      whose lines the delta touched are re-verified (that IS the delta work).
-    - `DELTA_LINES >= 2000` → full review — a delta that large is a new PR
-      in all but name, and hunk-local reasoning stops being sound.
-
-    Guardrail floor: if ANY delta file is source (per the step 11 buckets),
-    the CORRECTNESS agent is always dispatched regardless of what the delta
-    classification says — the same G1–G5 floor the `minor` fast path keeps.
-    Toolkit delta files additionally keep the Phase 1b-toolkit obligations
-    (the carry-forward fast path there handles the unchanged-artifact case).
-
+    §2a's routing table below is the authority for scope-to-agent mapping on
+    both lanes, and stays here.
+11b. **Re-review delta scoping** — **read only when:** `DELTA_KNOWN=1` from
+    step 6c, which only the sandbox lane computes. It lives at the end of
+    `sections/prior-review-and-delta.md`.
 12. Check diff size for tier, and raise the budget cap to match it
     (step 1b defaulted to the Small hard stop):
     - < 2000 lines → `review_tier = "full"` → `echo 900 > /tmp/REVIEW_HARD_STOP_S`
@@ -507,213 +348,13 @@ internal, test, or dead.
 Skip if review_scope is contract-toolkit, conformance-only, tests-only, docs-only, or config-only.
 On a delta-scoped re-review (step 11b), run it over the delta files only.
 
-### 1b-toolkit. Private Toolkit Consumer Setup (if review_scope=contract-toolkit or mixed-sdk-toolkit)
+### 1b-toolkit. Private Toolkit Consumer Setup
 
-Read:
-
-- `contract-toolkit/AGENTS.md`
-- `.mothership/pr-review/agents/toolkit-review.md`
-- `.mothership/pr-review/references/toolkit-consumer-registry.md`
-
-Classify the affected toolkit surfaces from `/tmp/DIFF.patch`. Then clone or
-reuse every mandatory consumer target from the registry. This validation setup
-is mandatory for affected surfaces; do not approve if a required check cannot
-run.
-
-Reset and create the private validation ledger (these files are written only
-here, so the reset lives here — not in Phase 0). It is the source of truth
-for toolkit compatibility status and verdict gating:
-
-```bash
-rm -f /tmp/TOOLKIT_ROVER_NOTE.md
-: > /tmp/TOOLKIT_PR_ARTIFACTS.txt
-: > /tmp/TOOLKIT_CHANGED_FILES.txt
-: > /tmp/TOOLKIT_CONSUMERS.md
-: > /tmp/TOOLKIT_VALIDATION.md
-printf '## Toolkit Validation Ledger\n\n' >> /tmp/TOOLKIT_VALIDATION.md
-```
-
-**Do not re-run what CI already ran.** The `Contract Toolkit /` CI legs on
-this HEAD run the same commands the reviewer used to re-run wholesale
-(`PKL tests and invariants`, `Verify generated output`, `Generated Python
-lint and SDK imports`). Read them instead:
-
-```bash
-# `bucket`, NOT `conclusion`. `gh pr checks --json` has no `conclusion`
-# field: it prints "Unknown JSON field" to stderr, EXITS 0, and writes
-# nothing to stdout — so this file would be empty and every leg would read
-# as missing. Buckets are pass / fail / skipping / pending.
-gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,bucket \
-  --jq '.[] | select(.name | startswith("Contract Toolkit")) | .name + " " + .bucket' \
-  > /tmp/TOOLKIT_CI_LEGS.txt
-```
-
-- Every leg `pass` → record the legs as the local-check evidence in the
-  ledger. Run a local command ONLY as the substrate for probing CI cannot
-  express — guard ablations, scratch collision contracts, comparing
-  PR-generated artifacts against a consumer's expectations.
-- Any leg missing / pending / failed → run that leg's command locally and
-  treat a failure caused by PR code or stale generated output as a finding:
-
-```bash
-contract-toolkit/scripts/regenerate-all.sh     # ↔ Verify generated output
-contract-toolkit/scripts/check-invariants.sh   # ↔ PKL tests and invariants
-(cd contract-toolkit && pkl test tests/*.pkl)  # ↔ PKL tests and invariants
-uv run --extra workflows python contract-toolkit/scripts/test-sdk-import.py  # ↔ Generated Python lint and SDK imports
-git diff --check
-```
-
-If a required command cannot run due to Rover environment/tooling failure,
-create `/tmp/TOOLKIT_ROVER_NOTE.md` with the sanitized note below.
-
-Record the evidence privately:
-
-```bash
-printf -- '- Generated SDK input contract: validated (CI toolkit legs green on this HEAD; PR-bound probing ran locally)\n' >> /tmp/TOOLKIT_VALIDATION.md
-```
-
-Capture PR-generated artifacts as the input to downstream checks. Do not use a
-consumer repository's released toolkit dependency as proof for this PR:
-
-```bash
-find contract-toolkit/examples -path '*/generated/*' -type f | sort > /tmp/TOOLKIT_PR_ARTIFACTS.txt
-git diff --name-only -- contract-toolkit/examples contract-toolkit/src > /tmp/TOOLKIT_CHANGED_FILES.txt
-```
-
-**Carry-forward fast path (re-reviews).** Hash the PR-generated artifacts
-and compare against the hash the prior review stamped (§3e stamps
-`<!-- TOOLKIT_ARTIFACT_HASH: ... -->` on toolkit-scope summaries):
-
-```bash
-ARTIFACT_HASH=$(cat /tmp/TOOLKIT_PR_ARTIFACTS.txt | xargs shasum -a 256 | shasum -a 256 | cut -d' ' -f1)
-PRIOR_HASH=$(grep -oE '<!-- TOOLKIT_ARTIFACT_HASH: [0-9a-f]{64} -->' /tmp/PRIOR_REVIEW.md \
-  | grep -oE '[0-9a-f]{64}' || true)
-```
-
-If `PRIOR_HASH` is non-empty and equals `ARTIFACT_HASH`, the generated
-artifacts are byte-identical to a commit whose downstream compatibility was
-already validated: mark every artifact-derived capability
-`validated (carried forward — artifacts byte-identical to previously
-validated commit)` in the ledger and **skip the consumer clone loop
-entirely**. Carry-forward covers the *consumer-side* checks only — new
-toolkit-source behavior the committed examples don't exercise (a new
-invariant, a changed codegen skip-list) still needs PR-bound local probing
-(scratch contracts, ablations), which requires no clones. Hash mismatch or
-no prior hash → full validation below.
-
-Use `/tmp/toolkit-review-consumers` for scratch clones:
-
-```bash
-mkdir -p /tmp/toolkit-review-consumers
-
-# Core consumers. Use existing /workspace checkout if present; otherwise clone.
-# Record branch and SHA privately in /tmp/TOOLKIT_CONSUMERS.md.
-for spec in \
-  "atlan-frontend beta" \
-  "blaze main" \
-  "heracles beta" \
-  "atlan-automation-engine-app main"
-do
-  repo="${spec% *}"
-  branch="${spec#* }"
-  if [ -d "/workspace/${repo}/.git" ]; then
-    target="/workspace/${repo}"
-  else
-    target="/tmp/toolkit-review-consumers/${repo}"
-    if [ ! -d "${target}/.git" ] && ! git clone "https://github.com/atlanhq/${repo}.git" "${target}"; then
-      printf '%s\n' "Review note: one required compatibility check could not be completed due to a Rover execution issue. Please re-run @sdk-review or request human review before merge." > /tmp/TOOLKIT_ROVER_NOTE.md
-      continue
-    fi
-  fi
-  if ! git -C "${target}" fetch origin "${branch}"; then
-    printf '%s\n' "Review note: one required compatibility check could not be completed due to a Rover execution issue. Please re-run @sdk-review or request human review before merge." > /tmp/TOOLKIT_ROVER_NOTE.md
-    continue
-  fi
-  printf '%s %s %s\n' "${repo}" "origin/${branch}" "$(git -C "${target}" rev-parse "origin/${branch}")" >> /tmp/TOOLKIT_CONSUMERS.md
-done
-```
-
-Cloning/fetching only establishes the validation target. It is not validation.
-For each affected capability, run the corresponding minimum actionable check in
-the registry using PR-generated artifacts or a scratch contract rewritten to
-amend/import `/workspace/application-sdk/contract-toolkit/src/*.pkl`. If no
-PR-bound command or inspection is possible, mark that capability `needs rerun`
-and do not approve.
-
-Each mandatory capability must append exactly one private status line to
-`/tmp/TOOLKIT_VALIDATION.md`:
-
-```text
-- UI rendering compatibility: validated (<private evidence recorded>)
-- Manifest substitution compatibility: validated (<private evidence recorded>)
-- Workflow execution contract: validated (<private evidence recorded>)
-- Generated SDK input contract: validated (<private evidence recorded>)
-- Representative app pattern: not applicable (<why>)
-```
-
-Allowed statuses are `validated`, `not applicable`, and `needs rerun`. Any
-`needs rerun` status forces `NEEDS_HUMAN`.
-The public review must mirror these as a `### Cross-Repo Validation` section
-using only capability aliases and status values. Do not include private
-consumer repository names, package names, branch names, SHAs, local paths, or
-system-app implementation details in the public section.
-
-For representative app patterns, inspect PR title, body, and diff for trigger
-terms from the registry. Clone/fetch only the matching pattern repos. Optional
-field additions do not require adoption in the representative app unless the PR
-claims compatibility or changes required generated/runtime behavior.
-
-Use these pattern specs after a trigger match:
-
-```bash
-# Pattern specs: "<pattern> <repo> <branch>"
-# query-intelligence atlan-query-intelligence-app main
-# publish atlan-publish-app main
-# popularity atlan-popularity-app main
-# lineage atlan-lineage-app main
-```
-
-For each matched pattern, reuse `/workspace/<repo>` if present, otherwise clone
-to `/tmp/toolkit-review-consumers/<repo>`, fetch the listed branch, and append
-the private SHA to `/tmp/TOOLKIT_CONSUMERS.md`.
-
-When validating a representative app contract, work only in a scratch copy. If
-the contract imports `@app-contract-toolkit/...`, rewrite that scratch copy to
-import the PR checkout source under
-`/workspace/application-sdk/contract-toolkit/src/` before running `pkl eval`.
-
-Scratch rewrite pattern:
-
-```bash
-scratch="/tmp/toolkit-review-consumers/scratch/<pattern>"
-mkdir -p "$scratch"
-cp -R "<consumer-contract-dir>"/. "$scratch"/
-rg -l '@app-contract-toolkit/' "$scratch" \
-  | xargs perl -0pi -e 's#@app-contract-toolkit/#/workspace/application-sdk/contract-toolkit/src/#g'
-pkl eval -m "$scratch/generated" "$scratch/app.pkl"
-```
-
-If the representative app does not have a contract yet, do not fail adoption.
-Validate the generic PR-generated artifact shape and record the representative
-pattern as `not applicable` with the reason.
-
-All consumer repo names, local paths, and SHAs are private evidence. Public PR
-comments may only use capability aliases:
-
-- `UI rendering compatibility`
-- `Manifest substitution compatibility`
-- `Workflow execution contract`
-- `Generated SDK input contract`
-- `Representative app pattern`
-
-If clone/fetch/auth/network fails for a mandatory target, create
-`/tmp/TOOLKIT_ROVER_NOTE.md` with exactly this public note and continue to
-Phase 2 so the review can request a rerun or human review:
-
-```text
-Review note: one required compatibility check could not be completed due to a Rover execution issue. Please re-run @sdk-review or request human review before merge.
-```
-
+**Read only when:** `review_scope` is `contract-toolkit` or
+`mixed-sdk-toolkit` — then read `sections/toolkit-consumer-setup.md`.
+Skip it entirely on every other scope — it is private-repo clone-and-validate setup for surfaces your scope
+does not touch, and on a two-file conformance PR it is the single largest
+block of context you would carry for no reason.
 ### 1c. Prepare Context by Tier
 
 **Token budgets per agent call (hard limits — never exceed):**
@@ -938,43 +579,14 @@ CORRECTNESS is ALWAYS kept — it carries guardrail coverage G1-G5.
 
 Parse JSON findings from each agent response.
 
-### 2b. Wave 2 — GPT-5.3-codex Adversarial (via proxy)
+### 2b. Wave 2 — cross-model adversarial (via proxy)
 
-After Wave 1, call GPT to challenge your findings.
-
-**Skip conditions** (no adversarial):
-- `review_scope` is tests-only, conformance-only, config-only, docs-only, or minor
-- `review_scope` is contract-toolkit and toolkit-review.md produced zero findings
-- `review_tier` is "staged" (massive PR — too much context for one GPT call)
-- Wave 1 produced zero findings (nothing to challenge)
-- Time budget already over 70% consumed — run `bash /tmp/budget.sh` here
-  and skip whenever it prints `OVER 70%` or `OVER HARD STOP`. This is the
-  single most expensive optional step in the run (a full GPT-5.3-codex
-  call over the whole diff plus every Wave 1 finding), so it is the first
-  thing an over-budget run must give up.
-
-If not skipped:
-
-```bash
-curl -s "$PROXY_BASE/proxy/litellm/chat/completions" \
-  -H "Authorization: Bearer $PROXY_JWT" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "gpt-5.3-codex",
-    "temperature": 0.2,
-    "max_tokens": 16000,
-    "messages": [
-      {"role": "system", "content": "<agents/adversarial.md content>"},
-      {"role": "user", "content": "<Wave 1 findings + PR diff + annotations>"}
-    ]
-  }'
-```
-
-GPT challenges every Opus finding. GPT also discovers findings Opus missed.
-
-If GPT unavailable or skipped: keep all Opus findings >= 80%.
-Note in review: "Cross-model adversarial: <skipped (reason) | ran | unavailable>."
-
+**Read only when:** you are on the mothership sandbox lane.
+On `LANE: sdk-loop`, skip `sections/adversarial-wave-2.md` entirely. It curls
+`$PROXY_BASE/proxy/litellm/...` with `$PROXY_JWT`; both are sandbox variables
+that do not exist on a GitHub Actions runner, so on the loop lane the step
+cannot succeed and reading it only pays for context. That lane's resolve phase
+contests every finding instead, so the challenge still happens.
 ### 2c. De-Bias (deterministic)
 
 | Opus (Wave 1) | GPT (Wave 2) | Action |
@@ -1555,134 +1167,9 @@ Submit minimal:
 
 ## Appendix A: Sandbox-only run guards
 
-Everything here is for the **mothership sandbox**. `@sdk-loop` skips this
-section entirely — its harness does the same jobs in Python, before any model
-runs, which is both cheaper and not subject to an agent deciding to skip a
-step. Kept out of the main flow so the common path stays readable rather than
-carrying ~120 lines that two thirds of runs must reason past.
-
-A1. **Reset per-run review artifacts** — these files are load-bearing signals
-    across later phases, so never let a prior iteration in the same sandbox
-    affect the current verdict or public post:
-    ```bash
-    mkdir -p /tmp/inline-comments
-    find /tmp/inline-comments -type f \( -name '*.md' -o -name '*.json' \) -delete
-    ```
-    The toolkit ledger files (`/tmp/TOOLKIT_*.md|txt`) are reset at the top of
-    Phase 1b-toolkit — the only place that writes them — so non-toolkit scopes
-    don't touch them at all.
-
-A2. **Stale SHA guard** — bail if the PR has moved since dispatch:
-   ```bash
-   CURRENT_SHA=$(jq -r '.headRefOid' /tmp/PR.json)
-   if [ "$CURRENT_SHA" != "$HEAD_SHA" ]; then
-     echo "PR moved from $HEAD_SHA to $CURRENT_SHA since dispatch — aborting cleanly."
-     # Submit a minimal review so the status check doesn't stay pending,
-     # then exit. A fresh @sdk-review on the new HEAD gets a new session.
-     exit 0
-   fi
-   ```
-
-
-**A3. Same-run replay guard — run this immediately after loading
-`/tmp/PRIOR_REVIEW.md`, before anything else.** When the Claude
-stream drops mid-run (sandbox VPN reconnect, container eviction,
-transient API error), mothership recovers by re-running this prompt
-**from the top in the same sandbox** — a fresh run, not a `--resume`.
-If the first pass had already posted its summary, that retry loads
-its own summary as `PRIOR_REVIEW`, sees an empty delta, and posts a
-SECOND summary for the same HEAD. The PR then shows two reviews with
-different wording from a single `@sdk-review` trigger, and the
-workflow's soft-success check passes because *a* summary exists.
-
-Every summary's footer carries the run URL that produced it (§3e),
-and §3f posts the summary **last**, after the inline comments and the
-commit status — so a summary bearing this run's URL means this run's
-submission completed in full. Check *every* summary on the PR, not
-just the one 6b loaded: that one is only the latest, and an unrelated
-review landing between the first pass and the replay would hide this
-run's footer behind it.
-
-```bash
-# GHA_RUN_URL is given in the session prompt — substitute it literally,
-# shell variables do not persist between Bash calls.
-gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate --slurp 2>/dev/null \
-  | jq -r '[.[][] | select(.body | contains("<!-- SDK_REVIEW -->")) | .body] | join("\n")' \
-  | grep -qF '<GHA_RUN_URL>' \
-  && echo "REPLAY: this run already posted its review summary"
-```
-
-If that prints `REPLAY`, **stop the entire run here**: post nothing,
-set no commit status, resolve no threads, do not continue to Phase 1.
-The review was already delivered by the pass that died.
-
-Key the guard on the run URL, never on `HEAD_SHA` alone — a genuine
-re-trigger against an unchanged HEAD comes from a *different* run and
-must still produce a review.
-
-This guard only catches a replay that re-enters the prompt from the top.
-A provider-level retry that replays a single assistant *turn* re-executes
-the `gh api … /comments -f body=…` call directly, with no prompt to
-re-read — that is how #3276 collected the identical summary five times.
-Nothing you can write here prevents it, so the workflow cleans up after
-it: `sdk_review_dedupe_verdicts.py` runs once the stream closes, keeps the
-newest summary this run posted and minimizes the rest (FND-636). It
-identifies "this run's" summaries by the `<GHA_RUN_URL>` in the §3e
-footer, the same key this guard greps — which is another reason that line
-is not optional. Drop it and the collapse silently stops working.
-
-**A4. Bot-trigger dedupe guard — run immediately after the replay guard.**
-This is now a *backstop*, not the authority. Since FND-636 the
-authoritative check is the `Dedupe check` step at the top of
-`sdk-review-dispatch`, which runs under the per-PR concurrency lock and
-declines before a sandbox is booted at all — deciding it here meant the
-sandbox had to start and reason before it could decline, so the run was
-paid for either way, and a degraded model skipped the check entirely
-(five duplicate triggers on #3285 became five runs). Keep this guard: it
-costs one API call, and it still catches the case where the comment
-landed between the workflow's read and the sandbox's start.
-
-Check: if `COMMENTER` is an automated trigger (`mothership-ai[bot]`
-or `atlan-ci`) **and** the newest summary's `<!-- REVIEWED_HEAD -->`
-equals `HEAD_SHA`, this run is a duplicate. Stop without posting.
-Humans (`COMMENTER` is any other login) are never stopped by this
-guard — re-reading the same diff is a legitimate human request.
-
-Use "newest summary" (the body already in `/tmp/PRIOR_REVIEW.md`),
-never the oldest.
-
-```bash
-# COMMENTER and HEAD_SHA are from the prompt header.
-BOT_TRIGGERS="mothership-ai[bot] atlan-ci"
-if echo "$BOT_TRIGGERS" | grep -qF "$COMMENTER"; then
-  NEWEST_REVIEWED_HEAD=$(grep -oE '<!-- REVIEWED_HEAD: [0-9a-f]{40} -->' /tmp/PRIOR_REVIEW.md \
-    | grep -oE '[0-9a-f]{40}' || true)
-  if [ -n "$NEWEST_REVIEWED_HEAD" ] && [ "$NEWEST_REVIEWED_HEAD" = "$HEAD_SHA" ]; then
-    echo "SKIP: bot-trigger dedupe — @${COMMENTER} re-triggered on HEAD ${HEAD_SHA} which the newest summary already reviewed. Backstop for the workflow's locked dedupe check. Stopping without posting."
-    # S4: Restore the commit status so the dispatch run's pending state
-    # does not linger after this no-op. The dispatch run always sets
-    # sdk-review to "pending" before the sandbox starts. If the sandbox
-    # exits here without posting a new verdict comment, the fast-path
-    # approve workflow never fires, and the pending status persists —
-    # which is misleading (the review was already delivered). Re-apply
-    # the status implied by the prior verdict.
-    PRIOR_VERDICT=$(grep -oE '<!-- VERDICT: [A-Z_]+ -->' /tmp/PRIOR_REVIEW.md \
-      | grep -oE '[A-Z_]+' | head -1 || true)
-    case "$PRIOR_VERDICT" in
-      "READY_TO_MERGE")
-        gh api "repos/${REPO}/statuses/${HEAD_SHA}" -X POST \
-          -f state=success -f context=sdk-review \
-          -f description="Approved (bot-retrigger skipped: already reviewed this HEAD)" 2>/dev/null || true;;
-      "")
-        : # No prior verdict found — leave status as-is to avoid stomping
-        ;;
-      *)
-        gh api "repos/${REPO}/statuses/${HEAD_SHA}" -X POST \
-          -f state=failure -f context=sdk-review \
-          -f description="Verdict: ${PRIOR_VERDICT} (bot-retrigger skipped: already reviewed this HEAD)" 2>/dev/null || true;;
-    esac
-    exit 0
-  fi
-fi
-```
-
+**Read only when:** you are on the mothership sandbox lane.
+On `LANE: sdk-loop`, skip `sections/sandbox-guards.md` entirely. The
+Runtime table above already records why the loop lane has no use for it: the
+Fence job dismisses duplicate triggers before any model runs, each phase is
+one invocation on a fresh runner, and the harness re-aims a moved HEAD. Every
+guard in that file answers a problem the loop lane does not have.

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -281,11 +281,31 @@ BUDGET
 
 8. **Branch freshness + conflict resolution.**
 
-    * `LANE: sdk-loop` — your token carries no write scope. **Report a behind
-      or conflicted branch as a finding and attempt nothing.** A push fails
-      with a 403 after the turn has already been paid for.
-    * mothership sandbox — **read only when:** you are on that lane; then
-      follow `sections/branch-freshness.md`.
+    ```bash
+    MERGE_STATUS=$(jq -r '.mergeStateStatus' /tmp/PR.json)
+    ```
+
+    **If `CONFLICTING` — BOTH LANES, and this stays here rather than behind a
+    pointer.** Do NOT attempt a local merge or push: resolving a conflict is
+    the author's decision, not the reviewer's. Submit a minimal review — "PR
+    has merge conflicts. Please rebase or comment `@sdk-review` after
+    resolving conflicts." — set the §3e verdict to `NEEDS_REBASE` (marker
+    `<!-- VERDICT: NEEDS_REBASE -->`), and EXIT. The GHA layer applies the
+    `sdk-review-needs-rebase` label from that marker, and `@sdk-loop` reads
+    `NEEDS_REBASE` as one of its terminal verdicts
+    (`VERDICTS_TERMINAL` in `.github/scripts/sdk_loop_common.py`) — a loop
+    round that swallowed it would keep spending rounds on a branch no resolve
+    phase can move.
+
+    **If `BEHIND`:**
+
+    * `LANE: sdk-loop` — your token carries no write scope, so
+      `update-branch` 403s. Review the branch as it is and note it in the
+      summary. A base merge cannot introduce a finding in the PR's own hunks,
+      which is what the review is about. Do not retry, and do not report the
+      403 as a defect. Nothing further to read.
+    * mothership sandbox — **read only when:** you are on that lane AND the
+      branch is `BEHIND`; then follow `sections/branch-freshness.md`.
 9. **Do not read CI.** Removed, not moved: the review cannot act on a check
    either way — it holds no write scope on this lane — and
    `sdk-review-downgrade-on-ci-failure.yml` already enforces CI against the

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -377,8 +377,33 @@ On a delta-scoped re-review (step 11b), run it over the delta files only.
 ### 1b-toolkit. Private Toolkit Consumer Setup
 
 **Read only when:** `review_scope` is `contract-toolkit` or
-`mixed-sdk-toolkit` — then read `sections/toolkit-consumer-setup.md`.
-Skip it entirely on every other scope — it is private-repo clone-and-validate setup for surfaces your scope
+`mixed-sdk-toolkit` AND you are on the mothership sandbox — then read
+`sections/toolkit-consumer-setup.md`.
+
+**On `LANE: sdk-loop`, do not read it and do not attempt any of it, even on a
+toolkit scope.** Its consumer validation clones private atlanhq repos, and
+this lane's credential cannot: `GH_TOKEN` is an App token scoped to THIS
+repository, and git has no other helper on the runner — so every clone dies
+with `fatal: could not read Username for 'https://github.com'`. A live
+toolkit-scope run (PR #3594) failed all five clones exactly this way, kept
+going, and was killed by the idle watchdog with no verdict after ~8 minutes.
+Instead, on this lane:
+
+```bash
+cat > /tmp/TOOLKIT_ROVER_NOTE.md <<'NOTE'
+Review note: private-consumer compatibility validation cannot run on the
+@sdk-loop lane (no credentials for consumer repos). Reviewed the toolkit
+surfaces statically. Re-run @sdk-review (mothership) or request human review
+for cross-repo validation before merge.
+NOTE
+```
+
+then review the toolkit surfaces from this repo's own diff and generated
+artifacts, and let §3e's Review Note block carry that note into the summary.
+The note downgrades confidence honestly; five guaranteed clone failures
+followed by a dead phase reports nothing at all.
+
+Skip the section entirely on every other scope — it is private-repo clone-and-validate setup for surfaces your scope
 does not touch, and on a two-file conformance PR it is the single largest
 block of context you would carry for no reason.
 ### 1c. Prepare Context by Tier

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -18,6 +18,7 @@ is pointed to from the step that owns it, with the condition for reading it.
 | `branch-freshness.md` | your lane holds a write scope |
 | `scope-classification.md` | your lane must derive `review_scope` itself |
 | `toolkit-consumer-setup.md` | `review_scope` is `contract-toolkit` or `mixed-sdk-toolkit` |
+| `verdict-stamp-mechanics.md` | diagnosing a verdict that produced no label/approval |
 
 This is not tidying. Everything you read stays in context for every turn that
 follows, and measured turn latency on the review model climbs from ~10s early
@@ -214,8 +215,13 @@ BUDGET
      an agent that searches the reference rules for prior art, gets nothing,
      and concludes there is none will raise a finding the rules already
      answer. That is the expensive failure; the wasted turn is the cheap one.
-   - `.mothership/review-policy.md`
-   - `.mothership/review.yaml`
+
+   `review-policy.md` and `review.yaml` are gone from this list on purpose.
+   The by-design patterns that lived in `review-policy.md` are now part of
+   `references/retro-log.md` — the single do-not-flag source, consulted by
+   whoever raises findings — and `review.yaml`'s rules were a paraphrase of
+   the rubric and CLAUDE.md, which this step already loads. Two files, two
+   tool calls, ~750 tokens on every review, zero unique content.
 
    **`references/*.md` is NOT read here.** It is ~125 KB — over half
    everything this step would otherwise load — and it is consumed by the
@@ -870,46 +876,19 @@ For BLOCKING/CRITICAL/HIGH findings, create inline comments:
 
 ### 3c. Verdict-Stamp: Owned by the GHA runner (sandbox does nothing)
 
-There is no mothership-side handler, and the sandbox **does not post
-`gh pr review`** and **does not apply labels**. Both happen outside
-the sandbox:
+Do **not** post `gh pr review`, `gh pr edit --add-label`, or any approval
+from inside the orchestration — on either lane. The verdict flows out via the
+structured marker in the §3e summary comment; the GHA layer parses it and
+owns the label, the commit status, and the `atlan-ci` approval.
 
-- **Approval**: `sdk-review-approve-on-verdict.yml` fires on
-  `issue_comment: created` from `mothership-ai[bot]` with the
-  `<!-- SDK_REVIEW -->` marker (within ~5s of the verdict comment
-  landing). It parses the verdict from the structured
-  `<!-- VERDICT: X -->` marker in §3e, applies the
-  `sdk-review-approved` / `sdk-review-needs-human` /
-  `sdk-review-needs-rebase` labels, sets the `sdk-review` commit
-  status, and posts the formal `atlan-ci` approval if the verdict is
-  `READY_TO_MERGE`. `sdk-review.yml`'s "Approve PR as atlan-ci" step
-  runs the same logic after the SSE stream ends as a fallback —
-  idempotency guards (label present + no existing approval) prevent
-  double-approval. atlan-ci is in CODEOWNERS, so its approval
-  satisfies `require_code_owner_review` on `main`;
-  `mothership-ai[bot]` is a GitHub App and can't be.
-- **Dismiss on human activity**: `sdk-review-dismiss-on-human.yml`
-  fires on `issue_comment` / `pull_request_review` from humans and
-  dismisses the atlan-ci approval + strips the label. So the bot can
-  unblock merges by itself until a human pushes back.
-- **Reset on push**: `sdk-review-reset-on-push.yml` fires on
-  `pull_request: synchronize` and strips the label + flips the
-  `sdk-review` status to pending on the new HEAD. Branch protection
-  separately auto-dismisses the approval (`dismiss_stale_reviews_on_push`).
-- **CI-failure downgrade**: `sdk-review-downgrade-on-ci-failure.yml`
-  fires on `check_suite: completed`; if a non-sdk-review check
-  failed on a HEAD that carries `sdk-review-approved`, it strips
-  the label, dismisses the approval, and flips status to failure.
-
-**Implication for the sandbox**: don't `gh pr edit --add-label` or
-`gh pr review --approve` from inside the orchestration. The verdict
-flows out via the structured marker in the summary comment in §3e;
-the GHA layer reads that and does the rest.
-
-The structured verdict marker is the contract. Keep
-`<!-- VERDICT: X -->` in sync with `### Verdict: ...` in the summary
-template. The token must be one of:
+The marker is the contract. Keep `<!-- VERDICT: X -->` in sync with
+`### Verdict: ...` in the summary template. The token must be one of:
 `READY_TO_MERGE`, `NEEDS_FIXES`, `BLOCKED`, `NEEDS_HUMAN`, `NEEDS_REBASE`.
+
+**Read only when:** a posted verdict did not produce the label or approval
+you expected and you are diagnosing why — `sections/verdict-stamp-mechanics.md`
+inventories the four workflows that react to the marker. Emitting the marker
+correctly requires none of it.
 
 ### 3d. Resolve Inline Threads (on APPROVE)
 

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -29,55 +29,46 @@ conformance-only `@sdk-loop` review all six conditions are false, which is
 original text verbatim, and a test asserts every one of them is still reachable
 from a pointer here.
 
-## Runtime
+## Runtime — lane capabilities
 
-Two lanes run this playbook, and they differ in what the SURROUNDING system
-already guarantees. Everything about what a good review IS — routing, agents,
-severity, the verdict — is identical. Only the bookkeeping differs, and doing
-a lane's bookkeeping twice is not free: each step is a model round trip, and
-several of them cannot even succeed on the wrong lane.
+Two lanes run this playbook. What a good review IS — routing, severity,
+convergence, the verdict — is identical on both. What DIFFERS is what the
+surrounding system can do, and every lane-conditional step below derives from
+this one table.
 
-<!-- CONTRACT: the literal string `LANE: sdk-loop` below is emitted by
-     review_prompt() in .github/scripts/sdk_loop_phase.py. Two files, one
-     string — exactly the shape that rots silently, because a playbook that
-     waits for a line nobody sends does not error, it just quietly runs the
-     wrong lane's steps and eats the 403s. Renaming it on either side without
-     the other breaks lane detection with no failing test and no log line
-     saying so. test_the_lane_marker_matches_the_playbook_contract in
-     .github/scripts/tests/test_sdk_loop.py asserts both sides agree; if you
-     change this string, that test fails and tells you where the other half
-     lives. Do not "fix" the test by loosening it. -->
+**You are told which lane you are on. Do not work it out.** The `@sdk-loop`
+harness emits the line `LANE: sdk-loop` in the dispatch prompt; its absence
+means the mothership sandbox. Probing for `/workspace` or a runner env var
+costs a turn and can be wrong.
 
-**You are told which lane you are on. Do not work it out.** The dispatch
-prompt states it: the `@sdk-loop` harness emits the line `LANE: sdk-loop`,
-and its absence means the mothership sandbox. Inferring it instead — probing
-for `/workspace`, reading `pwd`, checking for a runner env var — costs a turn
-and can be wrong; a live transcript shows an agent spending one on
-`ls -la /workspace/application-sdk … || echo "NO /workspace/application-sdk"`
-before doing any review work.
-
-This matters because the difference is not cosmetic. Several steps below
-**cannot succeed** on the wrong lane: they need a write scope the `@sdk-loop`
-review token does not have, and they fail with a 403 after the model has
-already been paid for the turn that made the call.
-
-| | mothership sandbox | `@sdk-loop` (GitHub Actions) |
+| Capability | mothership sandbox | `@sdk-loop` |
 |---|---|---|
-| Working directory | `/workspace/application-sdk` | the checkout you start in |
-| Duplicate triggers | A3/A4 guards | the Fence job, before any model runs |
-| Replay after a dropped stream | A3 guard | n/a — one invocation per job |
-| Stale / moved HEAD | A2 guard | the harness re-aims and restarts the round |
-| Per-run `/tmp` hygiene | A1 guard | fresh runner every phase |
-| Prior review + delta | you compute it (§6b, §6c) | handed to you in the prompt; still verify |
-| Branch update when BEHIND | §8 | your token has no write scope — report, do not attempt |
-| Commit status / labels / approval | the GHA layer (§3c) | the GHA layer (§3c) |
+| `write-branch` — push, update-branch, set commit status | yes | **no** (403) |
+| `clone-private` — clone other atlanhq repos | yes | **no** (no credential) |
+| `reach-proxy` — `$PROXY_BASE` / `$PROXY_JWT` | yes | **no** (unset) |
+| `given-scope` — `review_scope` arrives in the prompt | no — derive it | **yes** |
+| `given-delta` — prior review + delta arrive in the prompt | no — compute it | **yes** |
+| `needs-run-guards` — `/tmp` reset, replay + stale-SHA guards | yes | no — fresh runner, Fence job |
 
-**The review never writes to the branch on either lane.** It posts a summary
-comment and inline findings; it does not commit, push, run `pre-commit`, run
-tests, or fix CI. On `@sdk-loop` that is enforced by the credential rather
-than by this sentence: the review phase holds a token with no `contents` and
-no `statuses` scope, so an attempt fails with a 403 rather than doing harm.
-Do not treat such a 403 as something to work around.
+**How to use it.** A step tagged `requires: <capability>` runs only where this
+table says yes for your lane; where it says no, do what the step's fallback
+says and move on. A step tagged `given: <capability>` means the value is
+handed to you — verify it, never re-derive it. A step with neither tag runs
+identically on both lanes.
+
+**Two rules that hold on BOTH lanes regardless of capability:**
+
+* **The review never writes to the branch.** It posts a summary comment and
+  inline findings; it does not commit, push, run `pre-commit`, run tests, or
+  fix CI. On `@sdk-loop` the credential enforces this — a token with no
+  `contents` and no `statuses` scope. Do not treat such a 403 as something to
+  work around.
+* **A capability you lack is not a defect to report.** Take the fallback,
+  note it in the summary where the step says to, and continue. Retrying it,
+  or filing it as a finding, spends a turn and tells the reader nothing.
+
+Working directory: `/workspace/application-sdk` on the sandbox (`cd` there);
+on `@sdk-loop` you already start in the checkout.
 
 ## Time Budgets
 
@@ -138,25 +129,14 @@ PR_NUMBER, PR_URL, REPO, HEAD_SHA, BASE_REF, HEAD_REF,
 COMMENTER, COMMENT_ID, COMMENTER_INTENT
 ```
 
-1. **Set working directory.** On the mothership sandbox the repo is cloned
-   on the PR head ref into `/workspace/application-sdk`, so `cd` there. Under
-   `@sdk-loop` you already start in the checkout — do not look for
-   `/workspace`, it does not exist on a runner and probing for it costs a turn.
+1. **Set working directory** per the Runtime table. Do **not** warm
+   dependencies — this playbook never runs `pytest` or `pre-commit` (step 9).
 
-   Do **not** warm dependencies. This playbook never runs `pytest` or
-   `pre-commit` — §9 is explicit that the review does not run them — so the
-   `uv sync --all-extras` that used to sit here bought nothing and competed
-   with the review for I/O on every single run. `pr-resolve` and
-   `sdk-evolution` DO run them and warm deps for that reason; this playbook
-   is not those.
+1b. **Start the budget clock**, before any other work. Defaults to the
+    Small hard stop; step 12 raises it once the tier is known.
 
-1b. **Start the budget clock** — do this before any other work, so the
-    elapsed number covers the whole run. Defaults to the Small hard stop;
-    step 12 raises it once the tier is known.
-
-Run this block **exactly as written, unindented**. The heredoc terminator
-must sit at column 0 or `cat` never closes it and the shell hangs waiting
-for input:
+Run this block **exactly as written, unindented** — an indented heredoc
+terminator never closes and the shell hangs waiting for input:
 
 ```bash
 date +%s > /tmp/REVIEW_START_TS
@@ -177,11 +157,14 @@ printf '[budget] elapsed %dm %02ds / hard stop %dm (%d%%) — %s\n' \
 BUDGET
 ```
 
-2. **Auth setup** — `$GITHUB_TOKEN` is injected by mothership from its
-   GitHub App installation (see snapshots/_base). Make `gh` use it:
+2. **Auth setup.** On the mothership sandbox, `$GITHUB_TOKEN` is injected
+   from its GitHub App installation; make `gh` use it:
    ```bash
    echo "$GITHUB_TOKEN" | gh auth login --with-token 2>/dev/null
    ```
+   On `@sdk-loop`, `gh` is already authenticated from `GH_TOKEN` in the
+   environment — running the login above exits 1 there and buys nothing.
+   Skip it and go straight to step 3.
 
 3. **Fetch authoritative PR metadata** (no session/PR.md anymore):
    ```bash
@@ -195,11 +178,9 @@ BUDGET
    gh pr diff "$PR_NUMBER" --repo "$REPO" > /tmp/DIFF.patch
    ```
 
-4b–5. **Sandbox-only run guards** — resetting `/tmp` artifacts and the
-   stale-SHA bail-out. Under `@sdk-loop` neither applies: every phase gets a
-   fresh runner with nothing to reset, and the harness owns HEAD movement
-   (`head_state`, and the Fence job). See Appendix A. On the sandbox, run
-   them.
+4b–5. **Run guards** — `/tmp` reset and the stale-SHA bail-out.
+   `requires: needs-run-guards` → see Appendix A. Where the table says no,
+   skip both.
 
 6. **Read in-repo orchestration assets** — these are the source of truth
    for SDK review behavior. All paths are relative to the repo root:
@@ -207,35 +188,23 @@ BUDGET
    - `.mothership/pr-review/severity-rubric.yaml` (includes severity
      calibration + confidence floors — the single source for both)
    - the brief for each agent §2a will dispatch, **by explicit path**
-     (`.mothership/pr-review/agents/<name>.md`) — not all of them, and
-     never via Glob. `Glob ".mothership/pr-review/agents/*.md"` returns
-     **0 matches**: the tool is ripgrep-backed and ripgrep skips
-     dot-directories. Two measured runs each burned a turn on that
-     zero-match. The same trap applies to any grep over `.mothership/**` —
-     an agent that searches the reference rules for prior art, gets nothing,
-     and concludes there is none will raise a finding the rules already
-     answer. That is the expensive failure; the wasted turn is the cheap one.
+     (`.mothership/pr-review/agents/<name>.md`) — not all of them.
 
-   `review-policy.md` and `review.yaml` are gone from this list on purpose.
-   The by-design patterns that lived in `review-policy.md` are now part of
-   `references/retro-log.md` — the single do-not-flag source, consulted by
-   whoever raises findings — and `review.yaml`'s rules were a paraphrase of
-   the rubric and CLAUDE.md, which this step already loads. Two files, two
-   tool calls, ~750 tokens on every review, zero unique content.
+   **Never Glob or grep under `.mothership/**`.** The tool is ripgrep-backed
+   and ripgrep skips dot-directories, so it returns 0 matches and you cannot
+   tell that from "nothing there". An agent that searches the reference rules
+   for prior art, gets nothing, and concludes there is none will raise a
+   finding those rules already answer. Always read by explicit path.
 
-   **`references/*.md` is NOT read here.** It is ~125 KB — over half
-   everything this step would otherwise load — and it is consumed by the
-   Phase 2 agents, which receive their reference rules when dispatched
-   (§2a). Reading it up front pays for it twice, and pays for it at all on
-   reviews where no agent ever runs. Defer it to §6d.
+   This list is complete. Do not add `review-policy.md` or `review.yaml` —
+   both are delisted — and **do not read `references/*.md` here**; §6d
+   assigns those to whoever reviews that domain.
 
-6b/6c. **Prior review and the re-review delta.**
-
-    * `LANE: sdk-loop` — both are **handed to you in the dispatch prompt**: the
-      prior verdict, and the incremental range as `git diff <prior>..<head>`.
-      Verify them; do not recompute them.
-    * mothership sandbox — **read only when:** you are on that lane; then
-      follow 6b, 6c and 11b in `sections/prior-review-and-delta.md`.
+6b/6c. **Prior review and the re-review delta.** `given: given-delta` —
+    where the table says yes, the prior verdict and the incremental range
+    (`git diff <prior>..<head>`) arrive in the prompt; verify, do not
+    recompute. Otherwise **read only when:** your lane must compute them —
+    follow 6b, 6c and 11b in `sections/prior-review-and-delta.md`.
 6d. **Do NOT read `references/*.md`. The agents that use them read them.**
 
     Each Phase 2 agent now names the reference files it owns, at the top of
@@ -249,25 +218,12 @@ BUDGET
     | `ci-config.md`, `conformance.md` | `retro-log` |
     | `toolkit-review.md` | `toolkit-consumer-registry` |
 
-    The ownership is derived from each agent's own Domain Tags, not assigned
-    by hand: `[SEC]` → security-rules, `[QUAL]` → code-quality-rules, and so
-    on. A file owned by two agents is read by both — they are separate
-    contexts, and sharing costs nothing.
+    A file owned by two agents is read by both — separate contexts, sharing
+    costs nothing.
 
-    Why this is a real change and not tidying: these files are ~125 KB, the
-    single largest input to a review, and reading them here loaded ALL of them
-    for EVERY review no matter which agents ran. A `minor` PR dispatches only
-    `correctness` and paid for nine files to use two. Reading them at the point
-    of use also fixes an older ambiguity — §2a said each agent receives "their
-    reference rules" without anywhere defining which those were, so six of the
-    nine files were named by nothing at all and reached agents only because the
-    orchestrator had globbed everything.
-
-    You still read `severity-rubric.yaml`, `CLAUDE.md`, `review-policy.md` and
-    `review.yaml` in step 6: those govern YOUR decisions, not an agent's.
-
-    Exception: §1b-toolkit reads `toolkit-consumer-registry.md` directly,
-    because it needs the registry before any agent is dispatched.
+    You still read `severity-rubric.yaml` and `CLAUDE.md` in step 6: those
+    govern YOUR decisions, not an agent's. Exception: §1b-toolkit reads
+    `toolkit-consumer-registry.md` directly, before any agent is dispatched.
 
 7. **Always run a standard review.** There is a single mode. Ignore any
    free-form text after `@sdk-review` (`COMMENTER_INTENT`) — there are no
@@ -303,40 +259,28 @@ BUDGET
     round that swallowed it would keep spending rounds on a branch no resolve
     phase can move.
 
-    **If `BEHIND`:**
-
-    * `LANE: sdk-loop` — your token carries no write scope, so
-      `update-branch` 403s. Review the branch as it is and note it in the
-      summary. A base merge cannot introduce a finding in the PR's own hunks,
-      which is what the review is about. Do not retry, and do not report the
-      403 as a defect. Nothing further to read.
-    * mothership sandbox — **read only when:** you are on that lane AND the
-      branch is `BEHIND`; then follow `sections/branch-freshness.md`.
-9. **Do not read CI.** Removed, not moved: the review cannot act on a check
-   either way — it holds no write scope on this lane — and
-   `sdk-review-downgrade-on-ci-failure.yml` already enforces CI against the
-   verdict event-driven, which is the only race-free way to do it. CI legs
-   routinely finish AFTER a review posts, so a reviewer-side snapshot was
-   always a stale fact reported next to a verdict it could not influence.
-   Under `@sdk-loop` the prep phase owns branch and check state before the
-   first review starts. Spend no turn on `gh pr checks`.
+    **If `BEHIND`:** `requires: write-branch`. Where the table says yes,
+    **read only when:** the branch is actually `BEHIND` — then follow
+    `sections/branch-freshness.md`. Where it says no, review the branch as it
+    is and note it in the summary: a base merge cannot introduce a finding in
+    the PR's own hunks, which is what the review is about.
+9. **Do not read CI, on either lane.** `sdk-review-downgrade-on-ci-failure.yml`
+   enforces CI against the verdict event-driven; the review cannot act on a
+   check and its snapshot would be stale by the time anyone read it. Spend no
+   turn on `gh pr checks`.
 
 10. Read the repo's `CLAUDE.md` for project conventions.
 
 11. **Smart agent routing.** `review_scope` decides which specialists §2a
-    dispatches.
+    dispatches. `given: given-scope` — where the table says yes, the harness
+    computed it before the phase started; use it and do NOT re-derive it.
+    Otherwise **read only when:** your lane must derive it — follow
+    `sections/scope-classification.md`.
 
-    * `LANE: sdk-loop` — **you are told your scope. Do NOT derive it.** The
-      harness computed it in Python before the phase started, from the same
-      file-list arithmetic, and re-running that classification spends a turn to
-      reach the answer you already have.
-    * mothership sandbox — **read only when:** you are on that lane; then
-      follow `sections/scope-classification.md` to derive `review_scope`.
-
-    §2a's routing table below is the authority for scope-to-agent mapping on
-    both lanes, and stays here.
+    §2a's routing table is the authority for scope-to-agent mapping on both
+    lanes, and stays in this file.
 11b. **Re-review delta scoping** — **read only when:** `DELTA_KNOWN=1` from
-    step 6c, which only the sandbox lane computes. It lives at the end of
+    step 6c, i.e. your lane computed its own delta. It lives at the end of
     `sections/prior-review-and-delta.md`.
 12. Check diff size for tier, and raise the budget cap to match it
     (step 1b defaulted to the Small hard stop):
@@ -376,18 +320,13 @@ On a delta-scoped re-review (step 11b), run it over the delta files only.
 
 ### 1b-toolkit. Private Toolkit Consumer Setup
 
-**Read only when:** `review_scope` is `contract-toolkit` or
-`mixed-sdk-toolkit` AND you are on the mothership sandbox — then read
-`sections/toolkit-consumer-setup.md`.
+`requires: clone-private`. **Read only when:** `review_scope` is
+`contract-toolkit` or `mixed-sdk-toolkit` AND the Runtime table says your lane
+can clone private repos — then read `sections/toolkit-consumer-setup.md`.
 
-**On `LANE: sdk-loop`, do not read it and do not attempt any of it, even on a
-toolkit scope.** Its consumer validation clones private atlanhq repos, and
-this lane's credential cannot: `GH_TOKEN` is an App token scoped to THIS
-repository, and git has no other helper on the runner — so every clone dies
-with `fatal: could not read Username for 'https://github.com'`. A live
-toolkit-scope run (PR #3594) failed all five clones exactly this way, kept
-going, and was killed by the idle watchdog with no verdict after ~8 minutes.
-Instead, on this lane:
+Where it says no (`@sdk-loop`), **do not read it and do not attempt any of
+it, even on a toolkit scope.** Every clone dies with `fatal: could not read
+Username for 'https://github.com'`. Instead, on this lane:
 
 ```bash
 cat > /tmp/TOOLKIT_ROVER_NOTE.md <<'NOTE'
@@ -400,38 +339,20 @@ NOTE
 
 then review the toolkit surfaces from this repo's own diff and generated
 artifacts, and let §3e's Review Note block carry that note into the summary.
-The note downgrades confidence honestly; five guaranteed clone failures
-followed by a dead phase reports nothing at all.
+§2h turns a non-empty Rover note into `NEEDS_HUMAN`, so the gap is reported,
+not hidden.
 
-Skip the section entirely on every other scope — it is private-repo clone-and-validate setup for surfaces your scope
-does not touch, and on a two-file conformance PR it is the single largest
-block of context you would carry for no reason.
+Skip the section entirely on every other scope.
 ### 1c. Prepare Context by Tier
 
 **Token budgets (hard limits — never exceed). These bind the context of
 WHOEVER reviews, dispatched agent or not.**
 
-Written as "per agent call" when every review fanned out. It no longer does:
-§2a routes a single-specialist scope to the primary agent, and on twelve of
-fourteen measured `@sdk-loop` runs nothing was dispatched at all — so the only
-cap in this playbook applied to a code path those reviews never took, and the
-primary's own context went unbounded. Apply the same ceiling to yourself when
-you are the one reviewing.
-
-The ceiling is not the model's window and must not be raised to it. Two
-measured reasons:
-
-* **Latency.** Turn latency on the review model climbs with accumulated
-  context — ~10s early in a phase, 75-90s by turn 12 — so every token carried
-  is charged again on each of the remaining turns.
-* **Price.** `xai/grok-4.6` doubles its per-token rate above a 200K context.
-  A review that drifts over that line costs twice as much per token for the
-  rest of the phase, silently.
-
-Independently, PR-Agent caps its own input at 32K against models with far
-larger windows, on the stated grounds that "the AI model degrades in
-performance when the input is too long". Ours is deliberately looser than
-that; it is not looser than the numbers above.
+This ceiling applies to the context of whoever reviews — a dispatched agent,
+or you when nothing is dispatched. It is **not** the model's window and must
+not be raised to it: turn latency climbs from ~10s to 75-90s by turn 12 as
+context accumulates, and `xai/grok-4.6` doubles its per-token rate above a
+200K context.
 
 | Content | Max tokens (approx) |
 |---------|-------------------|
@@ -633,11 +554,8 @@ present. The toolkit agent must not include private consumer repo names, paths,
 or SHAs in public findings.
 
 **A dispatch cannot be interrupted, so this is your LAST decision point.**
-Once Wave 1 is dispatched you regain control only when the agents return —
-`budget.sh` runs at phase boundaries, and the next boundary is after them.
-Measured: 43 minutes inside a single dispatch against a 15-minute hard stop,
-which then printed `OVER HARD STOP` to nobody who could act on it. Spend the
-check here or not at all.
+Once Wave 1 is dispatched you regain control only when the agents return.
+Run the budget check here or not at all.
 
 **Degradation priority** — run `bash /tmp/budget.sh` BEFORE dispatching
 Wave 1 and drop agents by the measured percentage, not by feel:
@@ -655,12 +573,12 @@ Parse JSON findings from each agent response.
 
 ### 2b. Wave 2 — cross-model adversarial (via proxy)
 
-**Read only when:** you are on the mothership sandbox lane.
-On `LANE: sdk-loop`, skip `sections/adversarial-wave-2.md` entirely. It curls
-`$PROXY_BASE/proxy/litellm/...` with `$PROXY_JWT`; both are sandbox variables
-that do not exist on a GitHub Actions runner, so on the loop lane the step
-cannot succeed and reading it only pays for context. That lane's resolve phase
-contests every finding instead, so the challenge still happens.
+`requires: reach-proxy`. **Read only when:** the Runtime table says your
+lane can reach `$PROXY_BASE` — then follow `sections/adversarial-wave-2.md`.
+Where it says no, skip it: the step cannot succeed, and on `@sdk-loop` the
+resolve phase contests every finding instead, so the challenge still happens.
+Record the skip as the dispatch prompt tells you to — do not invent wording
+here, and never report it as "unavailable".
 ### 2c. De-Bias (deterministic)
 
 | Opus (Wave 1) | GPT (Wave 2) | Action |
@@ -677,13 +595,9 @@ If GPT was unavailable or skipped: keep all Opus findings >= 80%.
 
 ### 2d. Root-Cause Clustering & Class-Completeness Sweep
 
-Findings arrive atomized — one per file/line — but bugs travel in
-**classes**. If you report only the instances the agents happened to
-land on, the author fixes them one at a time and the same defect comes
-back for another review round (and another, and another). A single
-revert-scope bug once cost this repo five review rounds because each
-round fixed the one instance reported and never the class. Kill the
-whole class in one pass.
+Bugs travel in **classes**. Report only the instances the agents landed on
+and the author fixes them one at a time, round after round. Kill the class in
+one pass.
 
 Operate on the post-de-bias finding set, before locking the verdict:
 
@@ -722,15 +636,8 @@ Operate on the post-de-bias finding set, before locking the verdict:
    invariant, not the instances. This is the single highest-leverage step
    for holding a PR to 2-3 review rounds instead of 20+.
 
-**Scope — reviewer only.** This step targets the sdk-review reviewer, whose
-failure mode is *under*-generalization across serial human review rounds. Do
-not port it to the deterministic conformance remediation loop
-(`detect-fix-recheck`): that loop already fans out into independent,
-individually-gated per-finding fixes, and there per-site independence
-(fix-vs-suppress decided per site; uncorrelated model errors that recheck
-catches one at a time) is a feature, not a limitation. Clustering the *fixes*
-there would trade that robustness away for a round-count problem the
-self-iterating loop doesn't have.
+**Scope — reviewer only.** Do not port this to the conformance remediation
+loop (`detect-fix-recheck`); its per-site independence is a feature.
 
 ### 2e. Delta Tracking (if previous review exists)
 
@@ -756,19 +663,11 @@ what remains.
 
 ### 2e′. Nit convergence — keep the loop terminating AND the verdict reachable
 
-`@sdk-resolve` (the write counterpart, `.mothership/pr-resolve/`) drives a PR by
-looping review→fix→push until `### Findings` is **empty** (nits included). That
-loop only terminates if the *nit* stream is **bounded, diff-local, and
-actionable**. A reviewer that surfaces a fresh batch of pre-existing optional
-nits every pass — or lists observations it recommends no action on — makes that
-loop non-terminating: it spins round after round until the sandbox dies with no
-hand-off. The three rules below keep nits convergent.
-
-Since `READY_TO_MERGE` now requires an empty `### Findings` (§2h), these rules
-carry a second load: an unconvergent nit stream no longer just wastes resolver
-rounds, it withholds the approval indefinitely. A `Nit` that survives these
-three rules is one the resolver can clear; anything else must not be listed as a
-finding at all.
+`@sdk-resolve` loops review→fix→push until `### Findings` is **empty**, nits
+included, and `READY_TO_MERGE` requires that same empty list (§2h). So an
+unconvergent nit stream does not merely waste rounds — it withholds the
+approval indefinitely. A `Nit` that survives the three rules below is one the
+resolver can clear; anything else must not be listed as a finding at all.
 
 **They apply to `Nit`-tier findings ONLY.** Critical / High / Important
 findings — and any regression a pushed fix introduces — are ALWAYS raised, on
@@ -799,10 +698,7 @@ higher tiers is unchanged.
    never be cleared, so listing it would wedge the loop forever.
 
 Net effect: once the author's real fixes land, a re-review of the same
-substantive change returns an **empty** `### Findings` with `READY_TO_MERGE`, and
-the resolver converges — typically in 2–3 rounds — handing over a clean PR.
-`MAX_ROUNDS` stays the backstop for the rare case where a fix legitimately keeps
-spawning new work.
+substantive change returns an **empty** `### Findings` with `READY_TO_MERGE`.
 
 ### 2f. Guardrails G1-G7
 
@@ -831,34 +727,19 @@ MEDIUM/LOW/INFO findings: one-line suggested_fix only. No path_forward.
 | NEEDS_FIXES | Critical, G4/G6, **any Important, any Nit** | REQUEST_CHANGES |
 | READY_TO_MERGE | **`### Findings` is empty — 0 Critical, 0 Important AND 0 Nit** | APPROVE |
 
-CI is not a verdict input and is not reported. `sdk-review-downgrade-on-ci-failure.yml`
-strips an approval event-driven the moment any non-review check fails — the only
-race-free enforcement, since CI legs routinely finish after the review posts.
+CI is not a verdict input and is not reported.
 
-`READY_TO_MERGE` is strict: **any** finding still listed under
-`### Findings` forces `NEEDS_FIXES`, whatever its tier. A single
-Important does it; so does a single `Nit`. The verdict and the
-write-side resolver now agree on one bar — §2e′ already promises that
-"once the author's real fixes land, a re-review of the same substantive
-change returns an **empty** `### Findings` with `READY_TO_MERGE`", and
-the resolver has always looped until every finding "nits included" is
-cleared. Approving over an open nit made the reviewer the looser of the
-two and left the resolver still working on a PR that was already
-stamped.
+`READY_TO_MERGE` is strict: **any** finding still listed under `### Findings`
+forces `NEEDS_FIXES`, whatever its tier — a single Important does it, so does
+a single `Nit`.
 
-The load this puts on `Nit` discipline is the point, and §2e′ is what
-carries it: a `Nit` you list must be one the resolver can actually
-clear, or the loop wedges. **Before listing any `Nit`, apply the §2e′
-convergence rules** (diff-scope, re-review monotonicity, actionability).
-An observation that fails them is not a finding — put it in
-`### Strengths` or prose, never under `### Findings`. That was already
-the rule; it is now load-bearing for the verdict too.
+**Before listing any `Nit`, apply the §2e′ convergence rules** (diff-scope,
+re-review monotonicity, actionability). An observation that fails them is not
+a finding — put it in `### Strengths` or prose, never under `### Findings`.
 
-If you believe an Important should be downgraded, downgrade it
-explicitly in §2e with a one-line reason — do not silently approve over
-the top of it. Downgrading an Important to a `Nit` no longer buys an
-approval, so a finding you genuinely accept must be dropped with its
-reason, not demoted.
+To downgrade an Important, do it explicitly in §2e with a one-line reason.
+Demoting it to a `Nit` does not buy an approval, so a finding you genuinely
+accept must be DROPPED with its reason, not demoted.
 
 Print: `[Phase 2 complete] <N> findings across <C> classes, verdict=<verdict>`
 then `bash /tmp/budget.sh`.

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -357,7 +357,30 @@ does not touch, and on a two-file conformance PR it is the single largest
 block of context you would carry for no reason.
 ### 1c. Prepare Context by Tier
 
-**Token budgets per agent call (hard limits — never exceed):**
+**Token budgets (hard limits — never exceed). These bind the context of
+WHOEVER reviews, dispatched agent or not.**
+
+Written as "per agent call" when every review fanned out. It no longer does:
+§2a routes a single-specialist scope to the primary agent, and on twelve of
+fourteen measured `@sdk-loop` runs nothing was dispatched at all — so the only
+cap in this playbook applied to a code path those reviews never took, and the
+primary's own context went unbounded. Apply the same ceiling to yourself when
+you are the one reviewing.
+
+The ceiling is not the model's window and must not be raised to it. Two
+measured reasons:
+
+* **Latency.** Turn latency on the review model climbs with accumulated
+  context — ~10s early in a phase, 75-90s by turn 12 — so every token carried
+  is charged again on each of the remaining turns.
+* **Price.** `xai/grok-4.6` doubles its per-token rate above a 200K context.
+  A review that drifts over that line costs twice as much per token for the
+  rest of the phase, silently.
+
+Independently, PR-Agent caps its own input at 32K against models with far
+larger windows, on the stated grounds that "the AI model degrades in
+performance when the input is too long". Ours is deliberately looser than
+that; it is not looser than the numbers above.
 
 | Content | Max tokens (approx) |
 |---------|-------------------|
@@ -373,7 +396,7 @@ block of context you would carry for no reason.
 Read ALL changed source + test files completely. Send full diff.
 This fits within budget for most PRs.
 
-**Safety check:** Before sending to agents, measure total context:
+**Safety check:** Before reviewing — before dispatching, or before starting Phase 2 yourself if nothing is dispatched — measure total context:
 ```bash
 DIFF_CHARS=$(wc -c < /tmp/DIFF.patch)
 FILE_CHARS=0
@@ -403,7 +426,7 @@ grep -A 9999 "^diff --git a/<file>" /tmp/DIFF.patch | \
   sed '/^diff --git a\//q' | head -n -1
 ```
 
-**Per-agent safety check:** If a partition still exceeds 100K tokens:
+**Per-reviewer safety check:** If a partition — or your own context, when you are reviewing inline — still exceeds 100K tokens:
 - Truncate the LARGEST files: send first 500 lines + last 100 lines + function index
 - Format truncated files as:
   ```

--- a/.mothership/pr-review/references/retro-log.md
+++ b/.mothership/pr-review/references/retro-log.md
@@ -137,3 +137,49 @@
 > `PrivateOrchestrationInternalImport`, `TemporalImportOutsideAdapter`,
 > `RawTemporalInPublicSurface`), and `logger.critical()` usage
 > (`LoggerCriticalUsage`).
+
+## By-design patterns (merged from `.mothership/review-policy.md`)
+
+These are intentional. Do NOT flag them as issues. Moved here because
+CLAUDE.md declares this file the ONLY do-not-flag list while these lived in a
+second one — every review either read both files or silently missed one.
+
+
+### Known Tech Debt (Tracked)
+- `common/utils.py` contains mixed utilities — known dumping ground, tracked
+  in BLDX milestone. Only flag SECURITY issues in this file, not structural.
+
+### Infrastructure Abstraction Layers
+- `execution/_temporal/` uses direct `temporalio` imports — this IS the
+  abstraction layer. Not a violation.
+- `infrastructure/_dapr/` uses direct `dapr` imports — this IS the
+  abstraction layer. Not a violation.
+- `infrastructure/_redis/` uses direct `redis` imports — this IS the
+  abstraction layer. Not a violation.
+
+### Performance Patterns
+- `ThreadPoolExecutor` per query in low-frequency paths (< 10 calls per
+  workflow execution) is acceptable. Only flag if the path is hot (100+
+  calls per execution) or if the task has heartbeat enabled.
+- `run_in_thread` uses the default executor for non-heartbeat tasks. Only
+  flag if the task has `heartbeat_timeout_seconds` set AND the blocking
+  call is long-running (> 5s).
+
+### Test Patterns
+- Tests in `tests/unit/` use `asyncio_mode="auto"` — no `@pytest.mark.asyncio`
+  needed. Do not flag its absence.
+- `clean_app_registry` fixture is defined in `conftest.py` — tests that
+  define App subclasses should use it, but it's not always necessary if
+  the test doesn't register apps.
+
+### Credential Handling
+- `CredentialRef` objects in contracts are serializable references (no
+  actual secrets). They are safe to pass through Temporal payloads.
+- `CredentialResolver` is intentionally restricted to `@task` methods
+  because resolution requires I/O to the secret store.
+
+### Error Codes
+- `AAF-{COMPONENT}-{ID:03d}` format is intentional. Do not suggest
+  alternative error code schemes.
+- `NonRetryableError` and `RetryableError` are the two error base classes.
+  Do not suggest additional error hierarchies.

--- a/.mothership/pr-review/sections/adversarial-wave-2.md
+++ b/.mothership/pr-review/sections/adversarial-wave-2.md
@@ -1,0 +1,38 @@
+# 2b. Wave 2 — cross-model adversarial (via proxy)
+
+### 2b. Wave 2 — GPT-5.3-codex Adversarial (via proxy)
+
+After Wave 1, call GPT to challenge your findings.
+
+**Skip conditions** (no adversarial):
+- `review_scope` is tests-only, conformance-only, config-only, docs-only, or minor
+- `review_scope` is contract-toolkit and toolkit-review.md produced zero findings
+- `review_tier` is "staged" (massive PR — too much context for one GPT call)
+- Wave 1 produced zero findings (nothing to challenge)
+- Time budget already over 70% consumed — run `bash /tmp/budget.sh` here
+  and skip whenever it prints `OVER 70%` or `OVER HARD STOP`. This is the
+  single most expensive optional step in the run (a full GPT-5.3-codex
+  call over the whole diff plus every Wave 1 finding), so it is the first
+  thing an over-budget run must give up.
+
+If not skipped:
+
+```bash
+curl -s "$PROXY_BASE/proxy/litellm/chat/completions" \
+  -H "Authorization: Bearer $PROXY_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-5.3-codex",
+    "temperature": 0.2,
+    "max_tokens": 16000,
+    "messages": [
+      {"role": "system", "content": "<agents/adversarial.md content>"},
+      {"role": "user", "content": "<Wave 1 findings + PR diff + annotations>"}
+    ]
+  }'
+```
+
+GPT challenges every Opus finding. GPT also discovers findings Opus missed.
+
+If GPT unavailable or skipped: keep all Opus findings >= 80%.
+Note in review: "Cross-model adversarial: <skipped (reason) | ran | unavailable>."

--- a/.mothership/pr-review/sections/branch-freshness.md
+++ b/.mothership/pr-review/sections/branch-freshness.md
@@ -1,16 +1,10 @@
-# Phase 0 step 8 — Branch freshness and conflict resolution
+# Phase 0 step 8 (BEHIND branch) — mothership sandbox only
 
-8. **Branch freshness + conflict resolution** (before reviewing):
-   ```bash
-   MERGE_STATUS=$(jq -r '.mergeStateStatus' /tmp/PR.json)
-   ```
+The `CONFLICTING` half of step 8 stays in ORCHESTRATION.md: it applies to both
+lanes, and `@sdk-loop` depends on the `NEEDS_REBASE` verdict it produces. Only
+the `BEHIND` update lives here, because only the sandbox lane can perform it.
 
-   If `BEHIND` — **sandbox only.** `update-branch` writes to the PR branch and
-   needs `contents: write`; the `@sdk-loop` review phase holds a token without
-   it, so this 403s. On that lane, review the branch as it is and note it in
-   the summary — a base merge cannot introduce a finding in the PR's own
-   hunks, which is what the review is about. Do not retry, and do not report
-   the 403 as a defect.
+8. **Branch is `BEHIND` — update it, then re-read what changed.**
 
    ```bash
    # Tier 1: GitHub-side update (merges base into the PR branch)
@@ -24,10 +18,10 @@
    gh pr diff "$PR_NUMBER" --repo "$REPO" > /tmp/DIFF.patch
    ```
 
-   If `CONFLICTING`: do NOT attempt a local merge or push — the review is
-   read-only (see Runtime). A conflict-resolution merge is the author's
-   decision, not the reviewer's. Submit minimal review: "PR has merge conflicts. Please
-   rebase or comment `@sdk-review` after resolving conflicts." Set the
-   verdict in §3e to `NEEDS_REBASE` (the structured marker is
-   `<!-- VERDICT: NEEDS_REBASE -->`); the GHA layer applies the
-   `sdk-review-needs-rebase` label from there. EXIT.
+   NOTE — unresolved tension, do not silently "fix" it either way. `update-branch`
+   is a WRITE to the PR branch, and the Runtime section of ORCHESTRATION.md
+   states flatly that "the review never writes to the branch on either lane".
+   Both statements are currently in the playbook. On `@sdk-loop` the question is
+   moot (no write scope, and FND-1185 moved branch duty to the prep phase, which
+   has one). On the sandbox lane it is a live contradiction and wants a decision
+   from a human, not a reviewer picking one sentence over the other mid-run.

--- a/.mothership/pr-review/sections/branch-freshness.md
+++ b/.mothership/pr-review/sections/branch-freshness.md
@@ -1,0 +1,33 @@
+# Phase 0 step 8 — Branch freshness and conflict resolution
+
+8. **Branch freshness + conflict resolution** (before reviewing):
+   ```bash
+   MERGE_STATUS=$(jq -r '.mergeStateStatus' /tmp/PR.json)
+   ```
+
+   If `BEHIND` — **sandbox only.** `update-branch` writes to the PR branch and
+   needs `contents: write`; the `@sdk-loop` review phase holds a token without
+   it, so this 403s. On that lane, review the branch as it is and note it in
+   the summary — a base merge cannot introduce a finding in the PR's own
+   hunks, which is what the review is about. Do not retry, and do not report
+   the 403 as a defect.
+
+   ```bash
+   # Tier 1: GitHub-side update (merges base into the PR branch)
+   gh api "repos/$REPO/pulls/$PR_NUMBER/update-branch" \
+     -X PUT -f update_method=merge 2>/dev/null
+   sleep 10
+   # Re-fetch — SHA changed after merge
+   git fetch origin "$HEAD_REF" && git reset --hard "origin/$HEAD_REF"
+   # Re-fetch authoritative PR metadata and diff after the update
+   gh pr view "$PR_NUMBER" --repo "$REPO" --json number,state,isDraft,mergeable,mergeStateStatus,headRefName,baseRefName,headRefOid,title,body,labels > /tmp/PR.json
+   gh pr diff "$PR_NUMBER" --repo "$REPO" > /tmp/DIFF.patch
+   ```
+
+   If `CONFLICTING`: do NOT attempt a local merge or push — the review is
+   read-only (see Runtime). A conflict-resolution merge is the author's
+   decision, not the reviewer's. Submit minimal review: "PR has merge conflicts. Please
+   rebase or comment `@sdk-review` after resolving conflicts." Set the
+   verdict in §3e to `NEEDS_REBASE` (the structured marker is
+   `<!-- VERDICT: NEEDS_REBASE -->`); the GHA layer applies the
+   `sdk-review-needs-rebase` label from there. EXIT.

--- a/.mothership/pr-review/sections/prior-review-and-delta.md
+++ b/.mothership/pr-review/sections/prior-review-and-delta.md
@@ -1,0 +1,110 @@
+# Phase 0 steps 6b, 6c and 11b — prior review, delta, and delta scoping
+
+6b. **Load prior review into context (re-review continuity)** — if a
+    previous `<!-- SDK_REVIEW -->` summary comment exists on this
+    PR, read its full body and write it to `/tmp/PRIOR_REVIEW.md`. The
+    body becomes **input** to Phase 2 reasoning (not just a labeling
+    reference for §2e at the end): it tells the agents what was flagged
+    before, what the author said in response, and what should be
+    carried forward, downgraded, or re-checked given the current HEAD.
+
+    ```bash
+    # S5: use --paginate --slurp and pipe into standalone jq. The naive
+    # --paginate --jq idiom runs the jq filter once PER PAGE, so `last`
+    # picks the last match on the FIRST page, not the last match across all
+    # pages. On PRs with many comments spanning multiple API pages this
+    # would silently load an older review. --slurp collapses pages into one
+    # outer array; `.[][]` flattens into a single stream before `last`.
+    PRIOR_REVIEW=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+      --paginate --slurp 2>/dev/null \
+      | jq -r '[.[][] | select(.body | contains("<!-- SDK_REVIEW -->"))] | last | .body // ""')
+
+    if [ -n "$PRIOR_REVIEW" ]; then
+      printf '%s\n' "$PRIOR_REVIEW" > /tmp/PRIOR_REVIEW.md
+      echo "[bootstrap] prior sdk-review summary found — loaded into /tmp/PRIOR_REVIEW.md"
+    else
+      : > /tmp/PRIOR_REVIEW.md
+      echo "[bootstrap] no prior sdk-review summary — fresh review"
+    fi
+    ```
+
+    **CRITICAL — jq idiom:** two mistakes to avoid:
+    - `--jq '.[] | select(...) | .body' | head -1` collapses the raw
+      multiline body to its first line (the `<!-- SDK_REVIEW -->`
+      HTML marker) and silently drops the entire review content.
+    - `--paginate --jq '[.[] | select(...)] | last'` runs the jq filter
+      ONCE PER PAGE, so `last` picks the final match on page 1, not
+      across all pages. On a PR with enough comments to span pages,
+      this returns a stale older review. Always use `--paginate --slurp`
+      and pipe into standalone `jq -r '[.[][] | select(...)] | last'`.
+
+    Every subsequent phase that reasons about the PR (Phase 2 agents,
+    cross-model debias, verdict determination) should treat
+    `/tmp/PRIOR_REVIEW.md` as additional context when non-empty —
+    not because it's authoritative, but because it captures both the
+    prior bot's reasoning and (often, in author replies on inline
+    threads) the human's response, which materially changes what
+    counts as a "new" finding vs a known-and-discussed one.
+
+    **Replay and duplicate-trigger guards are sandbox-only** — Appendix A.
+    They exist because mothership recovers a dropped stream by re-running
+    this prompt from the top in the SAME sandbox, and because a bot can
+    re-trigger a review of a HEAD already reviewed. `@sdk-loop` has neither
+    shape: opencode is invoked once per job, and its Fence job decides
+    duplicate triggers before any model runs.
+
+6c. **Compute the re-review delta (scope-cutter).** Each review summary
+    stamps the HEAD it reviewed as `<!-- REVIEWED_HEAD: <sha> -->` (§3e).
+    On a re-review, use it to scope Phase 1–2 to what actually changed —
+    re-deriving conclusions about unchanged hunks is the single largest
+    waste in multi-round reviews. If step 8 updates the branch (BEHIND),
+    re-run this computation after it — the HEAD changes.
+
+    ```bash
+    PRIOR_HEAD=$(grep -oE '<!-- REVIEWED_HEAD: [0-9a-f]{40} -->' /tmp/PRIOR_REVIEW.md \
+      | grep -oE '[0-9a-f]{40}' || true)
+
+    DELTA_KNOWN=0
+    : > /tmp/DELTA.patch
+    : > /tmp/DELTA_FILES.txt
+    if [ -n "$PRIOR_HEAD" ] && git cat-file -e "$PRIOR_HEAD" 2>/dev/null; then
+      DELTA_KNOWN=1
+      # Restrict to the PR's own files so base-branch merges between rounds
+      # don't inflate the delta. A PR file also touched by a base merge shows
+      # base churn — acceptable: it errs toward MORE review, never less.
+      gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[].path' > /tmp/PR_FILES.txt
+      git diff "$PRIOR_HEAD".."$HEAD_SHA" -- $(cat /tmp/PR_FILES.txt) > /tmp/DELTA.patch || true
+      git diff --name-only "$PRIOR_HEAD".."$HEAD_SHA" -- $(cat /tmp/PR_FILES.txt) > /tmp/DELTA_FILES.txt || true
+    fi
+    DELTA_LINES=$(grep -cE '^[+-]' /tmp/DELTA.patch 2>/dev/null || echo 0)
+    ```
+
+    `DELTA_KNOWN=0` (no prior review, a pre-rollout summary without the
+    marker, or an unfetchable `PRIOR_HEAD`) means **unknown**, not "nothing
+    changed" — skip delta scoping and run the full review. Only
+    `DELTA_KNOWN=1` activates step 11b.
+
+11b. **Re-review delta scoping** (only when `DELTA_KNOWN=1` from step 6c).
+    Step 11 decides *which* specialists could run; on a re-review the delta
+    decides *how much work actually remains*:
+
+    - `DELTA_LINES == 0` (re-trigger on the same HEAD, or only base merges
+      since the prior round) → **verification-only re-review**: skip Wave 1
+      and Wave 2 discovery entirely. Phase 2 reduces to §2e labeling of the
+      prior findings against the current HEAD plus the §2h verdict — no new
+      hunks means no new findings can exist.
+    - `0 < DELTA_LINES < 2000` → **delta-scoped re-review**: re-run the
+      step 11 bucket classification over `/tmp/DELTA_FILES.txt` (not the
+      full PR file list) and dispatch only the matching specialists. Agents
+      receive `/tmp/DELTA.patch` as the diff, `/tmp/PRIOR_REVIEW.md`, and
+      full file contents for delta files only. Prior findings on unchanged
+      hunks carry forward per §2e without re-deriving them; prior findings
+      whose lines the delta touched are re-verified (that IS the delta work).
+    - `DELTA_LINES >= 2000` → full review — a delta that large is a new PR
+      in all but name, and hunk-local reasoning stops being sound.
+
+    Guardrail floor: if ANY delta file is source (per the step 11 buckets),
+    the CORRECTNESS agent is always dispatched regardless of what the delta
+    classification says — the same G1–G5 floor the `minor` fast path keeps.
+    Toolkit delta files additionally keep the Phase 1b-toolkit obligations
+    (the carry-forward fast path there handles the unchanged-artifact case).

--- a/.mothership/pr-review/sections/sandbox-guards.md
+++ b/.mothership/pr-review/sections/sandbox-guards.md
@@ -1,0 +1,134 @@
+# Appendix A: Sandbox-only run guards
+
+## Appendix A: Sandbox-only run guards
+
+Everything here is for the **mothership sandbox**. `@sdk-loop` skips this
+section entirely — its harness does the same jobs in Python, before any model
+runs, which is both cheaper and not subject to an agent deciding to skip a
+step. Kept out of the main flow so the common path stays readable rather than
+carrying ~120 lines that two thirds of runs must reason past.
+
+A1. **Reset per-run review artifacts** — these files are load-bearing signals
+    across later phases, so never let a prior iteration in the same sandbox
+    affect the current verdict or public post:
+    ```bash
+    mkdir -p /tmp/inline-comments
+    find /tmp/inline-comments -type f \( -name '*.md' -o -name '*.json' \) -delete
+    ```
+    The toolkit ledger files (`/tmp/TOOLKIT_*.md|txt`) are reset at the top of
+    Phase 1b-toolkit — the only place that writes them — so non-toolkit scopes
+    don't touch them at all.
+
+A2. **Stale SHA guard** — bail if the PR has moved since dispatch:
+   ```bash
+   CURRENT_SHA=$(jq -r '.headRefOid' /tmp/PR.json)
+   if [ "$CURRENT_SHA" != "$HEAD_SHA" ]; then
+     echo "PR moved from $HEAD_SHA to $CURRENT_SHA since dispatch — aborting cleanly."
+     # Submit a minimal review so the status check doesn't stay pending,
+     # then exit. A fresh @sdk-review on the new HEAD gets a new session.
+     exit 0
+   fi
+   ```
+
+
+**A3. Same-run replay guard — run this immediately after loading
+`/tmp/PRIOR_REVIEW.md`, before anything else.** When the Claude
+stream drops mid-run (sandbox VPN reconnect, container eviction,
+transient API error), mothership recovers by re-running this prompt
+**from the top in the same sandbox** — a fresh run, not a `--resume`.
+If the first pass had already posted its summary, that retry loads
+its own summary as `PRIOR_REVIEW`, sees an empty delta, and posts a
+SECOND summary for the same HEAD. The PR then shows two reviews with
+different wording from a single `@sdk-review` trigger, and the
+workflow's soft-success check passes because *a* summary exists.
+
+Every summary's footer carries the run URL that produced it (§3e),
+and §3f posts the summary **last**, after the inline comments and the
+commit status — so a summary bearing this run's URL means this run's
+submission completed in full. Check *every* summary on the PR, not
+just the one 6b loaded: that one is only the latest, and an unrelated
+review landing between the first pass and the replay would hide this
+run's footer behind it.
+
+```bash
+# GHA_RUN_URL is given in the session prompt — substitute it literally,
+# shell variables do not persist between Bash calls.
+gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate --slurp 2>/dev/null \
+  | jq -r '[.[][] | select(.body | contains("<!-- SDK_REVIEW -->")) | .body] | join("\n")' \
+  | grep -qF '<GHA_RUN_URL>' \
+  && echo "REPLAY: this run already posted its review summary"
+```
+
+If that prints `REPLAY`, **stop the entire run here**: post nothing,
+set no commit status, resolve no threads, do not continue to Phase 1.
+The review was already delivered by the pass that died.
+
+Key the guard on the run URL, never on `HEAD_SHA` alone — a genuine
+re-trigger against an unchanged HEAD comes from a *different* run and
+must still produce a review.
+
+This guard only catches a replay that re-enters the prompt from the top.
+A provider-level retry that replays a single assistant *turn* re-executes
+the `gh api … /comments -f body=…` call directly, with no prompt to
+re-read — that is how #3276 collected the identical summary five times.
+Nothing you can write here prevents it, so the workflow cleans up after
+it: `sdk_review_dedupe_verdicts.py` runs once the stream closes, keeps the
+newest summary this run posted and minimizes the rest (FND-636). It
+identifies "this run's" summaries by the `<GHA_RUN_URL>` in the §3e
+footer, the same key this guard greps — which is another reason that line
+is not optional. Drop it and the collapse silently stops working.
+
+**A4. Bot-trigger dedupe guard — run immediately after the replay guard.**
+This is now a *backstop*, not the authority. Since FND-636 the
+authoritative check is the `Dedupe check` step at the top of
+`sdk-review-dispatch`, which runs under the per-PR concurrency lock and
+declines before a sandbox is booted at all — deciding it here meant the
+sandbox had to start and reason before it could decline, so the run was
+paid for either way, and a degraded model skipped the check entirely
+(five duplicate triggers on #3285 became five runs). Keep this guard: it
+costs one API call, and it still catches the case where the comment
+landed between the workflow's read and the sandbox's start.
+
+Check: if `COMMENTER` is an automated trigger (`mothership-ai[bot]`
+or `atlan-ci`) **and** the newest summary's `<!-- REVIEWED_HEAD -->`
+equals `HEAD_SHA`, this run is a duplicate. Stop without posting.
+Humans (`COMMENTER` is any other login) are never stopped by this
+guard — re-reading the same diff is a legitimate human request.
+
+Use "newest summary" (the body already in `/tmp/PRIOR_REVIEW.md`),
+never the oldest.
+
+```bash
+# COMMENTER and HEAD_SHA are from the prompt header.
+BOT_TRIGGERS="mothership-ai[bot] atlan-ci"
+if echo "$BOT_TRIGGERS" | grep -qF "$COMMENTER"; then
+  NEWEST_REVIEWED_HEAD=$(grep -oE '<!-- REVIEWED_HEAD: [0-9a-f]{40} -->' /tmp/PRIOR_REVIEW.md \
+    | grep -oE '[0-9a-f]{40}' || true)
+  if [ -n "$NEWEST_REVIEWED_HEAD" ] && [ "$NEWEST_REVIEWED_HEAD" = "$HEAD_SHA" ]; then
+    echo "SKIP: bot-trigger dedupe — @${COMMENTER} re-triggered on HEAD ${HEAD_SHA} which the newest summary already reviewed. Backstop for the workflow's locked dedupe check. Stopping without posting."
+    # S4: Restore the commit status so the dispatch run's pending state
+    # does not linger after this no-op. The dispatch run always sets
+    # sdk-review to "pending" before the sandbox starts. If the sandbox
+    # exits here without posting a new verdict comment, the fast-path
+    # approve workflow never fires, and the pending status persists —
+    # which is misleading (the review was already delivered). Re-apply
+    # the status implied by the prior verdict.
+    PRIOR_VERDICT=$(grep -oE '<!-- VERDICT: [A-Z_]+ -->' /tmp/PRIOR_REVIEW.md \
+      | grep -oE '[A-Z_]+' | head -1 || true)
+    case "$PRIOR_VERDICT" in
+      "READY_TO_MERGE")
+        gh api "repos/${REPO}/statuses/${HEAD_SHA}" -X POST \
+          -f state=success -f context=sdk-review \
+          -f description="Approved (bot-retrigger skipped: already reviewed this HEAD)" 2>/dev/null || true;;
+      "")
+        : # No prior verdict found — leave status as-is to avoid stomping
+        ;;
+      *)
+        gh api "repos/${REPO}/statuses/${HEAD_SHA}" -X POST \
+          -f state=failure -f context=sdk-review \
+          -f description="Verdict: ${PRIOR_VERDICT} (bot-retrigger skipped: already reviewed this HEAD)" 2>/dev/null || true;;
+    esac
+    exit 0
+  fi
+fi
+```

--- a/.mothership/pr-review/sections/scope-classification.md
+++ b/.mothership/pr-review/sections/scope-classification.md
@@ -1,0 +1,72 @@
+# Phase 0 step 11 — Smart agent routing (deriving review_scope)
+
+11. **Smart agent routing** — classify the PR by which area it touches, and
+    dispatch only the matching specialist(s):
+    ```bash
+    gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[].path' > /tmp/PR_FILES.txt
+    TOTAL_FILES=$(wc -l < /tmp/PR_FILES.txt)
+    CT_FILES=$(grep -cE '^contract-toolkit/' /tmp/PR_FILES.txt || true)
+    SDK_FILES=$(grep -cE '^application_sdk/' /tmp/PR_FILES.txt || true)
+    CONF_FILES=$(grep -cE '^(packages/conformance/|remediation/)' /tmp/PR_FILES.txt || true)
+    TEST_FILES=$(grep -cE '^(tests/|contract-toolkit/tests/)' /tmp/PR_FILES.txt || true)
+    DOC_FILES=$(grep -cE '^(docs/|contract-toolkit/docs/|.*README\.md$)' /tmp/PR_FILES.txt || true)
+    CONFIG_FILES=$(grep -cE '^(pyproject\.toml|uv\.lock|\.pre-commit|\.github/|helm/)' /tmp/PR_FILES.txt || true)
+    # Agent-prompt / operational-meta files with NO Temporal/Dapr code surface:
+    # the mothership review+resolve playbooks, Claude Code config, and
+    # AGENTS/CLAUDE instruction files. Excluded from SOURCE_FILES below so a
+    # prompt-only PR is never routed into the full 3-agent SDK panel (the SDK
+    # correctness/quality/structure agents have no rules for reviewing prompts).
+    META_FILES=$(grep -cE '^(\.mothership/|\.claude/)|(^|/)(AGENTS|CLAUDE)\.md$' /tmp/PR_FILES.txt || true)
+    # SOURCE_FILES = files in NONE of the non-source buckets (conformance, tests,
+    # docs, config, meta). Computed by exclusion (grep -vc) rather than
+    # TOTAL - sum(buckets): a file matching two buckets (e.g. docs/CLAUDE.md is
+    # both DOC and META) would be subtracted twice by the arithmetic and could
+    # zero out a real source count, silently skipping code review. Mirrors the
+    # bucket patterns above (contract-toolkit is intentionally NOT excluded — CT
+    # PRs are routed by the first two rules before SOURCE_FILES is consulted).
+    SOURCE_FILES=$(grep -vcE '^(packages/conformance/|remediation/|tests/|contract-toolkit/tests/|docs/|contract-toolkit/docs/|pyproject\.toml|uv\.lock|\.pre-commit|\.github/|helm/|\.mothership/|\.claude/)|.*README\.md$|(^|/)(AGENTS|CLAUDE)\.md$' /tmp/PR_FILES.txt || true)
+    CHANGED_LINES=$(grep -cE '^[+-]' /tmp/DIFF.patch 2>/dev/null || echo 0)
+    # Security-sensitive paths NEVER take the fast path (a 3-line auth/secret
+    # change is exactly where a subtle blocker hides).
+    SECURITY_PATHS=$(grep -cE '(credential|secret|auth|token|_dapr|_temporal)' /tmp/PR_FILES.txt || true)
+    ```
+   This file-list based classification includes deleted files; do not classify
+   only from `+++ b/` diff headers. Apply in order; **first match wins**:
+   - If `CT_FILES > 0 && SDK_FILES == 0 && CONF_FILES == 0 && CONFIG_FILES == 0` → `review_scope=contract-toolkit`
+     (toolkit-review.md only; mandatory private consumer validation based on affected surface)
+   - If `CT_FILES > 0 && (SDK_FILES > 0 || CONFIG_FILES > 0)` → `review_scope=mixed-sdk-toolkit`
+     (standard SDK review agents + toolkit-review.md)
+   - If `META_FILES > 0 && SOURCE_FILES == 0 && CONFIG_FILES == 0 && CONF_FILES == 0
+     && CT_FILES == 0 && TEST_FILES == 0 && DOC_FILES == 0` → `review_scope=docs-only`
+     (agent-prompt / operational-meta files only — `.mothership/**`, `.claude/**`,
+     `AGENTS.md`, `CLAUDE.md` — carry no Temporal/Dapr code surface, so the SDK
+     domain agents have nothing to review. Take the docs-only skip path: submit
+     APPROVE, no Phase 2. Because META is excluded from `SOURCE_FILES`, a PR that
+     ALSO touches code routes on the real code — `config-only`, `full`, etc. — so
+     the meta files never drag prompt/markdown into the SDK correctness agents,
+     and code is never skipped just because prompts changed alongside it.)
+   - If `SOURCE_FILES == 0 && CONF_FILES > 0 && CT_FILES == 0` → `review_scope=conformance-only`
+     (`conformance.md` agent only — the conformance-suite specialist for
+     `packages/conformance/**` + `remediation/**`: SARIF detector correctness,
+     rule-catalog consistency, rule scope (sdk/app/both), the two CI gates, and
+     the paired remediation program in the SAME PR. NOT the SDK CORRECTNESS
+     agent — conformance code is AST/rule logic, not Temporal/Dapr runtime.
+     If `CONFIG_FILES > 0` too, also dispatch `ci-config.md` on the config slice.)
+   - If `SOURCE_FILES == 0 && TEST_FILES > 0` → `review_scope=tests-only`
+     (QUALITY agent only — focused on test patterns, coverage, assertions)
+   - If `SOURCE_FILES == 0 && DOC_FILES > 0 && TEST_FILES == 0` → `review_scope=docs-only`
+     (Skip Phase 2 — submit APPROVE with "Docs/meta-only PR, no code review needed")
+   - If `SOURCE_FILES == 0 && CONFIG_FILES > 0` → `review_scope=config-only`
+     (`ci-config.md` agent only — the CI/workflow/deps/infra specialist, NOT
+     the SDK CORRECTNESS agent. Reviews GHA injection/permissions/pinning,
+     shell robustness, dependency/supply-chain, and `helm/**`.)
+   - If `SOURCE_FILES <= 2 && TEST_FILES >= SOURCE_FILES * 3` → `review_scope=tests-focused`
+     (QUALITY agent + lightweight CORRECTNESS — mostly tests with a few source changes)
+   - If `SOURCE_FILES >= 1 && TOTAL_FILES <= 2 && CHANGED_LINES < 50 && CONF_FILES == 0
+     && CT_FILES == 0 && CONFIG_FILES == 0 && SECURITY_PATHS == 0` → `review_scope=minor`
+     (**fast path** for a tiny source change: CORRECTNESS agent only — it always
+     keeps guardrail coverage G1-G5 — skipping the heavier QUALITY/STRUCTURE
+     waves and the adversarial Wave 2, on the Small time budget. NEVER matches
+     credential/secret/auth or `_dapr`/`_temporal` seam paths; those fall through
+     to `full`.)
+   - Otherwise → `review_scope=full` (correctness + quality + structure)

--- a/.mothership/pr-review/sections/toolkit-consumer-setup.md
+++ b/.mothership/pr-review/sections/toolkit-consumer-setup.md
@@ -1,0 +1,208 @@
+# 1b-toolkit. Private Toolkit Consumer Setup
+
+### 1b-toolkit. Private Toolkit Consumer Setup (if review_scope=contract-toolkit or mixed-sdk-toolkit)
+
+Read:
+
+- `contract-toolkit/AGENTS.md`
+- `.mothership/pr-review/agents/toolkit-review.md`
+- `.mothership/pr-review/references/toolkit-consumer-registry.md`
+
+Classify the affected toolkit surfaces from `/tmp/DIFF.patch`. Then clone or
+reuse every mandatory consumer target from the registry. This validation setup
+is mandatory for affected surfaces; do not approve if a required check cannot
+run.
+
+Reset and create the private validation ledger (these files are written only
+here, so the reset lives here — not in Phase 0). It is the source of truth
+for toolkit compatibility status and verdict gating:
+
+```bash
+rm -f /tmp/TOOLKIT_ROVER_NOTE.md
+: > /tmp/TOOLKIT_PR_ARTIFACTS.txt
+: > /tmp/TOOLKIT_CHANGED_FILES.txt
+: > /tmp/TOOLKIT_CONSUMERS.md
+: > /tmp/TOOLKIT_VALIDATION.md
+printf '## Toolkit Validation Ledger\n\n' >> /tmp/TOOLKIT_VALIDATION.md
+```
+
+**Do not re-run what CI already ran.** The `Contract Toolkit /` CI legs on
+this HEAD run the same commands the reviewer used to re-run wholesale
+(`PKL tests and invariants`, `Verify generated output`, `Generated Python
+lint and SDK imports`). Read them instead:
+
+```bash
+# `bucket`, NOT `conclusion`. `gh pr checks --json` has no `conclusion`
+# field: it prints "Unknown JSON field" to stderr, EXITS 0, and writes
+# nothing to stdout — so this file would be empty and every leg would read
+# as missing. Buckets are pass / fail / skipping / pending.
+gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,bucket \
+  --jq '.[] | select(.name | startswith("Contract Toolkit")) | .name + " " + .bucket' \
+  > /tmp/TOOLKIT_CI_LEGS.txt
+```
+
+- Every leg `pass` → record the legs as the local-check evidence in the
+  ledger. Run a local command ONLY as the substrate for probing CI cannot
+  express — guard ablations, scratch collision contracts, comparing
+  PR-generated artifacts against a consumer's expectations.
+- Any leg missing / pending / failed → run that leg's command locally and
+  treat a failure caused by PR code or stale generated output as a finding:
+
+```bash
+contract-toolkit/scripts/regenerate-all.sh     # ↔ Verify generated output
+contract-toolkit/scripts/check-invariants.sh   # ↔ PKL tests and invariants
+(cd contract-toolkit && pkl test tests/*.pkl)  # ↔ PKL tests and invariants
+uv run --extra workflows python contract-toolkit/scripts/test-sdk-import.py  # ↔ Generated Python lint and SDK imports
+git diff --check
+```
+
+If a required command cannot run due to Rover environment/tooling failure,
+create `/tmp/TOOLKIT_ROVER_NOTE.md` with the sanitized note below.
+
+Record the evidence privately:
+
+```bash
+printf -- '- Generated SDK input contract: validated (CI toolkit legs green on this HEAD; PR-bound probing ran locally)\n' >> /tmp/TOOLKIT_VALIDATION.md
+```
+
+Capture PR-generated artifacts as the input to downstream checks. Do not use a
+consumer repository's released toolkit dependency as proof for this PR:
+
+```bash
+find contract-toolkit/examples -path '*/generated/*' -type f | sort > /tmp/TOOLKIT_PR_ARTIFACTS.txt
+git diff --name-only -- contract-toolkit/examples contract-toolkit/src > /tmp/TOOLKIT_CHANGED_FILES.txt
+```
+
+**Carry-forward fast path (re-reviews).** Hash the PR-generated artifacts
+and compare against the hash the prior review stamped (§3e stamps
+`<!-- TOOLKIT_ARTIFACT_HASH: ... -->` on toolkit-scope summaries):
+
+```bash
+ARTIFACT_HASH=$(cat /tmp/TOOLKIT_PR_ARTIFACTS.txt | xargs shasum -a 256 | shasum -a 256 | cut -d' ' -f1)
+PRIOR_HASH=$(grep -oE '<!-- TOOLKIT_ARTIFACT_HASH: [0-9a-f]{64} -->' /tmp/PRIOR_REVIEW.md \
+  | grep -oE '[0-9a-f]{64}' || true)
+```
+
+If `PRIOR_HASH` is non-empty and equals `ARTIFACT_HASH`, the generated
+artifacts are byte-identical to a commit whose downstream compatibility was
+already validated: mark every artifact-derived capability
+`validated (carried forward — artifacts byte-identical to previously
+validated commit)` in the ledger and **skip the consumer clone loop
+entirely**. Carry-forward covers the *consumer-side* checks only — new
+toolkit-source behavior the committed examples don't exercise (a new
+invariant, a changed codegen skip-list) still needs PR-bound local probing
+(scratch contracts, ablations), which requires no clones. Hash mismatch or
+no prior hash → full validation below.
+
+Use `/tmp/toolkit-review-consumers` for scratch clones:
+
+```bash
+mkdir -p /tmp/toolkit-review-consumers
+
+# Core consumers. Use existing /workspace checkout if present; otherwise clone.
+# Record branch and SHA privately in /tmp/TOOLKIT_CONSUMERS.md.
+for spec in \
+  "atlan-frontend beta" \
+  "blaze main" \
+  "heracles beta" \
+  "atlan-automation-engine-app main"
+do
+  repo="${spec% *}"
+  branch="${spec#* }"
+  if [ -d "/workspace/${repo}/.git" ]; then
+    target="/workspace/${repo}"
+  else
+    target="/tmp/toolkit-review-consumers/${repo}"
+    if [ ! -d "${target}/.git" ] && ! git clone "https://github.com/atlanhq/${repo}.git" "${target}"; then
+      printf '%s\n' "Review note: one required compatibility check could not be completed due to a Rover execution issue. Please re-run @sdk-review or request human review before merge." > /tmp/TOOLKIT_ROVER_NOTE.md
+      continue
+    fi
+  fi
+  if ! git -C "${target}" fetch origin "${branch}"; then
+    printf '%s\n' "Review note: one required compatibility check could not be completed due to a Rover execution issue. Please re-run @sdk-review or request human review before merge." > /tmp/TOOLKIT_ROVER_NOTE.md
+    continue
+  fi
+  printf '%s %s %s\n' "${repo}" "origin/${branch}" "$(git -C "${target}" rev-parse "origin/${branch}")" >> /tmp/TOOLKIT_CONSUMERS.md
+done
+```
+
+Cloning/fetching only establishes the validation target. It is not validation.
+For each affected capability, run the corresponding minimum actionable check in
+the registry using PR-generated artifacts or a scratch contract rewritten to
+amend/import `/workspace/application-sdk/contract-toolkit/src/*.pkl`. If no
+PR-bound command or inspection is possible, mark that capability `needs rerun`
+and do not approve.
+
+Each mandatory capability must append exactly one private status line to
+`/tmp/TOOLKIT_VALIDATION.md`:
+
+```text
+- UI rendering compatibility: validated (<private evidence recorded>)
+- Manifest substitution compatibility: validated (<private evidence recorded>)
+- Workflow execution contract: validated (<private evidence recorded>)
+- Generated SDK input contract: validated (<private evidence recorded>)
+- Representative app pattern: not applicable (<why>)
+```
+
+Allowed statuses are `validated`, `not applicable`, and `needs rerun`. Any
+`needs rerun` status forces `NEEDS_HUMAN`.
+The public review must mirror these as a `### Cross-Repo Validation` section
+using only capability aliases and status values. Do not include private
+consumer repository names, package names, branch names, SHAs, local paths, or
+system-app implementation details in the public section.
+
+For representative app patterns, inspect PR title, body, and diff for trigger
+terms from the registry. Clone/fetch only the matching pattern repos. Optional
+field additions do not require adoption in the representative app unless the PR
+claims compatibility or changes required generated/runtime behavior.
+
+Use these pattern specs after a trigger match:
+
+```bash
+# Pattern specs: "<pattern> <repo> <branch>"
+# query-intelligence atlan-query-intelligence-app main
+# publish atlan-publish-app main
+# popularity atlan-popularity-app main
+# lineage atlan-lineage-app main
+```
+
+For each matched pattern, reuse `/workspace/<repo>` if present, otherwise clone
+to `/tmp/toolkit-review-consumers/<repo>`, fetch the listed branch, and append
+the private SHA to `/tmp/TOOLKIT_CONSUMERS.md`.
+
+When validating a representative app contract, work only in a scratch copy. If
+the contract imports `@app-contract-toolkit/...`, rewrite that scratch copy to
+import the PR checkout source under
+`/workspace/application-sdk/contract-toolkit/src/` before running `pkl eval`.
+
+Scratch rewrite pattern:
+
+```bash
+scratch="/tmp/toolkit-review-consumers/scratch/<pattern>"
+mkdir -p "$scratch"
+cp -R "<consumer-contract-dir>"/. "$scratch"/
+rg -l '@app-contract-toolkit/' "$scratch" \
+  | xargs perl -0pi -e 's#@app-contract-toolkit/#/workspace/application-sdk/contract-toolkit/src/#g'
+pkl eval -m "$scratch/generated" "$scratch/app.pkl"
+```
+
+If the representative app does not have a contract yet, do not fail adoption.
+Validate the generic PR-generated artifact shape and record the representative
+pattern as `not applicable` with the reason.
+
+All consumer repo names, local paths, and SHAs are private evidence. Public PR
+comments may only use capability aliases:
+
+- `UI rendering compatibility`
+- `Manifest substitution compatibility`
+- `Workflow execution contract`
+- `Generated SDK input contract`
+- `Representative app pattern`
+
+If clone/fetch/auth/network fails for a mandatory target, create
+`/tmp/TOOLKIT_ROVER_NOTE.md` with exactly this public note and continue to
+Phase 2 so the review can request a rerun or human review:
+
+```text
+Review note: one required compatibility check could not be completed due to a Rover execution issue. Please re-run @sdk-review or request human review before merge.
+```

--- a/.mothership/pr-review/sections/toolkit-consumer-setup.md
+++ b/.mothership/pr-review/sections/toolkit-consumer-setup.md
@@ -1,5 +1,12 @@
 # 1b-toolkit. Private Toolkit Consumer Setup
 
+**mothership sandbox only.** On `LANE: sdk-loop` this file must not be
+followed: the consumer clones below need credentials for private atlanhq
+repos that the loop lane's scoped App token does not carry, and every clone
+fails with `could not read Username`. The router's 1b-toolkit pointer gives
+that lane its fallback (a Rover note + static surface review). Measured on a
+live run: five clone failures, then an idle-watchdog kill with no verdict.
+
 ### 1b-toolkit. Private Toolkit Consumer Setup (if review_scope=contract-toolkit or mixed-sdk-toolkit)
 
 Read:

--- a/.mothership/pr-review/sections/verdict-stamp-mechanics.md
+++ b/.mothership/pr-review/sections/verdict-stamp-mechanics.md
@@ -1,0 +1,34 @@
+# §3c mechanics — what reacts to the verdict marker
+
+Diagnostic reference. The rule the reviewer needs — never approve or
+label from inside the orchestration; emit the marker and stop — lives in
+ORCHESTRATION.md §3c. This file exists for the rarer question of why a
+posted verdict did not produce the expected label or approval.
+
+- **Approval**: `sdk-review-approve-on-verdict.yml` fires on
+  `issue_comment: created` from `mothership-ai[bot]` with the
+  `<!-- SDK_REVIEW -->` marker (within ~5s of the verdict comment
+  landing). It parses the verdict from the structured
+  `<!-- VERDICT: X -->` marker in §3e, applies the
+  `sdk-review-approved` / `sdk-review-needs-human` /
+  `sdk-review-needs-rebase` labels, sets the `sdk-review` commit
+  status, and posts the formal `atlan-ci` approval if the verdict is
+  `READY_TO_MERGE`. `sdk-review.yml`'s "Approve PR as atlan-ci" step
+  runs the same logic after the SSE stream ends as a fallback —
+  idempotency guards (label present + no existing approval) prevent
+  double-approval. atlan-ci is in CODEOWNERS, so its approval
+  satisfies `require_code_owner_review` on `main`;
+  `mothership-ai[bot]` is a GitHub App and can't be.
+- **Dismiss on human activity**: `sdk-review-dismiss-on-human.yml`
+  fires on `issue_comment` / `pull_request_review` from humans and
+  dismisses the atlan-ci approval + strips the label. So the bot can
+  unblock merges by itself until a human pushes back.
+- **Reset on push**: `sdk-review-reset-on-push.yml` fires on
+  `pull_request: synchronize` and strips the label + flips the
+  `sdk-review` status to pending on the new HEAD. Branch protection
+  separately auto-dismisses the approval (`dismiss_stale_reviews_on_push`).
+- **CI-failure downgrade**: `sdk-review-downgrade-on-ci-failure.yml`
+  fires on `check_suite: completed`; if a non-sdk-review check
+  failed on a HEAD that carries `sdk-review-approved`, it strips
+  the label, dismisses the approval, and flips status to failure.
+

--- a/.mothership/review-policy.md
+++ b/.mothership/review-policy.md
@@ -1,44 +1,7 @@
 # application-sdk — By-Design Patterns
 
-These patterns are intentional. Do NOT flag them as issues.
-
-## Accepted Patterns
-
-### Known Tech Debt (Tracked)
-- `common/utils.py` contains mixed utilities — known dumping ground, tracked
-  in BLDX milestone. Only flag SECURITY issues in this file, not structural.
-
-### Infrastructure Abstraction Layers
-- `execution/_temporal/` uses direct `temporalio` imports — this IS the
-  abstraction layer. Not a violation.
-- `infrastructure/_dapr/` uses direct `dapr` imports — this IS the
-  abstraction layer. Not a violation.
-- `infrastructure/_redis/` uses direct `redis` imports — this IS the
-  abstraction layer. Not a violation.
-
-### Performance Patterns
-- `ThreadPoolExecutor` per query in low-frequency paths (< 10 calls per
-  workflow execution) is acceptable. Only flag if the path is hot (100+
-  calls per execution) or if the task has heartbeat enabled.
-- `run_in_thread` uses the default executor for non-heartbeat tasks. Only
-  flag if the task has `heartbeat_timeout_seconds` set AND the blocking
-  call is long-running (> 5s).
-
-### Test Patterns
-- Tests in `tests/unit/` use `asyncio_mode="auto"` — no `@pytest.mark.asyncio`
-  needed. Do not flag its absence.
-- `clean_app_registry` fixture is defined in `conftest.py` — tests that
-  define App subclasses should use it, but it's not always necessary if
-  the test doesn't register apps.
-
-### Credential Handling
-- `CredentialRef` objects in contracts are serializable references (no
-  actual secrets). They are safe to pass through Temporal payloads.
-- `CredentialResolver` is intentionally restricted to `@task` methods
-  because resolution requires I/O to the secret store.
-
-### Error Codes
-- `AAF-{COMPONENT}-{ID:03d}` format is intentional. Do not suggest
-  alternative error code schemes.
-- `NonRetryableError` and `RetryableError` are the two error base classes.
-  Do not suggest additional error hierarchies.
+Moved. The single do-not-flag source is
+`.mothership/pr-review/references/retro-log.md`, which now carries every
+by-design pattern this file held (under "By-design patterns"). This tombstone
+stays because the path may be linked from old review comments; do not add
+patterns here — a second list is how reviews end up consulting neither.

--- a/.mothership/review.yaml
+++ b/.mothership/review.yaml
@@ -2,25 +2,17 @@ review_guidelines: |
   This is the Atlan application-sdk v3 Python library.
   Built on Temporal workflows + Dapr infrastructure abstractions.
 
-  Critical rules:
-  - BLOCKING: Non-deterministic operation in run()/@entrypoint
-  - BLOCKING: Contract field removal/rename/retype on Input/Output
-  - BLOCKING: Hardcoded secrets or credentials in logs
-  - CRITICAL: New public API without tests
-  - CRITICAL: Breaking API change without deprecation shim
+  This file is no longer part of the review's mandatory context
+  (ORCHESTRATION.md Phase 0 step 6 stopped listing it): every rule it
+  carried was a paraphrase of .mothership/pr-review/severity-rubric.yaml
+  (severities, confidence floors) or .mothership/pr-review/CLAUDE.md
+  (architecture), and a paraphrase read alongside its source is a drift
+  risk that costs a tool call on every review. The file remains for any
+  external reader; the rules live in those two files.
 
-  Architecture:
-  - Dependency direction: app/ -> execution/ -> infrastructure/
-  - No direct temporalio/dapr imports outside private modules
-  - All I/O in @task methods, never in run()
-  - Use self.run_in_thread() for blocking operations in @task
-  - CredentialRef in contracts, CredentialResolver in @task only
-
-  Ignore:
-  - The single do-not-flag source is
-    .mothership/pr-review/references/retro-log.md, plus the by-design
-    patterns in .mothership/review-policy.md. Consult those; this file
-    does not maintain its own list.
+  The single do-not-flag source is
+  .mothership/pr-review/references/retro-log.md (which now includes the
+  by-design patterns formerly in .mothership/review-policy.md).
 
 ignore_patterns:
   - "*.md"


### PR DESCRIPTION
`.mothership/pr-review/ORCHESTRATION.md` was 1,694 lines / **~20.6K tokens**, read in full by every review on both lanes before the agent saw a line of the PR. FND-1232.

## Why this is a cost, not tidying

Measured turn latency on the review model climbs from ~10s early in a phase to **75–90s by turn 12** as context accumulates, and a review runs 12–22 turns. Anything loaded and unused is charged to every remaining turn.

External calibration from the research on how this is done elsewhere: PR-Agent's `/review` renders **1,428 tokens** of scaffolding at default config (measured with tiktoken at a pinned SHA). Everything else in its window is diff.

## What moved

Six blocks are conditional on a lane or scope the reader is often not in — **and the playbook already said so.** The Runtime table records that the loop lane has no use for Appendix A's guards; the dispatch prompt tells it to skip the Wave 2 adversarial; `1b-toolkit` is private-repo setup for surfaces a conformance PR does not touch. Skipped in execution, paid for in context.

| moved to `sections/` | ~tokens | Read only when |
|---|--:|---|
| `toolkit-consumer-setup.md` | 2,314 | scope is `contract-toolkit` / `mixed-sdk-toolkit` |
| `sandbox-guards.md` (Appendix A) | 1,733 | mothership sandbox lane |
| `prior-review-and-delta.md` (§6b/6c/11b) | 1,553 | the lane computes its own delta |
| `scope-classification.md` (§11) | 1,430 | the lane must derive `review_scope` |
| `branch-freshness.md` (§8) | 425 | the lane holds a write scope |
| `adversarial-wave-2.md` (§2b) | 371 | mothership sandbox lane |

A conformance-only `@sdk-loop` review now loads **~14.0K tokens instead of ~20.6K — 32% less**, on every turn.

## Nothing was rewritten and nothing was dropped

Every moved line is present verbatim in its section file — verified line by line against the pre-split text, **zero non-blank lines unaccounted for**. The two lanes read the same words; only *when* differs.

Mothership clones the repo at `/workspace/application-sdk` and reads the playbook **from disk** (`sdk_review_dispatch.py:317-324`), so that lane follows the same pointers to the same files. This was checked before the split, because it is what would have made the approach unsafe.

## Guardrails

Four invariants in `test_review_playbook_sections.py`, because **every one of them fails silently** — nothing errors, no check goes red, the review just quietly gets worse:

- an orphaned section is never read
- a dangling pointer fails a `Read` mid-phase, after the turn is paid for
- a pointer with no stated condition gets read every time, defeating the split
- a re-inlined block silently restores the old size (router token ceiling)

Same failure shape `review_subagents` already refuses to trust for `{file:...}` template resolution.

## Deliberately not in this PR

- **The behavioural knobs** the same research turned up — a hard input cap (`max_model_tokens`-style, independent of the model window), a finding budget interpolated into the prompt, an explicit never-flag list. All three are genuinely absent here and worth adopting. They change what a review **reports**, and shipping them alongside a context move would leave any quality regression with three candidate causes and no way to attribute it.
- **§3e's toolkit-only summary blocks** (~700 tokens) stay inline. They sit inside a fenced template the agent copies verbatim; halving a template to save 700 tokens is the wrong trade.
- **Closing the rest of the gap to ~1,428** needs the compact-prompt rewrite, not another move. That is a behaviour change.

## Verification

- 142 tests pass: 5 new section invariants + `test_sdk_loop_scope.py` (which parses §2a's routing table straight out of the router — it stays) + the full `test_sdk_loop.py`
- line-by-line conservation check against the pre-split file: 0 lines lost
- `pre-commit run --files …` clean

Stacks cleanly with #3596; no overlapping files.