### PR TITLE
ci(loop): render the verdict in Python, behind the playbook that still writes it

### DIFF
--- a/.github/scripts/sdk_loop_findings.py
+++ b/.github/scripts/sdk_loop_findings.py
@@ -515,7 +515,27 @@ def render_summary(
 
 
 def load_payload(text: str | bytes) -> dict[str, Any]:
-    """Parse the agent's `findings.json`, refusing anything ambiguous."""
+    """Parse the agent's `findings.json`, refusing anything ambiguous.
+
+    **Not yet the completion gate, and it must become one before anything
+    consumes this.** Nothing reads `findings.json` today — the reviewer still
+    posts its own comment — so this only has to parse. The moment the runner
+    renders and posts the verdict instead, an empty `findings` list means
+    `READY_TO_MERGE`, which means `sdk_review_approve.py` casts the `atlan-ci`
+    CODEOWNER approval. An agent that crashes or gives up *after* writing its
+    file would then produce a merge-ready verdict from a review that never
+    happened.
+
+    `PACK_ID` does not close that hole: it proves the pack loaded, not that the
+    work was done. The gate needs a positive assertion the model cannot emit by
+    accident — `status: "complete"` plus a `reviewed_files` list that actually
+    covers the pack's files — and an empty findings list must be accepted only
+    when that assertion is present and covering. `REVIEW.md` already instructs
+    the reviewer to emit both; this function does not yet require them.
+
+    Ship that requirement in the same change that moves posting to Python, not
+    after it.
+    """
     try:
         payload = json.loads(text)
     except json.JSONDecodeError as exc:

--- a/.github/scripts/sdk_loop_findings.py
+++ b/.github/scripts/sdk_loop_findings.py
@@ -1,0 +1,636 @@
+#!/usr/bin/env python3
+"""Severity clamping, verdict computation and summary rendering for `@sdk-loop`.
+
+Everything here used to be the model's job, spread across five sections of
+`.mothership/pr-review/ORCHESTRATION.md` — §2f guardrails, §2h's verdict table,
+§3a's schema allowlist, §3e's 7.2 KB summary template and §3f's `sed` safety
+nets. None of it has an indeterminate answer, and all of it was being paid for
+twice: once as context the reviewer carried through every turn, and once as
+turns spent producing a comment by hand.
+
+Three things follow from moving it here, and they are the point of the module:
+
+1. **The frozen marker contract becomes structural.** `sdk_review_approve.py`,
+   `sdk_review_reconcile.py`, `sdk_review_dedupe_verdicts.py`,
+   `sdk_review_verdict_gate.py` and four `sdk-review-*.yml` workflows all find
+   their work by parsing HTML comment markers. Rendering those in Python makes
+   them unit-testable with no model in the loop, and deletes two whole failure
+   classes: the reviewer writing the literal string `<HEAD_SHA>` instead of the
+   sha, and an empty `<!-- ANSWERS_TRIGGER: -->` line on a `workflow_dispatch`
+   run. §3f carries a `sed` for each; neither is needed once the renderer owns
+   the output.
+
+2. **`### Findings` empty <=> READY_TO_MERGE becomes an invariant** rather than
+   an instruction the model is asked to honour. It is the resolve loop's
+   termination condition, so it is the one rule in the lane that must not be
+   probabilistic.
+
+3. **The severity vocabulary gets exactly one mapping.** See `severity.yaml`'s
+   `display` block for why there were three.
+
+The module is pure: it computes and renders, and posts nothing. `interpret_review`
+owns delivery, and — importantly — owns deciding whether a review actually
+happened. An empty findings list renders READY_TO_MERGE, so a caller that treats
+"the renderer produced a comment" as proof of work would turn a crashed agent
+into a merge-ready verdict. Callers must gate on the completion assertion, not
+on this module returning successfully.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+import yaml
+
+#: Canonical severity data. Never read by a model — see the file's own header.
+SEVERITY_DATA = (
+    Path(__file__).resolve().parents[2] / ".mothership/pr-loop/data/severity.yaml"
+)
+
+#: The only fields the inline-comment handler accepts. §3a of the pr-review
+#: playbook is emphatic that unknown fields 422 the request, and every one of
+#: the seven brief-level JSON examples in that corpus emits three fields it
+#: then has to strip (`scope`, `domain_tag`, `guardrail`). Validating against
+#: the allowlist here means a brief cannot teach a payload the poster must undo.
+FINDING_FIELDS = frozenset(
+    {
+        "title",
+        "pattern_id",
+        "severity",
+        "category",
+        "confidence",
+        "file",
+        "line",
+        "evidence",
+        "attack_path",
+        "reachable_from",
+        "by_design_check",
+        "suggested_fix",
+        "escalate_to_linear",
+    }
+)
+
+#: Fields a finding cannot be rendered without.
+REQUIRED_FIELDS = ("title", "severity", "confidence", "file")
+
+VERDICT_READY = "READY_TO_MERGE"
+VERDICT_FIXES = "NEEDS_FIXES"
+VERDICT_BLOCKED = "BLOCKED"
+VERDICT_HUMAN = "NEEDS_HUMAN"
+VERDICT_REBASE = "NEEDS_REBASE"
+
+#: Verdict precedence when several apply at once. BLOCKED outranks NEEDS_HUMAN
+#: because a guardrail violation is a fact about the code, while NEEDS_HUMAN is
+#: a fact about what the reviewer could not determine.
+_VERDICT_RANK = {
+    VERDICT_BLOCKED: 4,
+    VERDICT_HUMAN: 3,
+    VERDICT_REBASE: 2,
+    VERDICT_FIXES: 1,
+    VERDICT_READY: 0,
+}
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class SchemaError(ValueError):
+    """A findings payload the renderer refuses to render.
+
+    Raised rather than repaired on purpose. A payload this module cannot
+    validate is a phase failure — the alternative is rendering a partial review
+    that reads exactly like a complete one.
+    """
+
+
+# --------------------------------------------------------------------------
+# Severity data
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Severity:
+    """The `display` + `calibration` + `guardrails` view of `severity.yaml`."""
+
+    display: dict[str, dict[str, Any]]
+    tier_order: tuple[str, ...]
+    guardrails: dict[str, dict[str, Any]]
+    patterns: dict[str, dict[str, Any]]
+    floors: dict[str, float]
+
+    def tier(self, severity: str) -> str | None:
+        """Rendered tier for an emitted severity, or None when prose-only.
+
+        Raises on an unknown severity instead of passing it through. One brief
+        in the inherited corpus emits `IMPORTANT`, which belongs to none of the
+        three vocabularies that corpus uses; silently rendering it would put a
+        finding in the summary that the verdict never counted.
+        """
+        entry = self.display.get(severity)
+        if entry is None:
+            raise SchemaError(
+                f"unmapped severity {severity!r}; expected one of "
+                f"{sorted(self.display)}"
+            )
+        return entry["tier"]
+
+    def in_findings(self, severity: str) -> bool:
+        """Whether this severity renders under `### Findings` — i.e. blocks."""
+        entry = self.display.get(severity)
+        if entry is None:
+            raise SchemaError(f"unmapped severity {severity!r}")
+        return bool(entry["in_findings"])
+
+    def inline(self, severity: str) -> bool:
+        return bool(self.display[severity]["inline_comment"])
+
+    def floor(self, severity: str) -> float:
+        """Confidence floor for a severity.
+
+        INFO carries no floor in the canonical rubric — adding one would make
+        pr-review's generated copy diverge from the file it must reproduce — so
+        it falls back to LOW's, the nearest tier with the same prose-only
+        treatment.
+        """
+        if severity in self.floors:
+            return self.floors[severity]
+        if severity == "INFO":
+            return self.floors["LOW"]
+        raise SchemaError(f"no confidence floor for severity {severity!r}")
+
+    def guardrail_for(self, pattern_id: str | None) -> tuple[str, str] | None:
+        """`(guardrail id, forced verdict)` for a pattern, or None."""
+        if not pattern_id:
+            return None
+        for gid, entry in self.guardrails.items():
+            if pattern_id in entry["patterns"]:
+                return gid, entry["verdict"]
+        return None
+
+
+def load_severity(path: Path | str | None = None) -> Severity:
+    raw = yaml.safe_load(Path(path or SEVERITY_DATA).read_text(encoding="utf-8"))
+    patterns = {
+        pattern["pattern_id"]: pattern
+        for category in raw["categories"]
+        for pattern in category["patterns"]
+    }
+    return Severity(
+        display=raw["display"],
+        tier_order=tuple(raw["tier_order"]),
+        guardrails=raw["guardrails"],
+        patterns=patterns,
+        floors=raw["calibration"]["confidence_floors"],
+    )
+
+
+# --------------------------------------------------------------------------
+# Findings
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Finding:
+    title: str
+    severity: str
+    confidence: float
+    file: str
+    line: int | None = None
+    pattern_id: str | None = None
+    category: str | None = None
+    evidence: str | None = None
+    attack_path: str | None = None
+    reachable_from: str | None = None
+    by_design_check: str | None = None
+    suggested_fix: str | None = None
+    escalate_to_linear: bool | None = None
+    #: Set by `normalise`, not by the model.
+    tier: str | None = None
+    guardrail: str | None = None
+
+    def payload(self) -> dict[str, Any]:
+        """The finding as the inline-comment handler wants it — allowlist only."""
+        out: dict[str, Any] = {}
+        for name in FINDING_FIELDS:
+            value = getattr(self, name, None)
+            if value is not None:
+                out[name] = value
+        return out
+
+
+@dataclass
+class Dropped:
+    finding: Finding
+    reason: str
+
+
+@dataclass
+class Normalised:
+    kept: list[Finding] = field(default_factory=list)
+    prose: list[Finding] = field(default_factory=list)
+    dropped: list[Dropped] = field(default_factory=list)
+
+
+def parse_finding(raw: dict[str, Any]) -> Finding:
+    """Validate one raw finding against the allowlist."""
+    if not isinstance(raw, dict):
+        raise SchemaError(f"finding must be an object, got {type(raw).__name__}")
+    unknown = sorted(set(raw) - FINDING_FIELDS)
+    if unknown:
+        raise SchemaError(
+            f"finding carries fields the handler rejects (422): {unknown}. "
+            f"Allowed: {sorted(FINDING_FIELDS)}"
+        )
+    missing = [name for name in REQUIRED_FIELDS if raw.get(name) in (None, "")]
+    if missing:
+        raise SchemaError(f"finding missing required field(s): {missing}")
+    try:
+        confidence = float(raw["confidence"])
+    except (TypeError, ValueError) as exc:
+        raise SchemaError(f"confidence is not a number: {raw['confidence']!r}") from exc
+    if not 0.0 <= confidence <= 1.0:
+        raise SchemaError(f"confidence out of range: {confidence}")
+    known = {name: raw[name] for name in raw if name in FINDING_FIELDS}
+    known["confidence"] = confidence
+    return Finding(**known)
+
+
+def normalise(findings: Iterable[Finding], sev: Severity) -> Normalised:
+    """Clamp severities, apply per-severity floors, and split by destination.
+
+    Order matters and is the reverse of the obvious one: clamp BEFORE the floor
+    check. The floor is a property of the severity a finding actually gets, so
+    checking it first would hold a clamped-down finding to the floor of a tier
+    it no longer occupies — the flat-0.80 mistake the briefs make, in a
+    different disguise.
+
+    A guardrail violation skips the floor entirely. `CLAUDE.md`'s guardrail
+    table is explicit that they are reported "regardless of confidence score",
+    and a guardrail is the one thing whose absence from the summary changes a
+    merge decision.
+    """
+    out = Normalised()
+    for finding in findings:
+        pattern = sev.patterns.get(finding.pattern_id or "")
+        if pattern is not None:
+            ceiling = pattern["max_severity"]
+            if _rank(finding.severity, sev) > _rank(ceiling, sev):
+                finding.severity = ceiling
+
+        guardrail = sev.guardrail_for(finding.pattern_id)
+        if guardrail is not None:
+            finding.guardrail = guardrail[0]
+
+        if guardrail is None and finding.confidence < sev.floor(finding.severity):
+            out.dropped.append(
+                Dropped(
+                    finding,
+                    f"confidence {finding.confidence:.2f} below the "
+                    f"{finding.severity} floor {sev.floor(finding.severity):.2f}",
+                )
+            )
+            continue
+
+        finding.tier = sev.tier(finding.severity)
+        if sev.in_findings(finding.severity):
+            out.kept.append(finding)
+        else:
+            out.prose.append(finding)
+    return out
+
+
+def _rank(severity: str, sev: Severity) -> int:
+    """Order emitted severities so `max_severity` can be compared."""
+    order = ["INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL", "BLOCKING"]
+    if severity not in order:
+        raise SchemaError(f"unmapped severity {severity!r}")
+    return order.index(severity)
+
+
+# --------------------------------------------------------------------------
+# Verdict
+# --------------------------------------------------------------------------
+
+
+def compute_verdict(
+    kept: Sequence[Finding],
+    sev: Severity,
+    *,
+    needs_human: bool = False,
+    conflicting: bool = False,
+) -> str:
+    """§2h's table, as code.
+
+    `READY_TO_MERGE` is strict and stays strict: **any** finding rendered under
+    `### Findings` forces `NEEDS_FIXES`, whatever its tier. That is what makes
+    the resolve loop terminate — it fixes until the list is empty — and it is
+    why `severity.yaml` routes LOW and INFO to prose instead. A tier that
+    renders into Findings blocks the merge; there is no third state.
+    """
+    if conflicting:
+        # Decided from mergeStateStatus before the model is ever called, so it
+        # is not a finding and cannot be outvoted by one.
+        return VERDICT_REBASE
+
+    verdict = VERDICT_READY
+    if needs_human:
+        verdict = _worse(verdict, VERDICT_HUMAN)
+    if kept:
+        verdict = _worse(verdict, VERDICT_FIXES)
+    for finding in kept:
+        guardrail = sev.guardrail_for(finding.pattern_id)
+        if guardrail is not None:
+            verdict = _worse(verdict, guardrail[1])
+    return verdict
+
+
+def _worse(current: str, candidate: str) -> str:
+    return candidate if _VERDICT_RANK[candidate] > _VERDICT_RANK[current] else current
+
+
+# --------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------
+
+#: The human-readable spelling on the `### Verdict:` line. The machine-readable
+#: token in the marker is the underscored form; keeping both in one table is
+#: what stops them drifting, which §3e asks the model to do by hand.
+_VERDICT_PROSE = {
+    VERDICT_READY: "READY TO MERGE",
+    VERDICT_FIXES: "NEEDS FIXES",
+    VERDICT_BLOCKED: "BLOCKED",
+    VERDICT_HUMAN: "NEEDS HUMAN REVIEW",
+    VERDICT_REBASE: "NEEDS REBASE",
+}
+
+
+def render_markers(
+    verdict: str,
+    reviewed_head: str,
+    *,
+    answers_trigger: str | None = None,
+    toolkit_artifact_hash: str | None = None,
+) -> str:
+    """The five-marker block, in the frozen order.
+
+    `answers_trigger` is omitted entirely when absent rather than rendered
+    empty. §3e records why: the resolver's push guard uses the marker to tell
+    "the round I am waiting on has answered" from "an earlier round's verdict
+    landed late", and an empty marker reads as present-but-unparseable, which is
+    worse than a missing one. `COMMENT_ID` is blank on every `workflow_dispatch`
+    run, so this is the common path, not the edge case.
+    """
+    if verdict not in _VERDICT_PROSE:
+        raise SchemaError(f"unknown verdict {verdict!r}")
+    if not _SHA_RE.match(reviewed_head or ""):
+        raise SchemaError(
+            f"REVIEWED_HEAD must be a 40-char lowercase hex sha, got "
+            f"{reviewed_head!r}"
+        )
+    lines = [
+        "<!-- SDK_REVIEW -->",
+        f"<!-- VERDICT: {verdict} -->",
+        f"<!-- REVIEWED_HEAD: {reviewed_head} -->",
+    ]
+    # Strip BEFORE testing for presence. A whitespace-only COMMENT_ID is the
+    # blank `workflow_dispatch` value arriving with padding, not a malformed
+    # trigger id — treating it as the latter fails a run that should simply
+    # omit the line.
+    trigger = str(answers_trigger or "").strip()
+    if trigger:
+        if not trigger.isdigit():
+            raise SchemaError(f"ANSWERS_TRIGGER must be raw digits, got {trigger!r}")
+        lines.append(f"<!-- ANSWERS_TRIGGER: {trigger} -->")
+    if toolkit_artifact_hash:
+        lines.append(f"<!-- TOOLKIT_ARTIFACT_HASH: {toolkit_artifact_hash} -->")
+    return "\n".join(lines)
+
+
+def render_findings(kept: Sequence[Finding], sev: Severity) -> str:
+    """§3e's mandatory file-grouped bullet format.
+
+    Files sort alphabetically; within a file, by tier then line. An empty list
+    renders as an empty section — deliberately, because that emptiness is the
+    signal the resolve loop terminates on.
+    """
+    if not kept:
+        return ""
+    by_file: dict[str, list[Finding]] = {}
+    for finding in kept:
+        by_file.setdefault(finding.file, []).append(finding)
+
+    order = {tier: index for index, tier in enumerate(sev.tier_order)}
+    blocks: list[str] = []
+    for path in sorted(by_file):
+        rows = sorted(
+            by_file[path],
+            key=lambda f: (order.get(f.tier or "", 99), f.line or 0),
+        )
+        header = "**PR metadata**" if path == "PR metadata" else f"**`{path}`**"
+        bullets = [header]
+        for finding in rows:
+            tag = f" [{finding.category}]" if finding.category else ""
+            where = f" L{finding.line}" if finding.line else ""
+            fix = f" *Path: {finding.suggested_fix}*" if finding.suggested_fix else ""
+            bullets.append(f"- **{finding.tier}**{tag}{where} — {finding.title}.{fix}")
+        blocks.append("\n".join(bullets))
+    return "\n\n".join(blocks)
+
+
+def render_summary(
+    *,
+    verdict: str,
+    pr_number: int | str,
+    pr_title: str,
+    reviewed_head: str,
+    kept: Sequence[Finding],
+    sev: Severity,
+    summary: str,
+    strengths: Sequence[str] = (),
+    prose: Sequence[Finding] = (),
+    answers_trigger: str | None = None,
+    toolkit_artifact_hash: str | None = None,
+    is_rereview: bool = False,
+    delta: str | None = None,
+    review_note: str | None = None,
+    model: str = "",
+    run_url: str = "",
+    heading_subject: str = "SDK",
+) -> str:
+    """The whole verdict comment.
+
+    Callers pass `heading_subject="Contract Toolkit"` for toolkit scopes; the
+    `<!-- SDK_REVIEW -->` marker is unchanged either way because the approval
+    workflow parses that stable marker and not the heading.
+    """
+    kind = "Re-review" if is_rereview else "Review"
+    parts = [
+        render_markers(
+            verdict,
+            reviewed_head,
+            answers_trigger=answers_trigger,
+            toolkit_artifact_hash=toolkit_artifact_hash,
+        ),
+        f"## {heading_subject} {kind} (@sdk-loop): PR #{pr_number} — {pr_title}",
+        "",
+        f"### Verdict: {_VERDICT_PROSE[verdict]}",
+        "",
+        f"> {summary.strip()}" if summary.strip() else "> (no summary provided)",
+        "",
+        "---",
+        "",
+    ]
+    if delta:
+        parts += ["### Delta from previous review", "", delta.strip(), ""]
+
+    parts += ["### Findings", ""]
+    body = render_findings(kept, sev)
+    parts += [body, ""] if body else ["_None._", ""]
+
+    if prose:
+        parts += ["### Observations (not blocking)", ""]
+        parts += [
+            f"- {f.file}{f' L{f.line}' if f.line else ''} — {f.title}." for f in prose
+        ]
+        parts += [""]
+
+    if strengths:
+        parts += ["### Strengths", ""] + [f"- {s}" for s in strengths] + [""]
+
+    if review_note:
+        parts += ["### Review Note", "", review_note.strip(), ""]
+
+    parts += ["---", f"**Models:** {model or 'unknown'}"]
+    if run_url:
+        parts.append(f"**Run:** [view workflow logs + cost]({run_url})")
+    return "\n".join(parts).rstrip() + "\n"
+
+
+# --------------------------------------------------------------------------
+# Payload entry point
+# --------------------------------------------------------------------------
+
+
+def load_payload(text: str | bytes) -> dict[str, Any]:
+    """Parse the agent's `findings.json`, refusing anything ambiguous."""
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SchemaError(f"findings payload is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise SchemaError("findings payload must be a JSON object")
+    if not isinstance(payload.get("findings", []), list):
+        raise SchemaError("`findings` must be a list")
+    return payload
+
+
+# --------------------------------------------------------------------------
+# Shadow audit — the contract checker, while the model still writes the comment
+# --------------------------------------------------------------------------
+#
+# Step 1 of the migration runs the renderer BEHIND the existing playbook: the
+# reviewer still composes and posts its own comment, and this function checks
+# that comment against the contract the renderer would have guaranteed.
+#
+# It cannot compare byte-for-byte — the comment carries model prose (the
+# summary, `### Strengths`, finding bodies) that no renderer reproduces, so a
+# byte assertion would fail on the first run and the natural response would be
+# to weaken it until it passed. What it compares is the part that has one
+# correct answer: the markers, the verdict token, and the empty-Findings
+# invariant.
+#
+# It is deliberately non-fatal. The point of the step is to MEASURE how often
+# the model breaks the contract before anything depends on it not breaking —
+# failing rounds on a diagnostic would just make the measurement expensive.
+
+_FINDING_BULLET_RE = re.compile(r"^\s*[-*]\s+\*\*(Critical|Important|Nit)\*\*", re.M)
+_PLACEHOLDER_RE = re.compile(r"<!--\s*REVIEWED_HEAD:\s*<[^>]*>\s*-->")
+
+
+def audit_comment(body: str) -> list[str]:
+    """Contract violations in a model-authored verdict comment, worst first.
+
+    Every check here corresponds to a real failure this lane has already paid
+    for, and each one is something the renderer makes impossible by
+    construction. An empty list means the model produced what Python would
+    have.
+    """
+    problems: list[str] = []
+    text = body or ""
+
+    if "<!-- SDK_REVIEW -->" not in text:
+        problems.append("no <!-- SDK_REVIEW --> marker: no consumer will find this")
+        return problems
+    if not text.lstrip().startswith("<!-- SDK_REVIEW -->"):
+        problems.append("the marker block does not lead the comment")
+
+    verdict_match = re.search(r"<!--\s*VERDICT:\s*([A-Z_]+)\s*-->", text)
+    if verdict_match is None:
+        problems.append("no <!-- VERDICT: X --> marker: nothing can label or approve")
+        verdict = None
+    else:
+        verdict = verdict_match.group(1)
+        if verdict not in _VERDICT_PROSE:
+            problems.append(f"verdict token {verdict!r} is not one of the five")
+
+    if _PLACEHOLDER_RE.search(text):
+        # §3f carries a `sed` for exactly this; the renderer cannot emit it.
+        problems.append(
+            "REVIEWED_HEAD is the literal placeholder, not a sha — the next "
+            "round loses its delta base"
+        )
+    else:
+        head_match = re.search(r"<!--\s*REVIEWED_HEAD:\s*([^\s>]+)\s*-->", text)
+        if head_match is None:
+            problems.append(
+                "no REVIEWED_HEAD marker: next round falls back to a full review"
+            )
+        elif not _SHA_RE.match(head_match.group(1)):
+            problems.append(
+                f"REVIEWED_HEAD {head_match.group(1)!r} is not a 40-char lowercase sha"
+            )
+
+    if re.search(r"<!--\s*ANSWERS_TRIGGER:\s*-->", text):
+        # An empty marker is worse than a missing one: it reads as
+        # present-but-unparseable to the resolver's push guard.
+        problems.append("ANSWERS_TRIGGER is present but empty; it should be omitted")
+
+    findings_empty = _findings_are_empty(text)
+    if verdict is not None:
+        if findings_empty and verdict != VERDICT_READY:
+            problems.append(
+                f"### Findings is empty but the verdict is {verdict}; the resolve "
+                "loop has nothing left to fix and cannot terminate"
+            )
+        if not findings_empty and verdict == VERDICT_READY:
+            problems.append(
+                "### Findings is non-empty but the verdict is READY_TO_MERGE — "
+                "this would approve a PR with open findings"
+            )
+
+    if re.search(r"^\|\s*Severity\s*\|", text, re.M):
+        problems.append(
+            "findings rendered as a table; §3e mandates file-grouped bullets"
+        )
+
+    return problems
+
+
+def _findings_are_empty(text: str) -> bool:
+    """Whether `### Findings` carries any finding bullet.
+
+    Reads the section between `### Findings` and the next `###`/`---`, and
+    looks for the `- **Tier**` bullet shape §3e mandates. A section holding only
+    prose ("None", "_None._", "No findings") counts as empty, which is the
+    common spelling when a re-review clears everything.
+    """
+    match = re.search(r"^###\s+Findings\s*$", text, re.M)
+    if match is None:
+        return True
+    rest = text[match.end() :]
+    end = re.search(r"^(###\s|---\s*$)", rest, re.M)
+    section = rest[: end.start()] if end else rest
+    return _FINDING_BULLET_RE.search(section) is None

--- a/.github/scripts/sdk_loop_phase.py
+++ b/.github/scripts/sdk_loop_phase.py
@@ -68,6 +68,7 @@ from sdk_loop_common import (
     usage_cost_usd,
     usage_total,
 )
+from sdk_loop_findings import audit_comment
 from sdk_loop_prep import (  # noqa: E402
     OUTCOME_UPDATED,
     PrepResult,
@@ -429,6 +430,36 @@ class ReviewOutcome:
     verdict_url: str = ""
 
 
+def audit_verdict_contract(verdict_comment: dict[str, Any] | None) -> list[str]:
+    """Check the model's own verdict comment against the renderer's contract.
+
+    Step 1 of the pr-loop migration runs `sdk_loop_findings` BEHIND the current
+    playbook: the reviewer still composes and posts the comment, and this
+    reports where that comment differs from what the renderer would have
+    guaranteed. It is the evidence that de-risks handing the renderer the job
+    for real — before anything on the approval path depends on it.
+
+    Deliberately non-fatal, and deliberately not a byte comparison. The comment
+    carries model prose no renderer reproduces, so only the part with one
+    correct answer is checked: the markers, the verdict token, and the
+    empty-Findings invariant. Failing a round on a diagnostic would make the
+    measurement cost a review.
+
+    Returns the violations so a caller can assert on them; the phase only
+    prints.
+    """
+    if verdict_comment is None:
+        return []
+    problems = audit_comment(verdict_comment.get("body") or "")
+    if not problems:
+        print("verdict contract: clean")
+        return []
+    print(f"::warning::verdict contract: {len(problems)} violation(s)")
+    for problem in problems:
+        print(f"  - {problem}")
+    return problems
+
+
 def interpret_review(
     result: AgentResult,
     verdict_comment: dict[str, Any] | None,
@@ -773,11 +804,11 @@ def main(argv: list[str] | None = None) -> int:
             ).stdout
             or "[]"
         )
-        outcome = interpret_review(
-            result,
-            newest_verdict(comments, answers_trigger=os.environ.get("COMMENT_ID")),
-            state.live,
+        verdict_comment = newest_verdict(
+            comments, answers_trigger=os.environ.get("COMMENT_ID")
         )
+        outcome = interpret_review(result, verdict_comment, state.live)
+        audit_verdict_contract(verdict_comment)
         counts = opencode_usage(workspace)
         usage, cost = format_usage(counts), usage_total(counts)
         usd = usage_cost_usd(counts, REVIEW_MODEL)

--- a/.github/scripts/tests/test_severity_mapping.py
+++ b/.github/scripts/tests/test_severity_mapping.py
@@ -1,0 +1,127 @@
+"""The severity vocabulary — one emitted set, one displayed set, a total map.
+
+The corpus this lane forked from carries THREE spellings of severity with no
+mapping between them: the payload vocabulary (`BLOCKING`..`INFO`), the
+reference files' `Critical | Important | Minor`, and the verdict template's
+`Critical | Important | Nit`. One brief emits a fourth (`IMPORTANT`). Because
+`sdk_loop_finalize.py` keys only on whether `### Findings` is empty and never
+on a tier name, a mis-spelled tier never failed anything — it just quietly
+produced a finding the verdict had not counted.
+
+These tests exist so that can never be quiet again.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from sdk_loop_findings import SchemaError, load_severity  # noqa: E402
+
+DATA = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / ".mothership/pr-loop/data/severity.yaml"
+)
+RUBRIC = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / ".mothership/pr-review/severity-rubric.yaml"
+)
+
+EMITTED = ("BLOCKING", "CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO")
+
+
+def test_every_emitted_severity_maps() -> None:
+    """Exhaustive over the emitted vocabulary — no tier may be unhandled."""
+    sev = load_severity(DATA)
+    for severity in EMITTED:
+        sev.tier(severity)  # must not raise
+        sev.in_findings(severity)
+        assert sev.floor(severity) > 0
+
+
+@pytest.mark.parametrize("bogus", ["IMPORTANT", "Critical", "Nit", "", "MINOR"])
+def test_an_unmapped_severity_raises(bogus: str) -> None:
+    """A fourth spelling must fail loudly, not pass through.
+
+    `agents/conformance.md` in the inherited corpus emits `"IMPORTANT"`, which
+    belongs to none of the three vocabularies that corpus uses. Rendering it
+    silently is how a finding ends up in the summary that the verdict never
+    counted.
+    """
+    sev = load_severity(DATA)
+    with pytest.raises(SchemaError):
+        sev.tier(bogus)
+
+
+def test_only_blocking_tiers_render_into_findings() -> None:
+    """`### Findings` empty <=> READY_TO_MERGE, so Findings membership blocks.
+
+    LOW and INFO are prose-only on purpose: the resolve loop fixes until the
+    list is empty, so a tier that can never be actioned would wedge it forever.
+    This also matches `calibration.severity_meanings`, which already calls
+    MEDIUM/LOW/INFO "summary body only".
+    """
+    sev = load_severity(DATA)
+    assert [s for s in EMITTED if sev.in_findings(s)] == [
+        "BLOCKING",
+        "CRITICAL",
+        "HIGH",
+        "MEDIUM",
+    ]
+    assert sev.tier("LOW") is None
+    assert sev.tier("INFO") is None
+
+
+def test_tiers_are_exactly_the_rendered_vocabulary() -> None:
+    sev = load_severity(DATA)
+    rendered = {sev.tier(s) for s in EMITTED if sev.in_findings(s)}
+    assert rendered == set(sev.tier_order) == {"Critical", "Important", "Nit"}
+
+
+def test_confidence_floors_are_per_severity_not_flat() -> None:
+    """The regression guarded here is a brief re-introducing a flat floor.
+
+    Six pr-review briefs restate the floor as a flat `>= 0.80` and one as a
+    flat `0.85`, against `severity-rubric.yaml`'s own "do not restate these".
+    The harm is suppression: a flat 0.80 discards every valid MEDIUM (floor
+    0.55) and LOW (0.40); a flat 0.85 also discards every valid HIGH (0.80).
+    """
+    sev = load_severity(DATA)
+    assert sev.floor("BLOCKING") == 0.85
+    assert sev.floor("HIGH") == 0.80
+    assert sev.floor("MEDIUM") == 0.55
+    assert sev.floor("LOW") == 0.40
+    assert len({sev.floor(s) for s in EMITTED}) > 1, "floors collapsed to a flat value"
+
+
+def test_every_guardrail_names_a_real_pattern() -> None:
+    """A guardrail keyed on a pattern_id that does not exist never fires.
+
+    Silent by construction — the verdict simply comes back one tier softer than
+    it should, and nothing logs that a guardrail was skipped.
+    """
+    sev = load_severity(DATA)
+    for gid, entry in sev.guardrails.items():
+        unknown = [p for p in entry["patterns"] if p not in sev.patterns]
+        assert not unknown, f"{gid} names patterns that do not exist: {unknown}"
+
+
+def test_the_shared_blocks_still_match_pr_reviews_rubric() -> None:
+    """`severity.yaml` is canonical; pr-review's copy is generated from it.
+
+    `categories` and `calibration` must stay semantically identical or the
+    generator cannot reproduce `.mothership/pr-review/severity-rubric.yaml`,
+    and the two lanes start disagreeing about what a pattern means. The
+    loop-only additions (`display`, `guardrails`, `tier_order`) are what the
+    runner needs and no model ever sees.
+    """
+    canonical = yaml.safe_load(DATA.read_text(encoding="utf-8"))
+    published = yaml.safe_load(RUBRIC.read_text(encoding="utf-8"))
+    assert canonical["categories"] == published["categories"]
+    assert canonical["calibration"] == published["calibration"]
+    assert set(canonical) - set(published) == {"display", "guardrails", "tier_order"}

--- a/.github/scripts/tests/test_verdict_rendering.py
+++ b/.github/scripts/tests/test_verdict_rendering.py
@@ -1,0 +1,564 @@
+"""The frozen verdict-comment contract, now owned by Python.
+
+`sdk_review_approve.py`, `sdk_review_reconcile.py`,
+`sdk_review_dedupe_verdicts.py`, `sdk_review_verdict_gate.py` and four
+`sdk-review-*.yml` workflows all find their work by parsing HTML comment
+markers out of PR comments. Until now that contract was a 7.2 KB markdown
+template the reviewer was asked to fill in by hand, and the playbook carries
+two `sed` safety nets for the two ways it got that wrong: writing the literal
+placeholder `<HEAD_SHA>` instead of a sha, and emitting an empty
+`<!-- ANSWERS_TRIGGER: -->` on a `workflow_dispatch` run.
+
+This module is where that contract lives now. Every assertion here is a
+downstream consumer's parse, so a failure means a real PR would have gone
+unlabelled, unapproved, or been read by the resolver as answering the wrong
+round.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import sdk_loop_phase  # noqa: E402
+import sdk_review_approve as approve  # noqa: E402
+from sdk_loop_common import (  # noqa: E402
+    ALL_VERDICTS,
+    MARK_VERDICT_BLOCK,
+    parse_reviewed_head,
+    parse_verdict,
+)
+from sdk_loop_findings import (  # noqa: E402
+    SchemaError,
+    audit_comment,
+    compute_verdict,
+    load_severity,
+    normalise,
+    parse_finding,
+    render_markers,
+    render_summary,
+)
+
+DATA = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / ".mothership/pr-loop/data/severity.yaml"
+)
+HEAD = "24ff8e453fd023731a7bb7032694e202997a2c70"
+
+
+@pytest.fixture
+def sev():
+    return load_severity(DATA)
+
+
+def _finding(**over):
+    base = {
+        "title": "VERSION_RE never matches an indented PklProject version line",
+        "severity": "HIGH",
+        "confidence": 0.9,
+        "file": ".github/scripts/release_guard.py",
+        "line": 56,
+        "category": "CI",
+        "suggested_fix": "anchor the regex with `^\\s*`",
+    }
+    base.update(over)
+    return parse_finding(base)
+
+
+# --------------------------------------------------------------------------
+# Markers
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("verdict", ALL_VERDICTS)
+def test_every_verdict_token_round_trips(verdict: str) -> None:
+    """The five tokens the approval workflows accept, parsed back by their parser."""
+    block = render_markers(verdict, HEAD)
+    assert MARK_VERDICT_BLOCK in block
+    assert parse_verdict(block) == verdict
+    assert parse_reviewed_head(block) == HEAD
+
+
+def test_reviewed_head_must_be_a_real_sha() -> None:
+    """The `<HEAD_SHA>` placeholder class, deleted rather than sed-repaired.
+
+    §3f carries a `sed` net because the reviewer sometimes wrote the literal
+    placeholder. A caller cannot make that mistake here — and if it passes a
+    short sha or a branch name, it fails loudly instead of producing a comment
+    whose delta base the next round cannot resolve.
+    """
+    for bogus in ["<HEAD_SHA>", "24ff8e4", "", "main", HEAD.upper()]:
+        with pytest.raises(SchemaError):
+            render_markers("NEEDS_FIXES", bogus)
+
+
+def test_answers_trigger_is_omitted_not_emptied_on_dispatch() -> None:
+    """`COMMENT_ID` is blank on every `workflow_dispatch` run.
+
+    The resolver's push guard uses this marker to tell "the round I am waiting
+    on has answered" from "an earlier round's verdict landed late". An empty
+    marker reads as present-but-unparseable, which is worse than a missing one:
+    it can clear a push while the review is still running and strand the verdict.
+    """
+    for blank in (None, "", "   "):
+        block = render_markers("NEEDS_FIXES", HEAD, answers_trigger=blank)
+        assert "ANSWERS_TRIGGER" not in block
+
+    block = render_markers("NEEDS_FIXES", HEAD, answers_trigger="5491746224")
+    assert "<!-- ANSWERS_TRIGGER: 5491746224 -->" in block
+
+    with pytest.raises(SchemaError):
+        render_markers("NEEDS_FIXES", HEAD, answers_trigger="comment-5491746224")
+
+
+def test_toolkit_hash_only_when_given() -> None:
+    assert "TOOLKIT_ARTIFACT_HASH" not in render_markers("NEEDS_FIXES", HEAD)
+    block = render_markers("NEEDS_FIXES", HEAD, toolkit_artifact_hash="ab" * 32)
+    assert f"<!-- TOOLKIT_ARTIFACT_HASH: {'ab' * 32} -->" in block
+
+
+def test_the_marker_block_leads_the_comment(sev) -> None:
+    """Consumers scan from the top; the marker block must be the first bytes."""
+    body = render_summary(
+        verdict="READY_TO_MERGE",
+        pr_number=3580,
+        pr_title="ci(release): guard every release opener",
+        reviewed_head=HEAD,
+        kept=[],
+        sev=sev,
+        summary="Nothing outstanding.",
+    )
+    assert body.startswith(MARK_VERDICT_BLOCK + "\n")
+
+
+# --------------------------------------------------------------------------
+# The termination invariant
+# --------------------------------------------------------------------------
+
+
+def test_empty_findings_means_ready_to_merge(sev) -> None:
+    """The resolve loop's termination condition, as an invariant.
+
+    `@sdk-resolve` loops review -> fix -> push until `### Findings` is empty,
+    and READY_TO_MERGE requires that same empty list. Making this a renderer
+    property rather than an instruction is the whole reason verdict assembly
+    moved out of the model.
+    """
+    assert compute_verdict([], sev) == "READY_TO_MERGE"
+    body = render_summary(
+        verdict="READY_TO_MERGE",
+        pr_number=3586,
+        pr_title="chore(conformance): I005 false-positive shapes",
+        reviewed_head=HEAD,
+        kept=[],
+        sev=sev,
+        summary="All prior findings resolved.",
+    )
+    section = body.split("### Findings", 1)[1]
+    assert "_None._" in section
+    assert parse_verdict(body) == "READY_TO_MERGE"
+
+
+def test_any_rendered_finding_forces_needs_fixes(sev) -> None:
+    """Strict, and strict at every tier — a lone Nit does it too."""
+    for severity in ("MEDIUM", "HIGH", "CRITICAL"):
+        kept = normalise([_finding(severity=severity, confidence=0.95)], sev).kept
+        assert kept, severity
+        assert compute_verdict(kept, sev) == "NEEDS_FIXES", severity
+
+
+def test_prose_only_tiers_do_not_block(sev) -> None:
+    """LOW/INFO reach the summary but never `### Findings`, so they never block."""
+    result = normalise(
+        [_finding(severity="LOW", confidence=0.9), _finding(severity="INFO")], sev
+    )
+    assert result.kept == []
+    assert len(result.prose) == 2
+    assert compute_verdict(result.kept, sev) == "READY_TO_MERGE"
+
+
+# --------------------------------------------------------------------------
+# Guardrails, clamping, floors
+# --------------------------------------------------------------------------
+
+
+def test_a_guardrail_pattern_forces_its_verdict(sev) -> None:
+    kept = normalise(
+        [_finding(pattern_id="credential-in-log", severity="BLOCKING")], sev
+    ).kept
+    assert compute_verdict(kept, sev) == "BLOCKED"
+
+
+def test_severity_is_clamped_down_to_max(sev) -> None:
+    """The model may under- or over-call; `max_severity` is the ceiling."""
+    kept = normalise(
+        [_finding(pattern_id="missing-type-annotation", severity="BLOCKING")], sev
+    ).kept
+    assert kept[0].severity == "MEDIUM"
+    assert kept[0].tier == "Nit"
+
+
+def test_the_floor_is_applied_after_clamping(sev) -> None:
+    """Clamp first, then floor — the floor belongs to the tier it ends up in.
+
+    A finding the model called CRITICAL at 0.60 confidence, on a pattern capped
+    at MEDIUM, is a valid MEDIUM (floor 0.55). Checking the floor first would
+    hold it to CRITICAL's 0.85 and drop a real finding.
+    """
+    result = normalise(
+        [
+            _finding(
+                pattern_id="missing-type-annotation",
+                severity="CRITICAL",
+                confidence=0.6,
+            )
+        ],
+        sev,
+    )
+    assert result.kept and not result.dropped
+    assert result.kept[0].severity == "MEDIUM"
+
+
+def test_low_confidence_is_dropped_with_a_reason(sev) -> None:
+    result = normalise([_finding(severity="HIGH", confidence=0.5)], sev)
+    assert not result.kept
+    assert "below the HIGH floor" in result.dropped[0].reason
+
+
+def test_a_guardrail_ignores_the_confidence_floor(sev) -> None:
+    """`CLAUDE.md`: guardrail violations are reported regardless of confidence."""
+    result = normalise(
+        [_finding(pattern_id="field-removed", severity="BLOCKING", confidence=0.1)], sev
+    )
+    assert result.kept, "a guardrail was dropped by a confidence floor"
+    assert compute_verdict(result.kept, sev) == "BLOCKED"
+
+
+# --------------------------------------------------------------------------
+# Schema
+# --------------------------------------------------------------------------
+
+
+def test_fields_the_handler_422s_on_are_refused() -> None:
+    """All seven brief-level JSON examples emit exactly these three."""
+    for bad in ("scope", "domain_tag", "guardrail", "public_note"):
+        with pytest.raises(SchemaError, match="422"):
+            parse_finding(
+                {
+                    "title": "x",
+                    "severity": "HIGH",
+                    "confidence": 0.9,
+                    "file": "a.py",
+                    bad: "whatever",
+                }
+            )
+
+
+def test_the_payload_only_carries_allowlisted_fields(sev) -> None:
+    finding = _finding()
+    normalise([finding], sev)
+    assert set(finding.payload()) <= {
+        "title",
+        "pattern_id",
+        "severity",
+        "category",
+        "confidence",
+        "file",
+        "line",
+        "evidence",
+        "attack_path",
+        "reachable_from",
+        "by_design_check",
+        "suggested_fix",
+        "escalate_to_linear",
+    }
+    assert "tier" not in finding.payload()
+    assert "guardrail" not in finding.payload()
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        {"severity": "HIGH", "confidence": 0.9, "file": "a.py"},
+        {"title": "x", "confidence": 0.9, "file": "a.py"},
+        {"title": "x", "severity": "HIGH", "confidence": "high", "file": "a.py"},
+        {"title": "x", "severity": "HIGH", "confidence": 1.4, "file": "a.py"},
+    ],
+)
+def test_malformed_findings_raise(raw: dict) -> None:
+    with pytest.raises(SchemaError):
+        parse_finding(raw)
+
+
+# --------------------------------------------------------------------------
+# Rendering shape
+# --------------------------------------------------------------------------
+
+
+def test_findings_are_grouped_by_file_and_sorted_by_tier(sev) -> None:
+    """§3e's mandatory format: file-grouped bullets, never a markdown table."""
+    kept = normalise(
+        [
+            _finding(file="z.py", severity="MEDIUM", line=10, title="nit"),
+            _finding(file="a.py", severity="HIGH", line=99, title="important"),
+            _finding(
+                file="a.py",
+                severity="BLOCKING",
+                line=5,
+                title="critical",
+                pattern_id="credential-in-log",
+            ),
+        ],
+        sev,
+    ).kept
+    body = render_summary(
+        verdict=compute_verdict(kept, sev),
+        pr_number=1,
+        pr_title="t",
+        reviewed_head=HEAD,
+        kept=kept,
+        sev=sev,
+        summary="s",
+    )
+    section = body.split("### Findings", 1)[1]
+    assert section.index("**`a.py`**") < section.index("**`z.py`**")
+    assert section.index("**Critical**") < section.index("**Important**")
+    assert "| Severity |" not in section, "rendered a table; §3e forbids it"
+
+
+def test_rereview_titles_itself_a_rereview(sev) -> None:
+    body = render_summary(
+        verdict="READY_TO_MERGE",
+        pr_number=1,
+        pr_title="t",
+        reviewed_head=HEAD,
+        kept=[],
+        sev=sev,
+        summary="s",
+        is_rereview=True,
+        delta="- **Resolved (1)**: the regex anchor",
+    )
+    assert "Re-review" in body
+    assert "### Delta from previous review" in body
+
+
+def test_toolkit_scope_keeps_the_stable_marker(sev) -> None:
+    """The heading changes; `<!-- SDK_REVIEW -->` must not."""
+    body = render_summary(
+        verdict="NEEDS_HUMAN",
+        pr_number=3594,
+        pr_title="t",
+        reviewed_head=HEAD,
+        kept=[],
+        sev=sev,
+        summary="s",
+        heading_subject="Contract Toolkit",
+    )
+    assert "## Contract Toolkit Review" in body
+    assert MARK_VERDICT_BLOCK in body
+    assert parse_verdict(body) == "NEEDS_HUMAN"
+
+
+def test_conflicting_short_circuits_to_needs_rebase(sev) -> None:
+    """Decided from mergeStateStatus with no model call, so no finding outvotes it."""
+    kept = normalise(
+        [_finding(severity="BLOCKING", pattern_id="field-removed")], sev
+    ).kept
+    assert compute_verdict(kept, sev, conflicting=True) == "NEEDS_REBASE"
+
+
+# --------------------------------------------------------------------------
+# Round-trip against the merge authority itself
+# --------------------------------------------------------------------------
+
+
+def test_the_rendered_comment_parses_in_sdk_review_approve(sev) -> None:
+    """The strongest assertion in this module: the real approval path reads it.
+
+    Neither lane is the merge authority. `sdk_review_approve.py` is — it casts
+    the `atlan-ci` APPROVE, and `atlan-ci` is the CODEOWNER whose review
+    satisfies the branch ruleset on `main`. So the contract that matters is not
+    "sdk_loop_common can parse this", it is "the script that approves can".
+    Those are different modules with independently-written regexes.
+    """
+    for verdict in ALL_VERDICTS:
+        body = render_summary(
+            verdict=verdict,
+            pr_number=3587,
+            pr_title="chore(conformance): P025 false-positive shapes",
+            reviewed_head=HEAD,
+            kept=[],
+            sev=sev,
+            summary="s",
+            answers_trigger="5491746224",
+        )
+        assert any(m in body for m in approve.SUMMARY_MARKERS)
+        assert approve.VERDICT_RE.search(body).group(1) == verdict
+        assert approve.REVIEWED_HEAD_RE.search(body).group(1) == HEAD
+
+
+def test_the_rendered_comment_matches_a_real_posted_verdict(sev) -> None:
+    """Shape-check against a verdict `@sdk-loop` actually posted on PR #3580.
+
+    Marker order and spelling are copied from that comment verbatim. If the
+    renderer ever reorders or respaces them, downstream regexes would still
+    match — but the diff against the old lane's output would stop being
+    reviewable by eye, which is how the shadow comparison in the review phase
+    earns its keep.
+    """
+    real_prefix = [
+        "<!-- SDK_REVIEW -->",
+        "<!-- VERDICT: NEEDS_FIXES -->",
+        f"<!-- REVIEWED_HEAD: {HEAD} -->",
+        "<!-- ANSWERS_TRIGGER: 5491269936 -->",
+    ]
+    kept = normalise([_finding()], sev).kept
+    body = render_summary(
+        verdict=compute_verdict(kept, sev),
+        pr_number=3580,
+        pr_title="ci(release): guard every release opener",
+        reviewed_head=HEAD,
+        kept=kept,
+        sev=sev,
+        summary="s",
+        answers_trigger="5491269936",
+    )
+    assert body.splitlines()[:4] == real_prefix
+
+
+# --------------------------------------------------------------------------
+# The shadow audit
+# --------------------------------------------------------------------------
+
+
+def test_the_auditor_passes_a_well_formed_comment(sev) -> None:
+    kept = normalise([_finding()], sev).kept
+    body = render_summary(
+        verdict=compute_verdict(kept, sev),
+        pr_number=3580,
+        pr_title="t",
+        reviewed_head=HEAD,
+        kept=kept,
+        sev=sev,
+        summary="s",
+        answers_trigger="5491269936",
+    )
+    assert audit_comment(body) == []
+
+
+def test_the_auditor_passes_an_empty_findings_approval(sev) -> None:
+    body = render_summary(
+        verdict="READY_TO_MERGE",
+        pr_number=3586,
+        pr_title="t",
+        reviewed_head=HEAD,
+        kept=[],
+        sev=sev,
+        summary="s",
+    )
+    assert audit_comment(body) == []
+
+
+@pytest.mark.parametrize(
+    "mutate, expect",
+    [
+        # The two failures §3f carries a `sed` for.
+        (lambda b: b.replace(HEAD, "<HEAD_SHA>"), "literal placeholder"),
+        (
+            lambda b: b.replace(
+                "<!-- ANSWERS_TRIGGER: 5491269936 -->", "<!-- ANSWERS_TRIGGER: -->"
+            ),
+            "present but empty",
+        ),
+        # A verdict that would approve a PR with open findings.
+        (
+            lambda b: b.replace(
+                "<!-- VERDICT: NEEDS_FIXES -->", "<!-- VERDICT: READY_TO_MERGE -->"
+            ),
+            "would approve a PR with open findings",
+        ),
+        # Markers the consumers key on, removed.
+        (lambda b: b.replace("<!-- SDK_REVIEW -->\n", ""), "no <!-- SDK_REVIEW -->"),
+        (lambda b: b.replace("<!-- VERDICT: NEEDS_FIXES -->\n", ""), "no <!-- VERDICT"),
+        (lambda b: re.sub(r"<!-- REVIEWED_HEAD:[^>]*-->\n", "", b), "no REVIEWED_HEAD"),
+        # A short sha still parses in sdk_loop_common but loses the delta base.
+        (lambda b: b.replace(HEAD, HEAD[:7]), "not a 40-char lowercase sha"),
+        # An invented sixth verdict token.
+        (
+            lambda b: b.replace(
+                "<!-- VERDICT: NEEDS_FIXES -->", "<!-- VERDICT: LGTM -->"
+            ),
+            "not one of the five",
+        ),
+        # Prose before the markers pushes them out of the leading position.
+        (lambda b: "Here is my review!\n\n" + b, "does not lead the comment"),
+        # §3e forbids the table form outright.
+        (
+            lambda b: b.replace(
+                "### Findings", "### Findings\n\n| Severity | Where |\n|---|---|"
+            ),
+            "rendered as a table",
+        ),
+    ],
+)
+def test_the_auditor_catches_each_known_break(sev, mutate, expect: str) -> None:
+    """A checker that passes everything is worth nothing.
+
+    Every row is a real failure mode: the two the playbook's `sed` nets exist
+    for, the marker removals that make a verdict invisible to
+    `sdk_review_approve.py`, and the Findings/verdict disagreement that would
+    approve a PR with open findings.
+    """
+    kept = normalise([_finding()], sev).kept
+    body = render_summary(
+        verdict=compute_verdict(kept, sev),
+        pr_number=3580,
+        pr_title="t",
+        reviewed_head=HEAD,
+        kept=kept,
+        sev=sev,
+        summary="s",
+        answers_trigger="5491269936",
+    )
+    problems = audit_comment(mutate(body))
+    assert any(expect in p for p in problems), (expect, problems)
+
+
+def test_findings_emptiness_reads_prose_as_empty(sev) -> None:
+    """`_None._`, `None`, and an absent section all mean no findings."""
+    for spelling in ("_None._", "None", "No findings.", ""):
+        body = (
+            f"<!-- SDK_REVIEW -->\n<!-- VERDICT: READY_TO_MERGE -->\n"
+            f"<!-- REVIEWED_HEAD: {HEAD} -->\n## t\n\n### Findings\n\n{spelling}\n\n"
+            f"### Strengths\n- ok\n"
+        )
+        assert audit_comment(body) == [], spelling
+
+
+def test_the_review_phase_audits_the_comment_without_failing_the_round() -> None:
+    """The audit is a diagnostic, not a gate — at this step.
+
+    Failing a round on a contract violation would make the measurement cost a
+    review, and the point of running the renderer behind the playbook is to
+    find out how often the model breaks the contract BEFORE anything depends
+    on it not breaking. The outcome must be decided by `interpret_review`
+    alone.
+    """
+    broken = {
+        "body": (
+            "<!-- SDK_REVIEW -->\n<!-- VERDICT: READY_TO_MERGE -->\n"
+            "<!-- REVIEWED_HEAD: <HEAD_SHA> -->\n<!-- ANSWERS_TRIGGER: -->\n"
+            "## t\n\n### Findings\n\n- **Critical** [SEC] L1 — boom.\n"
+        )
+    }
+    problems = sdk_loop_phase.audit_verdict_contract(broken)
+    assert any("literal placeholder" in p for p in problems)
+    assert any("present but empty" in p for p in problems)
+    assert any("would approve a PR with open findings" in p for p in problems)
+
+    assert sdk_loop_phase.audit_verdict_contract(None) == []

--- a/.mothership/pr-loop/data/severity.yaml
+++ b/.mothership/pr-loop/data/severity.yaml
@@ -1,0 +1,321 @@
+# Canonical severity data for the @sdk-loop lane.
+#
+# THIS FILE IS NEVER READ BY A MODEL. `sdk_loop_findings.py` loads it; the
+# reviewer only ever sees the short vocabulary line in its argv prompt. That
+# is deliberate: `.mothership/pr-review/severity-rubric.yaml` was ~9 KB of the
+# reviewer's context on every round, and every byte of it describes a decision
+# the runner is better placed to make.
+#
+# It is also the canonical source for pr-review's copy. `gen_review_assets.py`
+# renders `.mothership/pr-review/severity-rubric.yaml` from the `categories`
+# and `calibration` blocks below and `--check` fails CI on drift, so the two
+# lanes cannot disagree about what a pattern means.
+#
+# How the runner uses it:
+#   - the model picks `pattern_id` and supplies evidence + attack_path
+#   - the runner looks up canonical_severity / max_severity and clamps DOWN
+#     when the model went higher
+#   - `required_conditions_for_*` must be substantiated in evidence or
+#     attack_path before the higher tier is allowed
+#   - `override_allowed: false` means no policy may soften the pattern
+#   - `confidence_floors` are applied PER SEVERITY, never as a flat number
+
+# --------------------------------------------------------------------------
+# display — the emitted -> rendered mapping
+# --------------------------------------------------------------------------
+#
+# The corpus this lane inherits carries THREE severity spellings with no
+# mapping between them: the payload vocabulary below, the reference files'
+# `Critical | Important | Minor`, and the verdict template's
+# `Critical | Important | Nit`. `sdk_loop_finalize.py` keys only on whether
+# `### Findings` is empty and never on a tier name, so the taxonomy was
+# decorative to the gate and load-bearing to the model — the worst
+# combination, and the reason one brief emits a fourth spelling ("IMPORTANT")
+# that belongs to none of them.
+#
+# Resolution: the model emits exactly one vocabulary (the six keys here,
+# which carry the real machinery above) and the runner maps it to the three
+# tiers the summary renders. The map is total. An emitted severity that is
+# not a key here is a schema violation that fails the phase, so a fourth
+# spelling fails loudly instead of vanishing.
+#
+# `in_findings: false` means the finding is reported in prose and does NOT
+# appear under `### Findings`. Read that deliberately: an empty `### Findings`
+# means READY_TO_MERGE and is the resolve loop's termination condition, so
+# every tier that renders into Findings BLOCKS the merge. Routing LOW and
+# INFO to prose narrows what blocks in exchange for a loop that terminates —
+# and it matches `calibration.severity_meanings`, which already calls
+# MEDIUM/LOW/INFO "summary body only".
+display:
+  BLOCKING: {tier: Critical, in_findings: true, inline_comment: true}
+  CRITICAL: {tier: Critical, in_findings: true, inline_comment: true}
+  HIGH: {tier: Important, in_findings: true, inline_comment: true}
+  MEDIUM: {tier: Nit, in_findings: true, inline_comment: false}
+  LOW: {tier: null, in_findings: false, inline_comment: false}
+  INFO: {tier: null, in_findings: false, inline_comment: false}
+
+#: Order the rendered tiers sort in, within a file.
+tier_order: [Critical, Important, Nit]
+
+# --------------------------------------------------------------------------
+# guardrails — the verdict-forcing subset
+# --------------------------------------------------------------------------
+#
+# G1-G7 live in prose in three places today (pr-review's CLAUDE.md table and
+# a partial restatement in four briefs). Here they are the data the verdict
+# function reads. `verdict` is what the guardrail forces regardless of every
+# other finding; a guardrail violation is never dropped by a confidence floor.
+guardrails:
+  G1: {name: Security Blockers, verdict: BLOCKED, patterns: [credential-in-log]}
+  G2:
+    name: Contract Safety
+    verdict: BLOCKED
+    patterns: [field-removed, field-renamed, field-type-changed]
+  G3:
+    name: Determinism
+    verdict: BLOCKED
+    patterns: [io-in-workflow, non-deterministic-in-workflow]
+  G4: {name: Test Coverage, verdict: NEEDS_FIXES, patterns: [public-api-no-test]}
+  G5: {name: Secret Safety, verdict: BLOCKED, patterns: [raw-credential-in-contract]}
+  G6:
+    name: Breaking API
+    verdict: NEEDS_FIXES
+    patterns: [breaking-change-no-deprecation]
+  # G7 (branch mergeable) is not a finding — the runner decides it from
+  # mergeStateStatus before the model is called at all, and CONFLICTING short
+  # circuits to NEEDS_REBASE with no model call.
+
+categories:
+  - id: temporal-determinism
+    description: "Temporal workflow replay safety violations"
+    patterns:
+      - pattern_id: io-in-workflow
+        canonical_severity: BLOCKING
+        max_severity: BLOCKING
+        description: "I/O operation (network, file, database) in run()/@entrypoint method body"
+        override_allowed: false
+
+      - pattern_id: non-deterministic-in-workflow
+        canonical_severity: BLOCKING
+        max_severity: BLOCKING
+        description: "datetime.now/utcnow, uuid4, random.*, or time.time in run()/@entrypoint"
+        override_allowed: false
+
+      - pattern_id: blocking-call-in-workflow
+        canonical_severity: HIGH
+        max_severity: CRITICAL
+        description: "Blocking synchronous call in async run()/@entrypoint without @task"
+        required_conditions_for_critical:
+          - "Call is long-running (>1s typical)"
+        override_allowed: true
+
+  - id: contract-safety
+    description: "Temporal payload contract evolution violations"
+    patterns:
+      - pattern_id: field-removed
+        canonical_severity: BLOCKING
+        max_severity: BLOCKING
+        description: "Field removed from Input/Output contract (breaks in-flight replay)"
+        override_allowed: false
+
+      - pattern_id: field-renamed
+        canonical_severity: BLOCKING
+        max_severity: BLOCKING
+        description: "Field renamed on Input/Output contract (breaks in-flight replay)"
+        override_allowed: false
+
+      - pattern_id: field-type-changed
+        canonical_severity: BLOCKING
+        max_severity: BLOCKING
+        description: "Field type changed on Input/Output contract (breaks in-flight replay)"
+        override_allowed: false
+
+      - pattern_id: mutable-default
+        canonical_severity: HIGH
+        max_severity: CRITICAL
+        description: "Mutable default on Input/Output field — use Field(default_factory=...)"
+        required_conditions_for_critical:
+          - "Field is used in workflow orchestration (not just task I/O)"
+        override_allowed: true
+
+      - pattern_id: missing-default-new-field
+        canonical_severity: HIGH
+        max_severity: HIGH
+        description: "New field on Input/Output without a default value (breaks existing callers)"
+        override_allowed: true
+
+  - id: blocking-operations
+    description: "Heartbeat and event loop safety in @task methods"
+    patterns:
+      - pattern_id: blocking-in-task
+        canonical_severity: HIGH
+        max_severity: CRITICAL
+        description: "Blocking operation in @task without self.run_in_thread()"
+        required_conditions_for_critical:
+          - "Task has heartbeat enabled"
+          - "Blocking operation is long-running (>5s)"
+        override_allowed: true
+
+      - pattern_id: sync-http-in-async
+        canonical_severity: HIGH
+        max_severity: HIGH
+        description: "Synchronous HTTP call (requests.get etc.) in async context"
+        override_allowed: true
+
+  - id: infrastructure-abstraction
+    description: "ADR-0005 infrastructure abstraction layer violations"
+    patterns:
+      - pattern_id: direct-temporal-import
+        canonical_severity: HIGH
+        max_severity: HIGH
+        description: "Direct temporalio import outside execution/_temporal/ module"
+        override_allowed: false
+
+      - pattern_id: direct-dapr-import
+        canonical_severity: HIGH
+        max_severity: HIGH
+        description: "Direct dapr import outside infrastructure/_dapr/ module"
+        override_allowed: false
+
+      - pattern_id: direct-redis-import
+        canonical_severity: MEDIUM
+        max_severity: HIGH
+        description: "Direct redis import outside infrastructure/_redis/ module"
+        override_allowed: true
+
+  - id: api-surface
+    description: "Public API stability and test coverage"
+    patterns:
+      - pattern_id: public-api-no-test
+        canonical_severity: CRITICAL
+        max_severity: CRITICAL
+        description: "New public API (exported in __init__.py) without corresponding test"
+        override_allowed: false
+
+      - pattern_id: breaking-change-no-deprecation
+        canonical_severity: CRITICAL
+        max_severity: CRITICAL
+        description: "Public export removed or signature changed without deprecation shim with warnings.warn()"
+        override_allowed: false
+
+      - pattern_id: missing-type-annotation
+        canonical_severity: MEDIUM
+        max_severity: MEDIUM
+        description: "Public method missing return type annotation"
+        override_allowed: true
+
+  - id: credential-safety
+    description: "Credential handling patterns"
+    patterns:
+      - pattern_id: raw-credential-in-contract
+        canonical_severity: HIGH
+        max_severity: CRITICAL
+        description: "Raw credential value passed in Input/Output (use CredentialRef instead)"
+        required_conditions_for_critical:
+          - "Credential passes through Temporal payload (visible in workflow history)"
+        override_allowed: false
+
+      - pattern_id: credential-in-log
+        canonical_severity: BLOCKING
+        max_severity: BLOCKING
+        description: "Credential, secret, token, or API key logged via logger or print"
+        override_allowed: false
+
+      - pattern_id: credential-resolve-outside-task
+        canonical_severity: HIGH
+        max_severity: HIGH
+        description: "CredentialResolver used outside @task method (no retry/heartbeat protection)"
+        override_allowed: true
+
+  - id: error-handling
+    description: "Exception handling patterns"
+    patterns:
+      - pattern_id: bare-except
+        canonical_severity: MEDIUM
+        max_severity: HIGH
+        description: "Bare except clause swallowing all exceptions"
+        required_conditions_for_high:
+          - "In a @task method or run() orchestration"
+        override_allowed: true
+
+      - pattern_id: silent-exception
+        canonical_severity: HIGH
+        max_severity: HIGH
+        description: "Exception caught, logged, but not re-raised — caller never knows about failure"
+        override_allowed: true
+
+      - pattern_id: missing-exception-chain
+        canonical_severity: LOW
+        max_severity: MEDIUM
+        description: "Exception re-raised without 'from e' — original traceback lost"
+        override_allowed: true
+
+  - id: dependency-direction
+    description: "ADR layer dependency violations"
+    patterns:
+      - pattern_id: reverse-dependency
+        canonical_severity: HIGH
+        max_severity: HIGH
+        description: "Import from infrastructure/ into app/ or execution/ into app/ (wrong direction)"
+        override_allowed: false
+
+      - pattern_id: cross-layer-skip
+        canonical_severity: MEDIUM
+        max_severity: HIGH
+        description: "app/ importing directly from infrastructure/ (should go through execution/)"
+        required_conditions_for_high:
+          - "Import is for runtime behavior (not just types)"
+        override_allowed: true
+
+  - id: v2-patterns
+    description: "Legacy v2 SDK patterns that should be migrated"
+    patterns:
+      - pattern_id: v2-import
+        canonical_severity: HIGH
+        max_severity: HIGH
+        description: "Import from application_sdk.workflows, .activities, or .handlers (removed in v3)"
+        override_allowed: false
+
+      - pattern_id: v2-interface
+        canonical_severity: HIGH
+        max_severity: HIGH
+        description: "Subclass of ActivitiesInterface, WorkflowInterface, or HandlerInterface"
+        override_allowed: false
+
+      - pattern_id: v2-decorator
+        canonical_severity: MEDIUM
+        max_severity: HIGH
+        description: "@workflow.defn or @activity.defn decorator (use @task instead)"
+        required_conditions_for_high:
+          - "In non-deprecated module"
+        override_allowed: true
+
+      - pattern_id: dataclass-on-contract
+        canonical_severity: MEDIUM
+        max_severity: MEDIUM
+        description: "@dataclass on Input/Output subclass (should be plain Pydantic BaseModel)"
+        override_allowed: true
+
+# Severity calibration + confidence floors — the single source (absorbed from
+# the deleted modes/standard.md; BLDX-1605). Do not restate these in agent
+# prompts or mode files.
+#
+# The floors are PER SEVERITY and that matters: six pr-review briefs restate
+# them as a flat `>= 0.80`, and one as a flat `0.85`. The harm is suppression,
+# not drift — a flat 0.80 discards every valid MEDIUM (floor 0.55) and LOW
+# (0.40), and a flat 0.85 additionally discards every valid HIGH (0.80). The
+# runner applies the table; no brief restates it.
+calibration:
+  severity_meanings:
+    BLOCKING: "Use pattern_id above when applicable; guardrail-class"
+    CRITICAL: "Use pattern_id above when applicable; guardrail-class"
+    HIGH: "Issues users will hit in common flows (inline comment REQUIRED)"
+    MEDIUM: "Issues users rarely hit (summary body only)"
+    LOW: "Defensive notes (summary body only)"
+    INFO: "Pattern observation (summary body only)"
+  confidence_floors:
+    BLOCKING: 0.85
+    CRITICAL: 0.85
+    HIGH: 0.80
+    MEDIUM: 0.55
+    LOW: 0.40


### PR DESCRIPTION
First step of the `@sdk-loop` playbook redesign. Ships the machinery that will own verdict assembly, runs it in **shadow** behind the current reviewer, and **changes no behaviour** — the model still composes and posts its own comment.

`.mothership/pr-review/**` is untouched.

## Why this, and why first

Measured on three real run transcripts (`33487902512`, `33491434992`, round 2 of `33495621438`): the review job is **907s of agent against 18s** of checkout, token mint and installs. CI overhead is 2% of it.

The expensive turns are not slow because of accumulated context — I checked, and that reading is wrong. Run `33491434992`'s per-turn series is `1 7 10 12 10 13 9 6 | 20 116 82 123 133 120 118 6 3`: turns 16–17 cost 6s and 3s at the **largest** context in the run, faster than turns 3–6 at almost none. Latency is not monotonic in turn index in any of the three runs. Turns are slow because of *what they produce* — and composing a 7.2 KB templated comment by hand is one of the things they produce.

This PR is deliberately the shadow step: it proves the frozen marker contract in Python before anything on the approval path depends on it.

## What lands

**`.mothership/pr-loop/data/severity.yaml`** — canonical severity data, never read by a model. Its `categories` and `calibration` blocks are semantically identical to `.mothership/pr-review/severity-rubric.yaml` (asserted by test), so that file can later be *generated* from this one rather than hand-maintained twice. Loop-only additions: `display`, `guardrails`, `tier_order`.

**A total severity mapping.** The corpus carries **three** spellings with no mapping between them — the payload vocabulary (`BLOCKING`…`INFO`), the reference files' `Critical | Important | Minor`, and the verdict template's `Critical | Important | Nit` — and `agents/conformance.md` emits a fourth (`IMPORTANT`) belonging to none of them. Because `sdk_loop_finalize.py` keys only on whether `### Findings` is empty and never on a tier name, a mis-spelled tier never failed anything; it quietly produced a finding the verdict had not counted. An unmapped severity now raises.

**`sdk_loop_findings.py`** — §3a schema validation, severity clamping, per-severity confidence floors, guardrails, the §2h verdict table, and the §3e renderer. Two failure classes the playbook carries a `sed` for become impossible by construction: a literal `<HEAD_SHA>` in place of a sha, and an empty `<!-- ANSWERS_TRIGGER: -->` on a `workflow_dispatch` run. `### Findings` empty ⇒ `READY_TO_MERGE` — the resolve loop's termination condition — becomes a renderer invariant instead of an instruction.

**The shadow itself** — `audit_comment()` plus `audit_verdict_contract()` in the review phase. It checks the model's own comment against the contract the renderer would have guaranteed, prints violations as warnings, and **does not fail the round**. The point is to measure how often the contract breaks before anything depends on it holding; failing a round on a diagnostic would make the measurement cost a review. The comparison is **structural, not byte-identity** — the comment carries model prose no renderer reproduces, so a byte assertion would fail on run one and get weakened until it passed.

## Two findings from building it

**The auditor reports zero violations across ten real posted verdicts** (PRs #3580, #3584, #3585, #3586, #3587, #3589). The marker contract is being honoured today. So the case for the renderer rests on turn elimination and on making the guarantee structural — *not* on repairing output that is currently broken. Ten negative tests prove the auditor is not simply passing everything.

**The floor is applied after clamping, not before.** A finding the model calls `CRITICAL` at 0.60 confidence, on a pattern capped at `MEDIUM`, is a valid MEDIUM (floor 0.55); checking the floor first would hold it to CRITICAL's 0.85 and drop a real finding. That is the flat-floor mistake six pr-review briefs make, in a different disguise.

## Tests

- `test_verdict_rendering.py` (43) — all five markers, all five verdict tokens, empty-Findings ⇒ READY_TO_MERGE, 40-hex `REVIEWED_HEAD`, `ANSWERS_TRIGGER` omitted-not-emptied, guardrail forcing, clamp-then-floor ordering, the §3e file-grouped bullet format, and 10 negative cases for the auditor. Includes a round-trip through **`sdk_review_approve.py`'s own regexes** — it, not either lane, is the merge authority that casts the `atlan-ci` CODEOWNER approval.
- `test_severity_mapping.py` (11) — exhaustive over the six emitted tiers, unmapped raises, floors are per-severity not flat, every guardrail names a real `pattern_id`, and the shared blocks still match pr-review's rubric.

199 pass across the loop suites. Pre-commit (ruff, ruff-format, isort, pyright) clean.

## Adjacent defect found, not fixed here

`sdk_review_approve.py:176` has `VERDICT_AUTHOR = "mothership-ai[bot]"` as a **single** login, on both `main` and every branch I checked. `sdk_review_reconcile.py` imports that module, so **the reconcile safety net is blind to every `@sdk-loop` verdict**, which are authored by `atlan-app-fleet[bot]`. `sdk-review-approve-on-verdict.yml`'s `if:` accepts both logins, so the workflow and the Python disagree. Out of scope for this PR; worth its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)