### PR TITLE
ci(loop): read the deterministic gate's verdict on this head, scoped to the diff

### DIFF
--- a/.github/scripts/sdk_loop_sarif.py
+++ b/.github/scripts/sdk_loop_sarif.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Conformance coverage for one PR head, for the `@sdk-loop` context pack.
+
+The reviewer and the conformance suite have been reviewing the same code
+without either knowing what the other found. `packages/conformance` ships 167
+detector-backed rules and `fetch_conformance_sarif.py` already knows how to
+find and download their SARIF — but nothing wires them to the review, so the
+reviewer re-litigates rules a gate has already decided, and the do-not-flag
+list that stops it doing so is maintained by hand in `retro-log.md`.
+
+This module answers one question for a given head sha: **what did the
+deterministic gate already decide about this exact commit?**
+
+Two things it deliberately does NOT do.
+
+It does not suppress on warn-tier. `retro-log.md` says it plainly: conformance
+surfaces WARN findings but does not block, "so the reviewer is the only
+enforcement". Measured against the catalog, only **19 of 167 rules are
+block-tier and SDK-binding** (19 block/both; there are zero block/sdk) — so the
+suppression set for an SDK PR is small, and treating warn-tier as covered would
+silently delete the reviewer's largest real surface. Warn-tier findings are
+passed through as context, not as suppression.
+
+It does not treat absence as clean. A series only uploads when its paths
+changed, and on round N+1 — right after a resolve push — the gate run for the
+new head very often does not exist yet. `unavailable` and `complete` are
+different states and the pack says which one it is, because a reviewer told
+"nothing fired" when nothing *ran* is a reviewer that skips the surface
+entirely.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+CATALOG = (
+    Path(__file__).resolve().parents[2]
+    / "packages/conformance/conformance/docs/rules/by-id"
+)
+
+#: `**Tier:** `block` · **Scope:** `both` · ...` on one line of each rule doc.
+_TIER_RE = re.compile(r"\*\*Tier:\*\*\s*`(\w+)`\s*·\s*\*\*Scope:\*\*\s*`(\w+)`")
+
+#: Scopes whose rules can fire on `application_sdk/**`. `app` cannot: those
+#: rules run against consumer apps, so for an SDK PR they are not coverage at
+#: all — counting them would suppress prose nothing actually blocks.
+SDK_SCOPES = frozenset({"sdk", "both"})
+
+#: The four states the pack can report. Ordered worst-known to best-known.
+STATE_UNAVAILABLE = "unavailable"
+STATE_PENDING = "pending"
+STATE_PARTIAL = "partial"
+STATE_COMPLETE = "complete"
+
+
+@dataclass(frozen=True)
+class Rule:
+    rule_id: str
+    tier: str
+    scope: str
+
+    @property
+    def suppresses_prose(self) -> bool:
+        """Whether a reviewer may skip this rule because CI already blocks it."""
+        return self.tier == "block" and self.scope in SDK_SCOPES
+
+
+def load_catalog(path: Path | str | None = None) -> dict[str, Rule]:
+    """Rule id -> tier/scope, parsed from the generated per-rule docs.
+
+    Reads the docs rather than importing `conformance.suite.schema.catalog`
+    because the loop runner has no reason to install the conformance package,
+    and a review must not fail because a sibling package did not resolve.
+    """
+    directory = Path(path or CATALOG)
+    rules: dict[str, Rule] = {}
+    for doc in sorted(directory.glob("*.md")):
+        match = _TIER_RE.search(doc.read_text(encoding="utf-8"))
+        if match is None:
+            # A doc without the line is a generator change, not a review
+            # failure. Skipping it means the rule is treated as uncovered,
+            # which errs toward the reviewer doing the work.
+            continue
+        rules[doc.stem] = Rule(doc.stem, match.group(1), match.group(2))
+    return rules
+
+
+@dataclass
+class Coverage:
+    """What the gate decided about one head sha."""
+
+    state: str
+    run_id: int | None = None
+    series_present: list[str] = field(default_factory=list)
+    series_missing: list[str] = field(default_factory=list)
+    #: Rule ids that fired at block tier and bind the SDK. The reviewer must
+    #: not restate these — CI is already refusing the merge over them.
+    blocked: list[str] = field(default_factory=list)
+    #: Rule ids that fired at warn tier. CI reports and does NOT block, so
+    #: these stay the reviewer's job; they are context, never suppression.
+    warned: list[str] = field(default_factory=list)
+    #: Findings the gate reported on files this PR did NOT touch. Context
+    #: only — never suppression. See `classify_findings`.
+    elsewhere: int = 0
+    detail: str = ""
+
+    @property
+    def suppression_set(self) -> frozenset[str]:
+        return frozenset(self.blocked)
+
+
+def run_for_head(
+    repo: str,
+    head_sha: str,
+    *,
+    workflow: str = "SDK Gate",
+    limit: int = 10,
+    gh: Callable[[list[str]], tuple[int, str]],
+) -> tuple[int | None, str]:
+    """The gate run for this EXACT sha -> `(run_id, state)`.
+
+    `fetch_conformance_sarif.py` discovers "the newest run on a branch that
+    carries live SARIF", which is right for publishing a dashboard and wrong
+    here: a review is about one commit, and the newest run on the branch can
+    easily be a different one.
+
+    Filtering happens **server-side** via `gh run list --commit`, not by pulling
+    a window of recent runs and matching `headSha` locally. That was the first
+    implementation and it was wrong in a way only a real-run check found: with a
+    client-side window, any head older than the last N gate runs reports
+    `unavailable` — indistinguishable from "the gate never ran". Probed against
+    three real PR heads, a 40-run window missed all three merged ones and
+    `--commit` found every one. The distinction matters most exactly when the
+    loop is several rounds deep and the head is no longer newest.
+
+    A run that exists but has not finished is `pending`, not `unavailable` — the
+    caller may choose to wait for one and never for the other.
+    """
+    code, out = gh(
+        [
+            "run",
+            "list",
+            "--repo",
+            repo,
+            "--workflow",
+            workflow,
+            "--commit",
+            head_sha,
+            "--limit",
+            str(limit),
+            "--json",
+            "databaseId,status,conclusion",
+        ]
+    )
+    if code != 0 or not out.strip():
+        return None, STATE_UNAVAILABLE
+    try:
+        runs = json.loads(out)
+    except json.JSONDecodeError:
+        return None, STATE_UNAVAILABLE
+    if not runs:
+        return None, STATE_UNAVAILABLE
+
+    finished = [r for r in runs if r.get("status") == "completed"]
+    if not finished:
+        return runs[0].get("databaseId"), STATE_PENDING
+    return finished[0].get("databaseId"), STATE_COMPLETE
+
+
+def result_paths(result: dict[str, Any]) -> list[str]:
+    """Every file a SARIF result points at."""
+    out = []
+    for location in result.get("locations", []) or []:
+        uri = (
+            (location.get("physicalLocation") or {}).get("artifactLocation") or {}
+        ).get("uri")
+        if uri:
+            out.append(uri)
+    return out
+
+
+def classify_findings(
+    sarif_docs: dict[str, Any],
+    catalog: dict[str, Rule],
+    changed_files: Sequence[str],
+) -> tuple[list[str], list[str], int]:
+    """`(blocked, warned, elsewhere)` — scoped to the files THIS PR changed.
+
+    **`changed_files` is required, and this is the whole correctness story of
+    the module.** The conformance suite scans the entire repository, so its
+    output describes repo state, not the PR. Measured on the gate run for one
+    real PR: 584 results across 137 files, and **zero** of them in any of the
+    five files that PR touched.
+
+    Handing those to a reviewer unscoped is wrong twice over. It implies the PR
+    caused findings it did not. And far worse, the suppression list would then
+    say "CI already blocks E002, do not restate" — silencing the reviewer on a
+    bare-except the PR genuinely introduced, because E002 happened to fire in
+    an unrelated file. That loses a real finding, silently, which is the exact
+    failure this whole ingestion is supposed to prevent.
+
+    So a finding counts only when it lands in a file the PR changed. Everything
+    else is counted and reported as context, never as suppression.
+
+    A rule id the catalog does not know is treated as **warned**, never
+    blocked. An unknown rule cannot be proven to block, and guessing wrong in
+    that direction makes the reviewer skip a surface nothing was checking.
+    """
+    changed = set(changed_files)
+    blocked: list[str] = []
+    warned: list[str] = []
+    elsewhere = 0
+    for doc in sarif_docs.values():
+        for run in doc.get("runs", []) or []:
+            for result in run.get("results", []) or []:
+                rule_id = result.get("ruleId")
+                if not rule_id:
+                    continue
+                paths = result_paths(result)
+                # A result with no location cannot be attributed to this PR.
+                if not paths or not (set(paths) & changed):
+                    elsewhere += 1
+                    continue
+                rule = catalog.get(rule_id)
+                bucket = blocked if (rule and rule.suppresses_prose) else warned
+                if rule_id not in bucket:
+                    bucket.append(rule_id)
+    return sorted(blocked), sorted(warned), elsewhere
+
+
+def render_section(coverage: Coverage) -> str:
+    """The pack's `50-ci-findings.md`.
+
+    Every state gets an explicit instruction. The reviewer must never have to
+    infer what an empty findings list means — that inference is exactly how
+    "the gate did not run" becomes "the gate found nothing".
+    """
+    lines = ["# Deterministic gate coverage for this head", ""]
+
+    if coverage.state == STATE_COMPLETE:
+        lines += [
+            "**State: complete.** Every conformance series that applies to the "
+            "changed paths ran against this exact commit.",
+            "",
+            "Everything below is scoped to the files THIS PR changed. The suite "
+            "scans the whole repository, so its unscoped output is mostly "
+            "pre-existing state that has nothing to do with this diff.",
+            "",
+            "Do NOT raise a finding that a block-tier rule below already "
+            "reports. CI is refusing the merge over it; restating it costs a "
+            "round and tells the author nothing new.",
+        ]
+    elif coverage.state == STATE_PARTIAL:
+        lines += [
+            "**State: partial.** Some series ran against this commit; the ones "
+            "listed as missing did not.",
+            "",
+            "Treat the missing surfaces as **unchecked** and review them "
+            "yourself. Only the series listed as present carry any suppression.",
+        ]
+    elif coverage.state == STATE_PENDING:
+        lines += [
+            "**State: pending.** The gate is still running for this commit.",
+            "",
+            "Assume no detector coverage. Review every surface yourself. Do "
+            "not wait for it — the round is not blocked on CI.",
+        ]
+    else:
+        lines += [
+            "**State: unavailable.** No completed gate run exists for this "
+            "commit. This is the normal case on the round straight after a "
+            "resolve push.",
+            "",
+            "Assume no detector coverage. Review every surface yourself.",
+        ]
+
+    if coverage.detail:
+        lines += ["", f"_{coverage.detail}_"]
+
+    if coverage.blocked:
+        lines += [
+            "",
+            "## Already blocked by CI — do not restate",
+            "",
+            *(f"- `{rule_id}`" for rule_id in coverage.blocked),
+        ]
+    if coverage.warned:
+        lines += [
+            "",
+            "## Reported by CI at warn tier — still yours to judge",
+            "",
+            "CI surfaces these and does **not** block on them, so they are not "
+            "suppressed. Raise them where they matter, with your own evidence.",
+            "",
+            *(f"- `{rule_id}`" for rule_id in coverage.warned),
+        ]
+    if coverage.elsewhere:
+        lines += [
+            "",
+            f"_{coverage.elsewhere} further finding(s) fired on files this PR "
+            "does not touch. They are pre-existing repo state, not this PR's "
+            "doing, and they suppress nothing here._",
+        ]
+    if coverage.series_missing:
+        lines += [
+            "",
+            "## Series that did NOT run against this commit",
+            "",
+            *(f"- `{name}` — unchecked" for name in coverage.series_missing),
+        ]
+    return "\n".join(lines).rstrip() + "\n"

--- a/.github/scripts/tests/test_sdk_loop_sarif.py
+++ b/.github/scripts/tests/test_sdk_loop_sarif.py
@@ -1,0 +1,310 @@
+"""Conformance coverage for a PR head — and the two ways it must not lie.
+
+The whole value of wiring the deterministic gate into the review is that the
+reviewer stops re-litigating rules a detector already decided. The whole RISK
+is the inverse: telling the reviewer a surface is covered when nothing checked
+it, so it skips the surface and nobody looks. Every test here is about keeping
+those two apart.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from sdk_loop_sarif import (  # noqa: E402
+    STATE_COMPLETE,
+    STATE_PARTIAL,
+    STATE_PENDING,
+    STATE_UNAVAILABLE,
+    Coverage,
+    Rule,
+    classify_findings,
+    load_catalog,
+    render_section,
+    run_for_head,
+)
+
+HEAD = "24ff8e453fd023731a7bb7032694e202997a2c70"
+
+
+def _gh(payload, code=0):
+    def fake(args):
+        return code, json.dumps(payload) if payload is not None else ""
+
+    return fake
+
+
+# --------------------------------------------------------------------------
+# The catalog
+# --------------------------------------------------------------------------
+
+
+def test_the_real_catalog_parses() -> None:
+    """All 167 generated rule docs, read the way the runner will read them."""
+    catalog = load_catalog()
+    assert len(catalog) == 167, f"parsed {len(catalog)}"
+    assert catalog["L001"].tier == "block"
+    assert catalog["L001"].scope == "both"
+
+
+def test_only_block_tier_sdk_binding_rules_may_suppress_prose() -> None:
+    """The suppression set is 19 rules, not 167 — and that is the point.
+
+    `retro-log.md` states it directly: conformance surfaces WARN findings but
+    does not block, "so the reviewer is the only enforcement". And an
+    `app`-scoped rule does not run against `application_sdk/**` at all, so for
+    an SDK PR it is not coverage in any sense. Treating either as covered would
+    silently delete the reviewer's largest real surface, which is exactly the
+    failure this module exists to avoid.
+    """
+    catalog = load_catalog()
+    suppressing = [r for r in catalog.values() if r.suppresses_prose]
+    assert len(suppressing) == 19, (
+        f"{len(suppressing)} rules claim to suppress reviewer prose; if the "
+        "catalog genuinely changed, update the number deliberately — do not "
+        "let it drift upward unnoticed"
+    )
+    assert all(r.tier == "block" for r in suppressing)
+    assert all(r.scope in ("sdk", "both") for r in suppressing)
+
+
+@pytest.mark.parametrize(
+    "rule, expected",
+    [
+        (Rule("X", "block", "both"), True),
+        (Rule("X", "block", "sdk"), True),
+        (Rule("X", "block", "app"), False),  # never runs on the SDK
+        (Rule("X", "warn", "both"), False),  # reported, not blocked
+        (Rule("X", "warn", "sdk"), False),
+    ],
+)
+def test_suppression_eligibility(rule: Rule, expected: bool) -> None:
+    assert rule.suppresses_prose is expected
+
+
+# --------------------------------------------------------------------------
+# Finding the run for THIS commit
+# --------------------------------------------------------------------------
+
+
+def test_the_lookup_filters_server_side_by_commit() -> None:
+    """The window bug, pinned.
+
+    The first implementation pulled the last N gate runs and matched `headSha`
+    locally. Probed against three real PR heads, a 40-run window reported
+    `unavailable` for all three merged ones — indistinguishable from "the gate
+    never ran" — while `gh run list --commit` found every one. A client-side
+    window degrades exactly when the loop is several rounds deep and the head
+    is no longer newest, which is when coverage matters most.
+    """
+    seen: list[list[str]] = []
+
+    def gh(args):
+        seen.append(args)
+        return 0, json.dumps(
+            [{"databaseId": 1, "status": "completed", "conclusion": "failure"}]
+        )
+
+    run_id, state = run_for_head("o/r", HEAD, gh=gh)
+    assert (run_id, state) == (1, STATE_COMPLETE)
+    assert (
+        "--commit" in seen[0] and HEAD in seen[0]
+    ), "the lookup must filter by commit server-side, not window-and-match"
+
+
+def test_a_failing_gate_run_still_counts() -> None:
+    """The suite reports findings by design, so `failure` carries real SARIF."""
+    runs = [{"databaseId": 7, "status": "completed", "conclusion": "failure"}]
+    assert run_for_head("o/r", HEAD, gh=_gh(runs))[1] == STATE_COMPLETE
+
+
+def test_a_still_running_gate_is_pending_not_unavailable() -> None:
+    """Different states, because a caller may wait for one and never the other."""
+    runs = [{"databaseId": 9, "status": "in_progress", "conclusion": None}]
+    assert run_for_head("o/r", HEAD, gh=_gh(runs)) == (9, STATE_PENDING)
+
+
+def test_no_run_for_this_head_is_unavailable() -> None:
+    """The common case on round N+1, straight after a resolve push."""
+    assert run_for_head("o/r", HEAD, gh=_gh([])) == (None, STATE_UNAVAILABLE)
+
+
+@pytest.mark.parametrize(
+    "gh",
+    [_gh(None, code=1), _gh(None), lambda args: (0, "not json")],
+)
+def test_a_broken_gh_call_degrades_to_unavailable(gh) -> None:
+    """Never raise. A review must not fail because the gate lookup did.
+
+    `unavailable` makes the reviewer do the work itself, which is the safe
+    direction; raising would turn a CI hiccup into a lost round.
+    """
+    assert run_for_head("o/r", HEAD, gh=gh) == (None, STATE_UNAVAILABLE)
+
+
+# --------------------------------------------------------------------------
+# Classifying what fired
+# --------------------------------------------------------------------------
+
+
+MINE = "application_sdk/app/base.py"
+THEIRS = "application_sdk/handler/service.py"
+
+
+def _sarif(*pairs):
+    """`(rule_id, path)` pairs -> a SARIF doc with real locations."""
+    return {
+        "s": {
+            "runs": [
+                {
+                    "results": [
+                        {
+                            "ruleId": rule_id,
+                            "locations": [
+                                {
+                                    "physicalLocation": {
+                                        "artifactLocation": {"uri": path}
+                                    }
+                                }
+                            ],
+                        }
+                        for rule_id, path in pairs
+                    ]
+                }
+            ]
+        }
+    }
+
+
+def test_findings_split_by_tier_and_scope() -> None:
+    catalog = {
+        "L001": Rule("L001", "block", "both"),
+        "E016": Rule("E016", "warn", "both"),
+        "K006": Rule("K006", "block", "app"),
+    }
+    blocked, warned, elsewhere = classify_findings(
+        _sarif(("L001", MINE), ("E016", MINE), ("K006", MINE)), catalog, [MINE]
+    )
+    assert blocked == ["L001"]
+    assert warned == ["E016", "K006"]
+    assert elsewhere == 0
+
+
+def test_findings_outside_the_diff_never_suppress() -> None:
+    """The bug real data caught, and the most dangerous one in the module.
+
+    The suite scans the whole repo. On the gate run for one real PR there were
+    584 results across 137 files and **zero** in the five files that PR
+    touched. Unscoped, the pack would have said "CI already blocks E002, do not
+    restate" — silencing the reviewer on a bare-except the PR genuinely
+    introduced, because E002 fired somewhere else entirely. That loses a real
+    finding, silently.
+    """
+    catalog = {"E002": Rule("E002", "block", "both")}
+    blocked, warned, elsewhere = classify_findings(
+        _sarif(("E002", THEIRS)), catalog, [MINE]
+    )
+    assert blocked == [], "a finding outside the diff must not suppress the reviewer"
+    assert warned == []
+    assert elsewhere == 1
+
+
+def test_a_result_with_no_location_is_not_attributed() -> None:
+    """Unattributable means "not this PR's", not "everywhere"."""
+    catalog = {"L001": Rule("L001", "block", "both")}
+    doc = {"s": {"runs": [{"results": [{"ruleId": "L001"}]}]}}
+    blocked, warned, elsewhere = classify_findings(doc, catalog, [MINE])
+    assert (blocked, warned, elsewhere) == ([], [], 1)
+
+
+def test_an_unknown_rule_is_warned_never_blocked() -> None:
+    """Guessing wrong toward "blocked" makes the reviewer skip a live surface.
+
+    An id the catalog does not know cannot be proven to block anything, so it
+    is passed through as context. The reviewer looking twice is cheap; the
+    reviewer not looking at all is the bug.
+    """
+    blocked, warned, _ = classify_findings(_sarif(("Z999", MINE)), {}, [MINE])
+    assert blocked == []
+    assert warned == ["Z999"]
+
+
+def test_duplicate_results_collapse() -> None:
+    catalog = {"L001": Rule("L001", "block", "both")}
+    blocked, _, _ = classify_findings(
+        _sarif(("L001", MINE), ("L001", MINE), ("L001", MINE)), catalog, [MINE]
+    )
+    assert blocked == ["L001"]
+
+
+def test_empty_sarif_yields_nothing() -> None:
+    assert classify_findings({}, {}, [MINE]) == ([], [], 0)
+    assert classify_findings({"s": {"runs": []}}, {}, [MINE]) == ([], [], 0)
+
+
+def test_pre_existing_findings_are_reported_as_context_not_suppression() -> None:
+    text = render_section(Coverage(state=STATE_COMPLETE, elsewhere=584))
+    assert "584 further finding(s)" in text
+    assert "suppress nothing here" in text
+    assert "scoped to the files THIS PR changed" in text
+
+
+# --------------------------------------------------------------------------
+# What the reviewer is told
+# --------------------------------------------------------------------------
+
+
+def test_every_state_carries_an_explicit_instruction() -> None:
+    """The reviewer must never infer what an empty findings list means.
+
+    That inference is precisely how "the gate did not run" becomes "the gate
+    found nothing", and a surface goes unreviewed by both.
+    """
+    for state in (STATE_COMPLETE, STATE_PARTIAL, STATE_PENDING, STATE_UNAVAILABLE):
+        text = render_section(Coverage(state=state))
+        assert f"**State: {state}." in text
+        assert len(text.splitlines()) > 3, f"{state} rendered no instruction"
+
+
+@pytest.mark.parametrize("state", [STATE_PENDING, STATE_UNAVAILABLE])
+def test_absence_never_reads_as_clean(state: str) -> None:
+    text = render_section(Coverage(state=state))
+    assert "Assume no detector coverage" in text
+    assert "Review every surface yourself" in text
+
+
+def test_partial_names_the_unchecked_series() -> None:
+    text = render_section(
+        Coverage(
+            state=STATE_PARTIAL,
+            series_present=["logging"],
+            series_missing=["tests", "security"],
+        )
+    )
+    assert "unchecked" in text
+    assert "`tests` — unchecked" in text
+    assert "`security` — unchecked" in text
+
+
+def test_blocked_and_warned_are_rendered_differently() -> None:
+    """Warn-tier must never be presented as suppression."""
+    text = render_section(
+        Coverage(state=STATE_COMPLETE, blocked=["L001"], warned=["E016"])
+    )
+    assert "do not restate" in text
+    assert "`L001`" in text
+    assert "still yours to judge" in text
+    assert "does **not** block" in text
+    assert "`E016`" in text
+
+
+def test_the_suppression_set_is_only_the_blocked_ids() -> None:
+    cov = Coverage(state=STATE_COMPLETE, blocked=["L001", "P001"], warned=["E016"])
+    assert cov.suppression_set == {"L001", "P001"}
+    assert "E016" not in cov.suppression_set


### PR DESCRIPTION
Second step of the `@sdk-loop` redesign (follows #3604, independent of it). Adds `sdk_loop_sarif.py`, which answers one question for a given head sha: **what did the conformance gate already decide about this exact commit?** Nothing consumes it yet — it lands with tests and a real-data verification so the context pack can use it next.

`packages/conformance` ships 167 detector-backed rules and `fetch_conformance_sarif.py` already knows how to find and download their SARIF, but nothing wires the two together. So the reviewer re-litigates rules a gate has already decided, and the list that stops it doing so is maintained by hand in `retro-log.md`.

## Two corrections that only real gate runs surfaced

Both were wrong in the direction that **loses findings**.

### 1. Scope every finding to the files the PR changed

The suite scans the whole repository. On the gate run for #3604 there were **584 results across 137 files and zero in any of the five files that PR touched.**

Unscoped, the pack would have told the reviewer *"CI already blocks E002, do not restate"* — silencing it on a bare-except the PR genuinely introduced, because E002 fired in an unrelated file. `classify_findings` now requires `changed_files`, counts everything else as context, and says so in the rendered section.

Verified both directions against the real SARIF from run `33534835381`:

| Scope | blocked | warned | elsewhere |
|---|---|---|---|
| #3604's actual 5 files | — | — | 584 |
| control: `application_sdk/handler/service.py` | `E002` | 10 rules | 538 |

### 2. Find the run server-side, by commit

The first version pulled the last 40 gate runs and matched `headSha` locally. Probed against three real PR heads, that window reported `unavailable` for **all three merged ones** — indistinguishable from "the gate never ran" — while `gh run list --commit` found every one. A client-side window degrades exactly when the loop is several rounds deep and the head is no longer newest, which is when coverage matters most.

## Two things it deliberately does not do

**It does not suppress on warn tier.** `retro-log.md` says it plainly: conformance surfaces WARN findings and does not block, *"so the reviewer is the only enforcement"*. Measured against the catalog, only **19 of 167 rules are block-tier and SDK-binding** (19 `block`/`both`; there are zero `block`/`sdk`). The suppression set is genuinely small, and treating warn-tier as covered would delete the reviewer's largest real surface. Warn-tier is passed through as context.

**It does not treat absence as clean.** A series uploads only when its paths changed, and on round N+1 — straight after a resolve push — the run for the new head very often does not exist yet. `complete` / `partial` / `pending` / `unavailable` are four states and each carries its own explicit instruction, because a reviewer told "nothing fired" when nothing *ran* is a reviewer that skips the surface entirely.

An unknown rule id is classified `warned`, never `blocked` — it cannot be proven to block anything, and the reviewer looking twice is cheaper than nobody looking.

Rendered section is **~165 tokens** on a PR with no scanned changes.

## Tests

27, including the diff-scoping bug pinned as its own case, an assertion that the lookup filters server-side, all four coverage states, and a guard that the 19-rule suppression set does not drift upward unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)