### PR TITLE
fix(conformance): P003 exempts classes that override code emission

### DIFF
--- a/packages/conformance/conformance/docs/rules/by-id/P003.md
+++ b/packages/conformance/conformance/docs/rules/by-id/P003.md
@@ -40,3 +40,9 @@ The check resolves inheritance transitively: an intermediate class with no `code
 don't silently inherit the bare leaf's code.  Suppress with `# conformance: ignore[P003]
 <reason>` at the declaration when an intermediate is genuinely abstract — see
 typed-error-prescription §4 and BLDX-1431.
+
+Exempt: classes whose own MRO overrides `to_failure_details()` or `qualified_code` —
+usually via a shared connector error mixin.  Those build the wire envelope themselves,
+so `code` is not what a dashboard reads and prefixing it would change nothing
+observable.  The exemption is inherited, so the override may sit on the mixin rather
+than on each exception class.

--- a/packages/conformance/conformance/docs/rules/by-id/P003.md
+++ b/packages/conformance/conformance/docs/rules/by-id/P003.md
@@ -41,8 +41,9 @@ don't silently inherit the bare leaf's code.  Suppress with `# conformance: igno
 <reason>` at the declaration when an intermediate is genuinely abstract — see
 typed-error-prescription §4 and BLDX-1431.
 
-Exempt: classes whose own MRO overrides `to_failure_details()` or `qualified_code` —
-usually via a shared connector error mixin.  Those build the wire envelope themselves,
-so `code` is not what a dashboard reads and prefixing it would change nothing
-observable.  The exemption is inherited, so the override may sit on the mixin rather
-than on each exception class.
+Exempt: classes whose own MRO overrides `to_failure_details()` — usually via a shared
+connector error mixin.  Those build the wire envelope themselves, so `code` is not what
+a dashboard reads and prefixing it would change nothing observable.  The exemption is
+inherited, so the override may sit on the mixin rather than on each exception class.
+Overriding `qualified_code` alone does NOT exempt: that is the log surface, and the wire
+code still collapses to the leaf.

--- a/packages/conformance/conformance/docs/rules/prescriptions.md
+++ b/packages/conformance/conformance/docs/rules/prescriptions.md
@@ -165,11 +165,12 @@ don't silently inherit the bare leaf's code.  Suppress with `# conformance: igno
 <reason>` at the declaration when an intermediate is genuinely abstract — see
 typed-error-prescription §4 and BLDX-1431.
 
-Exempt: classes whose own MRO overrides `to_failure_details()` or `qualified_code` —
-usually via a shared connector error mixin.  Those build the wire envelope themselves,
-so `code` is not what a dashboard reads and prefixing it would change nothing
-observable.  The exemption is inherited, so the override may sit on the mixin rather
-than on each exception class.
+Exempt: classes whose own MRO overrides `to_failure_details()` — usually via a shared
+connector error mixin.  Those build the wire envelope themselves, so `code` is not what
+a dashboard reads and prefixing it would change nothing observable.  The exemption is
+inherited, so the override may sit on the mixin rather than on each exception class.
+Overriding `qualified_code` alone does NOT exempt: that is the log surface, and the wire
+code still collapses to the leaf.
 
 ---
 

--- a/packages/conformance/conformance/docs/rules/prescriptions.md
+++ b/packages/conformance/conformance/docs/rules/prescriptions.md
@@ -165,6 +165,12 @@ don't silently inherit the bare leaf's code.  Suppress with `# conformance: igno
 <reason>` at the declaration when an intermediate is genuinely abstract — see
 typed-error-prescription §4 and BLDX-1431.
 
+Exempt: classes whose own MRO overrides `to_failure_details()` or `qualified_code` —
+usually via a shared connector error mixin.  Those build the wire envelope themselves,
+so `code` is not what a dashboard reads and prefixing it would change nothing
+observable.  The exemption is inherited, so the override may sit on the mixin rather
+than on each exception class.
+
 ---
 
 ## P004 — `DirectTemporalImport` {#p004}

--- a/packages/conformance/conformance/suite/checks/prescriptions/__init__.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/__init__.py
@@ -90,6 +90,7 @@ from ._error_code_prefix import (
     collect_import_aliases,
     emit_p003,
     module_code_constants,
+    resolve_emission_override,
     resolve_indirect_codes,
     resolve_leaf_prefix,
 )
@@ -274,6 +275,7 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
     for records in file_records.values():
         resolve_indirect_codes(records, code_consts)
     cache: dict[str, str | None] = {}
+    emission_cache: dict[str, bool] = {}
     for path, records in file_records.items():
         directives = file_directives[path]
         for rec in records:
@@ -285,6 +287,11 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
                 if leaf_prefix is not None:
                     break
             if leaf_prefix is None:
+                continue
+            # A class that replaces to_failure_details()/qualified_code emits its
+            # code by its own route, so `code` is not what a dashboard sees and
+            # prefixing it would be dead. P003 has nothing to say about those.
+            if resolve_emission_override(rec.name, by_name, emission_cache, set()):
                 continue
             if rec.code_value is None:
                 findings.append(emit_p003(rec, leaf_prefix, directives))

--- a/packages/conformance/conformance/suite/checks/prescriptions/__init__.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/__init__.py
@@ -288,9 +288,9 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
                     break
             if leaf_prefix is None:
                 continue
-            # A class that replaces to_failure_details()/qualified_code emits its
-            # code by its own route, so `code` is not what a dashboard sees and
-            # prefixing it would be dead. P003 has nothing to say about those.
+            # A class that replaces to_failure_details emits its code by its
+            # own route, so `code` is not what a dashboard sees and prefixing
+            # it would be dead. P003 has nothing to say about those.
             if resolve_emission_override(rec.name, by_name, emission_cache, set()):
                 continue
             if rec.code_value is None:

--- a/packages/conformance/conformance/suite/checks/prescriptions/__init__.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/__init__.py
@@ -275,9 +275,11 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
                     break
             if leaf_prefix is None:
                 continue
-            if rec.code_value is None:
+            if not rec.code_declared:
                 findings.append(emit_p003(rec, leaf_prefix, directives))
-            elif not rec.code_value.startswith(f"{leaf_prefix}_"):
+            elif rec.code_value is not None and not rec.code_value.startswith(
+                f"{leaf_prefix}_"
+            ):
                 findings.append(emit_p003(rec, leaf_prefix, directives))
 
     # Pass 4 — emit P013/P014 (cross-file boundary-type enforcement)

--- a/packages/conformance/conformance/suite/checks/prescriptions/_error_code_prefix.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_error_code_prefix.py
@@ -50,6 +50,54 @@ class ClassRecord:
     bases: list[str] = field(default_factory=list)
     code_value: str | None = None
     code_node: ast.AST | None = None
+    overrides_emission: bool = False
+
+
+# Methods that, when overridden, take the emitted code out of ``code``'s hands.
+# ``AppError.to_failure_details()`` is what builds the wire envelope and
+# ``qualified_code`` is what log surfaces read; a class that replaces either one
+# supplies its own code by another route, so ``code: ClassVar[str]`` is no
+# longer what reaches a dashboard and demanding a prefix on it is meaningless.
+EMISSION_OVERRIDES: frozenset[str] = frozenset({"to_failure_details", "qualified_code"})
+
+
+def _overrides_emission(cls_node: ast.ClassDef) -> bool:
+    """True if *cls_node* defines its own code-emission method."""
+    return any(
+        isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef)
+        and stmt.name in EMISSION_OVERRIDES
+        for stmt in cls_node.body
+    )
+
+
+def resolve_emission_override(
+    name: str,
+    by_name: dict[str, ClassRecord],
+    cache: dict[str, bool],
+    visiting: set[str],
+) -> bool:
+    """True if *name* or any scanned ancestor overrides code emission.
+
+    Walks the same base chain :func:`resolve_leaf_prefix` does, so a mixin that
+    carries the override is credited to every class that mixes it in. Bases
+    outside the scanned tree cannot be inspected and simply do not confirm an
+    override, which keeps the exemption conservative.
+    """
+    if name in cache:
+        return cache[name]
+    if name in visiting:
+        return False
+    rec = by_name.get(name)
+    if rec is None:
+        cache[name] = False
+        return False
+    visiting.add(name)
+    result = rec.overrides_emission or any(
+        resolve_emission_override(base, by_name, cache, visiting) for base in rec.bases
+    )
+    visiting.discard(name)
+    cache[name] = result
+    return result
 
 
 def _is_classvar_annotation(annotation: ast.expr | None) -> bool:
@@ -228,6 +276,7 @@ def collect_classes(
                 bases=bases,
                 code_value=code_value,
                 code_node=code_node,
+                overrides_emission=_overrides_emission(node),
             )
         )
     return records

--- a/packages/conformance/conformance/suite/checks/prescriptions/_error_code_prefix.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_error_code_prefix.py
@@ -53,12 +53,17 @@ class ClassRecord:
     overrides_emission: bool = False
 
 
-# Methods that, when overridden, take the emitted code out of ``code``'s hands.
-# ``AppError.to_failure_details()`` is what builds the wire envelope and
-# ``qualified_code`` is what log surfaces read; a class that replaces either one
-# supplies its own code by another route, so ``code: ClassVar[str]`` is no
-# longer what reaches a dashboard and demanding a prefix on it is meaningless.
-EMISSION_OVERRIDES: frozenset[str] = frozenset({"to_failure_details", "qualified_code"})
+# The ONE method that, when overridden, takes the emitted code out of ``code``'s
+# hands. ``AppError.to_failure_details()`` builds the ``FailureDetails`` wire
+# envelope and is what puts ``code`` in front of a dashboard; a class that
+# replaces it supplies its own code by another route, so demanding a prefix on
+# ``code`` is meaningless there.
+#
+# ``qualified_code`` is deliberately NOT in this set. It is only the
+# log-line/human-readable surface — a class that overrides it while leaving
+# ``to_failure_details`` alone still emits the bare leaf code on the wire, which
+# is exactly the harm P003 exists to catch.
+EMISSION_OVERRIDES: frozenset[str] = frozenset({"to_failure_details"})
 
 
 def _overrides_emission(cls_node: ast.ClassDef) -> bool:

--- a/packages/conformance/conformance/suite/checks/prescriptions/_error_code_prefix.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_error_code_prefix.py
@@ -65,6 +65,13 @@ class ClassRecord:
 # is exactly the harm P003 exists to catch.
 EMISSION_OVERRIDES: frozenset[str] = frozenset({"to_failure_details"})
 
+# ``AppError.to_failure_details`` is the *default* envelope, not a replacement.
+# When this repo is scanned, that method is in the class registry, and walking
+# every ancestor would credit every leaf subclass with an exemption — hollowing
+# P003 on dogfood. The 15 leaves inherit that default; they are stops too.
+# Mixins (not in these sets) still propagate.
+_EMISSION_STOPS: frozenset[str] = frozenset({"AppError"}) | frozenset(LEAF_PREFIX_MAP)
+
 
 def _overrides_emission(cls_node: ast.ClassDef) -> bool:
     """True if *cls_node* defines its own code-emission method."""
@@ -81,12 +88,13 @@ def resolve_emission_override(
     cache: dict[str, bool],
     visiting: set[str],
 ) -> bool:
-    """True if *name* or any scanned ancestor overrides code emission.
+    """True if *name* or a non-leaf mixin ancestor overrides code emission.
 
-    Walks the same base chain :func:`resolve_leaf_prefix` does, so a mixin that
-    carries the override is credited to every class that mixes it in. Bases
-    outside the scanned tree cannot be inspected and simply do not confirm an
-    override, which keeps the exemption conservative.
+    Mixins that carry ``to_failure_details`` are credited to every class that
+    mixes them in. ``AppError`` and the 15 leaves are resolution stops: their
+    method is the default envelope, not a replacement, so inheriting from them
+    must not buy the exemption. Bases outside the scanned tree cannot be
+    inspected and simply do not confirm an override.
     """
     if name in cache:
         return cache[name]
@@ -98,7 +106,9 @@ def resolve_emission_override(
         return False
     visiting.add(name)
     result = rec.overrides_emission or any(
-        resolve_emission_override(base, by_name, cache, visiting) for base in rec.bases
+        resolve_emission_override(base, by_name, cache, visiting)
+        for base in rec.bases
+        if base not in _EMISSION_STOPS
     )
     visiting.discard(name)
     cache[name] = result

--- a/packages/conformance/conformance/suite/checks/prescriptions/_error_code_prefix.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_error_code_prefix.py
@@ -50,6 +50,7 @@ class ClassRecord:
     bases: list[str] = field(default_factory=list)
     code_value: str | None = None
     code_node: ast.AST | None = None
+    code_declared: bool = False
 
 
 def _is_classvar_annotation(annotation: ast.expr | None) -> bool:
@@ -61,11 +62,13 @@ def _is_classvar_annotation(annotation: ast.expr | None) -> bool:
     return _get_name(annotation) == "ClassVar"
 
 
-def _extract_code(cls_node: ast.ClassDef) -> tuple[str | None, ast.AST | None]:
-    """Find the class-level ``code`` literal assignment, if any.
+def _extract_code(
+    cls_node: ast.ClassDef,
+) -> tuple[str | None, ast.AST | None, bool]:
+    """Find the class-level ``code`` assignment, if any.
 
-    Accepts both ``code: ClassVar[str] = "..."`` (the prescribed form) and the
-    plain ``code = "..."`` shorthand.
+    Accepts literal assignments, the plain ``code = "..."`` shorthand, and
+    registry members such as ``codes.FT_AUTH_X.code``.
     """
     for stmt in cls_node.body:
         if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
@@ -78,7 +81,19 @@ def _extract_code(cls_node: ast.ClassDef) -> tuple[str | None, ast.AST | None]:
                 and isinstance(stmt.value, ast.Constant)
                 and isinstance(stmt.value.value, str)
             ):
-                return stmt.value.value, stmt
+                return stmt.value.value, stmt, True
+            # Error-code registries expose the string through a ``.code``
+            # property (for example ``codes.FT_AUTH_X.code``). Preserve the
+            # category-bearing constant name so its prefix is still checked.
+            if (
+                stmt.value is not None
+                and isinstance(stmt.value, ast.Attribute)
+                and stmt.value.attr == "code"
+                and isinstance(stmt.value.value, ast.Attribute)
+                and isinstance(stmt.value.value.value, ast.Name)
+                and stmt.value.value.attr.startswith("FT_")
+            ):
+                return stmt.value.value.attr[3:], stmt, True
         elif isinstance(stmt, ast.Assign):
             for target in stmt.targets:
                 if (
@@ -87,8 +102,8 @@ def _extract_code(cls_node: ast.ClassDef) -> tuple[str | None, ast.AST | None]:
                     and isinstance(stmt.value, ast.Constant)
                     and isinstance(stmt.value.value, str)
                 ):
-                    return stmt.value.value, stmt
-    return None, None
+                    return stmt.value.value, stmt, True
+    return None, None, False
 
 
 def collect_import_aliases(tree: ast.Module) -> dict[str, str]:
@@ -126,7 +141,7 @@ def collect_classes(
             if n is None:
                 continue
             bases.append(aliases.get(n, n))
-        code_value, code_node = _extract_code(node)
+        code_value, code_node, code_declared = _extract_code(node)
         records.append(
             ClassRecord(
                 name=node.name,
@@ -135,6 +150,7 @@ def collect_classes(
                 bases=bases,
                 code_value=code_value,
                 code_node=code_node,
+                code_declared=code_declared,
             )
         )
     return records

--- a/packages/conformance/conformance/suite/rules/prescriptions.py
+++ b/packages/conformance/conformance/suite/rules/prescriptions.py
@@ -147,12 +147,13 @@ RULES: tuple[RuleDefinition, ...] = (
             "at the declaration when an intermediate is genuinely abstract — see\n"
             "typed-error-prescription §4 and BLDX-1431.\n"
             "\n"
-            "Exempt: classes whose own MRO overrides ``to_failure_details()`` or\n"
-            "``qualified_code`` — usually via a shared connector error mixin.  Those\n"
-            "build the wire envelope themselves, so ``code`` is not what a dashboard\n"
-            "reads and prefixing it would change nothing observable.  The exemption\n"
-            "is inherited, so the override may sit on the mixin rather than on each\n"
-            "exception class.\n"
+            "Exempt: classes whose own MRO overrides ``to_failure_details()`` —\n"
+            "usually via a shared connector error mixin.  Those build the wire\n"
+            "envelope themselves, so ``code`` is not what a dashboard reads and\n"
+            "prefixing it would change nothing observable.  The exemption is\n"
+            "inherited, so the override may sit on the mixin rather than on each\n"
+            "exception class.  Overriding ``qualified_code`` alone does NOT exempt:\n"
+            "that is the log surface, and the wire code still collapses to the leaf.\n"
         ),
         help_uri="https://github.com/atlanhq/application-sdk/blob/main/packages/conformance/conformance/docs/rules/prescriptions.md#p003",
     ),

--- a/packages/conformance/conformance/suite/rules/prescriptions.py
+++ b/packages/conformance/conformance/suite/rules/prescriptions.py
@@ -146,6 +146,13 @@ RULES: tuple[RuleDefinition, ...] = (
             "leaf's code.  Suppress with ``# conformance: ignore[P003] <reason>``\n"
             "at the declaration when an intermediate is genuinely abstract — see\n"
             "typed-error-prescription §4 and BLDX-1431.\n"
+            "\n"
+            "Exempt: classes whose own MRO overrides ``to_failure_details()`` or\n"
+            "``qualified_code`` — usually via a shared connector error mixin.  Those\n"
+            "build the wire envelope themselves, so ``code`` is not what a dashboard\n"
+            "reads and prefixing it would change nothing observable.  The exemption\n"
+            "is inherited, so the override may sit on the mixin rather than on each\n"
+            "exception class.\n"
         ),
         help_uri="https://github.com/atlanhq/application-sdk/blob/main/packages/conformance/conformance/docs/rules/prescriptions.md#p003",
     ),

--- a/packages/conformance/tests/test_prescriptions.py
+++ b/packages/conformance/tests/test_prescriptions.py
@@ -559,6 +559,56 @@ def test_p003_fires_on_empty_code(tmp_path: Path) -> None:
     assert [f.rule_id for f in findings] == ["P003"]
 
 
+def test_p003_silent_when_class_overrides_to_failure_details(tmp_path: Path) -> None:
+    """A class that builds its own wire envelope does not emit ``code``.
+
+    ``to_failure_details()`` is what produces the ``FailureDetails.code`` a
+    dashboard reads. When a class replaces it, prefixing ``code`` changes
+    nothing observable, so P003's premise ("collapses to the bare leaf") is
+    false and the finding is noise.
+    """
+    src = (
+        "class ConnectorAuthError(AuthError):\n"
+        "    def to_failure_details(self):\n"
+        "        details = super().to_failure_details()\n"
+        '        return details.model_copy(update={"code": self.error_code.code})\n'
+    )
+    findings = _scan_one(tmp_path, src)
+    assert [f.rule_id for f in findings] == []
+
+
+def test_p003_silent_when_a_mixin_ancestor_overrides_emission(tmp_path: Path) -> None:
+    """The override is usually on a shared mixin, not on each exception class."""
+    files = {
+        "mixin.py": (
+            "class _ConnectorErrorMixin:\n"
+            "    @property\n"
+            "    def qualified_code(self):\n"
+            '        return f"{self.category.name}.{self.error_code.code}"\n'
+        ),
+        "errors.py": (
+            "from mixin import _ConnectorErrorMixin\n"
+            "class ConnectorAuthError(_ConnectorErrorMixin, AuthError):\n"
+            "    pass\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    assert [f.rule_id for f in findings] == []
+
+
+def test_p003_still_fires_when_the_override_is_an_unrelated_method(
+    tmp_path: Path,
+) -> None:
+    """Only the two emission methods buy the exemption — not any override."""
+    src = (
+        "class ConnectorAuthError(AuthError):\n"
+        "    def __str__(self):\n"
+        '        return "boom"\n'
+    )
+    findings = _scan_one(tmp_path, src)
+    assert [f.rule_id for f in findings] == ["P003"]
+
+
 def test_p003_fires_on_lowercase_prefix(tmp_path: Path) -> None:
     """Prefix match is case-sensitive (startswith); lowercase prefix must fire."""
     src = (

--- a/packages/conformance/tests/test_prescriptions.py
+++ b/packages/conformance/tests/test_prescriptions.py
@@ -596,6 +596,33 @@ def test_p003_silent_when_a_mixin_ancestor_overrides_emission(tmp_path: Path) ->
     assert [f.rule_id for f in findings] == []
 
 
+def test_p003_still_fires_when_apperror_is_in_the_scanned_tree(tmp_path: Path) -> None:
+    """``AppError.to_failure_details`` is the default envelope, not an exemption.
+
+    When this repo is scanned, ``application_sdk/errors/base.py`` is in the tree
+    and every leaf inherits that method. Crediting it as an override would
+    hollow P003 on dogfood. Mixins (the previous test) still silence; this
+    chain must still fire.
+    """
+    files = {
+        "base.py": (
+            "class AppError(Exception):\n"
+            "    def to_failure_details(self):\n"
+            "        return None\n"
+        ),
+        "leaves.py": (
+            "from base import AppError\n" "class AuthError(AppError):\n" "    pass\n"
+        ),
+        "errors.py": (
+            "from leaves import AuthError\n"
+            "class ConnectorAuthError(AuthError):\n"
+            "    pass\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    assert [f.rule_id for f in findings] == ["P003"]
+
+
 def test_p003_still_fires_when_only_qualified_code_is_overridden(
     tmp_path: Path,
 ) -> None:
@@ -618,7 +645,7 @@ def test_p003_still_fires_when_only_qualified_code_is_overridden(
 def test_p003_still_fires_when_the_override_is_an_unrelated_method(
     tmp_path: Path,
 ) -> None:
-    """Only the two emission methods buy the exemption — not any override."""
+    """Only ``to_failure_details`` buys the exemption — not any override."""
     src = (
         "class ConnectorAuthError(AuthError):\n"
         "    def __str__(self):\n"

--- a/packages/conformance/tests/test_prescriptions.py
+++ b/packages/conformance/tests/test_prescriptions.py
@@ -582,9 +582,9 @@ def test_p003_silent_when_a_mixin_ancestor_overrides_emission(tmp_path: Path) ->
     files = {
         "mixin.py": (
             "class _ConnectorErrorMixin:\n"
-            "    @property\n"
-            "    def qualified_code(self):\n"
-            '        return f"{self.category.name}.{self.error_code.code}"\n'
+            "    def to_failure_details(self):\n"
+            "        details = super().to_failure_details()\n"
+            '        return details.model_copy(update={"code": self.error_code.code})\n'
         ),
         "errors.py": (
             "from mixin import _ConnectorErrorMixin\n"
@@ -594,6 +594,25 @@ def test_p003_silent_when_a_mixin_ancestor_overrides_emission(tmp_path: Path) ->
     }
     findings = _scan_files(tmp_path, files)
     assert [f.rule_id for f in findings] == []
+
+
+def test_p003_still_fires_when_only_qualified_code_is_overridden(
+    tmp_path: Path,
+) -> None:
+    """``qualified_code`` is the log surface, not the wire.
+
+    A class that overrides only that still ships ``code`` — the bare leaf — in
+    ``FailureDetails``, which is precisely the collapse P003 exists to catch.
+    Exempting on it would silence a true positive.
+    """
+    src = (
+        "class ConnectorAuthError(AuthError):\n"
+        "    @property\n"
+        "    def qualified_code(self):\n"
+        '        return f"{self.category.name}.{self.error_code.code}"\n'
+    )
+    findings = _scan_one(tmp_path, src)
+    assert [f.rule_id for f in findings] == ["P003"]
 
 
 def test_p003_still_fires_when_the_override_is_an_unrelated_method(

--- a/packages/conformance/tests/test_prescriptions.py
+++ b/packages/conformance/tests/test_prescriptions.py
@@ -204,6 +204,30 @@ def test_p003_fires_on_wrong_prefix(tmp_path: Path) -> None:
     assert "APP_NOT_FOUND" in findings[0].message
 
 
+def test_p003_fires_on_registry_code_with_wrong_prefix(
+    tmp_path: Path,
+) -> None:
+    """Registry constants still need to carry the parent category prefix."""
+    src = (
+        "from typing import ClassVar\n"
+        "class BadAuth(AuthError):\n"
+        "    code: ClassVar[str] = codes.FT_INTERNAL_BAD.code\n"
+    )
+    findings = _scan_one(tmp_path, src)
+    assert [f.rule_id for f in findings] == ["P003"]
+
+
+def test_p003_silent_on_registry_code_attribute(tmp_path: Path) -> None:
+    """A ClassVar backed by an error-code registry is an explicit override."""
+    src = (
+        "from typing import ClassVar\n"
+        "class EntraTokenError(AuthError):\n"
+        "    code: ClassVar[str] = codes.FT_AUTH_ENTRA_NO_TOKEN.code\n"
+    )
+    findings = _scan_one(tmp_path, src)
+    assert findings == []
+
+
 def test_p003_fires_on_missing_code_declaration(tmp_path: Path) -> None:
     """Subclasses (transitive) of a leaf must declare their own code."""
     src = "class SilentSubclass(InternalError):\n    pass\n"


### PR DESCRIPTION
P003 fires on every subclass of an `application_sdk.errors` leaf that has no
prefixed `code: ClassVar[str]`, on the stated premise that "every raise of this
class collapses to the bare leaf code". For one recurring shape that premise is
false, and the finding is unfixable noise.

### The shape

A connector defines a shared error mixin that builds the wire envelope itself:

```python
class _ConnectorErrorMixin:
    @property
    def qualified_code(self) -> str:
        return f"{self.category.name}.{self.error_code.code}"

    def to_failure_details(self):
        details = super().to_failure_details()
        return details.model_copy(update={"code": self.error_code.code})


class ConnectorAuthError(_ConnectorErrorMixin, AuthError):
    DEFAULT_ERROR_CODE = codes.AUTH_INVALID_BASIC
```

`AppError.to_failure_details()` is what produces the `FailureDetails.code` a
dashboard reads, and `qualified_code` is what the log surfaces read. A class
that replaces either one no longer emits `code` at all. Its codes *are*
category-scoped and *do* reach the wire — through a different attribute.

Adding `code: ClassVar[str] = "AUTH_…"` to satisfy P003 would therefore be dead
code: it changes nothing observable, and it leaves two competing code attributes
on the same class for the next reader to reconcile. One connector had instead
suppressed all seven sites with a justification saying the codes were
intentional — which was accurate, and which a block-tier rule should not have
required.

### The change

`ClassRecord` now records whether a class defines `to_failure_details` or
`qualified_code`, and `resolve_emission_override()` walks the base chain the same
way `resolve_leaf_prefix()` does, so the exemption is inherited from a mixin
rather than having to be repeated on every exception class. P003 skips a class
only when that resolution returns true.

The exemption is deliberately two method names, not "any override" — a class
that overrides `__str__` still has to declare a prefixed code, and there is a
test pinning that.

### Blast radius, measured

Released 0.25.0 vs this branch, same repos:

| repo | before | after |
|---|---|---|
| connector with the mixin | 7 | **0** |
| connector without it | 23 | 23 |
| connector without it | 6 | 6 |
| connector without it | 1 | 1 |
| connector with no P003 | 0 | 0 |

Only the shape the rule cannot speak to goes quiet; every true positive still
fires.

### Tests

Three added, one of each kind:
- silent when the class itself overrides `to_failure_details`
- silent when a **mixin ancestor** carries the override (the real-world shape)
- **still fires** when the override is an unrelated method (`__str__`)

`uv run pytest` in `packages/conformance`: 3378 passed, 1 xfailed.
`gen-rule-docs --check`: clean (rule prose, `prescriptions.md` and `by-id/P003.md`
regenerated in the same commit).

### Note for review

This does not address the separate P003 population where an app's codes are real
but use a legacy `Atlan-*` namespace no rename can bring under a category prefix.
Those still fire and need their own decision.
