### PR TITLE
fix(observability): route WARNING+ OTLP records to a dedicated queue and report drops

### DIFF
--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -9,10 +9,9 @@ from typing import Any, ClassVar
 
 from loguru import logger
 from opentelemetry import trace as otel_trace
-from opentelemetry._logs import LogRecord, SeverityNumber
+from opentelemetry._logs import LogRecord
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
 from opentelemetry.sdk._logs import LoggerProvider
-from opentelemetry.sdk._logs._internal.export import BatchLogRecordProcessor
 from opentelemetry.trace.span import TraceFlags
 
 from application_sdk.constants import (
@@ -49,6 +48,10 @@ from application_sdk.observability.logger_adaptor_errors import (
     UnsupportedLogRecordError,
 )
 from application_sdk.observability.observability import AtlanObservability
+from application_sdk.observability.otlp_log_queue import (
+    SeverityRoutedLogRecordProcessor,
+    severity_from_levelno,
+)
 from application_sdk.observability.utils import (
     build_otel_resource,
     get_observability_dir,
@@ -670,8 +673,63 @@ class _CloudflareTimeoutFilter(logging.Filter):
             return True  # conformance: ignore[E007] logging adapter; log call would recurse; returning default is correct fallback
 
 
+class _ProbeAccessLogFilter(logging.Filter):
+    """Drop uvicorn access lines for successful health/readiness probes.
+
+    Kubernetes hits ``/server/health`` and ``/server/ready`` every few seconds,
+    and uvicorn's access logger turns each into an INFO record that the stdlib
+    bridge then exports like any application log. On a real run those lines
+    were the only unattributed rows in the run's log window and pure noise in
+    the customer-facing view. The SDK's own request-log middleware already
+    skips these paths (``EXCLUDED_LOG_PATHS``); this applies the same list to
+    uvicorn's access logger, which the middleware cannot reach.
+
+    Only *successful* (2xx/3xx) probe hits are dropped. A failing probe is a
+    signal and still logs. Anything that does not look like a uvicorn access
+    record passes through untouched.
+    """
+
+    _excluded: ClassVar[frozenset[str] | None] = None
+
+    @classmethod
+    def _excluded_paths(cls) -> frozenset[str]:
+        if cls._excluded is None:
+            # Lazy: the middleware package imports this module at import time.
+            from application_sdk.server.middleware._constants import (  # noqa: PLC0415
+                EXCLUDED_LOG_PATHS,
+            )
+
+            cls._excluded = EXCLUDED_LOG_PATHS
+        return cls._excluded
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            if record.name != "uvicorn.access":
+                return True
+            args = record.args
+            # uvicorn: '%s - "%s %s HTTP/%s" %d' % (client, method, path, version, status)
+            if not isinstance(args, tuple) or len(args) < 5:
+                return True
+            path = str(args[2]).split("?", 1)[0]
+            status = args[4]
+            if (
+                path in self._excluded_paths()
+                and isinstance(status, int)
+                and 200 <= status < 400
+            ):
+                return False
+            return True
+        # conformance: ignore[E004] logging filter; a malformed record must pass through, never raise
+        except Exception:
+            return True  # conformance: ignore[E007] logging adapter; log call would recurse; returning default is correct fallback
+
+
 _intercept_handler = InterceptHandler()
 _intercept_handler.addFilter(_CloudflareTimeoutFilter())
+# Filters on a named logger run before propagation, so this sees uvicorn's
+# access records at their source even though uvicorn attaches no handlers
+# (``log_config=None`` in main.py) and everything reaches the root bridge.
+logging.getLogger("uvicorn.access").addFilter(_ProbeAccessLogFilter())
 logging.basicConfig(
     level=logging.getLevelNamesMapping()[LOG_LEVEL], handlers=[_intercept_handler]
 )
@@ -955,34 +1013,23 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
         # plus an optional secondary exporter to OTEL_WORKFLOW_LOGS_ENDPOINT
         # for archival pipelines (e.g. an OTel collector that writes to S3).
         # Set up the provider first so _log_sink can see logger_provider below.
+        #
+        # Each endpoint gets a severity-routed processor: WARNING+ records sit
+        # in their own batch queue so an INFO burst (publish phases log per
+        # asset) can never evict them, and every eviction is counted and
+        # reported. See ``otlp_log_queue`` for the RCA that motivated this.
         try:
             otlp_processors = []
 
             if ENABLE_OTLP_LOGS or _has_remote_otlp_endpoint():
                 otlp_processors.append(
-                    BatchLogRecordProcessor(
-                        OTLPLogExporter(
-                            endpoint=OTEL_EXPORTER_OTLP_ENDPOINT,
-                            timeout=OTEL_EXPORTER_TIMEOUT_SECONDS,
-                        ),
-                        schedule_delay_millis=OTEL_BATCH_DELAY_MS,
-                        max_export_batch_size=OTEL_BATCH_SIZE,
-                        max_queue_size=OTEL_QUEUE_SIZE,
-                    )
+                    self._build_otlp_processor(OTEL_EXPORTER_OTLP_ENDPOINT)
                 )
                 logging.info("OTLP exporter enabled: %s", OTEL_EXPORTER_OTLP_ENDPOINT)
 
             if ENABLE_OTLP_WORKFLOW_LOGS and OTEL_WORKFLOW_LOGS_ENDPOINT:
                 otlp_processors.append(
-                    BatchLogRecordProcessor(
-                        OTLPLogExporter(
-                            endpoint=OTEL_WORKFLOW_LOGS_ENDPOINT,
-                            timeout=OTEL_EXPORTER_TIMEOUT_SECONDS,
-                        ),
-                        schedule_delay_millis=OTEL_BATCH_DELAY_MS,
-                        max_export_batch_size=OTEL_BATCH_SIZE,
-                        max_queue_size=OTEL_QUEUE_SIZE,
-                    )
+                    self._build_otlp_processor(OTEL_WORKFLOW_LOGS_ENDPOINT)
                 )
                 logging.info(
                     "OTLP workflow logs exporter enabled: %s",
@@ -1037,6 +1084,25 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
         # Mark initialization complete only after all sinks are successfully added
         AtlanLoggerAdapter._initialized = True
 
+    @staticmethod
+    def _build_otlp_processor(endpoint: str) -> SeverityRoutedLogRecordProcessor:
+        """Build the severity-routed OTLP processor for one collector endpoint.
+
+        The factory is invoked once per lane (bulk + priority), so each lane
+        owns its own gRPC channel and a stalled bulk export never blocks a
+        priority flush.
+        """
+        return SeverityRoutedLogRecordProcessor(
+            lambda: OTLPLogExporter(
+                endpoint=endpoint,
+                timeout=OTEL_EXPORTER_TIMEOUT_SECONDS,
+            ),
+            endpoint=endpoint,
+            schedule_delay_millis=OTEL_BATCH_DELAY_MS,
+            max_export_batch_size=OTEL_BATCH_SIZE,
+            max_queue_size=OTEL_QUEUE_SIZE,
+        )
+
     def process_record(self, record: Any) -> dict[str, Any]:
         """Process a log record into a standardized dictionary format.
 
@@ -1074,8 +1140,12 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
         Returns:
             LogRecord: OpenTelemetry LogRecord object with mapped severity and attributes.
         """
-        severity_number = SEVERITY_MAPPING.get(
-            record["level"], SeverityNumber.UNSPECIFIED
+        # SEVERITY_MAPPING yields stdlib level numbers (INFO=20, WARNING=30…),
+        # but the OTLP encoder reads ``.value`` off a ``SeverityNumber`` enum and
+        # silently exports 0 (UNSPECIFIED) for anything else. Translate so the
+        # numeric severity downstream filters key on is actually populated.
+        severity_number = severity_from_levelno(
+            SEVERITY_MAPPING.get(record["level"], logging.NOTSET)
         )
 
         # Start with base attributes

--- a/application_sdk/observability/otlp_log_queue.py
+++ b/application_sdk/observability/otlp_log_queue.py
@@ -1,0 +1,271 @@
+"""Severity-routed OTLP log export with drop accounting.
+
+Why this exists
+---------------
+The OpenTelemetry ``BatchLogRecordProcessor`` buffers records in one bounded
+deque per exporter. When the app emits faster than the collector accepts, the
+deque evicts the *oldest* record regardless of severity and logs
+``"Queue full, dropping Log."`` at most once per 20 seconds, with no count.
+
+A production RCA showed the consequence: a publish phase logging two INFO
+lines per asset produced ~7,500 records in 20 seconds, the queue overflowed,
+and WARNING/ERROR records still waiting to be exported were evicted by INFO
+chatter. The customer-facing run page then showed a clean run, because the only
+survivor was the rate-limited "Queue full" line.
+
+What this module does
+---------------------
+:class:`SeverityRoutedLogRecordProcessor` sits in front of *two* standard
+``BatchLogRecordProcessor`` instances that share one endpoint:
+
+* **priority lane** — records at or above :data:`PRIORITY_MIN_SEVERITY`
+  (WARNING+). An INFO/DEBUG burst can never evict anything here, because it
+  never enters this queue.
+* **bulk lane** — everything else. It keeps the upstream oldest-evicts
+  behaviour and is the lane that absorbs bursts.
+
+Both lanes are the same size (``max_queue_size``), so WARNING+ capacity is a
+full, dedicated queue rather than whatever INFO left over.
+
+Every eviction is also *counted*, per lane, and reported through the SDK
+logger as a WARNING with the numbers ("dropped N records: INFO/DEBUG=a,
+WARNING+=b") — immediately on the first drop, then at most once per
+:data:`DROP_REPORT_INTERVAL_SECONDS`, and once more at shutdown. The report
+rides the priority lane, so a run that lost records is never indistinguishable
+from a clean run on the consumer side.
+
+Fullness detection reads two private attributes of the upstream processor
+(``_batch_processor._queue`` / ``_max_queue_size``). If a future OTel release
+renames them the routing still works and only the drop counters degrade to
+silence — export itself never depends on them.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+from typing import Any
+
+from opentelemetry._logs import SeverityNumber
+from opentelemetry.sdk._logs import LogRecordProcessor, ReadWriteLogRecord
+from opentelemetry.sdk._logs._internal.export import (
+    BatchLogRecordProcessor,
+    LogRecordExporter,
+)
+
+_logger = logging.getLogger(__name__)
+
+#: Records at or above this severity ride the priority lane.
+PRIORITY_MIN_SEVERITY: SeverityNumber = SeverityNumber.WARN
+
+#: Minimum seconds between two drop reports from one processor. The first
+#: drop is reported immediately; later drops accumulate until this much time
+#: has passed, then the next emission flushes the summary.
+DROP_REPORT_INTERVAL_SECONDS: float = 30.0
+
+# stdlib ``levelno`` -> OTel ``SeverityNumber`` for the five standard levels.
+# The SDK's loguru levels map onto stdlib numbers (see ``SEVERITY_MAPPING``),
+# so this is the only translation the OTLP path needs.
+_LEVELNO_TO_SEVERITY: dict[int, SeverityNumber] = {
+    logging.DEBUG: SeverityNumber.DEBUG,
+    logging.INFO: SeverityNumber.INFO,
+    logging.WARNING: SeverityNumber.WARN,
+    logging.ERROR: SeverityNumber.ERROR,
+    logging.CRITICAL: SeverityNumber.FATAL,
+}
+
+
+def severity_from_levelno(levelno: int) -> SeverityNumber:
+    """Map a stdlib log level number to the OTel ``SeverityNumber``.
+
+    Exact standard levels map directly; a custom level between two standard
+    ones takes the severity of the standard level just below it, matching how
+    ``logging`` itself treats such levels. Anything below ``DEBUG`` (including
+    ``NOTSET``) is ``UNSPECIFIED``.
+    """
+    if levelno in _LEVELNO_TO_SEVERITY:
+        return _LEVELNO_TO_SEVERITY[levelno]
+    for std_level in (
+        logging.CRITICAL,
+        logging.ERROR,
+        logging.WARNING,
+        logging.INFO,
+        logging.DEBUG,
+    ):
+        if levelno >= std_level:
+            return _LEVELNO_TO_SEVERITY[std_level]
+    return SeverityNumber.UNSPECIFIED
+
+
+def severity_value(record: ReadWriteLogRecord) -> int:
+    """Return the record's severity as a comparable integer.
+
+    Tolerates the three shapes seen in practice: a ``SeverityNumber`` enum, a
+    bare stdlib ``levelno`` int (what older SDK builds stamped), or ``None``.
+    """
+    severity = getattr(getattr(record, "log_record", None), "severity_number", None)
+    if isinstance(severity, SeverityNumber):
+        return severity.value
+    if isinstance(severity, int):
+        return severity_from_levelno(severity).value
+    return SeverityNumber.UNSPECIFIED.value
+
+
+def _queue_is_full(processor: BatchLogRecordProcessor) -> bool:
+    """True when the next ``on_emit`` on *processor* will evict a record.
+
+    Reads upstream private state defensively: any shape mismatch means
+    "unknown", reported as ``False`` so accounting degrades rather than
+    export breaking.
+    """
+    batch_processor = getattr(processor, "_batch_processor", None)
+    queue = getattr(batch_processor, "_queue", None)
+    capacity = getattr(batch_processor, "_max_queue_size", None)
+    if queue is None or not isinstance(capacity, int):
+        return False
+    try:
+        return len(queue) >= capacity
+    except TypeError:
+        return False
+
+
+class SeverityRoutedLogRecordProcessor(LogRecordProcessor):
+    """Route WARNING+ records to a dedicated batch queue and count every drop.
+
+    Args:
+        exporter_factory: Builds one exporter per lane. Called exactly twice.
+            Two exporters (two gRPC channels) keep the lanes independent — a
+            stalled bulk export never blocks a priority flush.
+        endpoint: Human-readable destination, used only in the drop report.
+        schedule_delay_millis: Passed through to both lanes.
+        max_export_batch_size: Passed through to both lanes.
+        max_queue_size: Per-lane queue capacity. Total buffered records can
+            reach ``2 * max_queue_size``.
+        priority_min_severity: Lowest severity that rides the priority lane.
+        drop_report_interval_seconds: Rate limit for drop reports.
+        clock: Monotonic clock, injectable for tests.
+    """
+
+    def __init__(
+        self,
+        exporter_factory: Callable[[], LogRecordExporter],
+        *,
+        endpoint: str,
+        schedule_delay_millis: float,
+        max_export_batch_size: int,
+        max_queue_size: int,
+        priority_min_severity: SeverityNumber = PRIORITY_MIN_SEVERITY,
+        drop_report_interval_seconds: float = DROP_REPORT_INTERVAL_SECONDS,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._endpoint = endpoint
+        self._priority_min = priority_min_severity.value
+        self._report_interval = drop_report_interval_seconds
+        self._clock = clock
+
+        def _lane() -> BatchLogRecordProcessor:
+            return BatchLogRecordProcessor(
+                exporter_factory(),
+                schedule_delay_millis=schedule_delay_millis,
+                max_export_batch_size=max_export_batch_size,
+                max_queue_size=max_queue_size,
+            )
+
+        self._bulk = _lane()
+        self._priority = _lane()
+
+        self._lock = threading.Lock()
+        self._pending_bulk = 0
+        self._pending_priority = 0
+        self._total_bulk = 0
+        self._total_priority = 0
+        self._last_report: float | None = None
+        self._reporting = threading.local()
+
+    # ------------------------------------------------------------------ routing
+
+    def on_emit(self, log_record: ReadWriteLogRecord) -> None:
+        is_priority = severity_value(log_record) >= self._priority_min
+        lane = self._priority if is_priority else self._bulk
+        if _queue_is_full(lane):
+            with self._lock:
+                if is_priority:
+                    self._pending_priority += 1
+                    self._total_priority += 1
+                else:
+                    self._pending_bulk += 1
+                    self._total_bulk += 1
+        lane.on_emit(log_record)
+        self._maybe_report()
+
+    def shutdown(self) -> None:
+        self._maybe_report(force=True)
+        self._priority.shutdown()
+        self._bulk.shutdown()
+
+    def force_flush(self, timeout_millis: int | None = None) -> bool:
+        flushed_priority = self._priority.force_flush(timeout_millis)
+        flushed_bulk = self._bulk.force_flush(timeout_millis)
+        return bool(flushed_priority and flushed_bulk)
+
+    # --------------------------------------------------------------- reporting
+
+    @property
+    def dropped_counts(self) -> dict[str, int]:
+        """Lifetime drop counters, keyed ``bulk`` / ``priority``."""
+        with self._lock:
+            return {"bulk": self._total_bulk, "priority": self._total_priority}
+
+    def _maybe_report(self, *, force: bool = False) -> None:
+        # The report is itself a log record that re-enters ``on_emit`` through
+        # the SDK's stdlib bridge; the thread-local guard keeps that single
+        # level of recursion from producing a second report.
+        if getattr(self._reporting, "active", False):
+            return
+        with self._lock:
+            pending = self._pending_bulk + self._pending_priority
+            if pending == 0:
+                return
+            now = self._clock()
+            if (
+                not force
+                and self._last_report is not None
+                and now - self._last_report < self._report_interval
+            ):
+                return
+            bulk, priority = self._pending_bulk, self._pending_priority
+            self._pending_bulk = self._pending_priority = 0
+            since = None if self._last_report is None else now - self._last_report
+            self._last_report = now
+
+        self._reporting.active = True
+        try:
+            window = (
+                "since the previous report"
+                if since is None
+                else f"in the last {since:.0f}s"
+            )
+            _logger.warning(
+                "OTLP log export dropped %d record(s) %s (INFO/DEBUG=%d, WARNING+=%d): "
+                "the collector at %s accepted records slower than the app emitted them. "
+                "WARNING and above use a separate queue, so they are only lost when "
+                "the WARNING+ count is non-zero.",
+                bulk + priority,
+                window,
+                bulk,
+                priority,
+                self._endpoint,
+            )
+        finally:
+            self._reporting.active = False
+
+
+__all__: list[Any] = [
+    "DROP_REPORT_INTERVAL_SECONDS",
+    "PRIORITY_MIN_SEVERITY",
+    "SeverityRoutedLogRecordProcessor",
+    "severity_from_levelno",
+    "severity_value",
+]

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.30.0
-source-sha:    a57bfceb669bc59667ae66948b6e8de3dd9959e2
-source-date:   2026-08-31T19:14:25Z
+sdk-version:   3.31.0
+source-sha:    37b8d728c500b5842e7976756283338b2dd5a7d5
+source-date:   2026-08-31T23:16:02Z
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/docs/concepts/monitoring.md
+++ b/docs/concepts/monitoring.md
@@ -289,6 +289,49 @@ env:
     value: "http://$(K8S_NODE_IP):4317"
 ```
 
+### OTLP log export: severity-routed queues and drop accounting
+
+Each OTLP log endpoint gets **two** batch queues, not one:
+
+| Lane | Carries | Capacity |
+|------|---------|----------|
+| priority | WARNING, ERROR, CRITICAL | `OTEL_QUEUE_SIZE` (default 2048) |
+| bulk | DEBUG, INFO, and the INFO/DEBUG-mapped custom levels (ACTIVITY, METRIC, TRACING) | `OTEL_QUEUE_SIZE` (default 2048) |
+
+Why: the upstream `BatchLogRecordProcessor` evicts the *oldest* buffered record
+when its queue is full, regardless of severity, and logs `Queue full, dropping
+Log.` at most once per 20 s with no count. A publish phase that logs per asset
+can emit thousands of INFO records in seconds; with a single queue those
+records evicted whatever was still waiting to be exported. Routing WARNING+
+into its own queue means an INFO burst can never evict a warning or error.
+
+Every eviction is counted per lane and reported through the SDK logger as a
+WARNING carrying the numbers: immediately on the first drop, then at most once
+every 30 s, and once more at shutdown.
+
+```
+OTLP log export dropped 1187 record(s) in the last 30s (INFO/DEBUG=1187, WARNING+=0):
+the collector at http://...:4317 accepted records slower than the app emitted them. ...
+```
+
+Reading it: `INFO/DEBUG` drops mean the collector was slower than emission for
+a while, so trim the app's INFO volume or raise `OTEL_QUEUE_SIZE`. A non-zero
+`WARNING+` count means the collector stalled long enough to fill the priority
+lane too, and the run's warnings and errors are incomplete downstream. The
+upstream `Queue full, dropping Log.` line still appears; the SDK report is the
+one with numbers.
+
+Two related details:
+
+- Exported records carry a real `SeverityNumber` (INFO=9, WARN=13, ERROR=17,
+  FATAL=21). Earlier releases passed the stdlib level number where the enum
+  was expected, so the encoder exported 0 (UNSPECIFIED) and only
+  `SeverityText` was populated.
+- Successful `GET /server/health` and `GET /server/ready` probe hits are not
+  exported as log records. Kubernetes probes them every few seconds, and the
+  resulting access lines were pure noise in every run's log view. A probe that
+  fails (non-2xx) is still logged.
+
 ---
 
 ## Structured Logging and `self.logger`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -270,7 +270,7 @@ Used by `RedisCapacityPool` for distributed slot locking. Leave empty if you use
 | `OTEL_EXPORTER_TIMEOUT_SECONDS` | `30` | Timeout for OTLP export operations. |
 | `OTEL_BATCH_DELAY_MS` | `5000` | Delay between batch exports (milliseconds). |
 | `OTEL_BATCH_SIZE` | `512` | Maximum export batch size. |
-| `OTEL_QUEUE_SIZE` | `2048` | Maximum export queue size. |
+| `OTEL_QUEUE_SIZE` | `2048` | Maximum export queue size **per lane**. Each OTLP log endpoint has two queues of this size: a WARNING+ priority lane and an INFO/DEBUG bulk lane, so buffered records per endpoint can reach twice this value. See `docs/concepts/monitoring.md`. |
 | `ATLAN_ENABLE_OBSERVABILITY_STORE_SINK` | `true` | Write observability data to the object store sink. **Fallback:** `ATLAN_ENABLE_OBSERVABILITY_DAPR_SINK`. |
 | `ATLAN_BASE_URL` | _(empty)_ | Atlan instance base URL. Used by the events interceptor. |
 

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -1824,6 +1824,40 @@ class TestCreateLogRecord:
         otel = logger_adapter._create_log_record(rec)
         assert otel.severity_number == SeverityNumber.UNSPECIFIED
 
+    @pytest.mark.parametrize(
+        ("level", "expected"),
+        [
+            ("DEBUG", "DEBUG"),
+            ("INFO", "INFO"),
+            ("ACTIVITY", "INFO"),
+            ("WARNING", "WARN"),
+            ("ERROR", "ERROR"),
+            ("CRITICAL", "FATAL"),
+        ],
+    )
+    def test_known_levels_map_to_otel_severity_enum(
+        self, logger_adapter: AtlanLoggerAdapter, level: str, expected: str
+    ):
+        """The record must carry a ``SeverityNumber`` enum, not the stdlib int.
+
+        The OTLP encoder reads ``.value`` off the enum; a bare int has none and
+        was exported as 0 (UNSPECIFIED), leaving only ``severity_text`` populated.
+        """
+        from opentelemetry._logs import SeverityNumber
+
+        rec = {
+            "timestamp": 1.0,
+            "level": level,
+            "message": "x",
+            "file": "f.py",
+            "line": 1,
+            "function": "fn",
+            "extra": {},
+        }
+        otel = logger_adapter._create_log_record(rec)
+        assert otel.severity_number is SeverityNumber[expected]
+        assert otel.severity_text == level
+
 
 class TestLoggingMethodsForwardToLoguru:
     """The level-specific methods must call into the loguru logger correctly.
@@ -2575,8 +2609,11 @@ class TestSecondaryWorkflowLogsExporter:
             mock.patch(
                 "application_sdk.observability.logger_adaptor.OTLPLogExporter"
             ) as mock_exporter,
+            # The severity-routed processor builds two BatchLogRecordProcessor
+            # lanes per endpoint; patch the upstream class where the router
+            # imports it so no export threads start in tests.
             mock.patch(
-                "application_sdk.observability.logger_adaptor.BatchLogRecordProcessor"
+                "application_sdk.observability.otlp_log_queue.BatchLogRecordProcessor"
             ),
             mock.patch("application_sdk.observability.logger_adaptor.LoggerProvider"),
         ):
@@ -2605,8 +2642,11 @@ class TestSecondaryWorkflowLogsExporter:
             secondary_endpoint=self.SECONDARY_SENTINEL,
         )
         endpoints = self._endpoints_passed_to_exporter(mock_exporter)
-        assert endpoints.count(self.PRIMARY_SENTINEL) == 1
-        assert endpoints.count(self.SECONDARY_SENTINEL) == 1
+        # Two exporters per endpoint: one per severity lane (bulk + priority),
+        # each owning its own gRPC channel so a stalled bulk export never
+        # blocks a WARNING+ flush.
+        assert endpoints.count(self.PRIMARY_SENTINEL) == 2
+        assert endpoints.count(self.SECONDARY_SENTINEL) == 2
 
     def test_secondary_skipped_when_flag_false(self):
         """Secondary exporter must not be constructed when the flag is off,
@@ -2658,6 +2698,71 @@ def _make_temporalio_record(
         args=(),
         exc_info=None,
     )
+
+
+def _make_uvicorn_access_record(
+    path: str, status: int, *, name: str = "uvicorn.access"
+) -> logging.LogRecord:
+    return logging.LogRecord(
+        name=name,
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg='%s - "%s %s HTTP/%s" %d',
+        args=("10.0.0.1:1234", "GET", path, "1.1", status),
+        exc_info=None,
+    )
+
+
+class TestProbeAccessLogFilter:
+    """Successful health/readiness probe access lines are dropped at the source."""
+
+    @pytest.fixture
+    def filt(self):
+        from application_sdk.observability.logger_adaptor import _ProbeAccessLogFilter
+
+        return _ProbeAccessLogFilter()
+
+    @pytest.mark.parametrize(
+        "path", ["/server/health", "/server/ready", "/health", "/ready", "/metrics"]
+    )
+    def test_successful_probe_hits_are_dropped(self, filt, path):
+        assert filt.filter(_make_uvicorn_access_record(path, 200)) is False
+        # Query strings do not defeat the match.
+        assert filt.filter(_make_uvicorn_access_record(f"{path}?x=1", 200)) is False
+
+    @pytest.mark.parametrize("status", [500, 503, 404])
+    def test_failing_probes_still_log(self, filt, status):
+        assert (
+            filt.filter(_make_uvicorn_access_record("/server/health", status)) is True
+        )
+
+    def test_other_paths_pass_through(self, filt):
+        assert (
+            filt.filter(_make_uvicorn_access_record("/workflows/v1/start", 200)) is True
+        )
+
+    def test_non_uvicorn_records_pass_through(self, filt):
+        rec = _make_uvicorn_access_record("/server/health", 200, name="my.app")
+        assert filt.filter(rec) is True
+
+    def test_malformed_args_pass_through(self, filt):
+        rec = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="free-form %s",
+            args=("text",),
+            exc_info=None,
+        )
+        assert filt.filter(rec) is True
+
+    def test_filter_is_installed_on_the_uvicorn_access_logger(self):
+        from application_sdk.observability.logger_adaptor import _ProbeAccessLogFilter
+
+        installed = logging.getLogger("uvicorn.access").filters
+        assert any(isinstance(f, _ProbeAccessLogFilter) for f in installed)
 
 
 class TestCloudflareTimeoutFilter:

--- a/tests/unit/observability/test_otlp_log_queue.py
+++ b/tests/unit/observability/test_otlp_log_queue.py
@@ -1,0 +1,367 @@
+"""Tests for the severity-routed OTLP log processor.
+
+Two layers:
+
+* Fake lanes (``BatchLogRecordProcessor`` patched) pin the routing, drop
+  accounting, rate limiting, re-entrancy guard and shutdown/flush forwarding
+  without starting export threads.
+* One real-lane test proves the guarantee end to end: with an exporter that
+  blocks, an INFO flood overflows the bulk lane while the WARNING record stays
+  queued and is exported once the collector recovers.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections import deque
+from types import SimpleNamespace
+from typing import Any
+from unittest import mock
+
+import pytest
+from opentelemetry._logs import LogRecord, SeverityNumber
+from opentelemetry.sdk._logs import ReadWriteLogRecord
+
+from application_sdk.observability import otlp_log_queue
+from application_sdk.observability.otlp_log_queue import (
+    SeverityRoutedLogRecordProcessor,
+    severity_from_levelno,
+    severity_value,
+)
+
+MODULE_LOGGER = "application_sdk.observability.otlp_log_queue"
+ENDPOINT = "http://collector.example:4317"
+
+
+def _record(severity: Any, body: str = "x") -> ReadWriteLogRecord:
+    return ReadWriteLogRecord(log_record=LogRecord(severity_number=severity, body=body))
+
+
+# ---------------------------------------------------------------------------
+# severity helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSeverityHelpers:
+    @pytest.mark.parametrize(
+        ("levelno", "expected"),
+        [
+            (logging.DEBUG, SeverityNumber.DEBUG),
+            (logging.INFO, SeverityNumber.INFO),
+            (logging.WARNING, SeverityNumber.WARN),
+            (logging.ERROR, SeverityNumber.ERROR),
+            (logging.CRITICAL, SeverityNumber.FATAL),
+            # custom levels take the standard level just below them
+            (25, SeverityNumber.INFO),
+            (35, SeverityNumber.WARN),
+            (60, SeverityNumber.FATAL),
+            # below DEBUG (incl. NOTSET) is unspecified
+            (logging.NOTSET, SeverityNumber.UNSPECIFIED),
+            (5, SeverityNumber.UNSPECIFIED),
+        ],
+    )
+    def test_severity_from_levelno(self, levelno: int, expected: SeverityNumber):
+        assert severity_from_levelno(levelno) is expected
+
+    def test_severity_value_accepts_enum_int_and_none(self):
+        assert (
+            severity_value(_record(SeverityNumber.ERROR)) == SeverityNumber.ERROR.value
+        )
+        # A bare stdlib levelno (what older SDK builds stamped) is translated.
+        assert severity_value(_record(logging.WARNING)) == SeverityNumber.WARN.value
+        assert severity_value(_record(None)) == SeverityNumber.UNSPECIFIED.value
+        # Records lacking the attribute path degrade to unspecified, never raise.
+        assert severity_value(SimpleNamespace()) == SeverityNumber.UNSPECIFIED.value  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# fake lanes: routing + accounting
+# ---------------------------------------------------------------------------
+
+
+class _FakeLane:
+    """Stand-in for BatchLogRecordProcessor exposing the same private shape."""
+
+    def __init__(
+        self,
+        exporter: Any,
+        *,
+        schedule_delay_millis: float,
+        max_export_batch_size: int,
+        max_queue_size: int,
+    ) -> None:
+        self.exporter = exporter
+        self.kwargs = {
+            "schedule_delay_millis": schedule_delay_millis,
+            "max_export_batch_size": max_export_batch_size,
+            "max_queue_size": max_queue_size,
+        }
+        self._batch_processor = SimpleNamespace(
+            _queue=deque(maxlen=max_queue_size), _max_queue_size=max_queue_size
+        )
+        self.emitted: list[ReadWriteLogRecord] = []
+        self.shutdown_calls = 0
+        self.flush_calls: list[int | None] = []
+        self.flush_result = True
+
+    def on_emit(self, record: ReadWriteLogRecord) -> None:
+        # Same semantics as upstream: appendleft on a bounded deque evicts the oldest.
+        self._batch_processor._queue.appendleft(record)
+        self.emitted.append(record)
+
+    def shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+    def force_flush(self, timeout_millis: int | None = None) -> bool:
+        self.flush_calls.append(timeout_millis)
+        return self.flush_result
+
+
+@pytest.fixture
+def clock() -> list[float]:
+    return [1000.0]
+
+
+@pytest.fixture
+def router(clock: list[float]):
+    factory = mock.Mock(side_effect=lambda: mock.Mock(name="exporter"))
+    with mock.patch.object(otlp_log_queue, "BatchLogRecordProcessor", _FakeLane):
+        proc = SeverityRoutedLogRecordProcessor(
+            factory,
+            endpoint=ENDPOINT,
+            schedule_delay_millis=5000,
+            max_export_batch_size=2,
+            max_queue_size=3,
+            drop_report_interval_seconds=30.0,
+            clock=lambda: clock[0],
+        )
+    proc.exporter_factory = factory  # type: ignore[attr-defined]
+    return proc
+
+
+class TestRouting:
+    def test_builds_two_lanes_with_own_exporters(self, router):
+        assert router.exporter_factory.call_count == 2
+        assert router._bulk.exporter is not router._priority.exporter
+        for lane in (router._bulk, router._priority):
+            assert lane.kwargs == {
+                "schedule_delay_millis": 5000,
+                "max_export_batch_size": 2,
+                "max_queue_size": 3,
+            }
+
+    @pytest.mark.parametrize(
+        "severity",
+        [
+            SeverityNumber.WARN,
+            SeverityNumber.ERROR,
+            SeverityNumber.FATAL,
+            logging.WARNING,
+            45,
+        ],
+    )
+    def test_warning_and_above_ride_priority_lane(self, router, severity):
+        rec = _record(severity)
+        router.on_emit(rec)
+        assert router._priority.emitted == [rec]
+        assert router._bulk.emitted == []
+
+    @pytest.mark.parametrize(
+        "severity", [SeverityNumber.INFO, SeverityNumber.DEBUG, logging.INFO, None]
+    )
+    def test_info_and_below_ride_bulk_lane(self, router, severity):
+        rec = _record(severity)
+        router.on_emit(rec)
+        assert router._bulk.emitted == [rec]
+        assert router._priority.emitted == []
+
+    def test_info_flood_never_evicts_a_warning(self, router):
+        warn = _record(SeverityNumber.WARN, "the one that matters")
+        router.on_emit(warn)
+        for i in range(50):
+            router.on_emit(_record(SeverityNumber.INFO, f"info-{i}"))
+        assert list(router._priority._batch_processor._queue) == [warn]
+        assert len(router._bulk._batch_processor._queue) == 3  # capacity, not 50
+
+
+class TestDropAccounting:
+    def _flood_bulk(self, router, n: int) -> None:
+        for i in range(n):
+            router.on_emit(_record(SeverityNumber.INFO, f"info-{i}"))
+
+    def test_first_drop_reported_immediately_with_counts(self, router, caplog):
+        caplog.set_level(logging.WARNING, logger=MODULE_LOGGER)
+        self._flood_bulk(router, 3)  # fills to capacity, nothing dropped yet
+        assert router.dropped_counts == {"bulk": 0, "priority": 0}
+        assert caplog.records == []
+
+        self._flood_bulk(router, 1)  # 4th record evicts the oldest
+        assert router.dropped_counts == {"bulk": 1, "priority": 0}
+        reports = [r for r in caplog.records if r.name == MODULE_LOGGER]
+        assert len(reports) == 1
+        msg = reports[0].getMessage()
+        assert reports[0].levelno == logging.WARNING
+        assert "dropped 1 record(s)" in msg
+        assert "INFO/DEBUG=1, WARNING+=0" in msg
+        assert ENDPOINT in msg
+
+    def test_reports_are_rate_limited_then_flushed_after_interval(
+        self, router, clock, caplog
+    ):
+        caplog.set_level(logging.WARNING, logger=MODULE_LOGGER)
+        self._flood_bulk(router, 4)  # first drop -> immediate report
+        self._flood_bulk(router, 10)  # 10 more drops inside the interval
+        reports = [r for r in caplog.records if r.name == MODULE_LOGGER]
+        assert len(reports) == 1, "second report must wait for the interval"
+
+        clock[0] += 31.0
+        router.on_emit(
+            _record(SeverityNumber.INFO, "tick")
+        )  # 11th drop, interval elapsed
+        reports = [r for r in caplog.records if r.name == MODULE_LOGGER]
+        assert len(reports) == 2
+        assert "dropped 11 record(s) in the last 31s" in reports[1].getMessage()
+        assert router.dropped_counts == {"bulk": 12, "priority": 0}
+
+    def test_priority_drops_are_counted_separately(self, router, caplog):
+        caplog.set_level(logging.WARNING, logger=MODULE_LOGGER)
+        for i in range(4):
+            router.on_emit(_record(SeverityNumber.ERROR, f"err-{i}"))
+        assert router.dropped_counts == {"bulk": 0, "priority": 1}
+        report = next(r for r in caplog.records if r.name == MODULE_LOGGER)
+        assert "INFO/DEBUG=0, WARNING+=1" in report.getMessage()
+
+    def test_shutdown_flushes_pending_report_and_shuts_both_lanes(self, router, caplog):
+        caplog.set_level(logging.WARNING, logger=MODULE_LOGGER)
+        self._flood_bulk(router, 4)  # immediate report for drop #1
+        self._flood_bulk(router, 5)  # 5 pending, inside the interval
+        router.shutdown()
+        reports = [r for r in caplog.records if r.name == MODULE_LOGGER]
+        assert len(reports) == 2
+        assert "dropped 5 record(s)" in reports[1].getMessage()
+        assert router._bulk.shutdown_calls == 1
+        assert router._priority.shutdown_calls == 1
+
+    def test_shutdown_without_drops_emits_no_report(self, router, caplog):
+        caplog.set_level(logging.WARNING, logger=MODULE_LOGGER)
+        router.on_emit(_record(SeverityNumber.INFO))
+        router.shutdown()
+        assert [r for r in caplog.records if r.name == MODULE_LOGGER] == []
+
+    def test_force_flush_forwards_to_both_lanes(self, router):
+        assert router.force_flush(timeout_millis=1234) is True
+        assert router._bulk.flush_calls == [1234]
+        assert router._priority.flush_calls == [1234]
+        router._bulk.flush_result = False
+        assert router.force_flush() is False
+
+    def test_report_reentry_does_not_recurse_or_double_report(self, router, caplog):
+        """The report re-enters on_emit through the SDK's stdlib bridge in prod.
+
+        Simulate that bridge with a handler that feeds the report back in as a
+        WARNING record: exactly one report must be produced, with no recursion.
+        """
+        caplog.set_level(logging.WARNING, logger=MODULE_LOGGER)
+        module_logger = logging.getLogger(MODULE_LOGGER)
+
+        class _Bridge(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                router.on_emit(_record(SeverityNumber.WARN, record.getMessage()))
+
+        bridge = _Bridge()
+        module_logger.addHandler(bridge)
+        try:
+            self._flood_bulk(router, 4)
+        finally:
+            module_logger.removeHandler(bridge)
+
+        reports = [r for r in caplog.records if r.name == MODULE_LOGGER]
+        assert len(reports) == 1
+        # The bridged report landed on the priority lane like any WARNING.
+        assert [r.log_record.body for r in router._priority.emitted] == [
+            reports[0].getMessage()
+        ]
+
+    def test_accounting_degrades_silently_when_private_shape_changes(self, router):
+        # Simulate an upstream OTel release renaming the private queue attrs:
+        # the lane still accepts records, but exposes no _queue/_max_queue_size.
+        router._bulk._batch_processor = SimpleNamespace()
+        router._bulk.on_emit = router._bulk.emitted.append
+        for i in range(10):
+            router.on_emit(_record(SeverityNumber.INFO, f"info-{i}"))
+        assert len(router._bulk.emitted) == 10  # export path unaffected
+        assert router.dropped_counts == {"bulk": 0, "priority": 0}
+
+
+# ---------------------------------------------------------------------------
+# real lanes: end-to-end guarantee with a stalled exporter
+# ---------------------------------------------------------------------------
+
+
+class _BlockingExporter:
+    """Exporter whose first export blocks until released, mimicking a stalled collector."""
+
+    def __init__(self) -> None:
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self.exported: list[str] = []
+        self._lock = threading.Lock()
+
+    def export(self, batch):  # noqa: ANN001 - upstream protocol
+        self.entered.set()
+        self.release.wait(timeout=10)
+        with self._lock:
+            self.exported.extend(str(r.log_record.body) for r in batch)
+        return 0
+
+    def shutdown(self, **kwargs: Any) -> None:
+        self.release.set()
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
+
+
+@pytest.mark.timeout(30)
+def test_real_lanes_warning_survives_info_flood_while_collector_stalls():
+    exporters: list[_BlockingExporter] = []
+
+    def factory() -> _BlockingExporter:
+        exporters.append(_BlockingExporter())
+        return exporters[-1]
+
+    capacity = 8
+    router = SeverityRoutedLogRecordProcessor(
+        factory,
+        endpoint=ENDPOINT,
+        schedule_delay_millis=60_000,  # only batch-size wakeups during the test
+        max_export_batch_size=capacity,
+        max_queue_size=capacity,
+    )
+    bulk_exporter, priority_exporter = exporters
+    try:
+        # First batch fills the bulk lane; the worker takes it and blocks in export.
+        for i in range(capacity):
+            router.on_emit(_record(SeverityNumber.INFO, f"batch1-{i}"))
+        assert bulk_exporter.entered.wait(timeout=10), "worker never started exporting"
+
+        # While the collector stalls: a warning arrives, then INFO keeps flooding.
+        router.on_emit(_record(SeverityNumber.WARN, "permission denied"))
+        for i in range(capacity + 5):
+            router.on_emit(_record(SeverityNumber.INFO, f"flood-{i}"))
+
+        counts = router.dropped_counts
+        assert counts["bulk"] == 5, counts
+        assert counts["priority"] == 0, counts
+        assert [
+            str(r.log_record.body) for r in router._priority._batch_processor._queue
+        ] == ["permission denied"]
+    finally:
+        bulk_exporter.release.set()
+        priority_exporter.release.set()
+        router.shutdown()
+
+    # Collector recovered: the warning was exported, the flood lost only its excess.
+    assert priority_exporter.exported == ["permission denied"]
+    assert "batch1-0" in bulk_exporter.exported
+    assert len(bulk_exporter.exported) == capacity * 2  # two full batches survived


### PR DESCRIPTION
### Changelog
- **Severity-routed OTLP log queues.** `SeverityRoutedLogRecordProcessor` (new `application_sdk/observability/otlp_log_queue.py`) fronts two standard `BatchLogRecordProcessor` lanes per endpoint: WARNING+ (priority) and INFO/DEBUG (bulk), each of `OTEL_QUEUE_SIZE`. The upstream processor evicts the *oldest* record when its single queue is full, regardless of severity; a publish-phase INFO burst can no longer evict warnings and errors that are still waiting to be exported.
- **Drop accounting.** Every eviction is counted per lane and reported as a WARNING with the numbers (`INFO/DEBUG=n, WARNING+=m`, the endpoint, and the window), immediately on the first drop, then at most every 30 s, and once more at shutdown. The upstream `Queue full, dropping Log.` line is rate-limited to one per 20 s and carries no count. Accounting reads two private upstream attributes defensively and degrades to silence if they are renamed; export never depends on them.
- **Real `SeverityNumber` on exported records.** `_create_log_record` passed the stdlib level int (INFO=20, WARNING=30) where the OTLP encoder expects the enum; the encoder reads `.value` and exported 0 (UNSPECIFIED) for every record. Now INFO=9, WARN=13, ERROR=17, FATAL=21.
- **No probe access-log noise.** `_ProbeAccessLogFilter` on the `uvicorn.access` logger drops 2xx/3xx hits on the middleware's `EXCLUDED_LOG_PATHS` (`/server/health`, `/server/ready`, …). Failing probes still log. Kubernetes probes every few seconds; these were the only unattributed rows in a run's log window.
- Docs: `docs/concepts/monitoring.md` (new section), `docs/configuration.md` (`OTEL_QUEUE_SIZE` is per lane). Capability manifest regenerated.

### Additional context (e.g. screenshots, logs, links)
- Linear: [FND-1258](https://linear.app/atlan-epd/issue/FND-1258) (project Surface connector logs, M1 · Pipeline and storage); related [CONNECT-1278](https://linear.app/atlan-epd/issue/CONNECT-1278).
- Origin: a production RCA. A run's publish phase logged two INFO lines per asset (~7,500 records in 20 s), the single queue overflowed, and the only surviving warning in the run view was the SDK's own drop notice. The customer-visible loss in that RCA was the run page's 5,000-row read window (separate fix); this PR is the SDK hardening that surfaced alongside it.
- Behavioural notes for reviewers: two gRPC channels per endpoint instead of one (one per lane) so a stalled bulk export never blocks a priority flush; buffered records per endpoint can reach `2 × OTEL_QUEUE_SIZE`; the drop report re-enters the pipeline through the stdlib bridge and is guarded against recursion.

### Checklist
- [x] Additional tests added — `tests/unit/observability/test_otlp_log_queue.py` (routing, flood never evicts WARN, drop counts + rate limit + re-entrancy + shutdown flush, real-lane end-to-end with a stalled exporter), severity-enum mapping and probe-filter tests in `test_logger_adaptor.py`; `tests/unit/observability` green (608 passed)
- [ ] All CI checks passed
- [x] Relevant documentation updated

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
