### PR TITLE
ci(loop): the new loop playbook — judgement only, 2.0K tokens

### DIFF
--- a/.github/scripts/tests/test_pr_loop_playbook.py
+++ b/.github/scripts/tests/test_pr_loop_playbook.py
@@ -1,0 +1,143 @@
+"""Invariants of the `@sdk-loop` playbook — the ones that fail silently.
+
+`.mothership/pr-loop/REVIEW.md` is injected into the reviewer's context on every
+round, so a regression here is paid on every review and shows up as nothing more
+than a slower, worse review. That is the same failure shape the pr-review
+playbook accumulated `test_review_playbook_sections.py` to guard against, for
+the same reason.
+
+The specific regressions:
+
+- The router grows back. The file this replaces reached 51 KB (83 KB on `main`)
+  by accretion, one reasonable-looking paragraph at a time.
+- Someone re-adds a "read these first" list, and the reviewer is back to eight
+  orientation turns loading a corpus the runner already applied.
+- The severity vocabulary drifts from the data the runner clamps against — the
+  exact two-files-one-string drift that produced three spellings and a fourth
+  nobody mapped.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+PLAYBOOK = ROOT / ".mothership/pr-loop/REVIEW.md"
+CONTRACT = ROOT / ".mothership/pr-loop/CONTRACT.md"
+SEVERITY = ROOT / ".mothership/pr-loop/data/severity.yaml"
+
+#: 1 token ~= 4 chars. The point of the redesign is that this file is small
+#: enough to be free; the number is a ratchet, not a target to grow into.
+CHARS_PER_TOKEN = 4
+PLAYBOOK_TOKEN_CEILING = 2_600
+
+
+def test_the_playbook_stays_small() -> None:
+    text = PLAYBOOK.read_text(encoding="utf-8")
+    tokens = len(text) // CHARS_PER_TOKEN
+    assert tokens <= PLAYBOOK_TOKEN_CEILING, (
+        f"REVIEW.md is ~{tokens} tokens, over the {PLAYBOOK_TOKEN_CEILING} "
+        "ceiling. It is injected on every round of every review. The file it "
+        "replaces got to 83 KB one reasonable paragraph at a time — if this "
+        "content genuinely belongs, move something else out first."
+    )
+
+
+def test_the_playbook_never_sends_the_reviewer_to_the_old_corpus() -> None:
+    """Structural, because prose prohibition demonstrably does not work.
+
+    The pr-review playbook delists `review-policy.md` and `review.yaml` in so
+    many words, and the reviewer read both in every transcript sampled. The
+    only reliable fix is not naming them — so this asserts the new playbook
+    does not.
+    """
+    text = PLAYBOOK.read_text(encoding="utf-8")
+    for forbidden in (
+        "ORCHESTRATION.md",
+        "severity-rubric.yaml",
+        "retro-log.md",
+        "review-policy.md",
+        "review.yaml",
+        "references/",
+        "pr-review/",
+    ):
+        assert forbidden not in text, (
+            f"REVIEW.md points the reviewer at {forbidden}. Everything in the "
+            "old corpus is either applied by the runner or in the pack; a "
+            "pointer here buys turns and nothing else."
+        )
+
+
+def test_the_playbook_does_not_point_at_the_maintainer_doc() -> None:
+    """`CONTRACT.md` is maintainer-facing and must stay out of agent context."""
+    assert "CONTRACT.md" not in PLAYBOOK.read_text(encoding="utf-8")
+    assert "No agent reads this file" in CONTRACT.read_text(encoding="utf-8")
+
+
+def test_the_emitted_vocabulary_matches_the_runner_data() -> None:
+    """One vocabulary, defined once.
+
+    The corpus this forked from carried three spellings with no mapping, and a
+    fourth (`IMPORTANT`) that belonged to none of them. The playbook tells the
+    reviewer what to emit; `severity.yaml` tells the runner what to accept. If
+    they disagree, every finding of the mismatched tier fails the round.
+    """
+    listed = set(
+        re.findall(
+            r"`(BLOCKING|CRITICAL|HIGH|MEDIUM|LOW|INFO)`",
+            PLAYBOOK.read_text(encoding="utf-8"),
+        )
+    )
+    accepted = set(yaml.safe_load(SEVERITY.read_text(encoding="utf-8"))["display"])
+    assert (
+        listed == accepted
+    ), f"playbook offers {sorted(listed)}, runner accepts {sorted(accepted)}"
+
+
+def test_the_playbook_names_the_completion_assertion() -> None:
+    """An empty findings list renders READY_TO_MERGE.
+
+    So the reviewer must be told, in the file it actually reads, that
+    `status` and `reviewed_files` are how a real empty result is told from a
+    crash. Without them a dead agent manufactures an approval.
+    """
+    text = PLAYBOOK.read_text(encoding="utf-8")
+    assert "reviewed_files" in text
+    assert '"status": "partial"' in text
+    assert "reads as an approval" in text
+
+
+def test_the_playbook_keeps_the_class_sweep() -> None:
+    """The single highest-leverage judgement step in the old playbook.
+
+    Nothing deterministic replaces it: clustering by root cause and sweeping the
+    diff for siblings is what holds a PR to two rounds instead of twenty. It is
+    the one large block deliberately carried over nearly whole.
+    """
+    text = PLAYBOOK.read_text(encoding="utf-8")
+    assert "Bugs travel in classes" in text
+    assert "Cluster by root cause" in text
+    assert "Sweep the whole diff" in text
+    assert "hollow" in text, "the always-pass gate check is missing"
+
+
+def test_the_playbook_keeps_nits_narrow_and_real_bugs_exempt() -> None:
+    """Convergence rules apply to MEDIUM only — never to a real defect.
+
+    Diff-scoping a Critical would suppress exactly the regressions the resolver
+    introduces, which is the one thing a review loop must never do.
+    """
+    # Collapse wrapping — these are prose assertions and the file is hard-wrapped.
+    text = " ".join(PLAYBOOK.read_text(encoding="utf-8").split())
+    assert "for `MEDIUM` **only**" in text
+    assert "exempt from all three" in text
+    assert "**especially** code the resolver just pushed" in text
+
+
+def test_the_playbook_forbids_reading_ci() -> None:
+    text = PLAYBOOK.read_text(encoding="utf-8")
+    assert "CI state" in text
+    assert "stale" in text

--- a/.github/scripts/tests/test_pr_loop_playbook.py
+++ b/.github/scripts/tests/test_pr_loop_playbook.py
@@ -34,6 +34,21 @@ SEVERITY = ROOT / ".mothership/pr-loop/data/severity.yaml"
 CHARS_PER_TOKEN = 4
 PLAYBOOK_TOKEN_CEILING = 2_600
 
+# Bound to the emit sentence, not every backtick in the file. A closed
+# allowlist regex (`BLOCKING|CRITICAL|...`) cannot fail on a seventh
+# spelling — `IMPORTANT` is already in the file as a negative example
+# and the equality still holds. Capture whatever that sentence offers.
+_EMIT_VOCABULARY = re.compile(
+    r"exactly one of\s+((?:`[^`]+`[,\s]*)+)\.",
+    re.DOTALL,
+)
+
+
+def _emitted_vocabulary(text: str) -> set[str]:
+    match = _EMIT_VOCABULARY.search(text)
+    assert match is not None, "playbook is missing the 'exactly one of' emit sentence"
+    return set(re.findall(r"`([^`]+)`", match.group(1)))
+
 
 def test_the_playbook_stays_small() -> None:
     text = PLAYBOOK.read_text(encoding="utf-8")
@@ -85,16 +100,23 @@ def test_the_emitted_vocabulary_matches_the_runner_data() -> None:
     reviewer what to emit; `severity.yaml` tells the runner what to accept. If
     they disagree, every finding of the mismatched tier fails the round.
     """
-    listed = set(
-        re.findall(
-            r"`(BLOCKING|CRITICAL|HIGH|MEDIUM|LOW|INFO)`",
-            PLAYBOOK.read_text(encoding="utf-8"),
-        )
-    )
+    listed = _emitted_vocabulary(PLAYBOOK.read_text(encoding="utf-8"))
     accepted = set(yaml.safe_load(SEVERITY.read_text(encoding="utf-8"))["display"])
     assert (
         listed == accepted
     ), f"playbook offers {sorted(listed)}, runner accepts {sorted(accepted)}"
+
+
+def test_the_vocabulary_gate_catches_a_seventh_spelling() -> None:
+    """The closed-allowlist regex this replaces could not fail on `IMPORTANT`."""
+    fake = (
+        "severity — exactly one of `BLOCKING`, `CRITICAL`, `HIGH`, "
+        "`MEDIUM`, `LOW`, `INFO`, `IMPORTANT`. No other spelling."
+    )
+    listed = _emitted_vocabulary(fake)
+    accepted = set(yaml.safe_load(SEVERITY.read_text(encoding="utf-8"))["display"])
+    assert "IMPORTANT" in listed
+    assert listed != accepted
 
 
 def test_the_playbook_names_the_completion_assertion() -> None:

--- a/.mothership/pr-loop/CONTRACT.md
+++ b/.mothership/pr-loop/CONTRACT.md
@@ -1,0 +1,73 @@
+# The verdict contract
+
+**Maintainer-facing. No agent reads this file, and no read list may point at
+it.** It records what the runner guarantees on the reviewer's behalf, and who
+depends on those guarantees.
+
+The rationale for individual decisions lives in the docstrings of
+`.github/scripts/sdk_loop_findings.py`, next to the code that implements them —
+this repo has been bitten before by rationale living in a second file that then
+drifts from the first.
+
+## The comment
+
+`sdk_loop_findings.render_summary()` emits the marker block, in this order:
+
+| Marker | Required | Read by |
+|---|---|---|
+| `<!-- SDK_REVIEW -->` | always | every consumer, to find the comment at all |
+| `<!-- VERDICT: X -->` | always | `sdk_review_approve.py` — labels, the `sdk-review` status, and the `atlan-ci` approval |
+| `<!-- REVIEWED_HEAD: <40-hex> -->` | always | the next round, to scope its delta; `sdk_review_approve.py`, to refuse a verdict for a stale sha |
+| `<!-- ANSWERS_TRIGGER: <digits> -->` | comment triggers only | the resolver's push guard, to tell this round's verdict from an earlier one landing late |
+| `<!-- TOOLKIT_ARTIFACT_HASH: <sha256> -->` | toolkit scopes only | the next round, to carry consumer validation forward |
+
+`X` is one of `READY_TO_MERGE`, `NEEDS_FIXES`, `BLOCKED`, `NEEDS_HUMAN`,
+`NEEDS_REBASE`. There is no sixth token.
+
+Two rules that are easy to get wrong and cost real debugging when they are:
+
+- **`ANSWERS_TRIGGER` is omitted, never emptied.** `COMMENT_ID` is blank on
+  every `workflow_dispatch` run. An empty marker reads as
+  present-but-unparseable and can clear a push mid-review, stranding the verdict.
+- **`REVIEWED_HEAD` is the reviewed sha, always 40 lowercase hex.** A short sha
+  parses but loses the next round's delta base.
+
+## The invariant
+
+`### Findings` empty ⇔ `READY_TO_MERGE`.
+
+This is the resolve loop's termination condition — it fixes until the list is
+empty — so it is the one rule in the lane that must not be probabilistic. The
+renderer owns it; nothing asks a model to honour it.
+
+It follows that **every tier rendered into `### Findings` blocks the merge**.
+That is why `severity.yaml` routes `LOW` and `INFO` to prose instead: a tier
+that cannot be actioned would wedge the loop forever.
+
+## Merge authority
+
+Neither lane approves anything. `sdk_review_approve.py` casts the `atlan-ci`
+review, and `atlan-ci` is the CODEOWNER whose approval satisfies the ruleset on
+`main`. `mothership-ai[bot]` and `atlan-app-fleet[bot]` are Apps and cannot.
+
+So the contract that matters is not "the loop can parse its own output" — it is
+"`sdk_review_approve.py` can". `test_verdict_rendering.py` round-trips through
+that module's own regexes for exactly this reason.
+
+**Known gap, not fixed here.** `sdk_review_approve.py`'s `VERDICT_AUTHOR` is a
+single login, `mothership-ai[bot]`. `sdk_review_reconcile.py` imports it, so the
+reconcile safety net is blind to every `@sdk-loop` verdict — those are authored
+by `atlan-app-fleet[bot]`. The approve workflow's own `if:` accepts both logins,
+so the YAML and the Python disagree. Verified on `main`.
+
+## The payload
+
+The reviewer returns one JSON object and posts nothing. Fields per finding are
+the allowlist in `sdk_loop_findings.FINDING_FIELDS`; anything else 422s the
+inline-comment handler, so the renderer rejects it rather than stripping it.
+
+`status` and `reviewed_files` are the completion assertion. They exist because
+an empty findings list renders `READY_TO_MERGE`: without a positive signal that
+a review happened, an agent that crashed after writing its file would
+manufacture a merge-ready verdict. `PACK_ID` proves the pack loaded; it does not
+prove the work was done.

--- a/.mothership/pr-loop/REVIEW.md
+++ b/.mothership/pr-loop/REVIEW.md
@@ -1,0 +1,170 @@
+# SDK reviewer — judgement
+
+You are reviewing one pull request for `atlanhq/application-sdk`, a Python SDK
+that connector builders use to write Temporal-backed metadata extractors.
+
+Everything with a determinate answer has already been decided for you and is in
+your context: the PR's facts, the diff, the files worth reading, which
+specialist you are, the rules that apply to these paths, and what the
+deterministic gate already found. **You are not orchestrating a review. You are
+doing one.**
+
+Do not go looking for the playbook, the severity rubric, the do-not-flag list or
+the reference rules. They are not yours to read — the runner has already applied
+everything mechanical in them, and reading them again costs turns and tells you
+nothing your pack has not.
+
+Your entire output is one JSON object written to the path named in your prompt.
+You do not post comments, set statuses, apply labels, or push. The runner renders
+the verdict from what you return.
+
+---
+
+## What counts as a finding
+
+A finding is a **specific defect, in code this PR adds or changes, that you can
+point at**. Four tests, all of which must pass:
+
+1. **Evidence you can quote.** Name the file and line and quote the code. "This
+   module could be more robust" is not a finding. If you cannot quote it, you
+   have not found it.
+
+2. **A consequence you can state.** What breaks, for whom, when? A finding whose
+   consequence you cannot name is an opinion about style.
+
+3. **Reachable.** Trace it. A defect on a path nothing calls, in a branch that
+   cannot be entered, or behind a flag that is never set, is at most an
+   observation. Say so rather than inflating it.
+
+4. **Actionable.** It names a concrete change the author can make. An
+   observation whose only path forward is *"no action needed"*, *"accept the
+   tool quirk"*, *"defensible either way"*, or a pure either/or preference is
+   **not a finding**. Put it in `notes` or `strengths`.
+
+The fourth test is not politeness — it is what lets the loop terminate. The
+resolve phase fixes until the findings list is empty, and the verdict is
+`READY_TO_MERGE` only when it is. A finding nobody can act on wedges the loop
+forever.
+
+## What is already handled — do not spend a turn on it
+
+- **Anything a block-tier detector reported on a file this PR changed.** Your
+  pack lists them under "Already blocked by CI". Restating one costs a round and
+  tells the author nothing.
+- **Severity arithmetic.** Emit your honest severity; the runner clamps it
+  against the rubric, applies the per-severity confidence floor, and maps it to
+  the rendered tier. Do not apply a floor of your own, and do not reason about
+  which tier blocks the merge.
+- **Known false positives and by-design patterns.** The runner filters them out
+  of what you return. Do not try to remember them.
+- **The verdict, the summary, the markers, the labels, the status.** All the
+  runner's. Return findings.
+- **CI state.** Not yours, on any round. It is enforced elsewhere, event-driven,
+  and any snapshot you took would be stale before anyone read it.
+
+## Nits are the narrow case
+
+A `MEDIUM` finding renders as a `Nit`, and a single Nit withholds the approval —
+so an unconvergent nit stream does not merely waste rounds, it withholds the
+merge indefinitely. Three rules, for `MEDIUM` **only**:
+
+1. **Only on lines this PR adds or modifies.** A nit on pre-existing, untouched
+   code — even in a file the PR changed, even when you were handed the whole
+   file for context — is out of scope. A PR is not the place to polish code it
+   did not write.
+2. **On a re-review, only on hunks that changed since the last round.** A line
+   you saw last round and passed must not draw a new nit this round. No mining a
+   fresh set of optional nits each pass.
+3. **Actionable, per the fourth test above.**
+
+`BLOCKING`, `CRITICAL` and `HIGH` are exempt from all three. A real bug is raised
+on any line, including code the resolver just pushed — **especially** code the
+resolver just pushed. Never suppress a real defect for convergence.
+
+## Bugs travel in classes
+
+This is the highest-leverage thing you do, and the reason a PR takes two rounds
+instead of twenty. Before you finish:
+
+1. **Cluster by root cause, not by file.** Two findings share a class when the
+   *same* underlying fix resolves both — "a multi-file writer that only reverts
+   `finding.file`", "an auto-detect that resets a customised value on a bare
+   re-run", "an externally-derived value interpolated into a shell-out". Name
+   each class in one line.
+
+2. **Sweep the whole diff for siblings.** For every class with at least one
+   confirmed finding, search the entire diff — and the module the fix will touch
+   — for other occurrences of the same shape that you did not flag individually.
+   Report each as its own finding and name the shared class in its title. A
+   swept-in sibling inherits the class's severity; it is the same defect.
+
+3. **Prove an added gate is not hollow.** When the class concerns a check, gate
+   or flag *this PR adds*, find the input for which it silently passes: a gate
+   returning `passed=true` unconditionally, an escalation flag the caller must
+   remember to set rather than a structural rule, a validator with an early
+   `return True`. An always-pass path is itself a finding, and the most expensive
+   kind — it defeats the safety net rather than tripping it.
+
+Report the class once, with its instances grouped, so the author fixes the
+invariant and not the symptoms.
+
+## Path forward
+
+Every `BLOCKING`, `CRITICAL` or `HIGH` finding carries a path forward in its
+`suggested_fix`. One of:
+
+- **Immediate fix** — "Fix this now, it breaks in production. Do X."
+- **Temporary fix plus follow-up** — "Quick fix: X. The right solution is Y."
+- **Wrong approach** — "This will not work because X. Do Y instead."
+- **Design decision needed** — "Two valid options, A or B. Needs a human."
+
+`MEDIUM` gets a one-line `suggested_fix` and nothing more.
+
+Do not say "this is wrong" and stop. Say what right looks like.
+
+## Judge like a builder
+
+The question behind every finding: *if I were building a connector on this SDK,
+does this change make my life easier or harder?* An SDK's defects are paid for
+by everyone downstream, which is why contract breaks and determinism violations
+outrank almost everything else — they corrupt workflows that are already running.
+
+## Output
+
+Write one JSON object to the path your prompt names:
+
+```json
+{
+  "pack_id": "<echo the PACK_ID from your prompt, verbatim>",
+  "status": "complete",
+  "reviewed_files": ["<every file you actually examined>"],
+  "findings": [ ... ],
+  "strengths": ["<what this PR does well>"],
+  "notes": "<2-3 sentences: is this fixing symptoms or causes, and what is the right path forward>"
+}
+```
+
+Each finding carries only these fields. Any other key is rejected by the
+comment handler and fails the round:
+
+`title`, `pattern_id`, `severity`, `category`, `confidence`, `file`, `line`,
+`evidence`, `attack_path`, `reachable_from`, `by_design_check`, `suggested_fix`,
+`escalate_to_linear`
+
+- `severity` — exactly one of `BLOCKING`, `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`,
+  `INFO`. No other spelling. `IMPORTANT`, `Critical`, `Minor` and `Nit` are not
+  values; emitting one fails the round rather than being quietly reinterpreted.
+- `pattern_id` — a rubric pattern id or a conformance rule id when one fits.
+  Omit it otherwise; do not invent one.
+- `confidence` — your honest 0.0-1.0. Do not pre-filter on it. The runner
+  applies the floor for the severity you chose, and floors differ by tier: a
+  MEDIUM at 0.6 is kept, a HIGH at 0.6 is not.
+
+`reviewed_files` is not decoration. It is how the runner tells a completed
+review that found nothing from an agent that died before it looked — and an
+empty findings list means `READY_TO_MERGE`, so that distinction decides whether
+a PR merges. List what you actually read.
+
+**If you run short of time**, return what you have with `"status": "partial"`
+and the files you got through. A partial review that says so is useful. A
+review that stops silently and returns an empty list reads as an approval.


### PR DESCRIPTION
**Stacked on #3604** (base branch is `vaibhavchopra/sdk-loop-verdict-renderer` — it needs `data/severity.yaml` to pin the emitted vocabulary against what the runner accepts). Review #3604 first.

`.mothership/pr-loop/REVIEW.md` is the playbook the redesigned lane injects. It replaces a 51 KB router (83 KB on `main`) with **8.1 KB / ~2.0K tokens** — and the difference is not compression. Everything with a determinate answer moved to the runner and simply is not in here.

## The measurement

From three real transcripts (`33487902512`, `33491434992`, round 2 of `33495621438`), the file this replaces costs **~115 KB / ~28.7K tokens loaded over eight turns before the diff is touched** — every run, every round, on a fresh runner that carries nothing forward.

This file is *injected*: zero turns, and the reviewer's first turn already holds the diff, the files, the applicable rules, and what the gate found.

## What it keeps, and why each earns its tokens

- **What counts as a finding** — four tests: quotable evidence, a stated consequence, reachability, actionability. The fourth is not politeness. The resolve phase fixes until the findings list is empty and `READY_TO_MERGE` requires it empty, so a finding nobody can act on wedges the loop forever.
- **Bugs travel in classes** — carried over nearly whole from §2d. Nothing deterministic replaces it and it is the highest-leverage step in the old playbook: cluster by root cause, sweep the diff for siblings, prove an added gate is not hollow. It is what holds a PR to two rounds instead of twenty.
- **Nit convergence** — diff-scoped, monotonic on re-review, actionable, and `MEDIUM` **only**. `BLOCKING`/`CRITICAL`/`HIGH` stay exempt on any line, *especially* code the resolver just pushed. Diff-scoping a real defect would suppress exactly the regressions a resolve loop introduces.
- **Path forward**, and the builder's question.

## What it drops, because the runner owns it now

Severity arithmetic and confidence floors · the do-not-flag list · verdict computation · the summary template and its five markers · CI state · every "read this file first" pointer.

## Two structural choices

**It never names the old corpus.** Not `ORCHESTRATION.md`, `severity-rubric.yaml`, `retro-log.md`, `references/`, or the two delisted files. Prose prohibition demonstrably does not work — pr-review delists `review-policy.md` and `review.yaml` in so many words, and the reviewer read both in **every** transcript I sampled. The only reliable fix is not mentioning them. A test enforces it.

**It tells the reviewer why `reviewed_files` matters.** An empty findings list renders `READY_TO_MERGE`, so without a positive completion signal an agent that died mid-review manufactures an approval. The file says that out loud, because a reviewer that understands the stake fills the field honestly.

`CONTRACT.md` is maintainer-facing and no agent reads it — asserted, along with the rule that `REVIEW.md` must not point at it. Rationale for individual decisions stays in the `sdk_loop_findings.py` docstrings, next to the code, rather than in a second document that drifts from the first (which is how `ORCHESTRATION.md` and `DESIGN.md` ended up carrying six identical paragraphs).

## Tests

8 invariants, each guarding a regression that would otherwise be silent:

| Invariant | Regression it catches |
|---|---|
| ~2.6K token ceiling | the router growing back by accretion, one reasonable paragraph at a time |
| no pointer into the old corpus | eight orientation turns coming back |
| emitted vocabulary == `severity.yaml` `display` keys | the three-spellings drift, and the fourth (`IMPORTANT`) nobody mapped |
| completion assertion present | a dead agent manufacturing an approval |
| class sweep intact | twenty-round PRs |
| nit rules + the Critical/High exemption | suppressing the regressions the resolver just introduced |
| CI prohibition | turns spent on a stale snapshot |
| `CONTRACT.md` unreferenced | maintainer prose entering agent context |

## Not in this PR

The pack builder that actually injects this (`sdk_loop_context.py` / `sdk_loop_rules.py`), the specialist briefs, and the rule cards. Those are the next step, and they are where the content migration from `references/` happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)