### PR TITLE
ci(loop): make the reviewer try to break the code, and check the tests ever failed

### DIFF
--- a/.github/scripts/sdk_loop_findings.py
+++ b/.github/scripts/sdk_loop_findings.py
@@ -515,7 +515,27 @@ def render_summary(
 
 
 def load_payload(text: str | bytes) -> dict[str, Any]:
-    """Parse the agent's `findings.json`, refusing anything ambiguous."""
+    """Parse the agent's `findings.json`, refusing anything ambiguous.
+
+    **Not yet the completion gate, and it must become one before anything
+    consumes this.** Nothing reads `findings.json` today — the reviewer still
+    posts its own comment — so this only has to parse. The moment the runner
+    renders and posts the verdict instead, an empty `findings` list means
+    `READY_TO_MERGE`, which means `sdk_review_approve.py` casts the `atlan-ci`
+    CODEOWNER approval. An agent that crashes or gives up *after* writing its
+    file would then produce a merge-ready verdict from a review that never
+    happened.
+
+    `PACK_ID` does not close that hole: it proves the pack loaded, not that the
+    work was done. The gate needs a positive assertion the model cannot emit by
+    accident — `status: "complete"` plus a `reviewed_files` list that actually
+    covers the pack's files — and an empty findings list must be accepted only
+    when that assertion is present and covering. `REVIEW.md` already instructs
+    the reviewer to emit both; this function does not yet require them.
+
+    Ship that requirement in the same change that moves posting to Python, not
+    after it.
+    """
     try:
         payload = json.loads(text)
     except json.JSONDecodeError as exc:

--- a/.github/scripts/sdk_loop_findings.py
+++ b/.github/scripts/sdk_loop_findings.py
@@ -1,0 +1,636 @@
+#!/usr/bin/env python3
+"""Severity clamping, verdict computation and summary rendering for `@sdk-loop`.
+
+Everything here used to be the model's job, spread across five sections of
+`.mothership/pr-review/ORCHESTRATION.md` — §2f guardrails, §2h's verdict table,
+§3a's schema allowlist, §3e's 7.2 KB summary template and §3f's `sed` safety
+nets. None of it has an indeterminate answer, and all of it was being paid for
+twice: once as context the reviewer carried through every turn, and once as
+turns spent producing a comment by hand.
+
+Three things follow from moving it here, and they are the point of the module:
+
+1. **The frozen marker contract becomes structural.** `sdk_review_approve.py`,
+   `sdk_review_reconcile.py`, `sdk_review_dedupe_verdicts.py`,
+   `sdk_review_verdict_gate.py` and four `sdk-review-*.yml` workflows all find
+   their work by parsing HTML comment markers. Rendering those in Python makes
+   them unit-testable with no model in the loop, and deletes two whole failure
+   classes: the reviewer writing the literal string `<HEAD_SHA>` instead of the
+   sha, and an empty `<!-- ANSWERS_TRIGGER: -->` line on a `workflow_dispatch`
+   run. §3f carries a `sed` for each; neither is needed once the renderer owns
+   the output.
+
+2. **`### Findings` empty <=> READY_TO_MERGE becomes an invariant** rather than
+   an instruction the model is asked to honour. It is the resolve loop's
+   termination condition, so it is the one rule in the lane that must not be
+   probabilistic.
+
+3. **The severity vocabulary gets exactly one mapping.** See `severity.yaml`'s
+   `display` block for why there were three.
+
+The module is pure: it computes and renders, and posts nothing. `interpret_review`
+owns delivery, and — importantly — owns deciding whether a review actually
+happened. An empty findings list renders READY_TO_MERGE, so a caller that treats
+"the renderer produced a comment" as proof of work would turn a crashed agent
+into a merge-ready verdict. Callers must gate on the completion assertion, not
+on this module returning successfully.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+import yaml
+
+#: Canonical severity data. Never read by a model — see the file's own header.
+SEVERITY_DATA = (
+    Path(__file__).resolve().parents[2] / ".mothership/pr-loop/data/severity.yaml"
+)
+
+#: The only fields the inline-comment handler accepts. §3a of the pr-review
+#: playbook is emphatic that unknown fields 422 the request, and every one of
+#: the seven brief-level JSON examples in that corpus emits three fields it
+#: then has to strip (`scope`, `domain_tag`, `guardrail`). Validating against
+#: the allowlist here means a brief cannot teach a payload the poster must undo.
+FINDING_FIELDS = frozenset(
+    {
+        "title",
+        "pattern_id",
+        "severity",
+        "category",
+        "confidence",
+        "file",
+        "line",
+        "evidence",
+        "attack_path",
+        "reachable_from",
+        "by_design_check",
+        "suggested_fix",
+        "escalate_to_linear",
+    }
+)
+
+#: Fields a finding cannot be rendered without.
+REQUIRED_FIELDS = ("title", "severity", "confidence", "file")
+
+VERDICT_READY = "READY_TO_MERGE"
+VERDICT_FIXES = "NEEDS_FIXES"
+VERDICT_BLOCKED = "BLOCKED"
+VERDICT_HUMAN = "NEEDS_HUMAN"
+VERDICT_REBASE = "NEEDS_REBASE"
+
+#: Verdict precedence when several apply at once. BLOCKED outranks NEEDS_HUMAN
+#: because a guardrail violation is a fact about the code, while NEEDS_HUMAN is
+#: a fact about what the reviewer could not determine.
+_VERDICT_RANK = {
+    VERDICT_BLOCKED: 4,
+    VERDICT_HUMAN: 3,
+    VERDICT_REBASE: 2,
+    VERDICT_FIXES: 1,
+    VERDICT_READY: 0,
+}
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class SchemaError(ValueError):
+    """A findings payload the renderer refuses to render.
+
+    Raised rather than repaired on purpose. A payload this module cannot
+    validate is a phase failure — the alternative is rendering a partial review
+    that reads exactly like a complete one.
+    """
+
+
+# --------------------------------------------------------------------------
+# Severity data
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Severity:
+    """The `display` + `calibration` + `guardrails` view of `severity.yaml`."""
+
+    display: dict[str, dict[str, Any]]
+    tier_order: tuple[str, ...]
+    guardrails: dict[str, dict[str, Any]]
+    patterns: dict[str, dict[str, Any]]
+    floors: dict[str, float]
+
+    def tier(self, severity: str) -> str | None:
+        """Rendered tier for an emitted severity, or None when prose-only.
+
+        Raises on an unknown severity instead of passing it through. One brief
+        in the inherited corpus emits `IMPORTANT`, which belongs to none of the
+        three vocabularies that corpus uses; silently rendering it would put a
+        finding in the summary that the verdict never counted.
+        """
+        entry = self.display.get(severity)
+        if entry is None:
+            raise SchemaError(
+                f"unmapped severity {severity!r}; expected one of "
+                f"{sorted(self.display)}"
+            )
+        return entry["tier"]
+
+    def in_findings(self, severity: str) -> bool:
+        """Whether this severity renders under `### Findings` — i.e. blocks."""
+        entry = self.display.get(severity)
+        if entry is None:
+            raise SchemaError(f"unmapped severity {severity!r}")
+        return bool(entry["in_findings"])
+
+    def inline(self, severity: str) -> bool:
+        return bool(self.display[severity]["inline_comment"])
+
+    def floor(self, severity: str) -> float:
+        """Confidence floor for a severity.
+
+        INFO carries no floor in the canonical rubric — adding one would make
+        pr-review's generated copy diverge from the file it must reproduce — so
+        it falls back to LOW's, the nearest tier with the same prose-only
+        treatment.
+        """
+        if severity in self.floors:
+            return self.floors[severity]
+        if severity == "INFO":
+            return self.floors["LOW"]
+        raise SchemaError(f"no confidence floor for severity {severity!r}")
+
+    def guardrail_for(self, pattern_id: str | None) -> tuple[str, str] | None:
+        """`(guardrail id, forced verdict)` for a pattern, or None."""
+        if not pattern_id:
+            return None
+        for gid, entry in self.guardrails.items():
+            if pattern_id in entry["patterns"]:
+                return gid, entry["verdict"]
+        return None
+
+
+def load_severity(path: Path | str | None = None) -> Severity:
+    raw = yaml.safe_load(Path(path or SEVERITY_DATA).read_text(encoding="utf-8"))
+    patterns = {
+        pattern["pattern_id"]: pattern
+        for category in raw["categories"]
+        for pattern in category["patterns"]
+    }
+    return Severity(
+        display=raw["display"],
+        tier_order=tuple(raw["tier_order"]),
+        guardrails=raw["guardrails"],
+        patterns=patterns,
+        floors=raw["calibration"]["confidence_floors"],
+    )
+
+
+# --------------------------------------------------------------------------
+# Findings
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Finding:
+    title: str
+    severity: str
+    confidence: float
+    file: str
+    line: int | None = None
+    pattern_id: str | None = None
+    category: str | None = None
+    evidence: str | None = None
+    attack_path: str | None = None
+    reachable_from: str | None = None
+    by_design_check: str | None = None
+    suggested_fix: str | None = None
+    escalate_to_linear: bool | None = None
+    #: Set by `normalise`, not by the model.
+    tier: str | None = None
+    guardrail: str | None = None
+
+    def payload(self) -> dict[str, Any]:
+        """The finding as the inline-comment handler wants it — allowlist only."""
+        out: dict[str, Any] = {}
+        for name in FINDING_FIELDS:
+            value = getattr(self, name, None)
+            if value is not None:
+                out[name] = value
+        return out
+
+
+@dataclass
+class Dropped:
+    finding: Finding
+    reason: str
+
+
+@dataclass
+class Normalised:
+    kept: list[Finding] = field(default_factory=list)
+    prose: list[Finding] = field(default_factory=list)
+    dropped: list[Dropped] = field(default_factory=list)
+
+
+def parse_finding(raw: dict[str, Any]) -> Finding:
+    """Validate one raw finding against the allowlist."""
+    if not isinstance(raw, dict):
+        raise SchemaError(f"finding must be an object, got {type(raw).__name__}")
+    unknown = sorted(set(raw) - FINDING_FIELDS)
+    if unknown:
+        raise SchemaError(
+            f"finding carries fields the handler rejects (422): {unknown}. "
+            f"Allowed: {sorted(FINDING_FIELDS)}"
+        )
+    missing = [name for name in REQUIRED_FIELDS if raw.get(name) in (None, "")]
+    if missing:
+        raise SchemaError(f"finding missing required field(s): {missing}")
+    try:
+        confidence = float(raw["confidence"])
+    except (TypeError, ValueError) as exc:
+        raise SchemaError(f"confidence is not a number: {raw['confidence']!r}") from exc
+    if not 0.0 <= confidence <= 1.0:
+        raise SchemaError(f"confidence out of range: {confidence}")
+    known = {name: raw[name] for name in raw if name in FINDING_FIELDS}
+    known["confidence"] = confidence
+    return Finding(**known)
+
+
+def normalise(findings: Iterable[Finding], sev: Severity) -> Normalised:
+    """Clamp severities, apply per-severity floors, and split by destination.
+
+    Order matters and is the reverse of the obvious one: clamp BEFORE the floor
+    check. The floor is a property of the severity a finding actually gets, so
+    checking it first would hold a clamped-down finding to the floor of a tier
+    it no longer occupies — the flat-0.80 mistake the briefs make, in a
+    different disguise.
+
+    A guardrail violation skips the floor entirely. `CLAUDE.md`'s guardrail
+    table is explicit that they are reported "regardless of confidence score",
+    and a guardrail is the one thing whose absence from the summary changes a
+    merge decision.
+    """
+    out = Normalised()
+    for finding in findings:
+        pattern = sev.patterns.get(finding.pattern_id or "")
+        if pattern is not None:
+            ceiling = pattern["max_severity"]
+            if _rank(finding.severity, sev) > _rank(ceiling, sev):
+                finding.severity = ceiling
+
+        guardrail = sev.guardrail_for(finding.pattern_id)
+        if guardrail is not None:
+            finding.guardrail = guardrail[0]
+
+        if guardrail is None and finding.confidence < sev.floor(finding.severity):
+            out.dropped.append(
+                Dropped(
+                    finding,
+                    f"confidence {finding.confidence:.2f} below the "
+                    f"{finding.severity} floor {sev.floor(finding.severity):.2f}",
+                )
+            )
+            continue
+
+        finding.tier = sev.tier(finding.severity)
+        if sev.in_findings(finding.severity):
+            out.kept.append(finding)
+        else:
+            out.prose.append(finding)
+    return out
+
+
+def _rank(severity: str, sev: Severity) -> int:
+    """Order emitted severities so `max_severity` can be compared."""
+    order = ["INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL", "BLOCKING"]
+    if severity not in order:
+        raise SchemaError(f"unmapped severity {severity!r}")
+    return order.index(severity)
+
+
+# --------------------------------------------------------------------------
+# Verdict
+# --------------------------------------------------------------------------
+
+
+def compute_verdict(
+    kept: Sequence[Finding],
+    sev: Severity,
+    *,
+    needs_human: bool = False,
+    conflicting: bool = False,
+) -> str:
+    """§2h's table, as code.
+
+    `READY_TO_MERGE` is strict and stays strict: **any** finding rendered under
+    `### Findings` forces `NEEDS_FIXES`, whatever its tier. That is what makes
+    the resolve loop terminate — it fixes until the list is empty — and it is
+    why `severity.yaml` routes LOW and INFO to prose instead. A tier that
+    renders into Findings blocks the merge; there is no third state.
+    """
+    if conflicting:
+        # Decided from mergeStateStatus before the model is ever called, so it
+        # is not a finding and cannot be outvoted by one.
+        return VERDICT_REBASE
+
+    verdict = VERDICT_READY
+    if needs_human:
+        verdict = _worse(verdict, VERDICT_HUMAN)
+    if kept:
+        verdict = _worse(verdict, VERDICT_FIXES)
+    for finding in kept:
+        guardrail = sev.guardrail_for(finding.pattern_id)
+        if guardrail is not None:
+            verdict = _worse(verdict, guardrail[1])
+    return verdict
+
+
+def _worse(current: str, candidate: str) -> str:
+    return candidate if _VERDICT_RANK[candidate] > _VERDICT_RANK[current] else current
+
+
+# --------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------
+
+#: The human-readable spelling on the `### Verdict:` line. The machine-readable
+#: token in the marker is the underscored form; keeping both in one table is
+#: what stops them drifting, which §3e asks the model to do by hand.
+_VERDICT_PROSE = {
+    VERDICT_READY: "READY TO MERGE",
+    VERDICT_FIXES: "NEEDS FIXES",
+    VERDICT_BLOCKED: "BLOCKED",
+    VERDICT_HUMAN: "NEEDS HUMAN REVIEW",
+    VERDICT_REBASE: "NEEDS REBASE",
+}
+
+
+def render_markers(
+    verdict: str,
+    reviewed_head: str,
+    *,
+    answers_trigger: str | None = None,
+    toolkit_artifact_hash: str | None = None,
+) -> str:
+    """The five-marker block, in the frozen order.
+
+    `answers_trigger` is omitted entirely when absent rather than rendered
+    empty. §3e records why: the resolver's push guard uses the marker to tell
+    "the round I am waiting on has answered" from "an earlier round's verdict
+    landed late", and an empty marker reads as present-but-unparseable, which is
+    worse than a missing one. `COMMENT_ID` is blank on every `workflow_dispatch`
+    run, so this is the common path, not the edge case.
+    """
+    if verdict not in _VERDICT_PROSE:
+        raise SchemaError(f"unknown verdict {verdict!r}")
+    if not _SHA_RE.match(reviewed_head or ""):
+        raise SchemaError(
+            f"REVIEWED_HEAD must be a 40-char lowercase hex sha, got "
+            f"{reviewed_head!r}"
+        )
+    lines = [
+        "<!-- SDK_REVIEW -->",
+        f"<!-- VERDICT: {verdict} -->",
+        f"<!-- REVIEWED_HEAD: {reviewed_head} -->",
+    ]
+    # Strip BEFORE testing for presence. A whitespace-only COMMENT_ID is the
+    # blank `workflow_dispatch` value arriving with padding, not a malformed
+    # trigger id — treating it as the latter fails a run that should simply
+    # omit the line.
+    trigger = str(answers_trigger or "").strip()
+    if trigger:
+        if not trigger.isdigit():
+            raise SchemaError(f"ANSWERS_TRIGGER must be raw digits, got {trigger!r}")
+        lines.append(f"<!-- ANSWERS_TRIGGER: {trigger} -->")
+    if toolkit_artifact_hash:
+        lines.append(f"<!-- TOOLKIT_ARTIFACT_HASH: {toolkit_artifact_hash} -->")
+    return "\n".join(lines)
+
+
+def render_findings(kept: Sequence[Finding], sev: Severity) -> str:
+    """§3e's mandatory file-grouped bullet format.
+
+    Files sort alphabetically; within a file, by tier then line. An empty list
+    renders as an empty section — deliberately, because that emptiness is the
+    signal the resolve loop terminates on.
+    """
+    if not kept:
+        return ""
+    by_file: dict[str, list[Finding]] = {}
+    for finding in kept:
+        by_file.setdefault(finding.file, []).append(finding)
+
+    order = {tier: index for index, tier in enumerate(sev.tier_order)}
+    blocks: list[str] = []
+    for path in sorted(by_file):
+        rows = sorted(
+            by_file[path],
+            key=lambda f: (order.get(f.tier or "", 99), f.line or 0),
+        )
+        header = "**PR metadata**" if path == "PR metadata" else f"**`{path}`**"
+        bullets = [header]
+        for finding in rows:
+            tag = f" [{finding.category}]" if finding.category else ""
+            where = f" L{finding.line}" if finding.line else ""
+            fix = f" *Path: {finding.suggested_fix}*" if finding.suggested_fix else ""
+            bullets.append(f"- **{finding.tier}**{tag}{where} — {finding.title}.{fix}")
+        blocks.append("\n".join(bullets))
+    return "\n\n".join(blocks)
+
+
+def render_summary(
+    *,
+    verdict: str,
+    pr_number: int | str,
+    pr_title: str,
+    reviewed_head: str,
+    kept: Sequence[Finding],
+    sev: Severity,
+    summary: str,
+    strengths: Sequence[str] = (),
+    prose: Sequence[Finding] = (),
+    answers_trigger: str | None = None,
+    toolkit_artifact_hash: str | None = None,
+    is_rereview: bool = False,
+    delta: str | None = None,
+    review_note: str | None = None,
+    model: str = "",
+    run_url: str = "",
+    heading_subject: str = "SDK",
+) -> str:
+    """The whole verdict comment.
+
+    Callers pass `heading_subject="Contract Toolkit"` for toolkit scopes; the
+    `<!-- SDK_REVIEW -->` marker is unchanged either way because the approval
+    workflow parses that stable marker and not the heading.
+    """
+    kind = "Re-review" if is_rereview else "Review"
+    parts = [
+        render_markers(
+            verdict,
+            reviewed_head,
+            answers_trigger=answers_trigger,
+            toolkit_artifact_hash=toolkit_artifact_hash,
+        ),
+        f"## {heading_subject} {kind} (@sdk-loop): PR #{pr_number} — {pr_title}",
+        "",
+        f"### Verdict: {_VERDICT_PROSE[verdict]}",
+        "",
+        f"> {summary.strip()}" if summary.strip() else "> (no summary provided)",
+        "",
+        "---",
+        "",
+    ]
+    if delta:
+        parts += ["### Delta from previous review", "", delta.strip(), ""]
+
+    parts += ["### Findings", ""]
+    body = render_findings(kept, sev)
+    parts += [body, ""] if body else ["_None._", ""]
+
+    if prose:
+        parts += ["### Observations (not blocking)", ""]
+        parts += [
+            f"- {f.file}{f' L{f.line}' if f.line else ''} — {f.title}." for f in prose
+        ]
+        parts += [""]
+
+    if strengths:
+        parts += ["### Strengths", ""] + [f"- {s}" for s in strengths] + [""]
+
+    if review_note:
+        parts += ["### Review Note", "", review_note.strip(), ""]
+
+    parts += ["---", f"**Models:** {model or 'unknown'}"]
+    if run_url:
+        parts.append(f"**Run:** [view workflow logs + cost]({run_url})")
+    return "\n".join(parts).rstrip() + "\n"
+
+
+# --------------------------------------------------------------------------
+# Payload entry point
+# --------------------------------------------------------------------------
+
+
+def load_payload(text: str | bytes) -> dict[str, Any]:
+    """Parse the agent's `findings.json`, refusing anything ambiguous."""
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SchemaError(f"findings payload is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise SchemaError("findings payload must be a JSON object")
+    if not isinstance(payload.get("findings", []), list):
+        raise SchemaError("`findings` must be a list")
+    return payload
+
+
+# --------------------------------------------------------------------------
+# Shadow audit — the contract checker, while the model still writes the comment
+# --------------------------------------------------------------------------
+#
+# Step 1 of the migration runs the renderer BEHIND the existing playbook: the
+# reviewer still composes and posts its own comment, and this function checks
+# that comment against the contract the renderer would have guaranteed.
+#
+# It cannot compare byte-for-byte — the comment carries model prose (the
+# summary, `### Strengths`, finding bodies) that no renderer reproduces, so a
+# byte assertion would fail on the first run and the natural response would be
+# to weaken it until it passed. What it compares is the part that has one
+# correct answer: the markers, the verdict token, and the empty-Findings
+# invariant.
+#
+# It is deliberately non-fatal. The point of the step is to MEASURE how often
+# the model breaks the contract before anything depends on it not breaking —
+# failing rounds on a diagnostic would just make the measurement expensive.
+
+_FINDING_BULLET_RE = re.compile(r"^\s*[-*]\s+\*\*(Critical|Important|Nit)\*\*", re.M)
+_PLACEHOLDER_RE = re.compile(r"<!--\s*REVIEWED_HEAD:\s*<[^>]*>\s*-->")
+
+
+def audit_comment(body: str) -> list[str]:
+    """Contract violations in a model-authored verdict comment, worst first.
+
+    Every check here corresponds to a real failure this lane has already paid
+    for, and each one is something the renderer makes impossible by
+    construction. An empty list means the model produced what Python would
+    have.
+    """
+    problems: list[str] = []
+    text = body or ""
+
+    if "<!-- SDK_REVIEW -->" not in text:
+        problems.append("no <!-- SDK_REVIEW --> marker: no consumer will find this")
+        return problems
+    if not text.lstrip().startswith("<!-- SDK_REVIEW -->"):
+        problems.append("the marker block does not lead the comment")
+
+    verdict_match = re.search(r"<!--\s*VERDICT:\s*([A-Z_]+)\s*-->", text)
+    if verdict_match is None:
+        problems.append("no <!-- VERDICT: X --> marker: nothing can label or approve")
+        verdict = None
+    else:
+        verdict = verdict_match.group(1)
+        if verdict not in _VERDICT_PROSE:
+            problems.append(f"verdict token {verdict!r} is not one of the five")
+
+    if _PLACEHOLDER_RE.search(text):
+        # §3f carries a `sed` for exactly this; the renderer cannot emit it.
+        problems.append(
+            "REVIEWED_HEAD is the literal placeholder, not a sha — the next "
+            "round loses its delta base"
+        )
+    else:
+        head_match = re.search(r"<!--\s*REVIEWED_HEAD:\s*([^\s>]+)\s*-->", text)
+        if head_match is None:
+            problems.append(
+                "no REVIEWED_HEAD marker: next round falls back to a full review"
+            )
+        elif not _SHA_RE.match(head_match.group(1)):
+            problems.append(
+                f"REVIEWED_HEAD {head_match.group(1)!r} is not a 40-char lowercase sha"
+            )
+
+    if re.search(r"<!--\s*ANSWERS_TRIGGER:\s*-->", text):
+        # An empty marker is worse than a missing one: it reads as
+        # present-but-unparseable to the resolver's push guard.
+        problems.append("ANSWERS_TRIGGER is present but empty; it should be omitted")
+
+    findings_empty = _findings_are_empty(text)
+    if verdict is not None:
+        if findings_empty and verdict != VERDICT_READY:
+            problems.append(
+                f"### Findings is empty but the verdict is {verdict}; the resolve "
+                "loop has nothing left to fix and cannot terminate"
+            )
+        if not findings_empty and verdict == VERDICT_READY:
+            problems.append(
+                "### Findings is non-empty but the verdict is READY_TO_MERGE — "
+                "this would approve a PR with open findings"
+            )
+
+    if re.search(r"^\|\s*Severity\s*\|", text, re.M):
+        problems.append(
+            "findings rendered as a table; §3e mandates file-grouped bullets"
+        )
+
+    return problems
+
+
+def _findings_are_empty(text: str) -> bool:
+    """Whether `### Findings` carries any finding bullet.
+
+    Reads the section between `### Findings` and the next `###`/`---`, and
+    looks for the `- **Tier**` bullet shape §3e mandates. A section holding only
+    prose ("None", "_None._", "No findings") counts as empty, which is the
+    common spelling when a re-review clears everything.
+    """
+    match = re.search(r"^###\s+Findings\s*$", text, re.M)
+    if match is None:
+        return True
+    rest = text[match.end() :]
+    end = re.search(r"^(###\s|---\s*$)", rest, re.M)
+    section = rest[: end.start()] if end else rest
+    return _FINDING_BULLET_RE.search(section) is None

--- a/.github/scripts/sdk_loop_pack.py
+++ b/.github/scripts/sdk_loop_pack.py
@@ -1,0 +1,428 @@
+"""Assemble the reviewer's first turn, so it does not have to go and find one.
+
+`REVIEW.md` opens by telling the reviewer that everything with a determinate
+answer is already in its context: the PR's facts, the diff, the files worth
+reading, which specialist it is, and what the deterministic gate found. Until
+this module existed that sentence was aspirational — the prompt said "read the
+playbook and follow it", and the reviewer spent its first several turns
+orienting: listing files, grepping for callers, working out its own scope.
+
+Those turns are the most expensive ones in the review. They happen while the
+context is smallest and cheapest, they produce facts the runner already holds or
+can compute in milliseconds, and every one of them lands in the transcript that
+the *remaining* turns then carry.
+
+## Why the pack is narrow rather than large
+
+The obvious move once you own the context is to put everything in it. That is
+measurably wrong. Retrieval-quality work on review agents finds models degrade
+with excess context through attention dilution — a reviewer handed the whole
+module reliably comments on the parts of it the PR did not touch. So the pack is
+deliberately bounded:
+
+* the diff, which is the subject
+* the symbols the diff actually changed, resolved by parsing the file rather
+  than by pattern-matching the patch
+* who calls those symbols, capped, because reachability decides severity: the
+  same defect is a nit on a private helper and a blocker on something every
+  connector executes
+* the tests that already exist next to the change, so "untested" is a claim the
+  reviewer can check rather than assume
+* what the deterministic gate already decided, so the review does not spend a
+  round restating a blocking CI finding
+
+Caps are constants here rather than parameters. A cap that callers can raise
+gets raised, and then the pack is large again by increments nobody reviewed.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Sequence
+
+#: Symbols carried into the pack. Past this the diff is broad enough that the
+#: per-module split is the right answer, not a longer list.
+MAX_SYMBOLS = 40
+
+#: Callers listed per symbol. Enough to establish blast radius; a full list is
+#: a search result, and the reviewer does not need to read one to size a
+#: finding.
+MAX_CALLERS_PER_SYMBOL = 6
+
+#: Existing test files surfaced alongside the change.
+MAX_NEARBY_TESTS = 12
+
+#: Files scanned when resolving callers. The SDK is small enough that this is
+#: milliseconds; the bound exists so a runaway repo cannot stall a review.
+MAX_SCANNED_FILES = 4000
+
+_HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+_NEW_FILE = re.compile(r"^\+\+\+ b/(.+)$")
+_OLD_FILE = re.compile(r"^--- a/(.+)$")
+
+_TEST_PATH = re.compile(r"(^|/)tests?/|(^|/)test_[^/]+\.py$|_test\.py$")
+
+
+@dataclass(frozen=True)
+class ChangedFile:
+    path: str
+    added: tuple[int, ...]
+    removed_count: int
+    is_deleted: bool
+
+    @property
+    def is_test(self) -> bool:
+        return bool(_TEST_PATH.search(self.path))
+
+    @property
+    def is_python(self) -> bool:
+        return self.path.endswith(".py")
+
+
+@dataclass(frozen=True)
+class Symbol:
+    """A function or class the diff changed, with the lines it changed in it."""
+
+    name: str
+    qualname: str
+    kind: str
+    path: str
+    lineno: int
+    end_lineno: int
+
+
+@dataclass
+class Pack:
+    scope: str
+    mode: str
+    agents: tuple[str, ...]
+    files: tuple[ChangedFile, ...]
+    symbols: tuple[Symbol, ...] = ()
+    callers: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    nearby_tests: tuple[str, ...] = ()
+    gate: str = ""
+    truncated: tuple[str, ...] = ()
+
+    @property
+    def changed_lines(self) -> int:
+        return sum(len(f.added) + f.removed_count for f in self.files)
+
+    @property
+    def touches_config(self) -> bool:
+        return any(
+            f.path.startswith((".github/", "helm/"))
+            or f.path in ("pyproject.toml", "uv.lock")
+            for f in self.files
+        )
+
+    @property
+    def touches_conformance(self) -> bool:
+        return any(
+            f.path.startswith(("packages/conformance/", "remediation/"))
+            for f in self.files
+        )
+
+
+# --------------------------------------------------------------------------
+# The diff
+# --------------------------------------------------------------------------
+
+
+def parse_diff(text: str) -> tuple[ChangedFile, ...]:
+    """Changed files and the line numbers each one adds.
+
+    Line numbers are taken from the hunk headers rather than counted, because a
+    counted offset drifts silently on a malformed or truncated patch and the
+    reviewer then gets symbol attributions that are subtly wrong — worse than
+    none, since it will quote the wrong code as evidence.
+    """
+    out: list[ChangedFile] = []
+    path: str | None = None
+    old_path: str | None = None
+    added: list[int] = []
+    removed = 0
+    deleted = False
+    cursor = 0
+
+    def flush() -> None:
+        nonlocal path, old_path, added, removed, deleted
+        # A deleted file has no `+++ b/…` line at all — its identity lives on
+        # the `---` side. Dropping it would hide the shape a removed public
+        # export makes in a diff, which is exactly the change most worth review.
+        resolved = path or (old_path if deleted else None)
+        if resolved is not None:
+            out.append(
+                ChangedFile(
+                    path=resolved,
+                    added=tuple(added),
+                    removed_count=removed,
+                    is_deleted=deleted,
+                )
+            )
+        path, old_path, added, removed, deleted = None, None, [], 0, False
+
+    for line in text.splitlines():
+        if line.startswith("diff --git "):
+            flush()
+            continue
+        old = _OLD_FILE.match(line)
+        if old:
+            old_path = old.group(1)
+            continue
+        new = _NEW_FILE.match(line)
+        if new:
+            path = new.group(1)
+            deleted = path == "/dev/null"
+            continue
+        if line.startswith("+++ /dev/null"):
+            deleted = True
+            continue
+        hunk = _HUNK.match(line)
+        if hunk:
+            cursor = int(hunk.group(1))
+            continue
+        # `not deleted` matters: a deleted file never gets a `+++ b/…` line, so
+        # `path` stays None while its removals are still real changed lines. The
+        # obvious `if path is None: continue` silently counts a 900-line
+        # deletion as zero and hands it the single-pass depth.
+        if path is None and not deleted:
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            added.append(cursor)
+            cursor += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            removed += 1
+        elif line.startswith(" "):
+            cursor += 1
+    flush()
+    return tuple(f for f in out if f.path != "/dev/null")
+
+
+# --------------------------------------------------------------------------
+# What the diff actually changed
+# --------------------------------------------------------------------------
+
+
+def touched_symbols(repo: Path, files: Iterable[ChangedFile]) -> tuple[Symbol, ...]:
+    """Functions and classes containing at least one added line.
+
+    Resolved by parsing the file rather than by reading `@@` headers. Git's
+    hunk-header function hint is a heuristic — it reports the nearest preceding
+    `def` textually, which is the wrong answer for nested functions, decorators
+    and methods, and the reviewer would inherit that error as a fact.
+
+    A file that does not parse is skipped rather than guessed at. It is either
+    not Python or it is syntactically broken, and in the second case the review
+    has a much louder finding available to it than a symbol list.
+    """
+    found: list[Symbol] = []
+    for changed in files:
+        if changed.is_deleted or not changed.is_python or not changed.added:
+            continue
+        source_path = repo / changed.path
+        try:
+            tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+        added = set(changed.added)
+        for node, qualname in _walk_defs(tree):
+            end = getattr(node, "end_lineno", node.lineno) or node.lineno
+            if any(node.lineno <= line <= end for line in added):
+                found.append(
+                    Symbol(
+                        name=node.name,
+                        qualname=qualname,
+                        kind=_kind(node),
+                        path=changed.path,
+                        lineno=node.lineno,
+                        end_lineno=end,
+                    )
+                )
+    # Innermost first: a method is more specific than the class holding it, and
+    # when the cap bites the specific ones are the ones worth keeping.
+    found.sort(key=lambda s: (-s.qualname.count("."), s.path, s.lineno))
+    return tuple(found[:MAX_SYMBOLS])
+
+
+def _kind(node: ast.AST) -> str:
+    if isinstance(node, ast.ClassDef):
+        return "class"
+    return "function"
+
+
+def _walk_defs(tree: ast.AST, prefix: str = "") -> Iterable[tuple[ast.AST, str]]:
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            qualname = f"{prefix}{node.name}"
+            yield node, qualname
+            yield from _walk_defs(node, prefix=f"{qualname}.")
+
+
+# --------------------------------------------------------------------------
+# Who calls it — the input severity actually depends on
+# --------------------------------------------------------------------------
+
+
+def find_callers(
+    repo: Path, symbols: Sequence[Symbol], *, scan_root: str = "."
+) -> dict[str, tuple[str, ...]]:
+    """Files referencing each changed symbol, excluding where it is defined.
+
+    Reachability is the input that decides how much a finding is worth: the same
+    defect is a nit on a private helper and a blocker on something every
+    connector executes. The reviewer would otherwise establish this by grepping,
+    which costs a turn and is the single most common orientation step in the
+    measured transcripts.
+
+    Name-based and therefore approximate — a same-named symbol elsewhere counts.
+    That is stated in the rendered pack rather than hidden, because a reviewer
+    told "approximate" will verify a blocker and accept a nit, which is the
+    right allocation of effort.
+    """
+    if not symbols:
+        return {}
+    wanted = {s.name for s in symbols}
+    defining = {s.path for s in symbols}
+    pattern = re.compile(
+        r"\b(" + "|".join(re.escape(n) for n in sorted(wanted)) + r")\b"
+    )
+
+    hits: dict[str, list[str]] = {name: [] for name in wanted}
+    scanned = 0
+    for path in sorted((repo / scan_root).rglob("*.py")):
+        scanned += 1
+        if scanned > MAX_SCANNED_FILES:
+            break
+        rel = str(path.relative_to(repo))
+        if rel in defining or "/.venv/" in f"/{rel}" or rel.startswith(".venv/"):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for match in set(pattern.findall(text)):
+            bucket = hits[match]
+            if rel not in bucket and len(bucket) < MAX_CALLERS_PER_SYMBOL:
+                bucket.append(rel)
+    return {name: tuple(paths) for name, paths in hits.items() if paths}
+
+
+def nearby_tests(repo: Path, files: Iterable[ChangedFile]) -> tuple[str, ...]:
+    """Test files that already exercise the changed modules.
+
+    So that "this is untested" becomes a claim the reviewer can check instead of
+    an assumption it can make for free. An unfounded missing-tests finding is
+    among the most expensive false positives available: it is plausible, it is
+    tedious to refute, and refuting it is the author's job.
+    """
+    modules = {
+        Path(f.path).stem
+        for f in files
+        if f.is_python and not f.is_test and not f.is_deleted
+    }
+    if not modules:
+        return ()
+    out: list[str] = []
+    for path in (
+        sorted((repo / "tests").rglob("test_*.py")) if (repo / "tests").exists() else []
+    ):
+        rel = str(path.relative_to(repo))
+        if Path(rel).stem.removeprefix("test_") in modules:
+            out.append(rel)
+        elif any(m in rel for m in modules):
+            out.append(rel)
+        if len(out) >= MAX_NEARBY_TESTS:
+            break
+    return tuple(out)
+
+
+# --------------------------------------------------------------------------
+# Assembly
+# --------------------------------------------------------------------------
+
+
+def build_pack(
+    *,
+    repo: Path,
+    diff: str,
+    scope: str,
+    routing,
+    gate: str = "",
+) -> Pack:
+    """Everything the reviewer needs, and deliberately nothing else."""
+    files = parse_diff(diff)
+    pack = Pack(scope=scope, mode="", agents=(), files=files, gate=gate)
+    pack.mode = routing.mode_for(pack.changed_lines)
+    pack.agents = routing.route(scope).resolve(
+        touches_config=pack.touches_config,
+        touches_conformance=pack.touches_conformance,
+    )
+    pack.symbols = touched_symbols(repo, files)
+    pack.callers = find_callers(repo, pack.symbols)
+    pack.nearby_tests = nearby_tests(repo, files)
+
+    truncated: list[str] = []
+    if len(pack.symbols) == MAX_SYMBOLS:
+        truncated.append(f"symbol list capped at {MAX_SYMBOLS}")
+    if len(pack.nearby_tests) == MAX_NEARBY_TESTS:
+        truncated.append(f"nearby tests capped at {MAX_NEARBY_TESTS}")
+    pack.truncated = tuple(truncated)
+    return pack
+
+
+def render(pack: Pack, agent: str) -> str:
+    """The reviewer's first turn, as text.
+
+    Every cap that bit is stated. A pack that silently truncated would let the
+    reviewer conclude a symbol has no callers when the list was simply cut,
+    which turns a blocker into a nit for a reason nobody can see afterwards.
+    """
+    lines = [
+        f"You are the {agent} specialist.",
+        "",
+        f"Scope: {pack.scope} · review mode: {pack.mode} · "
+        f"{len(pack.files)} files, {pack.changed_lines} changed lines",
+    ]
+    if pack.mode == "per_module":
+        lines.append(
+            "This diff is past the size where a single pass finds things "
+            "reliably; you are reviewing one module of it."
+        )
+    lines += ["", "## Files in this change", ""]
+    for f in pack.files:
+        mark = " (deleted)" if f.is_deleted else " (test)" if f.is_test else ""
+        lines.append(f"- {f.path}{mark} · +{len(f.added)}/-{f.removed_count}")
+
+    if pack.symbols:
+        lines += ["", "## What this diff changed", ""]
+        for s in pack.symbols:
+            callers = pack.callers.get(s.name, ())
+            where = (
+                f" — referenced in {', '.join(callers)}"
+                if callers
+                else " — no references found in this repo"
+            )
+            lines.append(f"- {s.kind} `{s.qualname}` ({s.path}:{s.lineno}){where}")
+        lines.append("")
+        lines.append(
+            "References are resolved by name, so a same-named symbol elsewhere "
+            "may appear. Verify before resting a blocking finding on one."
+        )
+
+    if pack.nearby_tests:
+        lines += ["", "## Tests that already cover these modules", ""]
+        lines += [f"- {t}" for t in pack.nearby_tests]
+        lines.append("")
+        lines.append("Check these before reporting anything as untested.")
+
+    if pack.gate:
+        lines += ["", "## Already blocked by CI — do not restate", "", pack.gate]
+
+    if pack.truncated:
+        lines += ["", "## Truncated", ""]
+        lines += [f"- {t}" for t in pack.truncated]
+
+    return "\n".join(lines)

--- a/.github/scripts/sdk_loop_pack.py
+++ b/.github/scripts/sdk_loop_pack.py
@@ -59,6 +59,24 @@ MAX_NEARBY_TESTS = 12
 #: milliseconds; the bound exists so a runaway repo cannot stall a review.
 MAX_SCANNED_FILES = 4000
 
+#: Sentinel key meaning "the caller scan hit its budget", so `render` can say so
+#: instead of reporting an incomplete search as a finished one.
+SCAN_EXHAUSTED = "\x00scan-exhausted"
+
+
+def _is_vendored(rel: str) -> bool:
+    """Paths that are never this repo's own source.
+
+    Matched on a path segment rather than a prefix: a virtualenv can sit at the
+    root or inside a package, and either way its contents are not callers.
+    """
+    return any(
+        part in (".venv", "venv", "node_modules", ".git", "site-packages")
+        or part.endswith(".egg-info")
+        for part in rel.split("/")
+    )
+
+
 _HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
 _NEW_FILE = re.compile(r"^\+\+\+ b/(.+)$")
 _OLD_FILE = re.compile(r"^--- a/(.+)$")
@@ -292,13 +310,21 @@ def find_callers(
 
     hits: dict[str, list[str]] = {name: [] for name in wanted}
     scanned = 0
+    exhausted = False
     for path in sorted((repo / scan_root).rglob("*.py")):
+        rel = str(path.relative_to(repo))
+        # Skipped BEFORE the budget is charged. Counting first spent the cap on
+        # files that were never read, and `sorted()` puts dot-prefixed
+        # directories first — so a repo with a checked-out `.venv` could
+        # exhaust the budget before reaching one source file, leaving
+        # `find_callers` empty while the pack printed "no references found in
+        # this repo" as a fact.
+        if rel in defining or _is_vendored(rel):
+            continue
         scanned += 1
         if scanned > MAX_SCANNED_FILES:
+            exhausted = True
             break
-        rel = str(path.relative_to(repo))
-        if rel in defining or "/.venv/" in f"/{rel}" or rel.startswith(".venv/"):
-            continue
         try:
             text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
@@ -307,7 +333,39 @@ def find_callers(
             bucket = hits[match]
             if rel not in bucket and len(bucket) < MAX_CALLERS_PER_SYMBOL:
                 bucket.append(rel)
-    return {name: tuple(paths) for name, paths in hits.items() if paths}
+    found = {name: tuple(paths) for name, paths in hits.items() if paths}
+    if exhausted:
+        # Surfaced rather than swallowed: an empty result after an exhausted
+        # scan is indistinguishable from a genuine zero, and the reviewer sizes
+        # findings on reachability.
+        found[SCAN_EXHAUSTED] = ()
+    return found
+
+
+def _test_roots(repo: Path, files: Sequence[ChangedFile]) -> list[Path]:
+    """Where this repo keeps tests for the files being changed.
+
+    The repo-root `tests/` is not the only one. `.github/scripts/` keeps its
+    suite in `.github/scripts/tests/` — which is where every CI-lane PR, the
+    most common input this lane sees, puts its tests. Looking only at
+    `repo/tests` returned nothing for those, and `render` then silently dropped
+    both the section and its instruction to check it before calling anything
+    untested. Silently, because an empty section and an absent one look the
+    same to the reviewer.
+
+    So: the root suite, plus a `tests/` directory beside any changed file.
+    """
+    roots: list[Path] = []
+    if (repo / "tests").is_dir():
+        roots.append(repo / "tests")
+    for changed in files:
+        for parent in (repo / changed.path).parents:
+            candidate = parent / "tests"
+            if candidate.is_dir() and candidate not in roots:
+                roots.append(candidate)
+            if parent == repo:
+                break
+    return roots
 
 
 def nearby_tests(repo: Path, files: Iterable[ChangedFile]) -> tuple[str, ...]:
@@ -318,17 +376,22 @@ def nearby_tests(repo: Path, files: Iterable[ChangedFile]) -> tuple[str, ...]:
     among the most expensive false positives available: it is plausible, it is
     tedious to refute, and refuting it is the author's job.
     """
+    # Materialised once: `files` may be a generator, and it is walked twice.
+    changed = list(files)
     modules = {
         Path(f.path).stem
-        for f in files
+        for f in changed
         if f.is_python and not f.is_test and not f.is_deleted
     }
     if not modules:
         return ()
+    candidates: list[Path] = []
+    for root in _test_roots(repo, changed):
+        for path in sorted(root.rglob("test_*.py")):
+            if path not in candidates:
+                candidates.append(path)
     out: list[str] = []
-    for path in (
-        sorted((repo / "tests").rglob("test_*.py")) if (repo / "tests").exists() else []
-    ):
+    for path in candidates:
         rel = str(path.relative_to(repo))
         if Path(rel).stem.removeprefix("test_") in modules:
             out.append(rel)
@@ -420,6 +483,13 @@ def render(pack: Pack, agent: str) -> str:
 
     if pack.gate:
         lines += ["", "## Already blocked by CI — do not restate", "", pack.gate]
+
+    if SCAN_EXHAUSTED in pack.callers:
+        lines += [
+            "",
+            "The caller scan hit its file budget, so the references above are "
+            "incomplete. Do not read a missing reference as proof nothing calls it.",
+        ]
 
     if pack.truncated:
         lines += ["", "## Truncated", ""]

--- a/.github/scripts/sdk_loop_phase.py
+++ b/.github/scripts/sdk_loop_phase.py
@@ -68,6 +68,7 @@ from sdk_loop_common import (
     usage_cost_usd,
     usage_total,
 )
+from sdk_loop_findings import audit_comment
 from sdk_loop_prep import (  # noqa: E402
     OUTCOME_UPDATED,
     PrepResult,
@@ -429,6 +430,36 @@ class ReviewOutcome:
     verdict_url: str = ""
 
 
+def audit_verdict_contract(verdict_comment: dict[str, Any] | None) -> list[str]:
+    """Check the model's own verdict comment against the renderer's contract.
+
+    Step 1 of the pr-loop migration runs `sdk_loop_findings` BEHIND the current
+    playbook: the reviewer still composes and posts the comment, and this
+    reports where that comment differs from what the renderer would have
+    guaranteed. It is the evidence that de-risks handing the renderer the job
+    for real — before anything on the approval path depends on it.
+
+    Deliberately non-fatal, and deliberately not a byte comparison. The comment
+    carries model prose no renderer reproduces, so only the part with one
+    correct answer is checked: the markers, the verdict token, and the
+    empty-Findings invariant. Failing a round on a diagnostic would make the
+    measurement cost a review.
+
+    Returns the violations so a caller can assert on them; the phase only
+    prints.
+    """
+    if verdict_comment is None:
+        return []
+    problems = audit_comment(verdict_comment.get("body") or "")
+    if not problems:
+        print("verdict contract: clean")
+        return []
+    print(f"::warning::verdict contract: {len(problems)} violation(s)")
+    for problem in problems:
+        print(f"  - {problem}")
+    return problems
+
+
 def interpret_review(
     result: AgentResult,
     verdict_comment: dict[str, Any] | None,
@@ -773,11 +804,11 @@ def main(argv: list[str] | None = None) -> int:
             ).stdout
             or "[]"
         )
-        outcome = interpret_review(
-            result,
-            newest_verdict(comments, answers_trigger=os.environ.get("COMMENT_ID")),
-            state.live,
+        verdict_comment = newest_verdict(
+            comments, answers_trigger=os.environ.get("COMMENT_ID")
         )
+        outcome = interpret_review(result, verdict_comment, state.live)
+        audit_verdict_contract(verdict_comment)
         counts = opencode_usage(workspace)
         usage, cost = format_usage(counts), usage_total(counts)
         usd = usage_cost_usd(counts, REVIEW_MODEL)

--- a/.github/scripts/sdk_loop_redgreen.py
+++ b/.github/scripts/sdk_loop_redgreen.py
@@ -1,0 +1,291 @@
+"""Did this PR's tests ever fail?
+
+A test written alongside a fix proves nothing unless it would have failed
+without the fix. That is the whole of red-green, and it is the one question
+about test quality with a deterministic answer: take the tests this PR adds or
+changes, run them against the *base* revision of the source, and see which ones
+pass anyway. The ones that pass never captured the change. They are decoration,
+and decoration is worse than an absent test because it buys confidence nobody
+checked.
+
+This matters more, not less, when the tests were written by a model. The
+literature on LLM-authored tests is blunt: generated properties are frequently
+trivial ("returns a value of the right type") or simply false. Meta drives its
+generation loop with a mutation score for exactly this reason. Mutation testing
+is the stronger instrument and it is also minutes per run; red-green answers the
+sharper question — *did this test capture THIS change* — for one checkout and
+one test run, which is what fits inside a review budget.
+
+## The result classes, and why ERROR is a pass
+
+Running new tests against old source has three interesting outcomes:
+
+* **FAILED** — the test captured the change. This is the good case, and the
+  point of the exercise.
+* **ERROR / collection failure** — the test could not even import against the
+  old source, because it references something this PR introduced. That is red
+  in the strongest possible sense and counts as captured. Treating a collection
+  error as "inconclusive" would mark every test of a new module as suspect,
+  which is precisely backwards.
+* **PASSED** — the test holds with or without the change. It is not a
+  regression test for this PR. It may still be a perfectly good test of
+  something else, which is why this is reported and never blocks.
+
+## Why it never blocks
+
+There are legitimate green-on-base tests: a test that documents existing
+behaviour the PR must preserve, a refactor with no behavioural delta, a test
+backfilling coverage of old code. A gate here would punish all three. The number
+is reported, the reviewer reads it as a signal, and a human decides.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable, Protocol, Sequence
+
+#: Tests carried into one verification run. A PR that changes more test
+#: functions than this is better served by the reviewer reading them than by a
+#: long machine list, and the cap keeps the run inside the review budget.
+MAX_TESTS = 60
+
+CAPTURED = "captured"
+NOT_CAPTURED = "not_captured"
+INCONCLUSIVE = "inconclusive"
+
+
+@dataclass(frozen=True)
+class TestRef:
+    """One test function this PR adds or changes."""
+
+    path: str
+    name: str
+
+    @property
+    def node_id(self) -> str:
+        return f"{self.path}::{self.name}"
+
+
+@dataclass(frozen=True)
+class Outcome:
+    test: TestRef
+    status: str
+    detail: str = ""
+
+
+@dataclass
+class Report:
+    outcomes: list[Outcome] = field(default_factory=list)
+    skipped_reason: str = ""
+
+    @property
+    def captured(self) -> list[Outcome]:
+        return [o for o in self.outcomes if o.status == CAPTURED]
+
+    @property
+    def not_captured(self) -> list[Outcome]:
+        return [o for o in self.outcomes if o.status == NOT_CAPTURED]
+
+    @property
+    def rate(self) -> float | None:
+        """Share of examined tests that actually failed against base.
+
+        None when nothing was examined — distinct from 0.0, which means every
+        test examined passed on the old source. Collapsing the two would report
+        a PR with no test changes as having the worst possible score.
+        """
+        graded = [o for o in self.outcomes if o.status in (CAPTURED, NOT_CAPTURED)]
+        if not graded:
+            return None
+        return len([o for o in graded if o.status == CAPTURED]) / len(graded)
+
+
+class CommandRunner(Protocol):
+    def __call__(
+        self, args: Sequence[str], cwd: Path
+    ) -> subprocess.CompletedProcess: ...
+
+
+def _run(args: Sequence[str], cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=False)
+
+
+# --------------------------------------------------------------------------
+# Which tests to examine
+# --------------------------------------------------------------------------
+
+
+def changed_test_functions(repo: Path, files: Iterable) -> tuple[TestRef, ...]:
+    """Test functions containing at least one line this PR added.
+
+    Function-level rather than file-level on purpose. A PR that appends one test
+    to a 900-line file has changed one test, and re-running the other forty
+    against base would report a pile of green-on-base results that say nothing
+    about this change — noise that would bury the one row that matters.
+    """
+    refs: list[TestRef] = []
+    for changed in files:
+        if changed.is_deleted or not changed.is_test or not changed.is_python:
+            continue
+        if not changed.added:
+            continue
+        try:
+            tree = ast.parse((repo / changed.path).read_text(encoding="utf-8"))
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+        added = set(changed.added)
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not node.name.startswith("test"):
+                continue
+            end = getattr(node, "end_lineno", node.lineno) or node.lineno
+            if any(node.lineno <= line <= end for line in added):
+                refs.append(TestRef(path=changed.path, name=node.name))
+    return tuple(refs[:MAX_TESTS])
+
+
+# --------------------------------------------------------------------------
+# Running them against the old source
+# --------------------------------------------------------------------------
+
+_RESULT = re.compile(
+    r"^(?P<node>\S+::\S+)\s+(?P<status>PASSED|FAILED|ERROR|SKIPPED)", re.M
+)
+
+
+def parse_pytest_report(stdout: str) -> dict[str, str]:
+    """`pytest -v` node id -> status.
+
+    Parsed from the verbose line rather than from the exit code, because the run
+    is expected to fail: a non-zero exit is the *success* condition here, and a
+    caller keying on it would invert the entire result.
+    """
+    return {m.group("node"): m.group("status") for m in _RESULT.finditer(stdout)}
+
+
+def classify(status: str | None) -> tuple[str, str]:
+    """One pytest status -> what it says about the test.
+
+    ERROR is `captured`, deliberately. A test that cannot import against the old
+    source references something this PR introduced, which is red in the
+    strongest sense available. Reading it as inconclusive would mark every test
+    of a new module as suspect — exactly backwards.
+    """
+    if status == "FAILED":
+        return CAPTURED, "failed against base — it captures this change"
+    if status == "ERROR":
+        return CAPTURED, "could not run against base — it references new code"
+    if status == "PASSED":
+        return NOT_CAPTURED, "passes against base — it does not capture this change"
+    if status == "SKIPPED":
+        return INCONCLUSIVE, "skipped against base"
+    return INCONCLUSIVE, "no result reported against base"
+
+
+def verify(
+    *,
+    repo: Path,
+    base_ref: str,
+    tests: Sequence[TestRef],
+    workdir: Path,
+    runner: CommandRunner = _run,
+    copy_file: Callable[[Path, Path], None] | None = None,
+) -> Report:
+    """Run `tests` against `base_ref`'s source and report what each proves.
+
+    The base tree is materialised in a throwaway location and the PR's *test*
+    files are overlaid on it. Overlaying only the test files is the whole trick:
+    keeping the old source and taking the new tests is exactly the state the
+    author was in before they wrote the fix.
+
+    Nothing is stashed and the working tree is never touched — a stash here
+    would be shared with every other checkout on the machine.
+    """
+    report = Report()
+    if not tests:
+        report.skipped_reason = "no test functions added or changed in this PR"
+        return report
+
+    created = runner(
+        ["git", "worktree", "add", "--detach", str(workdir), base_ref], repo
+    )
+    if created.returncode != 0:
+        report.skipped_reason = (
+            f"could not materialise base {base_ref}: {created.stderr.strip()[:200]}"
+        )
+        return report
+
+    try:
+        copier = copy_file or _copy
+        for path in sorted({t.path for t in tests}):
+            source = repo / path
+            target = workdir / path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            copier(source, target)
+
+        result = runner(
+            [
+                "uv",
+                "run",
+                "pytest",
+                "-v",
+                "--no-header",
+                "-p",
+                "no:randomly",
+                *sorted({t.node_id for t in tests}),
+            ],
+            workdir,
+        )
+        statuses = parse_pytest_report(result.stdout)
+        for test in tests:
+            status, detail = classify(statuses.get(test.node_id))
+            report.outcomes.append(Outcome(test=test, status=status, detail=detail))
+    finally:
+        runner(["git", "worktree", "remove", "--force", str(workdir)], repo)
+    return report
+
+
+def _copy(source: Path, target: Path) -> None:
+    target.write_bytes(source.read_bytes())
+
+
+# --------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------
+
+
+def render(report: Report) -> str:
+    """The advisory section for the review summary.
+
+    Phrased as a question to the author rather than a verdict, because there are
+    legitimate reasons a test passes against base — documenting behaviour the PR
+    must preserve, a refactor with no behavioural delta, backfilled coverage of
+    old code. The number informs; a human decides.
+    """
+    if report.skipped_reason:
+        return f"**Red-green:** not run — {report.skipped_reason}."
+
+    rate = report.rate
+    if rate is None:
+        return "**Red-green:** no gradeable result."
+
+    lines = [
+        f"**Red-green:** {len(report.captured)}/{len(report.captured) + len(report.not_captured)}"
+        f" of this PR's new tests fail against the base revision ({rate:.0%})."
+    ]
+    if report.not_captured:
+        lines.append("")
+        lines.append(
+            "These pass with or without the change, so they are not regression "
+            "tests for it. That can be deliberate — documenting behaviour the "
+            "change must preserve, or backfilling old coverage — but if one was "
+            "meant to capture this fix, it does not:"
+        )
+        lines.append("")
+        lines += [f"- `{o.test.node_id}`" for o in report.not_captured]
+    return "\n".join(lines)

--- a/.github/scripts/sdk_loop_routing.py
+++ b/.github/scripts/sdk_loop_routing.py
@@ -1,0 +1,139 @@
+"""Who reviews this PR, and how deep — owned by this lane.
+
+The routing used until now lived as a markdown table in the *other* lane's
+playbook, mirrored into a Python dict, with a drift check parsing the markdown
+to keep the two in step. That arrangement made `pr-review/ORCHESTRATION.md` the
+author of this lane's behaviour: restructuring or retiring it would silently
+change who reviews what, and a redesign cannot claim to have replaced a document
+it still takes instructions from.
+
+`agents.yaml` is this lane's own copy of that decision. The old table is left
+alone and continues to govern the sandbox lane.
+
+The scope buckets survive the move because they encode real knowledge about this
+repository that no principle replaces. `depth` is new: the old table routed on
+scope alone, so a 40-line change and a 4,000-line change in the same directory
+drew an identical review. See the data file for the inspection numbers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_PATH = (
+    Path(__file__).resolve().parents[2] / ".mothership/pr-loop/data/agents.yaml"
+)
+
+#: Conditions an `also` entry may carry. Anything else is a typo that would
+#: silently never fire, so the loader refuses it rather than dispatching one
+#: specialist fewer than intended for the rest of the lane's life.
+CONDITIONS = frozenset({"always", "when_touches_config", "when_touches_conformance"})
+
+SINGLE_PASS = "single_pass"
+PER_MODULE = "per_module"
+MODES = frozenset({SINGLE_PASS, PER_MODULE})
+
+
+class RoutingError(ValueError):
+    """The routing data is malformed or incomplete."""
+
+
+@dataclass(frozen=True)
+class Route:
+    scope: str
+    agents: tuple[str, ...]
+    also: dict[str, str]
+
+    def resolve(
+        self, *, touches_config: bool, touches_conformance: bool
+    ) -> tuple[str, ...]:
+        """The specialists to dispatch, in a stable order.
+
+        Order is `agents` then `also`, deduplicated, because the dispatch order
+        shows up in logs and a set would make it vary between runs for no
+        reason.
+        """
+        out = list(self.agents)
+        for name, condition in self.also.items():
+            fires = (
+                condition == "always"
+                or (condition == "when_touches_config" and touches_config)
+                or (condition == "when_touches_conformance" and touches_conformance)
+            )
+            if fires and name not in out:
+                out.append(name)
+        return tuple(out)
+
+
+@dataclass(frozen=True)
+class Depth:
+    max_changed_lines: int | None
+    mode: str
+
+
+@dataclass(frozen=True)
+class Routing:
+    routes: dict[str, Route]
+    depth: tuple[Depth, ...]
+
+    def route(self, scope: str) -> Route:
+        try:
+            return self.routes[scope]
+        except KeyError:
+            raise RoutingError(
+                f"no route for scope {scope!r}. A scope the classifier can emit "
+                "but the routing does not cover dispatches nobody and returns a "
+                "verdict over an unreviewed diff."
+            ) from None
+
+    def mode_for(self, changed_lines: int) -> str:
+        """First rule whose ceiling the diff fits under wins."""
+        for rule in self.depth:
+            if (
+                rule.max_changed_lines is None
+                or changed_lines <= rule.max_changed_lines
+            ):
+                return rule.mode
+        raise RoutingError("depth ladder has no catch-all rule")
+
+
+def load_routing(path: Path | str | None = None) -> Routing:
+    raw: dict[str, Any] = (
+        yaml.safe_load(Path(path or DEFAULT_PATH).read_text(encoding="utf-8")) or {}
+    )
+
+    routes: dict[str, Route] = {}
+    for scope, entry in (raw.get("routes") or {}).items():
+        also = entry.get("also") or {}
+        for name, condition in also.items():
+            if condition not in CONDITIONS:
+                raise RoutingError(
+                    f"{scope}: `also.{name}` has condition {condition!r}, which is "
+                    f"not one of {sorted(CONDITIONS)} — it would never fire."
+                )
+        if not (entry.get("why") or "").strip():
+            raise RoutingError(
+                f"{scope}: every route states why it dispatches what it does. A "
+                "route nobody can justify is one nobody can safely change."
+            )
+        routes[scope] = Route(
+            scope=scope, agents=tuple(entry.get("agents") or ()), also=dict(also)
+        )
+
+    depth: list[Depth] = []
+    for rule in raw.get("depth") or ():
+        mode = rule.get("mode")
+        if mode not in MODES:
+            raise RoutingError(f"depth mode {mode!r} is not one of {sorted(MODES)}")
+        depth.append(Depth(max_changed_lines=rule.get("max_changed_lines"), mode=mode))
+    if not depth or depth[-1].max_changed_lines is not None:
+        raise RoutingError(
+            "the depth ladder needs a final rule with max_changed_lines: null — "
+            "without it a large enough diff matches nothing and gets no review."
+        )
+
+    return Routing(routes=routes, depth=tuple(depth))

--- a/.github/scripts/tests/test_pr_loop_agents.py
+++ b/.github/scripts/tests/test_pr_loop_agents.py
@@ -1,0 +1,280 @@
+"""The specialist briefs, held to the contract the runner actually enforces.
+
+Every failure guarded here is silent at review time. A brief that teaches a
+field the comment handler rejects produces a 422 mid-submission; one that
+teaches a severity spelling outside the vocabulary fails the round; one that
+points at the old corpus buys back the orientation turns the redesign exists to
+remove. None of these announce themselves — the review just costs more, or ends
+without a verdict.
+
+The briefs are deliberately domain-only. What counts as a finding, how nits
+converge, how classes are swept, what the output looks like and how severity is
+calibrated all live in `REVIEW.md`, which every specialist already holds. A
+brief that restates any of it creates a second copy to keep in sync, and the
+inherited corpus is a standing demonstration of where that ends: seven briefs
+each carrying their own JSON example, three of which emit fields the poster then
+has to strip.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from sdk_loop_common import PHASE2_AGENTS  # noqa: E402
+from sdk_loop_findings import FINDING_FIELDS, load_severity  # noqa: E402
+from sdk_loop_routing import RoutingError, load_routing  # noqa: E402
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1]
+REPO = pathlib.Path(__file__).resolve().parents[3]
+AGENTS = REPO / ".mothership/pr-loop/agents"
+ROUTING_DATA = REPO / ".mothership/pr-loop/data/agents.yaml"
+
+#: All seven together. A review reads one to four of them, so this is a ceiling
+#: on the whole set rather than a per-file budget — and it is set just above
+#: today's size so that growth is a decision somebody makes, not an accretion.
+TOTAL_CHAR_CEILING = 14_000
+
+
+def _briefs() -> dict[str, str]:
+    return {p.stem: p.read_text(encoding="utf-8") for p in sorted(AGENTS.glob("*.md"))}
+
+
+def test_every_dispatchable_agent_has_a_brief() -> None:
+    """A registered agent with no brief is dispatched with no domain at all —
+    it reviews, plausibly, and covers nothing in particular."""
+    missing = sorted(set(PHASE2_AGENTS) - set(_briefs()))
+    assert not missing, f"agents registered for dispatch with no brief: {missing}"
+
+
+def test_no_brief_is_orphaned() -> None:
+    """A brief nothing dispatches is dead text that still has to be maintained,
+    and its absence from every review is invisible."""
+    orphaned = sorted(set(_briefs()) - set(PHASE2_AGENTS))
+    assert not orphaned, f"briefs no scope dispatches: {orphaned}"
+
+
+@pytest.mark.parametrize("name", sorted(_briefs()))
+def test_no_brief_points_at_the_old_corpus(name: str) -> None:
+    """The redesign's central claim is that the reviewer's first turn already
+    holds everything it needs. One pointer into the old corpus reintroduces the
+    orientation turns — and prose prohibition demonstrably does not work here,
+    which is why the fix is to never mention the files at all."""
+    text = _briefs()[name]
+    for forbidden in (
+        "ORCHESTRATION.md",
+        "severity-rubric.yaml",
+        "retro-log.md",
+        "review-policy.md",
+        "review.yaml",
+        "references/",
+        "pr-review/",
+    ):
+        assert forbidden not in text, f"{name}.md points at {forbidden}"
+
+
+@pytest.mark.parametrize("name", sorted(_briefs()))
+def test_no_brief_teaches_a_severity_outside_the_vocabulary(name: str) -> None:
+    """`severity.yaml` documents three competing spellings in the inherited
+    corpus and a fourth (`IMPORTANT`) that belongs to none of them. The runner
+    fails the round on an unmapped severity rather than reinterpreting it, so a
+    brief teaching the wrong word costs a whole review."""
+    text = _briefs()[name]
+    valid = set(load_severity().display)
+    for stale in ("IMPORTANT", "Critical**", "Minor", "Nit-tier"):
+        assert stale not in text, f"{name}.md teaches the stale severity {stale!r}"
+    # Any all-caps token that looks like a severity must actually be one.
+    for word in ("BLOCKING", "CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"):
+        if word in text:
+            assert word in valid, f"{name}.md uses {word}, absent from severity.yaml"
+
+
+@pytest.mark.parametrize("name", sorted(_briefs()))
+def test_no_brief_teaches_a_field_the_handler_rejects(name: str) -> None:
+    """Unknown fields 422 the inline-comment request. Three of the inherited
+    briefs emit `scope`, `domain_tag` and `guardrail`, which the poster then has
+    to strip — a brief should not be able to teach a payload that must be undone."""
+    text = _briefs()[name]
+    for stripped in ("domain_tag", "escalate_to_jira", "guardrail:"):
+        assert (
+            stripped not in text
+        ), f"{name}.md teaches the rejected field {stripped!r}"
+    for line in text.splitlines():
+        if line.strip().startswith('"') and '":' in line:
+            key = line.strip().split('"')[1]
+            assert key in FINDING_FIELDS, f"{name}.md emits unknown field {key!r}"
+
+
+@pytest.mark.parametrize("name", sorted(_briefs()))
+def test_no_brief_restates_the_shared_contract(name: str) -> None:
+    """Domain only. The shared judgement contract is in REVIEW.md, which every
+    specialist holds; a second copy here is a second thing to keep in sync, and
+    it is charged to context on every dispatch."""
+    text = _briefs()[name].lower()
+    for duplicated in (
+        "```json",
+        "confidence floor",
+        "reviewed_files",
+        "ready_to_merge",
+        "pack_id",
+    ):
+        assert duplicated not in text, (
+            f"{name}.md restates the shared contract ({duplicated!r}). "
+            "That belongs in REVIEW.md, which every specialist already holds."
+        )
+
+
+def test_the_brief_set_stays_small() -> None:
+    """Context is the product. The inherited briefs total ~33 KB; this set
+    exists to be a fraction of that, and a ceiling is the only thing that stops
+    it growing back one reasonable paragraph at a time."""
+    total = sum(len(t) for t in _briefs().values())
+    assert total <= TOTAL_CHAR_CEILING, (
+        f"the brief set is {total} chars, over the {TOTAL_CHAR_CEILING} ceiling. "
+        "Cut, or move the material to the runner — do not raise the ceiling casually."
+    )
+
+
+@pytest.mark.parametrize("name", sorted(_briefs()))
+def test_every_brief_states_what_earns_a_finding(name: str) -> None:
+    """The domain half of the four tests. A brief that lists what to look for
+    without saying where the bar sits produces exactly the observation-shaped
+    output the resolve loop cannot terminate on."""
+    text = _briefs()[name].lower()
+    assert (
+        "what earns a finding" in text or "how to answer" in text
+    ), f"{name}.md never says where its bar sits"
+
+
+# ---------------------------------------------------------------------------
+# Routing — owned by this lane, not mirrored from the other one
+# ---------------------------------------------------------------------------
+
+
+def _emitted_scopes() -> set[str]:
+    """Every scope `classify_scope` can return, read from its own source.
+
+    Parsed rather than enumerated by hand: the failure this guards is somebody
+    adding a scope to the classifier and not to the routing, and a hand-written
+    list here would be updated in the same commit that forgets the routing.
+    """
+    source = pathlib.Path(SCRIPTS / "sdk_loop_common.py").read_text(encoding="utf-8")
+    body = source.split("def classify_scope")[1].split("\ndef ")[0]
+    return set(re.findall(r'return "([a-z-]+)"', body))
+
+
+def test_every_scope_the_classifier_emits_has_a_route() -> None:
+    """A scope with no route dispatches nobody and still returns a verdict —
+    an approval over a diff nothing read."""
+    routing = load_routing(ROUTING_DATA)
+    missing = sorted(_emitted_scopes() - set(routing.routes))
+    assert not missing, f"scopes the classifier emits with no route: {missing}"
+
+
+def test_every_routed_agent_has_a_brief() -> None:
+    """The other half of the same wire: a route naming an agent with no brief
+    dispatches a specialist that has no domain."""
+    routing = load_routing(ROUTING_DATA)
+    named = {a for r in routing.routes.values() for a in (*r.agents, *r.also)}
+    missing = sorted(named - set(_briefs()))
+    assert not missing, f"routes dispatch agents with no brief: {missing}"
+
+
+def test_the_routing_never_reads_the_other_lane(monkeypatch) -> None:
+    """The point of moving it, asserted as behaviour rather than as prose.
+
+    Both modules *mention* the old playbook in their docstrings — explaining
+    why the routing moved is the reason they exist. What must not happen is a
+    read: while `SCOPE_AGENTS` was asserted against a table in
+    `pr-review/ORCHESTRATION.md`, that file authored this lane's behaviour, and
+    retiring or restructuring it would silently change who reviews what.
+
+    So: make every read of anything under `pr-review/` explode, then load the
+    routing. If it survives, the dependency is genuinely gone.
+    """
+    real_read_text = pathlib.Path.read_text
+
+    def guarded(self, *args, **kwargs):
+        if "pr-review" in str(self):
+            raise AssertionError(f"the routing read the other lane: {self}")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "read_text", guarded)
+    routing = load_routing(ROUTING_DATA)
+    assert routing.routes, "loaded nothing"
+    assert routing.route("full").resolve(
+        touches_config=False, touches_conformance=False
+    )
+
+
+def test_docs_only_dispatches_nobody() -> None:
+    """Prose findings on prose are the purest effective false positive:
+    correct, unactioned, and corrosive to trust in the rest of the review."""
+    routing = load_routing(ROUTING_DATA)
+    resolved = routing.route("docs-only").resolve(
+        touches_config=False, touches_conformance=False
+    )
+    assert resolved == ()
+
+
+def test_conditional_specialists_fire_only_on_their_condition() -> None:
+    routing = load_routing(ROUTING_DATA)
+    full = routing.route("full")
+    plain = full.resolve(touches_config=False, touches_conformance=False)
+    with_config = full.resolve(touches_config=True, touches_conformance=False)
+    assert "reachability" in plain, "an `always` condition did not fire"
+    assert "ci-config" not in plain
+    assert "ci-config" in with_config
+    assert with_config.index("correctness") < with_config.index(
+        "ci-config"
+    ), "dispatch order is not stable — it shows up in logs"
+
+
+def test_an_unknown_condition_fails_to_load(tmp_path) -> None:
+    """A typo'd condition would never fire, dispatching one specialist fewer
+    for the rest of the lane's life without anything going red."""
+    bad = tmp_path / "agents.yaml"
+    bad.write_text(
+        "version: 1\n"
+        "routes:\n"
+        "  full:\n"
+        "    agents: [correctness]\n"
+        "    also:\n"
+        "      reachability: when_the_moon_is_full\n"
+        "    why: because\n"
+        "depth:\n  - max_changed_lines: null\n    mode: single_pass\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(RoutingError, match="never fire"):
+        load_routing(bad)
+
+
+def test_the_depth_ladder_needs_a_catch_all(tmp_path) -> None:
+    """Without one, a large enough diff matches no rule and gets no review."""
+    bad = tmp_path / "agents.yaml"
+    bad.write_text(
+        "version: 1\nroutes: {}\n"
+        "depth:\n  - max_changed_lines: 400\n    mode: single_pass\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(RoutingError, match="catch-all|max_changed_lines: null"):
+        load_routing(bad)
+
+
+def test_a_large_diff_is_split_rather_than_reviewed_in_one_pass() -> None:
+    """The dimension the inherited table did not have.
+
+    Inspection research puts defect detection at 70-90% for 200-400 changed
+    lines and 28% past 1,000. A 4,000-line diff and a 40-line diff in the same
+    directory used to draw an identical review; the large one came back just as
+    confident and had read far less of it.
+    """
+    routing = load_routing(ROUTING_DATA)
+    assert routing.mode_for(120) == "single_pass"
+    assert routing.mode_for(400) == "single_pass"
+    assert routing.mode_for(3000) == "per_module"

--- a/.github/scripts/tests/test_pr_loop_pack.py
+++ b/.github/scripts/tests/test_pr_loop_pack.py
@@ -315,3 +315,93 @@ def test_a_deleted_file_still_counts_its_removed_lines() -> None:
     pack = build_pack(repo=REPO, diff=diff, scope="full", routing=routing)
     assert pack.changed_lines == 900
     assert pack.mode == "per_module", "a large deletion was sized as a small change"
+
+
+def test_tests_beside_the_changed_file_are_found_not_just_the_root_suite(
+    tmp_path,
+) -> None:
+    """`.github/scripts/` keeps its suite in `.github/scripts/tests/` — where
+    every CI-lane PR, the most common input this lane sees, puts its tests.
+    Looking only at `repo/tests` returned nothing for those, and `render` then
+    dropped both the section and its instruction to check it before calling
+    anything untested. Silently: an empty section and an absent one look the
+    same to the reviewer.
+    """
+    scripts = tmp_path / ".github" / "scripts"
+    (scripts / "tests").mkdir(parents=True)
+    (scripts / "widget.py").write_text("x = 1\n", encoding="utf-8")
+    (scripts / "tests" / "test_widget.py").write_text(
+        "import pytest\n", encoding="utf-8"
+    )
+
+    changed = parse_diff(
+        "diff --git a/.github/scripts/widget.py b/.github/scripts/widget.py\n"
+        "--- a/.github/scripts/widget.py\n+++ b/.github/scripts/widget.py\n"
+        "@@ -0,0 +1 @@\n+x = 1\n"
+    )
+    found = nearby_tests(tmp_path, changed)
+    assert ".github/scripts/tests/test_widget.py" in found
+
+
+def test_a_generator_of_changed_files_is_not_consumed_twice(tmp_path) -> None:
+    """`files` is typed Iterable and is now walked twice — once for the test
+    roots and once for the module names. A generator would be empty on the
+    second pass and silently return no tests."""
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "app.py").write_text("x = 1\n", encoding="utf-8")
+    (tmp_path / "tests" / "test_app.py").write_text("import pytest\n", encoding="utf-8")
+    changed = parse_diff(
+        "diff --git a/app.py b/app.py\n--- a/app.py\n+++ b/app.py\n"
+        "@@ -0,0 +1 @@\n+x = 1\n"
+    )
+    assert nearby_tests(tmp_path, iter(changed)) == ("tests/test_app.py",)
+
+
+def test_vendored_directories_do_not_consume_the_scan_budget(tmp_path) -> None:
+    """`sorted()` puts dot-prefixed directories first, and the budget used to be
+    charged before the skip — so a checked-out `.venv` could exhaust the cap
+    before one source file was read. `find_callers` then returned {} and the
+    pack printed "no references found in this repo" as a fact.
+    """
+    (tmp_path / "a.py").write_text("def target():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "caller.py").write_text("target()\n", encoding="utf-8")
+    venv = tmp_path / ".venv" / "lib"
+    venv.mkdir(parents=True)
+    for i in range(pack_mod.MAX_SCANNED_FILES + 50):
+        (venv / f"v{i}.py").write_text("pass\n", encoding="utf-8")
+
+    changed = parse_diff(
+        "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -0,0 +1,2 @@\n"
+        "+def target():\n+    return 1\n"
+    )
+    callers = find_callers(tmp_path, touched_symbols(tmp_path, changed))
+    assert callers.get("target") == (
+        "caller.py",
+    ), "the vendored tree ate the budget before the real caller was reached"
+    assert pack_mod.SCAN_EXHAUSTED not in callers
+
+
+def test_an_exhausted_scan_is_stated_not_reported_as_zero(tmp_path) -> None:
+    """An empty result after a cut-short scan is indistinguishable from a
+    genuine zero, and the reviewer sizes findings on reachability."""
+    (tmp_path / "a.py").write_text("def target():\n    return 1\n", encoding="utf-8")
+    for i in range(5):
+        (tmp_path / f"f{i}.py").write_text("pass\n", encoding="utf-8")
+    changed = parse_diff(
+        "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -0,0 +1,2 @@\n"
+        "+def target():\n+    return 1\n"
+    )
+    symbols = touched_symbols(tmp_path, changed)
+
+    original = pack_mod.MAX_SCANNED_FILES
+    pack_mod.MAX_SCANNED_FILES = 2
+    try:
+        callers = find_callers(tmp_path, symbols)
+    finally:
+        pack_mod.MAX_SCANNED_FILES = original
+
+    assert pack_mod.SCAN_EXHAUSTED in callers
+    routing = load_routing(ROUTING_DATA)
+    pack = build_pack(repo=REPO, diff=DIFF, scope="full", routing=routing)
+    pack.callers = callers
+    assert "caller scan hit its file budget" in render(pack, "correctness")

--- a/.github/scripts/tests/test_pr_loop_pack.py
+++ b/.github/scripts/tests/test_pr_loop_pack.py
@@ -1,0 +1,317 @@
+"""The reviewer's first turn, assembled rather than discovered.
+
+The failures guarded here are the ones that make a review quietly worse rather
+than visibly broken: a symbol attributed to the wrong function, so the reviewer
+quotes the wrong code as evidence; a caller list silently truncated, so a
+blocker is sized as a nit; a pack that grows until the reviewer comments on code
+the PR did not touch.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import textwrap
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import sdk_loop_pack as pack_mod  # noqa: E402
+from sdk_loop_pack import (  # noqa: E402
+    build_pack,
+    find_callers,
+    nearby_tests,
+    parse_diff,
+    render,
+    touched_symbols,
+)
+from sdk_loop_routing import load_routing  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+ROUTING_DATA = REPO / ".mothership/pr-loop/data/agents.yaml"
+
+
+DIFF = """\
+diff --git a/application_sdk/app/base.py b/application_sdk/app/base.py
+--- a/application_sdk/app/base.py
++++ b/application_sdk/app/base.py
+@@ -10,6 +10,8 @@ class App:
+     def existing(self):
+         return 1
++    def added_method(self):
++        return 2
+@@ -40,3 +42,4 @@ def module_level():
+     pass
++CONSTANT = 3
+diff --git a/tests/unit/test_base.py b/tests/unit/test_base.py
+--- a/tests/unit/test_base.py
++++ b/tests/unit/test_base.py
+@@ -1,2 +1,3 @@
+ import pytest
++# new line
+"""
+
+
+# ---------------------------------------------------------------------------
+# Diff parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_diff_reports_files_and_added_line_numbers() -> None:
+    files = parse_diff(DIFF)
+    by_path = {f.path: f for f in files}
+    assert set(by_path) == {"application_sdk/app/base.py", "tests/unit/test_base.py"}
+    # 12,13 from the first hunk; the second starts at +42 and its one context
+    # line pushes the addition to 43. Asserted as literals so a regression in
+    # hunk-header arithmetic shows up as a wrong line, not a plausible one.
+    assert by_path["application_sdk/app/base.py"].added == (12, 13, 43)
+    assert by_path["tests/unit/test_base.py"].is_test
+
+
+def test_line_numbers_come_from_hunk_headers_not_a_running_count() -> None:
+    """A counted offset drifts silently on a truncated patch, and the reviewer
+    then gets symbol attributions that are subtly wrong — worse than none,
+    because it quotes the wrong code as evidence."""
+    truncated = DIFF[: DIFF.index("@@ -40")]
+    files = parse_diff(truncated)
+    assert files[0].added == (12, 13)
+
+
+def test_a_deleted_file_is_marked_not_dropped() -> None:
+    """A deleted file is a fact the reviewer needs — it is how a removed public
+    export looks in a diff — but it has no symbols to resolve."""
+    deleted = textwrap.dedent(
+        """\
+        diff --git a/application_sdk/gone.py b/application_sdk/gone.py
+        --- a/application_sdk/gone.py
+        +++ /dev/null
+        @@ -1,2 +0,0 @@
+        -x = 1
+        """
+    )
+    files = parse_diff(deleted)
+    assert len(files) == 1
+    assert files[0].is_deleted
+
+
+# ---------------------------------------------------------------------------
+# Symbol resolution
+# ---------------------------------------------------------------------------
+
+
+def test_symbols_are_resolved_by_parsing_not_by_hunk_hint(tmp_path) -> None:
+    """Git's `@@` function hint reports the nearest preceding `def` textually,
+    which is wrong for methods and nested functions. Parsing gets the enclosing
+    definition right, and the reviewer inherits it as fact either way."""
+    src = tmp_path / "application_sdk" / "app"
+    src.mkdir(parents=True)
+    (src / "base.py").write_text(
+        textwrap.dedent(
+            """\
+            class App:
+                def existing(self):
+                    return 1
+
+                def added_method(self):
+                    return 2
+
+
+            def module_level():
+                pass
+            """
+        ),
+        encoding="utf-8",
+    )
+    changed = parse_diff(
+        "diff --git a/application_sdk/app/base.py b/application_sdk/app/base.py\n"
+        "--- a/application_sdk/app/base.py\n"
+        "+++ b/application_sdk/app/base.py\n"
+        "@@ -4,0 +5,2 @@\n"
+        "+    def added_method(self):\n"
+        "+        return 2\n"
+    )
+    symbols = touched_symbols(tmp_path, changed)
+    names = {s.qualname for s in symbols}
+    assert "App.added_method" in names, "the enclosing method was not resolved"
+    assert "App.existing" not in names, "an untouched sibling was attributed"
+
+
+def test_a_file_that_does_not_parse_is_skipped_not_guessed(tmp_path) -> None:
+    """Either it is not Python or it is syntactically broken, and in the second
+    case the review has a far louder finding available than a symbol list."""
+    (tmp_path / "broken.py").write_text("def (: oops\n", encoding="utf-8")
+    changed = parse_diff(
+        "diff --git a/broken.py b/broken.py\n--- a/broken.py\n+++ b/broken.py\n"
+        "@@ -0,0 +1 @@\n+def (: oops\n"
+    )
+    assert touched_symbols(tmp_path, changed) == ()
+
+
+def test_the_symbol_list_is_capped_and_keeps_the_specific_ones(tmp_path) -> None:
+    """When the cap bites, a method is worth more than the class holding it."""
+    body = "\n".join(
+        f"class C{i}:\n    def m{i}(self):\n        return {i}\n" for i in range(60)
+    )
+    (tmp_path / "many.py").write_text(body, encoding="utf-8")
+    total_lines = len(body.splitlines())
+    changed = parse_diff(
+        "diff --git a/many.py b/many.py\n--- a/many.py\n+++ b/many.py\n"
+        f"@@ -0,0 +1,{total_lines} @@\n"
+        + "\n".join(f"+{ln}" for ln in body.splitlines())
+    )
+    symbols = touched_symbols(tmp_path, changed)
+    assert len(symbols) == pack_mod.MAX_SYMBOLS
+    assert all("." in s.qualname for s in symbols), "the cap kept classes over methods"
+
+
+# ---------------------------------------------------------------------------
+# Callers — the input severity depends on
+# ---------------------------------------------------------------------------
+
+
+def test_callers_exclude_the_defining_file(tmp_path) -> None:
+    (tmp_path / "a.py").write_text("def target():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("from a import target\ntarget()\n", encoding="utf-8")
+    changed = parse_diff(
+        "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -0,0 +1,2 @@\n"
+        "+def target():\n+    return 1\n"
+    )
+    symbols = touched_symbols(tmp_path, changed)
+    callers = find_callers(tmp_path, symbols)
+    assert callers["target"] == ("b.py",)
+
+
+def test_the_caller_list_is_capped(tmp_path) -> None:
+    """Uncapped this is a search result, and the reviewer does not need to read
+    one to size a finding."""
+    (tmp_path / "a.py").write_text("def target():\n    return 1\n", encoding="utf-8")
+    for i in range(pack_mod.MAX_CALLERS_PER_SYMBOL + 4):
+        (tmp_path / f"c{i}.py").write_text("target()\n", encoding="utf-8")
+    changed = parse_diff(
+        "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -0,0 +1,2 @@\n"
+        "+def target():\n+    return 1\n"
+    )
+    callers = find_callers(tmp_path, touched_symbols(tmp_path, changed))
+    assert len(callers["target"]) == pack_mod.MAX_CALLERS_PER_SYMBOL
+
+
+def test_nearby_tests_are_surfaced_so_untested_is_checkable(tmp_path) -> None:
+    """An unfounded missing-tests finding is among the most expensive false
+    positives available: plausible, tedious to refute, and refuting it is the
+    author's job."""
+    (tmp_path / "application_sdk").mkdir()
+    (tmp_path / "application_sdk" / "storage.py").write_text(
+        "x = 1\n", encoding="utf-8"
+    )
+    tests = tmp_path / "tests" / "unit"
+    tests.mkdir(parents=True)
+    (tests / "test_storage.py").write_text("import pytest\n", encoding="utf-8")
+    (tests / "test_unrelated.py").write_text("import pytest\n", encoding="utf-8")
+    changed = parse_diff(
+        "diff --git a/application_sdk/storage.py b/application_sdk/storage.py\n"
+        "--- a/application_sdk/storage.py\n+++ b/application_sdk/storage.py\n"
+        "@@ -0,0 +1 @@\n+x = 1\n"
+    )
+    found = nearby_tests(tmp_path, changed)
+    assert "tests/unit/test_storage.py" in found
+    assert "tests/unit/test_unrelated.py" not in found
+
+
+# ---------------------------------------------------------------------------
+# Assembly and rendering
+# ---------------------------------------------------------------------------
+
+
+def test_the_pack_routes_and_sizes_itself() -> None:
+    routing = load_routing(ROUTING_DATA)
+    pack = build_pack(repo=REPO, diff=DIFF, scope="full", routing=routing)
+    assert "correctness" in pack.agents
+    assert "reachability" in pack.agents, "an `always` condition did not fire"
+    assert pack.mode == "single_pass"
+
+
+def test_a_large_diff_asks_for_the_split_mode() -> None:
+    big = "diff --git a/application_sdk/x.py b/application_sdk/x.py\n"
+    big += "--- a/application_sdk/x.py\n+++ b/application_sdk/x.py\n@@ -0,0 +1,900 @@\n"
+    big += "\n".join(f"+line{i}" for i in range(900))
+    routing = load_routing(ROUTING_DATA)
+    pack = build_pack(repo=REPO, diff=big, scope="full", routing=routing)
+    assert pack.mode == "per_module"
+    assert "past the size where a single pass finds things" in render(
+        pack, "correctness"
+    )
+
+
+def test_config_only_touches_pull_in_ci_config() -> None:
+    diff = (
+        "diff --git a/.github/workflows/x.yml b/.github/workflows/x.yml\n"
+        "--- a/.github/workflows/x.yml\n+++ b/.github/workflows/x.yml\n"
+        "@@ -0,0 +1 @@\n+on: push\n"
+    )
+    routing = load_routing(ROUTING_DATA)
+    pack = build_pack(repo=REPO, diff=diff, scope="full", routing=routing)
+    assert pack.touches_config
+    assert "ci-config" in pack.agents
+
+
+def test_truncation_is_stated_rather_than_silent() -> None:
+    """A pack that silently truncated lets the reviewer conclude a symbol has no
+    callers when the list was simply cut — turning a blocker into a nit for a
+    reason nobody can see afterwards."""
+    routing = load_routing(ROUTING_DATA)
+    pack = build_pack(repo=REPO, diff=DIFF, scope="full", routing=routing)
+    pack.truncated = ("symbol list capped at 40",)
+    assert "## Truncated" in render(pack, "correctness")
+
+
+def test_the_gate_section_says_not_to_restate_it() -> None:
+    """Restating a blocking CI finding costs a round and tells the author
+    nothing they were not already told."""
+    routing = load_routing(ROUTING_DATA)
+    pack = build_pack(
+        repo=REPO, diff=DIFF, scope="full", routing=routing, gate="- L001 at x.py:3"
+    )
+    rendered = render(pack, "correctness")
+    assert "do not restate" in rendered.lower()
+    assert "L001" in rendered
+
+
+def test_the_reference_caveat_is_stated() -> None:
+    """Name-based resolution is approximate. A reviewer told so will verify a
+    blocker and accept a nit, which is the right allocation of effort."""
+    routing = load_routing(ROUTING_DATA)
+    pack = build_pack(repo=REPO, diff=DIFF, scope="full", routing=routing)
+    if pack.symbols:
+        assert "resolved by name" in render(pack, "correctness")
+
+
+@pytest.mark.parametrize("agent", ["correctness", "quality", "structure"])
+def test_the_pack_names_the_specialist(agent: str) -> None:
+    """`REVIEW.md` says which specialist you are arrives in context. Inferring
+    it costs a turn and can be wrong."""
+    routing = load_routing(ROUTING_DATA)
+    pack = build_pack(repo=REPO, diff=DIFF, scope="full", routing=routing)
+    assert render(pack, agent).startswith(f"You are the {agent} specialist.")
+
+
+def test_a_deleted_file_still_counts_its_removed_lines() -> None:
+    """A deleted file has no `+++ b/…` line, so the path stays unset while its
+    removals are still real changed lines. Counting them as zero would hand a
+    900-line deletion the single-pass depth and review it as if it were small —
+    and a large deletion is exactly where a removed public export hides.
+    """
+    body = "\n".join(f"-line{i}" for i in range(900))
+    diff = (
+        "diff --git a/application_sdk/gone.py b/application_sdk/gone.py\n"
+        "--- a/application_sdk/gone.py\n+++ /dev/null\n@@ -1,900 +0,0 @@\n"
+        + body
+        + "\n"
+    )
+    files = parse_diff(diff)
+    assert files[0].removed_count == 900
+
+    routing = load_routing(ROUTING_DATA)
+    pack = build_pack(repo=REPO, diff=diff, scope="full", routing=routing)
+    assert pack.changed_lines == 900
+    assert pack.mode == "per_module", "a large deletion was sized as a small change"

--- a/.github/scripts/tests/test_redgreen.py
+++ b/.github/scripts/tests/test_redgreen.py
@@ -1,0 +1,301 @@
+"""Red-green: did this PR's tests ever fail?
+
+The verifier's whole value is that its answer is deterministic, so the tests
+here are about the classification rules rather than about pytest. Two of them
+guard inversions that would make the result actively misleading — reading a
+collection error as doubt, and keying on the subprocess exit code when a
+non-zero exit is the *success* condition.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import sdk_loop_redgreen as rg  # noqa: E402
+from sdk_loop_pack import parse_diff  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+HYPOTHESES = REPO / ".mothership/pr-loop/HYPOTHESES.md"
+
+
+def _ref(name: str, path: str = "tests/unit/test_x.py") -> rg.TestRef:
+    return rg.TestRef(path=path, name=name)
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def test_a_failing_test_captured_the_change() -> None:
+    status, _ = rg.classify("FAILED")
+    assert status == rg.CAPTURED
+
+
+def test_a_collection_error_counts_as_captured_not_as_doubt() -> None:
+    """A test that cannot import against the old source references something
+    this PR introduced — red in the strongest sense available. Reading it as
+    inconclusive would mark every test of a new module as suspect, which is
+    exactly backwards and would make the metric useless on the PRs that add the
+    most new code."""
+    status, detail = rg.classify("ERROR")
+    assert status == rg.CAPTURED
+    assert "references new code" in detail
+
+
+def test_a_passing_test_did_not_capture_the_change() -> None:
+    status, detail = rg.classify("PASSED")
+    assert status == rg.NOT_CAPTURED
+    assert "does not capture" in detail
+
+
+@pytest.mark.parametrize("status", ["SKIPPED", None])
+def test_unresolved_statuses_are_inconclusive_not_counted(status) -> None:
+    """Counting a skip as either outcome would move the headline number for a
+    reason that has nothing to do with test quality."""
+    assert rg.classify(status)[0] == rg.INCONCLUSIVE
+
+
+# ---------------------------------------------------------------------------
+# Parsing pytest, without keying on the exit code
+# ---------------------------------------------------------------------------
+
+
+def test_the_report_is_parsed_from_output_not_the_exit_code() -> None:
+    """The run is EXPECTED to fail — a non-zero exit is the success condition
+    here. A caller keying on `returncode` would invert the entire result."""
+    stdout = textwrap.dedent(
+        """\
+        tests/unit/test_x.py::test_a PASSED
+        tests/unit/test_x.py::test_b FAILED
+        tests/unit/test_x.py::test_c ERROR
+        """
+    )
+    parsed = rg.parse_pytest_report(stdout)
+    assert parsed == {
+        "tests/unit/test_x.py::test_a": "PASSED",
+        "tests/unit/test_x.py::test_b": "FAILED",
+        "tests/unit/test_x.py::test_c": "ERROR",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Which tests get examined
+# ---------------------------------------------------------------------------
+
+
+def test_only_test_functions_this_pr_touched_are_examined(tmp_path) -> None:
+    """A PR appending one test to a 900-line file changed one test. Re-running
+    the other forty against base would report a pile of green-on-base results
+    that say nothing about this change, burying the row that matters."""
+    tests_dir = tmp_path / "tests" / "unit"
+    tests_dir.mkdir(parents=True)
+    (tests_dir / "test_x.py").write_text(
+        textwrap.dedent(
+            """\
+            def test_old():
+                assert True
+
+
+            def test_new():
+                assert True
+
+
+            def helper_not_a_test():
+                return 1
+            """
+        ),
+        encoding="utf-8",
+    )
+    changed = parse_diff(
+        "diff --git a/tests/unit/test_x.py b/tests/unit/test_x.py\n"
+        "--- a/tests/unit/test_x.py\n+++ b/tests/unit/test_x.py\n"
+        "@@ -4,0 +5,2 @@\n+def test_new():\n+    assert True\n"
+    )
+    refs = rg.changed_test_functions(tmp_path, changed)
+    names = {r.name for r in refs}
+    assert names == {"test_new"}, f"examined the wrong set: {names}"
+
+
+def test_non_test_files_are_ignored(tmp_path) -> None:
+    (tmp_path / "application_sdk").mkdir()
+    (tmp_path / "application_sdk" / "x.py").write_text(
+        "def test_lookalike():\n    pass\n"
+    )
+    changed = parse_diff(
+        "diff --git a/application_sdk/x.py b/application_sdk/x.py\n"
+        "--- a/application_sdk/x.py\n+++ b/application_sdk/x.py\n"
+        "@@ -0,0 +1,2 @@\n+def test_lookalike():\n+    pass\n"
+    )
+    assert rg.changed_test_functions(tmp_path, changed) == ()
+
+
+# ---------------------------------------------------------------------------
+# The rate, and the distinction that matters
+# ---------------------------------------------------------------------------
+
+
+def test_no_gradeable_tests_reports_none_not_zero() -> None:
+    """0.0 means every test examined passed on the old source. None means none
+    were examined. Collapsing them would report a PR with no test changes as
+    having the worst possible score."""
+    empty = rg.Report()
+    assert empty.rate is None
+
+    all_green = rg.Report(outcomes=[rg.Outcome(_ref("test_a"), rg.NOT_CAPTURED)])
+    assert all_green.rate == 0.0
+
+
+def test_inconclusive_outcomes_do_not_move_the_rate() -> None:
+    report = rg.Report(
+        outcomes=[
+            rg.Outcome(_ref("test_a"), rg.CAPTURED),
+            rg.Outcome(_ref("test_b"), rg.INCONCLUSIVE),
+        ]
+    )
+    assert report.rate == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Running against base
+# ---------------------------------------------------------------------------
+
+
+def test_verify_overlays_only_the_test_files(tmp_path) -> None:
+    """Keeping the old source and taking the new tests is exactly the state the
+    author was in before they wrote the fix. Overlaying anything else would be
+    running the new code against itself."""
+    calls: list[list[str]] = []
+    copied: list[tuple[str, str]] = []
+
+    def runner(args, cwd):
+        calls.append(list(args))
+        if args[:3] == ["git", "worktree", "add"]:
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[0] == "uv":
+            return subprocess.CompletedProcess(
+                args, 1, "tests/unit/test_x.py::test_a FAILED\n", ""
+            )
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    def copy_file(src, dst):
+        copied.append((str(src), str(dst)))
+
+    report = rg.verify(
+        repo=tmp_path,
+        base_ref="abc123",
+        tests=[_ref("test_a")],
+        workdir=tmp_path / "wt",
+        runner=runner,
+        copy_file=copy_file,
+    )
+    assert len(copied) == 1 and copied[0][0].endswith("tests/unit/test_x.py")
+    assert report.rate == 1.0
+    assert any(
+        c[:3] == ["git", "worktree", "remove"] for c in calls
+    ), "the throwaway worktree was not cleaned up"
+
+
+def test_a_base_that_cannot_be_materialised_is_reported_not_guessed(tmp_path) -> None:
+    """Silently reporting zero captured tests because the checkout failed would
+    accuse the author of writing decorative tests on the strength of a git
+    error."""
+
+    def runner(args, cwd):
+        if args[:3] == ["git", "worktree", "add"]:
+            return subprocess.CompletedProcess(args, 128, "", "fatal: bad object")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    report = rg.verify(
+        repo=tmp_path,
+        base_ref="deadbeef",
+        tests=[_ref("test_a")],
+        workdir=tmp_path / "wt",
+        runner=runner,
+    )
+    assert report.rate is None
+    assert "could not materialise" in report.skipped_reason
+
+
+def test_the_worktree_is_cleaned_up_even_when_the_run_raises(tmp_path) -> None:
+    """The runner is shared with every other checkout on this machine; a leaked
+    worktree outlives the review."""
+    removed: list[str] = []
+
+    def runner(args, cwd):
+        if args[:3] == ["git", "worktree", "add"]:
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[:3] == ["git", "worktree", "remove"]:
+            removed.append(args[-1])
+            return subprocess.CompletedProcess(args, 0, "", "")
+        raise RuntimeError("pytest exploded")
+
+    with pytest.raises(RuntimeError):
+        rg.verify(
+            repo=tmp_path,
+            base_ref="abc",
+            tests=[_ref("test_a")],
+            workdir=tmp_path / "wt",
+            runner=runner,
+            copy_file=lambda s, d: None,
+        )
+    assert removed, "the worktree leaked when the run raised"
+
+
+# ---------------------------------------------------------------------------
+# Reporting — advisory, never a verdict
+# ---------------------------------------------------------------------------
+
+
+def test_the_report_asks_rather_than_accuses() -> None:
+    """There are legitimate green-on-base tests: documenting behaviour the
+    change must preserve, a refactor with no behavioural delta, backfilled
+    coverage. A gate would punish all three."""
+    report = rg.Report(
+        outcomes=[
+            rg.Outcome(_ref("test_a"), rg.CAPTURED),
+            rg.Outcome(_ref("test_b"), rg.NOT_CAPTURED),
+        ]
+    )
+    text = rg.render(report)
+    assert "1/2" in text and "50%" in text
+    assert "can be deliberate" in text
+    assert "BLOCK" not in text.upper().replace("BLOCKING", "")
+
+
+def test_a_pr_with_no_test_changes_says_so() -> None:
+    assert "not run" in rg.render(rg.Report(skipped_reason="no test functions added"))
+
+
+# ---------------------------------------------------------------------------
+# The hypotheses brief
+# ---------------------------------------------------------------------------
+
+
+def test_the_hypotheses_brief_demands_the_file_before_the_tests() -> None:
+    """Committing to the list first is what stops the exercise collapsing into
+    tests for the paths already known to pass — the failure mode of every suite
+    written after the code it tests."""
+    text = HYPOTHESES.read_text(encoding="utf-8")
+    assert "before you write any test" in text
+    assert "hypotheses.md" in text
+
+
+def test_the_hypotheses_brief_shows_a_bad_example() -> None:
+    """ "Test that resolve() works" is what this produces without a counterexample
+    to point at."""
+    text = HYPOTHESES.read_text(encoding="utf-8")
+    assert "Not this" in text
+
+
+def test_the_hypotheses_brief_does_not_point_at_the_old_corpus() -> None:
+    text = HYPOTHESES.read_text(encoding="utf-8")
+    for forbidden in ("ORCHESTRATION.md", "pr-review/", "retro-log.md"):
+        assert forbidden not in text

--- a/.github/scripts/tests/test_severity_mapping.py
+++ b/.github/scripts/tests/test_severity_mapping.py
@@ -1,0 +1,127 @@
+"""The severity vocabulary — one emitted set, one displayed set, a total map.
+
+The corpus this lane forked from carries THREE spellings of severity with no
+mapping between them: the payload vocabulary (`BLOCKING`..`INFO`), the
+reference files' `Critical | Important | Minor`, and the verdict template's
+`Critical | Important | Nit`. One brief emits a fourth (`IMPORTANT`). Because
+`sdk_loop_finalize.py` keys only on whether `### Findings` is empty and never
+on a tier name, a mis-spelled tier never failed anything — it just quietly
+produced a finding the verdict had not counted.
+
+These tests exist so that can never be quiet again.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from sdk_loop_findings import SchemaError, load_severity  # noqa: E402
+
+DATA = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / ".mothership/pr-loop/data/severity.yaml"
+)
+RUBRIC = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / ".mothership/pr-review/severity-rubric.yaml"
+)
+
+EMITTED = ("BLOCKING", "CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO")
+
+
+def test_every_emitted_severity_maps() -> None:
+    """Exhaustive over the emitted vocabulary — no tier may be unhandled."""
+    sev = load_severity(DATA)
+    for severity in EMITTED:
+        sev.tier(severity)  # must not raise
+        sev.in_findings(severity)
+        assert sev.floor(severity) > 0
+
+
+@pytest.mark.parametrize("bogus", ["IMPORTANT", "Critical", "Nit", "", "MINOR"])
+def test_an_unmapped_severity_raises(bogus: str) -> None:
+    """A fourth spelling must fail loudly, not pass through.
+
+    `agents/conformance.md` in the inherited corpus emits `"IMPORTANT"`, which
+    belongs to none of the three vocabularies that corpus uses. Rendering it
+    silently is how a finding ends up in the summary that the verdict never
+    counted.
+    """
+    sev = load_severity(DATA)
+    with pytest.raises(SchemaError):
+        sev.tier(bogus)
+
+
+def test_only_blocking_tiers_render_into_findings() -> None:
+    """`### Findings` empty <=> READY_TO_MERGE, so Findings membership blocks.
+
+    LOW and INFO are prose-only on purpose: the resolve loop fixes until the
+    list is empty, so a tier that can never be actioned would wedge it forever.
+    This also matches `calibration.severity_meanings`, which already calls
+    MEDIUM/LOW/INFO "summary body only".
+    """
+    sev = load_severity(DATA)
+    assert [s for s in EMITTED if sev.in_findings(s)] == [
+        "BLOCKING",
+        "CRITICAL",
+        "HIGH",
+        "MEDIUM",
+    ]
+    assert sev.tier("LOW") is None
+    assert sev.tier("INFO") is None
+
+
+def test_tiers_are_exactly_the_rendered_vocabulary() -> None:
+    sev = load_severity(DATA)
+    rendered = {sev.tier(s) for s in EMITTED if sev.in_findings(s)}
+    assert rendered == set(sev.tier_order) == {"Critical", "Important", "Nit"}
+
+
+def test_confidence_floors_are_per_severity_not_flat() -> None:
+    """The regression guarded here is a brief re-introducing a flat floor.
+
+    Six pr-review briefs restate the floor as a flat `>= 0.80` and one as a
+    flat `0.85`, against `severity-rubric.yaml`'s own "do not restate these".
+    The harm is suppression: a flat 0.80 discards every valid MEDIUM (floor
+    0.55) and LOW (0.40); a flat 0.85 also discards every valid HIGH (0.80).
+    """
+    sev = load_severity(DATA)
+    assert sev.floor("BLOCKING") == 0.85
+    assert sev.floor("HIGH") == 0.80
+    assert sev.floor("MEDIUM") == 0.55
+    assert sev.floor("LOW") == 0.40
+    assert len({sev.floor(s) for s in EMITTED}) > 1, "floors collapsed to a flat value"
+
+
+def test_every_guardrail_names_a_real_pattern() -> None:
+    """A guardrail keyed on a pattern_id that does not exist never fires.
+
+    Silent by construction — the verdict simply comes back one tier softer than
+    it should, and nothing logs that a guardrail was skipped.
+    """
+    sev = load_severity(DATA)
+    for gid, entry in sev.guardrails.items():
+        unknown = [p for p in entry["patterns"] if p not in sev.patterns]
+        assert not unknown, f"{gid} names patterns that do not exist: {unknown}"
+
+
+def test_the_shared_blocks_still_match_pr_reviews_rubric() -> None:
+    """`severity.yaml` is canonical; pr-review's copy is generated from it.
+
+    `categories` and `calibration` must stay semantically identical or the
+    generator cannot reproduce `.mothership/pr-review/severity-rubric.yaml`,
+    and the two lanes start disagreeing about what a pattern means. The
+    loop-only additions (`display`, `guardrails`, `tier_order`) are what the
+    runner needs and no model ever sees.
+    """
+    canonical = yaml.safe_load(DATA.read_text(encoding="utf-8"))
+    published = yaml.safe_load(RUBRIC.read_text(encoding="utf-8"))
+    assert canonical["categories"] == published["categories"]
+    assert canonical["calibration"] == published["calibration"]
+    assert set(canonical) - set(published) == {"display", "guardrails", "tier_order"}

--- a/.github/scripts/tests/test_verdict_rendering.py
+++ b/.github/scripts/tests/test_verdict_rendering.py
@@ -1,0 +1,564 @@
+"""The frozen verdict-comment contract, now owned by Python.
+
+`sdk_review_approve.py`, `sdk_review_reconcile.py`,
+`sdk_review_dedupe_verdicts.py`, `sdk_review_verdict_gate.py` and four
+`sdk-review-*.yml` workflows all find their work by parsing HTML comment
+markers out of PR comments. Until now that contract was a 7.2 KB markdown
+template the reviewer was asked to fill in by hand, and the playbook carries
+two `sed` safety nets for the two ways it got that wrong: writing the literal
+placeholder `<HEAD_SHA>` instead of a sha, and emitting an empty
+`<!-- ANSWERS_TRIGGER: -->` on a `workflow_dispatch` run.
+
+This module is where that contract lives now. Every assertion here is a
+downstream consumer's parse, so a failure means a real PR would have gone
+unlabelled, unapproved, or been read by the resolver as answering the wrong
+round.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import sdk_loop_phase  # noqa: E402
+import sdk_review_approve as approve  # noqa: E402
+from sdk_loop_common import (  # noqa: E402
+    ALL_VERDICTS,
+    MARK_VERDICT_BLOCK,
+    parse_reviewed_head,
+    parse_verdict,
+)
+from sdk_loop_findings import (  # noqa: E402
+    SchemaError,
+    audit_comment,
+    compute_verdict,
+    load_severity,
+    normalise,
+    parse_finding,
+    render_markers,
+    render_summary,
+)
+
+DATA = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / ".mothership/pr-loop/data/severity.yaml"
+)
+HEAD = "24ff8e453fd023731a7bb7032694e202997a2c70"
+
+
+@pytest.fixture
+def sev():
+    return load_severity(DATA)
+
+
+def _finding(**over):
+    base = {
+        "title": "VERSION_RE never matches an indented PklProject version line",
+        "severity": "HIGH",
+        "confidence": 0.9,
+        "file": ".github/scripts/release_guard.py",
+        "line": 56,
+        "category": "CI",
+        "suggested_fix": "anchor the regex with `^\\s*`",
+    }
+    base.update(over)
+    return parse_finding(base)
+
+
+# --------------------------------------------------------------------------
+# Markers
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("verdict", ALL_VERDICTS)
+def test_every_verdict_token_round_trips(verdict: str) -> None:
+    """The five tokens the approval workflows accept, parsed back by their parser."""
+    block = render_markers(verdict, HEAD)
+    assert MARK_VERDICT_BLOCK in block
+    assert parse_verdict(block) == verdict
+    assert parse_reviewed_head(block) == HEAD
+
+
+def test_reviewed_head_must_be_a_real_sha() -> None:
+    """The `<HEAD_SHA>` placeholder class, deleted rather than sed-repaired.
+
+    §3f carries a `sed` net because the reviewer sometimes wrote the literal
+    placeholder. A caller cannot make that mistake here — and if it passes a
+    short sha or a branch name, it fails loudly instead of producing a comment
+    whose delta base the next round cannot resolve.
+    """
+    for bogus in ["<HEAD_SHA>", "24ff8e4", "", "main", HEAD.upper()]:
+        with pytest.raises(SchemaError):
+            render_markers("NEEDS_FIXES", bogus)
+
+
+def test_answers_trigger_is_omitted_not_emptied_on_dispatch() -> None:
+    """`COMMENT_ID` is blank on every `workflow_dispatch` run.
+
+    The resolver's push guard uses this marker to tell "the round I am waiting
+    on has answered" from "an earlier round's verdict landed late". An empty
+    marker reads as present-but-unparseable, which is worse than a missing one:
+    it can clear a push while the review is still running and strand the verdict.
+    """
+    for blank in (None, "", "   "):
+        block = render_markers("NEEDS_FIXES", HEAD, answers_trigger=blank)
+        assert "ANSWERS_TRIGGER" not in block
+
+    block = render_markers("NEEDS_FIXES", HEAD, answers_trigger="5491746224")
+    assert "<!-- ANSWERS_TRIGGER: 5491746224 -->" in block
+
+    with pytest.raises(SchemaError):
+        render_markers("NEEDS_FIXES", HEAD, answers_trigger="comment-5491746224")
+
+
+def test_toolkit_hash_only_when_given() -> None:
+    assert "TOOLKIT_ARTIFACT_HASH" not in render_markers("NEEDS_FIXES", HEAD)
+    block = render_markers("NEEDS_FIXES", HEAD, toolkit_artifact_hash="ab" * 32)
+    assert f"<!-- TOOLKIT_ARTIFACT_HASH: {'ab' * 32} -->" in block
+
+
+def test_the_marker_block_leads_the_comment(sev) -> None:
+    """Consumers scan from the top; the marker block must be the first bytes."""
+    body = render_summary(
+        verdict="READY_TO_MERGE",
+        pr_number=3580,
+        pr_title="ci(release): guard every release opener",
+        reviewed_head=HEAD,
+        kept=[],
+        sev=sev,
+        summary="Nothing outstanding.",
+    )
+    assert body.startswith(MARK_VERDICT_BLOCK + "\n")
+
+
+# --------------------------------------------------------------------------
+# The termination invariant
+# --------------------------------------------------------------------------
+
+
+def test_empty_findings_means_ready_to_merge(sev) -> None:
+    """The resolve loop's termination condition, as an invariant.
+
+    `@sdk-resolve` loops review -> fix -> push until `### Findings` is empty,
+    and READY_TO_MERGE requires that same empty list. Making this a renderer
+    property rather than an instruction is the whole reason verdict assembly
+    moved out of the model.
+    """
+    assert compute_verdict([], sev) == "READY_TO_MERGE"
+    body = render_summary(
+        verdict="READY_TO_MERGE",
+        pr_number=3586,
+        pr_title="chore(conformance): I005 false-positive shapes",
+        reviewed_head=HEAD,
+        kept=[],
+        sev=sev,
+        summary="All prior findings resolved.",
+    )
+    section = body.split("### Findings", 1)[1]
+    assert "_None._" in section
+    assert parse_verdict(body) == "READY_TO_MERGE"
+
+
+def test_any_rendered_finding_forces_needs_fixes(sev) -> None:
+    """Strict, and strict at every tier — a lone Nit does it too."""
+    for severity in ("MEDIUM", "HIGH", "CRITICAL"):
+        kept = normalise([_finding(severity=severity, confidence=0.95)], sev).kept
+        assert kept, severity
+        assert compute_verdict(kept, sev) == "NEEDS_FIXES", severity
+
+
+def test_prose_only_tiers_do_not_block(sev) -> None:
+    """LOW/INFO reach the summary but never `### Findings`, so they never block."""
+    result = normalise(
+        [_finding(severity="LOW", confidence=0.9), _finding(severity="INFO")], sev
+    )
+    assert result.kept == []
+    assert len(result.prose) == 2
+    assert compute_verdict(result.kept, sev) == "READY_TO_MERGE"
+
+
+# --------------------------------------------------------------------------
+# Guardrails, clamping, floors
+# --------------------------------------------------------------------------
+
+
+def test_a_guardrail_pattern_forces_its_verdict(sev) -> None:
+    kept = normalise(
+        [_finding(pattern_id="credential-in-log", severity="BLOCKING")], sev
+    ).kept
+    assert compute_verdict(kept, sev) == "BLOCKED"
+
+
+def test_severity_is_clamped_down_to_max(sev) -> None:
+    """The model may under- or over-call; `max_severity` is the ceiling."""
+    kept = normalise(
+        [_finding(pattern_id="missing-type-annotation", severity="BLOCKING")], sev
+    ).kept
+    assert kept[0].severity == "MEDIUM"
+    assert kept[0].tier == "Nit"
+
+
+def test_the_floor_is_applied_after_clamping(sev) -> None:
+    """Clamp first, then floor — the floor belongs to the tier it ends up in.
+
+    A finding the model called CRITICAL at 0.60 confidence, on a pattern capped
+    at MEDIUM, is a valid MEDIUM (floor 0.55). Checking the floor first would
+    hold it to CRITICAL's 0.85 and drop a real finding.
+    """
+    result = normalise(
+        [
+            _finding(
+                pattern_id="missing-type-annotation",
+                severity="CRITICAL",
+                confidence=0.6,
+            )
+        ],
+        sev,
+    )
+    assert result.kept and not result.dropped
+    assert result.kept[0].severity == "MEDIUM"
+
+
+def test_low_confidence_is_dropped_with_a_reason(sev) -> None:
+    result = normalise([_finding(severity="HIGH", confidence=0.5)], sev)
+    assert not result.kept
+    assert "below the HIGH floor" in result.dropped[0].reason
+
+
+def test_a_guardrail_ignores_the_confidence_floor(sev) -> None:
+    """`CLAUDE.md`: guardrail violations are reported regardless of confidence."""
+    result = normalise(
+        [_finding(pattern_id="field-removed", severity="BLOCKING", confidence=0.1)], sev
+    )
+    assert result.kept, "a guardrail was dropped by a confidence floor"
+    assert compute_verdict(result.kept, sev) == "BLOCKED"
+
+
+# --------------------------------------------------------------------------
+# Schema
+# --------------------------------------------------------------------------
+
+
+def test_fields_the_handler_422s_on_are_refused() -> None:
+    """All seven brief-level JSON examples emit exactly these three."""
+    for bad in ("scope", "domain_tag", "guardrail", "public_note"):
+        with pytest.raises(SchemaError, match="422"):
+            parse_finding(
+                {
+                    "title": "x",
+                    "severity": "HIGH",
+                    "confidence": 0.9,
+                    "file": "a.py",
+                    bad: "whatever",
+                }
+            )
+
+
+def test_the_payload_only_carries_allowlisted_fields(sev) -> None:
+    finding = _finding()
+    normalise([finding], sev)
+    assert set(finding.payload()) <= {
+        "title",
+        "pattern_id",
+        "severity",
+        "category",
+        "confidence",
+        "file",
+        "line",
+        "evidence",
+        "attack_path",
+        "reachable_from",
+        "by_design_check",
+        "suggested_fix",
+        "escalate_to_linear",
+    }
+    assert "tier" not in finding.payload()
+    assert "guardrail" not in finding.payload()
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        {"severity": "HIGH", "confidence": 0.9, "file": "a.py"},
+        {"title": "x", "confidence": 0.9, "file": "a.py"},
+        {"title": "x", "severity": "HIGH", "confidence": "high", "file": "a.py"},
+        {"title": "x", "severity": "HIGH", "confidence": 1.4, "file": "a.py"},
+    ],
+)
+def test_malformed_findings_raise(raw: dict) -> None:
+    with pytest.raises(SchemaError):
+        parse_finding(raw)
+
+
+# --------------------------------------------------------------------------
+# Rendering shape
+# --------------------------------------------------------------------------
+
+
+def test_findings_are_grouped_by_file_and_sorted_by_tier(sev) -> None:
+    """§3e's mandatory format: file-grouped bullets, never a markdown table."""
+    kept = normalise(
+        [
+            _finding(file="z.py", severity="MEDIUM", line=10, title="nit"),
+            _finding(file="a.py", severity="HIGH", line=99, title="important"),
+            _finding(
+                file="a.py",
+                severity="BLOCKING",
+                line=5,
+                title="critical",
+                pattern_id="credential-in-log",
+            ),
+        ],
+        sev,
+    ).kept
+    body = render_summary(
+        verdict=compute_verdict(kept, sev),
+        pr_number=1,
+        pr_title="t",
+        reviewed_head=HEAD,
+        kept=kept,
+        sev=sev,
+        summary="s",
+    )
+    section = body.split("### Findings", 1)[1]
+    assert section.index("**`a.py`**") < section.index("**`z.py`**")
+    assert section.index("**Critical**") < section.index("**Important**")
+    assert "| Severity |" not in section, "rendered a table; §3e forbids it"
+
+
+def test_rereview_titles_itself_a_rereview(sev) -> None:
+    body = render_summary(
+        verdict="READY_TO_MERGE",
+        pr_number=1,
+        pr_title="t",
+        reviewed_head=HEAD,
+        kept=[],
+        sev=sev,
+        summary="s",
+        is_rereview=True,
+        delta="- **Resolved (1)**: the regex anchor",
+    )
+    assert "Re-review" in body
+    assert "### Delta from previous review" in body
+
+
+def test_toolkit_scope_keeps_the_stable_marker(sev) -> None:
+    """The heading changes; `<!-- SDK_REVIEW -->` must not."""
+    body = render_summary(
+        verdict="NEEDS_HUMAN",
+        pr_number=3594,
+        pr_title="t",
+        reviewed_head=HEAD,
+        kept=[],
+        sev=sev,
+        summary="s",
+        heading_subject="Contract Toolkit",
+    )
+    assert "## Contract Toolkit Review" in body
+    assert MARK_VERDICT_BLOCK in body
+    assert parse_verdict(body) == "NEEDS_HUMAN"
+
+
+def test_conflicting_short_circuits_to_needs_rebase(sev) -> None:
+    """Decided from mergeStateStatus with no model call, so no finding outvotes it."""
+    kept = normalise(
+        [_finding(severity="BLOCKING", pattern_id="field-removed")], sev
+    ).kept
+    assert compute_verdict(kept, sev, conflicting=True) == "NEEDS_REBASE"
+
+
+# --------------------------------------------------------------------------
+# Round-trip against the merge authority itself
+# --------------------------------------------------------------------------
+
+
+def test_the_rendered_comment_parses_in_sdk_review_approve(sev) -> None:
+    """The strongest assertion in this module: the real approval path reads it.
+
+    Neither lane is the merge authority. `sdk_review_approve.py` is — it casts
+    the `atlan-ci` APPROVE, and `atlan-ci` is the CODEOWNER whose review
+    satisfies the branch ruleset on `main`. So the contract that matters is not
+    "sdk_loop_common can parse this", it is "the script that approves can".
+    Those are different modules with independently-written regexes.
+    """
+    for verdict in ALL_VERDICTS:
+        body = render_summary(
+            verdict=verdict,
+            pr_number=3587,
+            pr_title="chore(conformance): P025 false-positive shapes",
+            reviewed_head=HEAD,
+            kept=[],
+            sev=sev,
+            summary="s",
+            answers_trigger="5491746224",
+        )
+        assert any(m in body for m in approve.SUMMARY_MARKERS)
+        assert approve.VERDICT_RE.search(body).group(1) == verdict
+        assert approve.REVIEWED_HEAD_RE.search(body).group(1) == HEAD
+
+
+def test_the_rendered_comment_matches_a_real_posted_verdict(sev) -> None:
+    """Shape-check against a verdict `@sdk-loop` actually posted on PR #3580.
+
+    Marker order and spelling are copied from that comment verbatim. If the
+    renderer ever reorders or respaces them, downstream regexes would still
+    match — but the diff against the old lane's output would stop being
+    reviewable by eye, which is how the shadow comparison in the review phase
+    earns its keep.
+    """
+    real_prefix = [
+        "<!-- SDK_REVIEW -->",
+        "<!-- VERDICT: NEEDS_FIXES -->",
+        f"<!-- REVIEWED_HEAD: {HEAD} -->",
+        "<!-- ANSWERS_TRIGGER: 5491269936 -->",
+    ]
+    kept = normalise([_finding()], sev).kept
+    body = render_summary(
+        verdict=compute_verdict(kept, sev),
+        pr_number=3580,
+        pr_title="ci(release): guard every release opener",
+        reviewed_head=HEAD,
+        kept=kept,
+        sev=sev,
+        summary="s",
+        answers_trigger="5491269936",
+    )
+    assert body.splitlines()[:4] == real_prefix
+
+
+# --------------------------------------------------------------------------
+# The shadow audit
+# --------------------------------------------------------------------------
+
+
+def test_the_auditor_passes_a_well_formed_comment(sev) -> None:
+    kept = normalise([_finding()], sev).kept
+    body = render_summary(
+        verdict=compute_verdict(kept, sev),
+        pr_number=3580,
+        pr_title="t",
+        reviewed_head=HEAD,
+        kept=kept,
+        sev=sev,
+        summary="s",
+        answers_trigger="5491269936",
+    )
+    assert audit_comment(body) == []
+
+
+def test_the_auditor_passes_an_empty_findings_approval(sev) -> None:
+    body = render_summary(
+        verdict="READY_TO_MERGE",
+        pr_number=3586,
+        pr_title="t",
+        reviewed_head=HEAD,
+        kept=[],
+        sev=sev,
+        summary="s",
+    )
+    assert audit_comment(body) == []
+
+
+@pytest.mark.parametrize(
+    "mutate, expect",
+    [
+        # The two failures §3f carries a `sed` for.
+        (lambda b: b.replace(HEAD, "<HEAD_SHA>"), "literal placeholder"),
+        (
+            lambda b: b.replace(
+                "<!-- ANSWERS_TRIGGER: 5491269936 -->", "<!-- ANSWERS_TRIGGER: -->"
+            ),
+            "present but empty",
+        ),
+        # A verdict that would approve a PR with open findings.
+        (
+            lambda b: b.replace(
+                "<!-- VERDICT: NEEDS_FIXES -->", "<!-- VERDICT: READY_TO_MERGE -->"
+            ),
+            "would approve a PR with open findings",
+        ),
+        # Markers the consumers key on, removed.
+        (lambda b: b.replace("<!-- SDK_REVIEW -->\n", ""), "no <!-- SDK_REVIEW -->"),
+        (lambda b: b.replace("<!-- VERDICT: NEEDS_FIXES -->\n", ""), "no <!-- VERDICT"),
+        (lambda b: re.sub(r"<!-- REVIEWED_HEAD:[^>]*-->\n", "", b), "no REVIEWED_HEAD"),
+        # A short sha still parses in sdk_loop_common but loses the delta base.
+        (lambda b: b.replace(HEAD, HEAD[:7]), "not a 40-char lowercase sha"),
+        # An invented sixth verdict token.
+        (
+            lambda b: b.replace(
+                "<!-- VERDICT: NEEDS_FIXES -->", "<!-- VERDICT: LGTM -->"
+            ),
+            "not one of the five",
+        ),
+        # Prose before the markers pushes them out of the leading position.
+        (lambda b: "Here is my review!\n\n" + b, "does not lead the comment"),
+        # §3e forbids the table form outright.
+        (
+            lambda b: b.replace(
+                "### Findings", "### Findings\n\n| Severity | Where |\n|---|---|"
+            ),
+            "rendered as a table",
+        ),
+    ],
+)
+def test_the_auditor_catches_each_known_break(sev, mutate, expect: str) -> None:
+    """A checker that passes everything is worth nothing.
+
+    Every row is a real failure mode: the two the playbook's `sed` nets exist
+    for, the marker removals that make a verdict invisible to
+    `sdk_review_approve.py`, and the Findings/verdict disagreement that would
+    approve a PR with open findings.
+    """
+    kept = normalise([_finding()], sev).kept
+    body = render_summary(
+        verdict=compute_verdict(kept, sev),
+        pr_number=3580,
+        pr_title="t",
+        reviewed_head=HEAD,
+        kept=kept,
+        sev=sev,
+        summary="s",
+        answers_trigger="5491269936",
+    )
+    problems = audit_comment(mutate(body))
+    assert any(expect in p for p in problems), (expect, problems)
+
+
+def test_findings_emptiness_reads_prose_as_empty(sev) -> None:
+    """`_None._`, `None`, and an absent section all mean no findings."""
+    for spelling in ("_None._", "None", "No findings.", ""):
+        body = (
+            f"<!-- SDK_REVIEW -->\n<!-- VERDICT: READY_TO_MERGE -->\n"
+            f"<!-- REVIEWED_HEAD: {HEAD} -->\n## t\n\n### Findings\n\n{spelling}\n\n"
+            f"### Strengths\n- ok\n"
+        )
+        assert audit_comment(body) == [], spelling
+
+
+def test_the_review_phase_audits_the_comment_without_failing_the_round() -> None:
+    """The audit is a diagnostic, not a gate — at this step.
+
+    Failing a round on a contract violation would make the measurement cost a
+    review, and the point of running the renderer behind the playbook is to
+    find out how often the model breaks the contract BEFORE anything depends
+    on it not breaking. The outcome must be decided by `interpret_review`
+    alone.
+    """
+    broken = {
+        "body": (
+            "<!-- SDK_REVIEW -->\n<!-- VERDICT: READY_TO_MERGE -->\n"
+            "<!-- REVIEWED_HEAD: <HEAD_SHA> -->\n<!-- ANSWERS_TRIGGER: -->\n"
+            "## t\n\n### Findings\n\n- **Critical** [SEC] L1 — boom.\n"
+        )
+    }
+    problems = sdk_loop_phase.audit_verdict_contract(broken)
+    assert any("literal placeholder" in p for p in problems)
+    assert any("present but empty" in p for p in problems)
+    assert any("would approve a PR with open findings" in p for p in problems)
+
+    assert sdk_loop_phase.audit_verdict_contract(None) == []

--- a/.mothership/pr-loop/HYPOTHESES.md
+++ b/.mothership/pr-loop/HYPOTHESES.md
@@ -1,0 +1,65 @@
+# Break it
+
+Before you judge whether this change is correct, try to make it wrong. Write
+down how it breaks, then turn each way into a test. This is the one part of the
+review where being imaginative is the job.
+
+## Write the hypotheses down first
+
+Produce a file, `.sdk-loop/hypotheses.md`, before you write any test. Committing
+to the list first is what stops the exercise collapsing into tests for the paths
+you already know pass — the failure mode of every test suite written after the
+code it tests.
+
+Each hypothesis is one line: **the input or condition, and what you expect to go
+wrong.**
+
+```
+- concurrent entry: two activities call `resolve()` on the same key; the second
+  overwrites the first's cached credential
+- boundary: `page_size=0` makes the paginator loop forever rather than return
+  empty
+- partial failure: the upstream returns 200 with a truncated body; the parser
+  reports success over half a record
+```
+
+Not this:
+
+```
+- test that resolve() works
+- check error handling
+```
+
+## Where to look
+
+The classes below are where defects in this SDK actually live. Work through
+them against the changed code; most will not apply, and saying so is fine.
+
+- **Boundaries** — empty, one, exactly the limit, one past it, zero, negative,
+  null, the maximum the type holds.
+- **Concurrency** — two callers at once, the same caller re-entering, a retry
+  overlapping its own first attempt, shared mutable state across activities.
+- **Partial failure** — the call that succeeds halfway: a write that lands then
+  raises, a batch where record 3 of 10 fails, a connection dropped mid-stream.
+- **Hostile input** — malformed upstream payloads, unexpected nulls, encodings,
+  a field that is a string where the contract says integer.
+- **Exhaustion** — retries used up, memory on a large page, a timeout expiring
+  while a lock is held.
+- **Replay** — for anything in a workflow method: what happens when this code
+  runs a second time against the same history?
+
+## Then write the tests
+
+One test per hypothesis that survives contact with the code. Each must fail
+against the *unfixed* source — that is the point, and the runner checks it.
+
+A test you cannot make fail against the old code has not captured this change.
+It may still be worth keeping, but do not count it as covering the fix.
+
+## What to report
+
+Hypotheses that the code already handles are not findings — note them in
+`strengths` if the handling is non-obvious. A hypothesis you could not resolve
+either way is an honest `NEEDS_HUMAN` input, not a guess. A hypothesis that
+breaks the code is a finding, and it arrives with its own reproduction, which
+makes it the most useful kind you can file.

--- a/.mothership/pr-loop/agents/ci-config.md
+++ b/.mothership/pr-loop/agents/ci-config.md
@@ -1,0 +1,32 @@
+# CI and configuration
+
+You own workflows, actions, scripts and dependency changes — the machinery that
+decides whether anything else is enforced.
+
+## What you are looking for
+
+**A gate that cannot fail.** The most expensive defect in CI is a check that
+reports success without checking: a step whose exit code is swallowed, a `find`
+whose empty result is a pass, a matrix leg that skips silently when its input is
+missing, a conditional that never evaluates true. Trace how each new check
+*fails*. If you cannot make it red, it is not a gate.
+
+**Branching logic inlined in YAML.** It cannot be regression-tested. It belongs
+in a script with a test.
+
+**Permissions and secrets.** A token scope wider than the job needs. A secret
+reaching a step that logs. An `on:` trigger that exposes a write-scoped token to
+untrusted input.
+
+**Supply chain.** Unpinned action refs, a new dependency that is not the package
+it appears to be, a version published days ago, a lockfile bypassed.
+
+**Trigger correctness.** `branches:` filters that mean a required check never
+runs on the PRs it is meant to gate, and `paths:` filters that skip the job that
+would have caught the change.
+
+## What earns a finding here
+
+Workflow defects hide because the workflow is green — green is what a
+never-running check looks like. Prefer findings you can state as "on input X,
+this passes and should not".

--- a/.mothership/pr-loop/agents/conformance.md
+++ b/.mothership/pr-loop/agents/conformance.md
@@ -1,0 +1,33 @@
+# Conformance
+
+You own the detector suite itself — the rules, their catalog entries and the
+remediation programs. You are reviewing the thing that judges other repos, so a
+defect here is a fleet-wide defect.
+
+## What you are looking for
+
+**Does the rule fire on what it claims, and stay silent otherwise?** Every rule
+change needs a matched pair: a case that fires and a case that must not. A rule
+shipped with only positive tests has an unmeasured false-positive rate, and the
+fleet pays it.
+
+**Is this fixing the rule, or fixing the finding?** The failure mode this suite
+has repeatedly hit is a rule narrowed until one repo's code stops tripping it —
+an allowlist for a bare name, a hardcoded comment string, a carve-out
+reverse-engineered from a single connector. That silences the symptom and
+retires the rule. If the change exempts precisely the case that reported it, say
+so plainly.
+
+**Tier and scope.** `BLOCK` means a customer-facing risk and needs a stated
+customer impact. `WARN` means good-to-have. Scope (`sdk` / `app` / `both`)
+decides which surface the rule runs against; a mismatch means a rule that
+reports a zero it never computed.
+
+**Catalog and prose in step.** A rule whose implementation, catalog entry and
+documentation disagree will be triaged wrong by whoever meets it next.
+
+## What earns a finding here
+
+Weakening a rule is the finding to raise loudest, and it is easy to miss because
+the diff looks like a bug fix. Ask what the rule stops catching after this
+change, and whether that class was worth catching.

--- a/.mothership/pr-loop/agents/correctness.md
+++ b/.mothership/pr-loop/agents/correctness.md
@@ -1,0 +1,35 @@
+# Correctness
+
+You own logic, security and the invariants that corrupt running workflows.
+Everything about *what counts as a finding*, severity, nits, classes and output
+shape is already in your instructions. This brief is only your domain.
+
+## What you are looking for
+
+**Determinism.** `run()` and `@entrypoint` bodies replay. `datetime.now()`,
+`uuid4()`, `random`, file or network I/O there corrupt in-flight workflow
+history — the damage lands on runs that started before this PR merged, which is
+why this outranks nearly everything else you could find.
+
+**Contract evolution.** A removed, renamed or retyped field on an `Input` or
+`Output` breaks workflows mid-execution and cascades into consumer repos that
+pin this SDK. Additive-only, defaults on new fields, `default_factory` for
+mutables. A field that changed meaning without changing name is the same defect
+wearing a disguise.
+
+**Concurrency and failure.** Races, unawaited coroutines, shared mutable state
+across activities, resource leaks on the error path, retries that are not
+idempotent, `except` blocks that swallow the reason a run failed.
+
+**Security.** Secrets reaching logs, payloads or exceptions. Externally-derived
+values interpolated into SQL, shells or paths. Auth or tenant checks that a new
+code path routes around.
+
+## What earns a finding here
+
+Trace the path. A defect behind a flag nobody sets, or in a branch that cannot
+be entered, is an observation — say so rather than inflating it. For anything
+you rate `BLOCKING` or `CRITICAL`, name the input or interleaving that reaches
+it; "this could race" without a schedule is a guess.
+
+An SDK's defects are paid for by every connector downstream. Weight accordingly.

--- a/.mothership/pr-loop/agents/quality.md
+++ b/.mothership/pr-loop/agents/quality.md
@@ -1,0 +1,32 @@
+# Quality
+
+You own tests and the experience of the developer who uses this SDK next.
+
+## What you are looking for
+
+**Whether the tests could fail.** This is the whole job. A test that passes
+against the unfixed code proves nothing, and a suite of them is worse than no
+suite because it buys false confidence. Ask of each new test: what change to the
+source would make this fail? If you cannot name one, that is the finding.
+
+Specifically: assertions on mocks rather than behaviour, `assert result is not
+None` as the only check, a fixture that stubs the thing under test, a regression
+test that does not encode the regression, parametrised cases that differ only in
+values that never reach an assertion.
+
+**Coverage of the failure path.** New error handling with no test that triggers
+it. New retry logic with no test for exhaustion. New parsing with no malformed
+input.
+
+**The builder's experience.** Error messages that do not say what to do next.
+New public API without a docstring that a connector author could act on. A
+required argument added to a public signature.
+
+## What earns a finding here
+
+Raw coverage percentage is not yours — CI blocks below its threshold and the
+number tells you nothing about whether the tests mean anything. *Meaningfulness*
+is yours, and it is the more valuable question.
+
+Missing tests for a new public surface is a real finding. Missing tests for
+pre-existing untested code is not this PR's problem.

--- a/.mothership/pr-loop/agents/reachability.md
+++ b/.mothership/pr-loop/agents/reachability.md
@@ -1,0 +1,24 @@
+# Reachability
+
+You answer one question for the other specialists: **is this code reached, and
+from where?**
+
+You do not raise style, architecture or test findings. You raise two things:
+
+**Dead on arrival.** Code this PR adds that nothing calls — an unregistered
+handler, a branch behind a condition that cannot hold, a parameter no caller
+passes, an exception nothing raises. New unreachable code is usually a wiring
+mistake, and it is invisible in a diff that reads correctly line by line.
+
+**Reached from further than it looks.** A change to a shared helper, a public
+export, a base class or a contract that consumer repos import. Name the callers.
+The severity of everything else in the review depends on this: the same defect
+is a nit on an internal path and a blocker on one that every connector executes.
+
+## How to answer
+
+Trace, do not guess. Name the entry point and the call chain. When you cannot
+establish reachability, say that explicitly — "no caller found in this repo;
+may be reached by consumers" is a useful answer and an honest one. A confident
+wrong reachability claim is worse than none, because the other specialists will
+size their findings on it.

--- a/.mothership/pr-loop/agents/structure.md
+++ b/.mothership/pr-loop/agents/structure.md
@@ -1,0 +1,32 @@
+# Structure
+
+You own architecture: where code lives, what may depend on what, and whether
+this change makes the next one harder.
+
+## What you are looking for
+
+**Dependency direction.** `app/` → `execution/` → `infrastructure/`, never the
+reverse. An import that inverts it is a finding even when it works today.
+
+**Abstraction seams.** Third-party SDKs are reached through their adapter
+packages. A `temporalio`, `dapr` or `redis` import *outside* its seam leaks a
+vendor into code that is supposed to be portable. Inside the seam it is the
+implementation — that is what an adapter looks like from the inside.
+
+**Typed contracts.** Public surfaces carry real models. `dict[str, Any]` on a
+public signature is an escape hatch that pushes the cost onto every caller.
+
+**A second way to do something.** The most expensive structural defect in an SDK
+is not a bad abstraction, it is a *duplicate* one: a new helper that overlaps an
+existing one, a second config path, a parallel error hierarchy. Two ways means
+every future reader must learn which is current, and every future change must be
+made twice or diverge.
+
+## What earns a finding here
+
+Structural opinions are the easiest to inflate and the easiest to ignore, so
+hold yourself to the consequence test hard: name what breaks, or what becomes
+unmaintainable, and for whom. "This could be cleaner" is not a finding.
+
+If the PR is working *within* an existing pattern you dislike, that is not this
+PR's problem. Flag the pattern only if this change extends it materially.

--- a/.mothership/pr-loop/agents/toolkit-review.md
+++ b/.mothership/pr-loop/agents/toolkit-review.md
@@ -1,0 +1,33 @@
+# Contract toolkit
+
+You own `contract-toolkit/` — the generator whose output every connector repo
+regenerates from. A defect here is not one repo's bug; it is a change to files
+80+ repos will regenerate on their next bump.
+
+## What you are looking for
+
+**What the generated artifacts become.** Read the change in terms of its output,
+not its source. A renamed key, a changed default, a field that stops being
+emitted, a new required input — each one lands in every consumer's generated
+tree, and the consumer's own post-processing may or may not survive it.
+
+**Silent clobbering.** Generation that overwrites hand-authored files, or
+whole-dict assignment where a merge was intended. The failure is invisible in
+the toolkit's own tests and only appears as a lost customisation downstream.
+
+**Backwards compatibility of the contract surface.** A generator change that
+requires every consumer to edit their contract before they can regenerate is a
+migration, not a bump — say so, and say what the migration is.
+
+**The freshness gate.** A change that makes regenerated output differ from what
+consumers have committed turns their freshness check red until they regenerate.
+That is sometimes correct and always worth stating.
+
+## What earns a finding here
+
+Say what a consumer sees on their next bump. "This changes the emitted key" is
+the finding; the diff line is the evidence.
+
+Never name internal consumer repositories, internal paths or clone locations in
+anything you return — this output is posted publicly. Describe the affected
+surface generically.

--- a/.mothership/pr-loop/data/agents.yaml
+++ b/.mothership/pr-loop/data/agents.yaml
@@ -1,0 +1,132 @@
+# Which specialists this lane dispatches, and how deep they go.
+#
+# THIS FILE IS NEVER READ BY A MODEL. The runner resolves the route before the
+# reviewer starts and tells each specialist only which one it is.
+#
+# ---------------------------------------------------------------------------
+# Why this file exists rather than a table in a playbook
+# ---------------------------------------------------------------------------
+#
+# The routing this lane used until now lived as a markdown table in the OTHER
+# lane's playbook, mirrored into a Python dict, with a drift check parsing the
+# markdown to keep them in step. That made the old playbook the author of the
+# new lane's behaviour: retiring or restructuring it would silently change who
+# reviews what, and the redesign cannot claim to have replaced a document it
+# still takes instructions from.
+#
+# So this lane owns its routing outright. The old table stays where it is and
+# keeps governing the sandbox lane; nothing here is derived from it.
+#
+# ---------------------------------------------------------------------------
+# What changed in the move, and why
+# ---------------------------------------------------------------------------
+#
+# The scope buckets are kept, because they encode real knowledge about this
+# repository's layout that no principle replaces — `packages/conformance/`
+# genuinely does need a different reader than `application_sdk/`.
+#
+# `depth` is new. The old table routed on scope alone, so a 40-line change and
+# a 4,000-line change in the same directory got an identical review. Inspection
+# research is consistent and unkind here: defect detection runs 70-90% at
+# 200-400 changed lines, 87% under 100, and collapses to 28% past 1,000. A
+# reviewer handed a 3,000-line diff and one budget does not escape that curve by
+# being a model — it fails the same way, more confidently. Splitting the pass
+# per module keeps each unit inside the range where finding things actually
+# works.
+
+version: 1
+
+# --------------------------------------------------------------------------
+# scope -> specialists
+# --------------------------------------------------------------------------
+#
+# `agents` is the set the scope always dispatches. `also` is added when the
+# condition holds — these were special cases buried in Python before, which
+# meant the routing could not be read off any single artefact.
+
+routes:
+  full:
+    agents: [correctness, quality, structure]
+    also:
+      reachability: always
+      ci-config: when_touches_config
+      conformance: when_touches_conformance
+    why: >-
+      A change inside application_sdk/ is the case every other route is a
+      narrowing of. Reachability rides along because the severity of everything
+      the other three find depends on who calls it.
+
+  minor:
+    agents: [correctness]
+    why: >-
+      The fast path. Correctness alone rather than nothing, because guardrail
+      coverage — determinism, contract breaks, secrets — must not depend on a
+      diff being large enough to earn a full review.
+
+  mixed-sdk-toolkit:
+    agents: [correctness, quality, structure, toolkit-review]
+    also:
+      reachability: always
+    why: >-
+      Touches both the SDK and the generator that 80+ repos regenerate from, so
+      it needs both readings; neither subsumes the other.
+
+  contract-toolkit:
+    agents: [toolkit-review]
+    why: >-
+      Judged by what its generated artifacts become downstream, which is a
+      different question from whether the toolkit's own code is sound.
+
+  tests-only:
+    agents: [quality]
+    why: >-
+      The whole diff is tests, so the only question is whether they could fail.
+
+  tests-focused:
+    agents: [quality, correctness]
+    why: >-
+      Mostly tests with some source. Correctness joins because a test change
+      accompanying a source change is exactly where a hollow test hides.
+
+  conformance-only:
+    agents: [conformance]
+    also:
+      ci-config: when_touches_config
+    why: >-
+      Reviewing the detectors that judge every other repo. A defect here is a
+      fleet defect.
+
+  config-only:
+    agents: [ci-config]
+    why: >-
+      Workflows, actions and dependencies — the machinery that decides whether
+      anything else is enforced at all.
+
+  docs-only:
+    agents: []
+    why: >-
+      No specialist. Dispatching one produces prose findings on prose, which is
+      the purest form of the effective false positive: correct, unactioned, and
+      corrosive to trust in everything else the lane says.
+
+# --------------------------------------------------------------------------
+# depth — how much diff one pass may carry
+# --------------------------------------------------------------------------
+#
+# Evaluated top to bottom; the first rule whose ceiling the diff fits under
+# wins. `per_module` runs the scope's specialists once per changed module and
+# then sweeps for classes across the results, so no single pass exceeds the
+# range where detection holds up.
+
+depth:
+  - max_changed_lines: 400
+    mode: single_pass
+    why: >-
+      Inside the band where inspection research puts detection at 70-90%.
+
+  - max_changed_lines: null
+    mode: per_module
+    why: >-
+      Past ~400 changed lines a single pass degrades toward 28% and the review
+      returns a confident verdict over code it did not really read. Splitting is
+      the only lever that does not require the author to split the PR.

--- a/.mothership/pr-loop/data/severity.yaml
+++ b/.mothership/pr-loop/data/severity.yaml
@@ -1,0 +1,321 @@
+# Canonical severity data for the @sdk-loop lane.
+#
+# THIS FILE IS NEVER READ BY A MODEL. `sdk_loop_findings.py` loads it; the
+# reviewer only ever sees the short vocabulary line in its argv prompt. That
+# is deliberate: `.mothership/pr-review/severity-rubric.yaml` was ~9 KB of the
+# reviewer's context on every round, and every byte of it describes a decision
+# the runner is better placed to make.
+#
+# It is also the canonical source for pr-review's copy. `gen_review_assets.py`
+# renders `.mothership/pr-review/severity-rubric.yaml` from the `categories`
+# and `calibration` blocks below and `--check` fails CI on drift, so the two
+# lanes cannot disagree about what a pattern means.
+#
+# How the runner uses it:
+#   - the model picks `pattern_id` and supplies evidence + attack_path
+#   - the runner looks up canonical_severity / max_severity and clamps DOWN
+#     when the model went higher
+#   - `required_conditions_for_*` must be substantiated in evidence or
+#     attack_path before the higher tier is allowed
+#   - `override_allowed: false` means no policy may soften the pattern
+#   - `confidence_floors` are applied PER SEVERITY, never as a flat number
+
+# --------------------------------------------------------------------------
+# display — the emitted -> rendered mapping
+# --------------------------------------------------------------------------
+#
+# The corpus this lane inherits carries THREE severity spellings with no
+# mapping between them: the payload vocabulary below, the reference files'
+# `Critical | Important | Minor`, and the verdict template's
+# `Critical | Important | Nit`. `sdk_loop_finalize.py` keys only on whether
+# `### Findings` is empty and never on a tier name, so the taxonomy was
+# decorative to the gate and load-bearing to the model — the worst
+# combination, and the reason one brief emits a fourth spelling ("IMPORTANT")
+# that belongs to none of them.
+#
+# Resolution: the model emits exactly one vocabulary (the six keys here,
+# which carry the real machinery above) and the runner maps it to the three
+# tiers the summary renders. The map is total. An emitted severity that is
+# not a key here is a schema violation that fails the phase, so a fourth
+# spelling fails loudly instead of vanishing.
+#
+# `in_findings: false` means the finding is reported in prose and does NOT
+# appear under `### Findings`. Read that deliberately: an empty `### Findings`
+# means READY_TO_MERGE and is the resolve loop's termination condition, so
+# every tier that renders into Findings BLOCKS the merge. Routing LOW and
+# INFO to prose narrows what blocks in exchange for a loop that terminates —
+# and it matches `calibration.severity_meanings`, which already calls
+# MEDIUM/LOW/INFO "summary body only".
+display:
+  BLOCKING: {tier: Critical, in_findings: true, inline_comment: true}
+  CRITICAL: {tier: Critical, in_findings: true, inline_comment: true}
+  HIGH: {tier: Important, in_findings: true, inline_comment: true}
+  MEDIUM: {tier: Nit, in_findings: true, inline_comment: false}
+  LOW: {tier: null, in_findings: false, inline_comment: false}
+  INFO: {tier: null, in_findings: false, inline_comment: false}
+
+#: Order the rendered tiers sort in, within a file.
+tier_order: [Critical, Important, Nit]
+
+# --------------------------------------------------------------------------
+# guardrails — the verdict-forcing subset
+# --------------------------------------------------------------------------
+#
+# G1-G7 live in prose in three places today (pr-review's CLAUDE.md table and
+# a partial restatement in four briefs). Here they are the data the verdict
+# function reads. `verdict` is what the guardrail forces regardless of every
+# other finding; a guardrail violation is never dropped by a confidence floor.
+guardrails:
+  G1: {name: Security Blockers, verdict: BLOCKED, patterns: [credential-in-log]}
+  G2:
+    name: Contract Safety
+    verdict: BLOCKED
+    patterns: [field-removed, field-renamed, field-type-changed]
+  G3:
+    name: Determinism
+    verdict: BLOCKED
+    patterns: [io-in-workflow, non-deterministic-in-workflow]
+  G4: {name: Test Coverage, verdict: NEEDS_FIXES, patterns: [public-api-no-test]}
+  G5: {name: Secret Safety, verdict: BLOCKED, patterns: [raw-credential-in-contract]}
+  G6:
+    name: Breaking API
+    verdict: NEEDS_FIXES
+    patterns: [breaking-change-no-deprecation]
+  # G7 (branch mergeable) is not a finding — the runner decides it from
+  # mergeStateStatus before the model is called at all, and CONFLICTING short
+  # circuits to NEEDS_REBASE with no model call.
+
+categories:
+  - id: temporal-determinism
+    description: "Temporal workflow replay safety violations"
+    patterns:
+      - pattern_id: io-in-workflow
+        canonical_severity: BLOCKING
+        max_severity: BLOCKING
+        description: "I/O operation (network, file, database) in run()/@entrypoint method body"
+        override_allowed: false
+
+      - pattern_id: non-deterministic-in-workflow
+        canonical_severity: BLOCKING
+        max_severity: BLOCKING
+        description: "datetime.now/utcnow, uuid4, random.*, or time.time in run()/@entrypoint"
+        override_allowed: false
+
+      - pattern_id: blocking-call-in-workflow
+        canonical_severity: HIGH
+        max_severity: CRITICAL
+        description: "Blocking synchronous call in async run()/@entrypoint without @task"
+        required_conditions_for_critical:
+          - "Call is long-running (>1s typical)"
+        override_allowed: true
+
+  - id: contract-safety
+    description: "Temporal payload contract evolution violations"
+    patterns:
+      - pattern_id: field-removed
+        canonical_severity: BLOCKING
+        max_severity: BLOCKING
+        description: "Field removed from Input/Output contract (breaks in-flight replay)"
+        override_allowed: false
+
+      - pattern_id: field-renamed
+        canonical_severity: BLOCKING
+        max_severity: BLOCKING
+        description: "Field renamed on Input/Output contract (breaks in-flight replay)"
+        override_allowed: false
+
+      - pattern_id: field-type-changed
+        canonical_severity: BLOCKING
+        max_severity: BLOCKING
+        description: "Field type changed on Input/Output contract (breaks in-flight replay)"
+        override_allowed: false
+
+      - pattern_id: mutable-default
+        canonical_severity: HIGH
+        max_severity: CRITICAL
+        description: "Mutable default on Input/Output field — use Field(default_factory=...)"
+        required_conditions_for_critical:
+          - "Field is used in workflow orchestration (not just task I/O)"
+        override_allowed: true
+
+      - pattern_id: missing-default-new-field
+        canonical_severity: HIGH
+        max_severity: HIGH
+        description: "New field on Input/Output without a default value (breaks existing callers)"
+        override_allowed: true
+
+  - id: blocking-operations
+    description: "Heartbeat and event loop safety in @task methods"
+    patterns:
+      - pattern_id: blocking-in-task
+        canonical_severity: HIGH
+        max_severity: CRITICAL
+        description: "Blocking operation in @task without self.run_in_thread()"
+        required_conditions_for_critical:
+          - "Task has heartbeat enabled"
+          - "Blocking operation is long-running (>5s)"
+        override_allowed: true
+
+      - pattern_id: sync-http-in-async
+        canonical_severity: HIGH
+        max_severity: HIGH
+        description: "Synchronous HTTP call (requests.get etc.) in async context"
+        override_allowed: true
+
+  - id: infrastructure-abstraction
+    description: "ADR-0005 infrastructure abstraction layer violations"
+    patterns:
+      - pattern_id: direct-temporal-import
+        canonical_severity: HIGH
+        max_severity: HIGH
+        description: "Direct temporalio import outside execution/_temporal/ module"
+        override_allowed: false
+
+      - pattern_id: direct-dapr-import
+        canonical_severity: HIGH
+        max_severity: HIGH
+        description: "Direct dapr import outside infrastructure/_dapr/ module"
+        override_allowed: false
+
+      - pattern_id: direct-redis-import
+        canonical_severity: MEDIUM
+        max_severity: HIGH
+        description: "Direct redis import outside infrastructure/_redis/ module"
+        override_allowed: true
+
+  - id: api-surface
+    description: "Public API stability and test coverage"
+    patterns:
+      - pattern_id: public-api-no-test
+        canonical_severity: CRITICAL
+        max_severity: CRITICAL
+        description: "New public API (exported in __init__.py) without corresponding test"
+        override_allowed: false
+
+      - pattern_id: breaking-change-no-deprecation
+        canonical_severity: CRITICAL
+        max_severity: CRITICAL
+        description: "Public export removed or signature changed without deprecation shim with warnings.warn()"
+        override_allowed: false
+
+      - pattern_id: missing-type-annotation
+        canonical_severity: MEDIUM
+        max_severity: MEDIUM
+        description: "Public method missing return type annotation"
+        override_allowed: true
+
+  - id: credential-safety
+    description: "Credential handling patterns"
+    patterns:
+      - pattern_id: raw-credential-in-contract
+        canonical_severity: HIGH
+        max_severity: CRITICAL
+        description: "Raw credential value passed in Input/Output (use CredentialRef instead)"
+        required_conditions_for_critical:
+          - "Credential passes through Temporal payload (visible in workflow history)"
+        override_allowed: false
+
+      - pattern_id: credential-in-log
+        canonical_severity: BLOCKING
+        max_severity: BLOCKING
+        description: "Credential, secret, token, or API key logged via logger or print"
+        override_allowed: false
+
+      - pattern_id: credential-resolve-outside-task
+        canonical_severity: HIGH
+        max_severity: HIGH
+        description: "CredentialResolver used outside @task method (no retry/heartbeat protection)"
+        override_allowed: true
+
+  - id: error-handling
+    description: "Exception handling patterns"
+    patterns:
+      - pattern_id: bare-except
+        canonical_severity: MEDIUM
+        max_severity: HIGH
+        description: "Bare except clause swallowing all exceptions"
+        required_conditions_for_high:
+          - "In a @task method or run() orchestration"
+        override_allowed: true
+
+      - pattern_id: silent-exception
+        canonical_severity: HIGH
+        max_severity: HIGH
+        description: "Exception caught, logged, but not re-raised — caller never knows about failure"
+        override_allowed: true
+
+      - pattern_id: missing-exception-chain
+        canonical_severity: LOW
+        max_severity: MEDIUM
+        description: "Exception re-raised without 'from e' — original traceback lost"
+        override_allowed: true
+
+  - id: dependency-direction
+    description: "ADR layer dependency violations"
+    patterns:
+      - pattern_id: reverse-dependency
+        canonical_severity: HIGH
+        max_severity: HIGH
+        description: "Import from infrastructure/ into app/ or execution/ into app/ (wrong direction)"
+        override_allowed: false
+
+      - pattern_id: cross-layer-skip
+        canonical_severity: MEDIUM
+        max_severity: HIGH
+        description: "app/ importing directly from infrastructure/ (should go through execution/)"
+        required_conditions_for_high:
+          - "Import is for runtime behavior (not just types)"
+        override_allowed: true
+
+  - id: v2-patterns
+    description: "Legacy v2 SDK patterns that should be migrated"
+    patterns:
+      - pattern_id: v2-import
+        canonical_severity: HIGH
+        max_severity: HIGH
+        description: "Import from application_sdk.workflows, .activities, or .handlers (removed in v3)"
+        override_allowed: false
+
+      - pattern_id: v2-interface
+        canonical_severity: HIGH
+        max_severity: HIGH
+        description: "Subclass of ActivitiesInterface, WorkflowInterface, or HandlerInterface"
+        override_allowed: false
+
+      - pattern_id: v2-decorator
+        canonical_severity: MEDIUM
+        max_severity: HIGH
+        description: "@workflow.defn or @activity.defn decorator (use @task instead)"
+        required_conditions_for_high:
+          - "In non-deprecated module"
+        override_allowed: true
+
+      - pattern_id: dataclass-on-contract
+        canonical_severity: MEDIUM
+        max_severity: MEDIUM
+        description: "@dataclass on Input/Output subclass (should be plain Pydantic BaseModel)"
+        override_allowed: true
+
+# Severity calibration + confidence floors — the single source (absorbed from
+# the deleted modes/standard.md; BLDX-1605). Do not restate these in agent
+# prompts or mode files.
+#
+# The floors are PER SEVERITY and that matters: six pr-review briefs restate
+# them as a flat `>= 0.80`, and one as a flat `0.85`. The harm is suppression,
+# not drift — a flat 0.80 discards every valid MEDIUM (floor 0.55) and LOW
+# (0.40), and a flat 0.85 additionally discards every valid HIGH (0.80). The
+# runner applies the table; no brief restates it.
+calibration:
+  severity_meanings:
+    BLOCKING: "Use pattern_id above when applicable; guardrail-class"
+    CRITICAL: "Use pattern_id above when applicable; guardrail-class"
+    HIGH: "Issues users will hit in common flows (inline comment REQUIRED)"
+    MEDIUM: "Issues users rarely hit (summary body only)"
+    LOW: "Defensive notes (summary body only)"
+    INFO: "Pattern observation (summary body only)"
+  confidence_floors:
+    BLOCKING: 0.85
+    CRITICAL: 0.85
+    HIGH: 0.80
+    MEDIUM: 0.55
+    LOW: 0.40


### PR DESCRIPTION
**Stacked on #3626** (base `vaibhavchopra/sdk-loop-context-pack` — reuses its diff parser). Chain: #3604 → #3625 → #3626 → this.

Part of the `@sdk-loop` redesign.

## Two halves of one idea

The reviewer writes down **how the change could break** before it writes any test. The runner then checks whether the tests this PR adds **would have failed without the change**.

### `HYPOTHESES.md` — the list comes first

A test suite written after the code it tests drifts toward the paths already known to pass, and a model asked to "add tests" produces exactly that. So the brief demands the hypotheses in a file *before* any test is written, and shows a bad example next to good ones — because *"test that resolve() works"* is what you get without a counterexample to point at:

```
- concurrent entry: two activities call `resolve()` on the same key; the second
  overwrites the first's cached credential
- boundary: `page_size=0` makes the paginator loop forever rather than return empty
- partial failure: upstream returns 200 with a truncated body; the parser reports
  success over half a record
```

Six classes to work through — boundaries, concurrency, partial failure, hostile input, exhaustion, replay — chosen because that's where defects in *this* SDK actually live.

### `sdk_loop_redgreen.py` — the deterministic half

Take the test functions this PR adds or changes, materialise the base revision, **overlay only the test files**, run them.

Overlaying only the tests is the trick: old source plus new tests is exactly the state the author was in before they wrote the fix. **A test that passes there never captured the change** — it's decoration, and decoration is worse than an absent test because it buys confidence nobody checked.

## Three decisions that carry the design

**`ERROR` counts as captured, not as doubt.** A test that can't even import against the old source references something this PR introduced — that's red in the strongest sense available. Reading it as inconclusive would mark every test of a new module as suspect, which is backwards and would make the metric useless on exactly the PRs that add the most code.

**Parsed from pytest's output, never its exit code.** The run is *expected* to fail — a non-zero exit is the success condition here. A caller keying on `returncode` would invert the entire result.

**`rate` returns `None`, not `0.0`, when nothing was gradeable.** `0.0` means every examined test passed on old source; `None` means none were examined. Collapsing them reports a PR with no test changes as having the worst possible score.

Also: examined at **function** level, not file level. A PR appending one test to a 900-line file changed one test; re-running the other forty would bury the row that matters under green-on-base noise.

## Advisory, never blocking

Per the rollout decision. There are legitimate green-on-base tests — documenting behaviour the change must preserve, a refactor with no behavioural delta, backfilled coverage of old code — and a gate would punish all three. The summary phrases it as a question:

> **Red-green:** 1/2 of this PR's new tests fail against the base revision (50%).
> These pass with or without the change… That can be deliberate — documenting behaviour the change must preserve, or backfilling old coverage — but if one was meant to capture this fix, it does not.

## Why not mutation testing

It answers a broader question (are the tests strong in general) at minutes per run, against a 15-minute hard stop on Small-tier PRs. Red-green answers the sharper one — *did this test capture **this** change* — for one checkout and one test run. Diff coverage already covers the commoner "new code, no test" case. Revisit if the narrow tail (code tests *execute* but don't *constrain*) proves to bite.

## Safety

The base tree is a throwaway `git worktree`, removed in a `finally` — asserted by a test that makes the run raise. **No stash:** the stash stack is shared with every other checkout on this machine.

A base that can't be materialised reports `skipped_reason` rather than zero captured tests — otherwise a git error would accuse the author of writing decorative tests.

## Tests (18)

Classification rules including both inversions above · function-level selection · non-test files ignored · `None` vs `0.0` · inconclusive outcomes not moving the rate · overlay copies only test files · worktree cleaned up even when the run raises · failed checkout reported not guessed · the report asking rather than accusing · the brief demanding the file first and carrying a bad example.

37 pass with #3626's suite. `pre-commit` green.

## Not in this change

Nothing calls this yet — the cutover wires it, and adds diff coverage alongside.
