### PR TITLE
feat(contract-toolkit): register qlik-sense-enterprise-windows connector type

### DIFF
--- a/contract-toolkit/src/Connectors.pkl
+++ b/contract-toolkit/src/Connectors.pkl
@@ -153,6 +153,10 @@ hidden const QLIKSENSE: Type = new {
   value = "qlik-sense"
   category = "bi"
 }
+hidden const QLIKSENSE_ENTERPRISE_WINDOWS: Type = new {
+  value = "qlik-sense-enterprise-windows"
+  category = "bi"
+}
 hidden const KAFKA: Type = new {
   value = "kafka"
   category = "eventbus"


### PR DESCRIPTION
## Summary
- Adds `QLIKSENSE_ENTERPRISE_WINDOWS` (`"qlik-sense-enterprise-windows"`, category `"bi"`) to `Connectors.pkl`
- Without this registration, the platform doesn't recognise the connector type when creating Connection entities — the frontend falls back to `"qlik-sense"`, grouping EW assets under Qlik Sense Cloud instead of their own category
- Follows the same pattern as Kafka flavours (`APACHE_KAFKA`, `CONFLUENT_KAFKA`, `AMAZON_MSK`) which are each registered separately from the base `KAFKA` type

## Context
The `atlan-qlik-sense-app` repo's `ent-windows` branch defines an EW entrypoint with `connector = new Connectors.Type { value = "qlik-sense-enterprise-windows"; category = "bi" }` (inline type). The generated `ConnectionCreator` widget correctly emits `ui.connector: "qlik-sense-enterprise-windows"`, but the platform doesn't resolve it because the type isn't in the registry. This PR closes that gap.

## Test plan
- [ ] `pkl test` passes on existing Connectors tests
- [ ] After toolkit release + version bump in `atlan-qlik-sense-app`, EW connections are created as `default/qlik-sense-enterprise-windows/{epoch}` and appear under "Qlik Sense Enterprise Windows Assets" in the monitor

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>