### PR TITLE
fix(testing): serve the lazy decorator, not its submodule, from the integration package (FND-1242)

### DIFF
--- a/application_sdk/testing/integration/__init__.py
+++ b/application_sdk/testing/integration/__init__.py
@@ -286,6 +286,26 @@ def __dir__() -> list[str]:
     return sorted({*globals(), *_LAZY_EXPORTS, *_LAZY_SUBMODULES})
 
 
+# ``lazy`` is the one name that is both a lazy export (the decorator) and a
+# submodule (its home). The lazy machinery cannot serve that collision: the
+# import system binds the *submodule* onto this package as a side effect of any
+# ``from .lazy import ...`` — ``runner`` does one — and an attribute already
+# present on the package means ``__getattr__`` is never consulted. So the
+# documented ``from application_sdk.testing.integration import lazy`` returned
+# the module, and every ``lazy(...)`` call site died with ``TypeError: 'module'
+# object is not callable`` — order-dependently, whenever anything touched a
+# ``.lazy``-importing submodule first (resolving ``BaseIntegrationTest`` from
+# this package is enough).
+#
+# Bind the callable eagerly instead. ``lazy.py`` imports nothing beyond the
+# stdlib, so this costs the laziness budget nothing — and it wins permanently:
+# the module-level name shadows ``__getattr__`` for good, and a later import of
+# the submodule is served from ``sys.modules`` without re-binding the parent
+# attribute. ``lazy`` stays in ``_LAZY_EXPORTS`` (and the ``TYPE_CHECKING``
+# block) so the three parallel lists keep matching; its entry is simply never
+# consulted at runtime.
+from .lazy import lazy as lazy  # noqa: E402
+
 # =============================================================================
 # Public API
 # =============================================================================

--- a/application_sdk/testing/integration/__init__.py
+++ b/application_sdk/testing/integration/__init__.py
@@ -304,7 +304,9 @@ def __dir__() -> list[str]:
 # attribute. ``lazy`` stays in ``_LAZY_EXPORTS`` (and the ``TYPE_CHECKING``
 # block) so the three parallel lists keep matching; its entry is simply never
 # consulted at runtime.
-from .lazy import lazy as lazy  # noqa: E402
+from .lazy import (  # noqa: E402 — eager bind: export/submodule name collision
+    lazy as lazy,
+)
 
 # =============================================================================
 # Public API

--- a/tests/unit/testing/integration/test_fixtures.py
+++ b/tests/unit/testing/integration/test_fixtures.py
@@ -660,6 +660,72 @@ print("OK")
         assert result.returncode == 0, result.stderr
         assert "OK" in result.stdout
 
+    def test_lazy_is_the_decorator_not_its_home_submodule(self) -> None:
+        """``from ...integration import lazy`` must yield the callable (FND).
+
+        ``lazy`` is the one name that is both an export and a submodule. The
+        import system binds the *submodule* onto the package as a side effect
+        of any ``from .lazy import ...`` — ``runner`` does one — and an
+        attribute already on the package means ``__getattr__`` is never
+        consulted. Before the eager binding in ``__init__`` that returned the
+        module, and every adopter's ``lazy(...)`` scenario died at collection
+        with ``TypeError: 'module' object is not callable``.
+
+        Subprocess-isolated and run in BOTH orders, because the failure was
+        order-dependent: resolving ``BaseIntegrationTest`` first imports
+        ``runner`` and with it ``.lazy``, which is exactly the poisoned path.
+        """
+        for imports in (
+            "from application_sdk.testing.integration import lazy",
+            # BaseIntegrationTest first: runner imports .lazy, binding the
+            # submodule attribute before `lazy` itself is resolved.
+            "from application_sdk.testing.integration import BaseIntegrationTest, lazy",
+        ):
+            script = f"""
+{imports}
+
+from application_sdk.testing.integration import evaluate_if_lazy, is_lazy
+
+assert callable(lazy), type(lazy)
+wrapped = lazy(lambda: 1)
+assert is_lazy(wrapped)
+assert evaluate_if_lazy(wrapped) == 1
+print("OK")
+"""
+            result = _run_python(script)
+            assert result.returncode == 0, result.stderr
+            assert "OK" in result.stdout
+
+    def test_submodule_path_import_still_works(self) -> None:
+        """The explicit submodule path keeps working alongside the export.
+
+        Connectors that worked around the shadowing import from the submodule
+        directly; both spellings must resolve to the same callable.
+        """
+        script = """
+from application_sdk.testing.integration import lazy as exported
+from application_sdk.testing.integration.lazy import lazy as from_module
+
+assert exported is from_module
+print("OK")
+"""
+        result = _run_python(script)
+        assert result.returncode == 0, result.stderr
+        assert "OK" in result.stdout
+
+    def test_export_submodule_collisions_are_bound_eagerly(self) -> None:
+        """Any name on both lists must be pre-bound so ``__getattr__``'s
+        precedence never decides it. Today that set is exactly ``lazy``; a new
+        collision must add its own eager binding or rename the submodule."""
+        from application_sdk.testing import integration
+
+        collisions = set(integration._LAZY_EXPORTS) & integration._LAZY_SUBMODULES
+        assert collisions == {"lazy"}
+        for name in collisions:
+            bound = integration.__dict__.get(name)
+            assert bound is not None, f"{name} is not eagerly bound"
+            assert not inspect.ismodule(bound), f"{name} is bound to its submodule"
+
     def test_type_checking_block_matches_the_lazy_map(self) -> None:
         """The third parallel list, read the way its only two readers read it.
 


### PR DESCRIPTION
### Changelog
- `testing.integration.__init__` now binds the `lazy` decorator eagerly, so `from application_sdk.testing.integration import lazy` yields the callable instead of the `lazy` submodule.
- Regression tests: subprocess-isolated, both import orders (`lazy` alone, and `BaseIntegrationTest` first — the poisoned path), plus a guard that any future export/submodule name collision must be eagerly bound.

### Why
`lazy` is the one name that is both a lazy export (in `__all__`) and a submodule. The import machinery binds the **submodule** onto the package as a side effect of any `from .lazy import ...` — `runner` does one — and an attribute already present on the package means `__getattr__` is never consulted. The documented import (the one `lazy.py`'s own docstrings show) then returns the module, and every `lazy(...)` scenario dies at collection with `TypeError: 'module' object is not callable`.

This is order-dependent: resolving `BaseIntegrationTest` from the package first is enough. Every connector integration suite written as

```python
from application_sdk.testing.integration import Scenario, equals, lazy
```

breaks on the 3.31.0 bump. Reproduced on atlan-athena-app (main + SDK 3.31.0): all four scenario modules fail collection with exactly this error.

### Why the eager bind (and not `__getattr__` precedence)
Flipping `__getattr__` to check `_LAZY_EXPORTS` before `_LAZY_SUBMODULES` is not enough — once anything imports `.lazy`, the import system has bound the submodule as a package attribute and `__getattr__` is bypassed entirely. A module-level binding shadows it permanently, and a later import of the submodule is served from `sys.modules` without re-binding the parent attribute. `lazy.py` is stdlib-only (`collections.abc` + `typing`), so the package's laziness budget pays nothing. `lazy` stays in `_LAZY_EXPORTS` and the `TYPE_CHECKING` block so the three parallel lists keep matching (both pinned by existing tests).

### Additional context
- Linear: FND-1242
- Found during the FND-402 e2e sweep while validating the fleet bump (contract-toolkit 0.23.0 + SDK 3.31.0) on atlan-athena-app.
- Fleet impact: every connector adopting 3.31.0 whose integration scenarios import `lazy` from the package hits this at collection; without this fix each repo needs the `from application_sdk.testing.integration.lazy import lazy` workaround.

### Checklist
- [x] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated (n/a — the documented import now works as documented)

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)? **No**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

