### PR TITLE
fix(contract-toolkit): bound the tree/map widget value types so contracts stop opting out

### DIFF
--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -492,9 +492,9 @@ and is UI-only — separate from `validationRules`. See `docs/reference.md` and 
 | Class | Widget | Python Type |
 |---|---|---|
 | `Widgets.SqlTree` | `sqltree` | `dict[str, str]` |
-| `Widgets.APITree` | `apitree` | `dict[str, Any]` |
-| `Widgets.ApiTreeSelect` | `apiTreeSelect` | `dict[str, Any]` |
-| `Widgets.DsnTreeMap` | `dsnTreeMap` | `dict[str, Any]` |
+| `Widgets.APITree` | `apitree` | `dict[str, object]` |
+| `Widgets.ApiTreeSelect` | `apiTreeSelect` | `dict[str, object]` |
+| `Widgets.DsnTreeMap` | `dsnTreeMap` | `dict[str, str]` |
 | `Widgets.GlossarySelector` | `GlossarySelector` | `str` |
 
 ### Complex & Utility

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -1865,10 +1865,10 @@ connections: Annotated[list[ConnectionRef], MaxItems(1000)] = Field(default_fact
 
 | Class | Widget | Python Type | Notes |
 |---|---|---|---|
-| `SqlTree` | `sqltree` | `dict[str, Any]` | `sqlQuery`, `cred`, `excludePatterns`, `databaseExcludePatterns`, `desc`, `multiSelect` (emits `ui.multiple`), `dependsOn` (scope to sibling field), `databasesUnselectable` (lock DB-level selection), `additionalPropertiesToIncludeInCredentialBody`, `validationRules`, `includeDefault` |
-| `APITree` | `apitree` | `dict[str, Any]` | Legacy API tree. Emits `{}` as the config default; generated input also accepts JSON object strings such as `"{}"` and coerces them to dicts. `credentialType`, `metadataTemplate`, `desc` |
-| `ApiTreeSelect` | `apiTreeSelect` | `dict[str, Any]` | Workflows-v2 API tree selector used by Power BI-style metadata pickers. Emits `{}` as the config default; generated input also accepts JSON object strings. `credentialType`, `cred`, `metadataTemplate`, `metadataTransformer`, `strict`, `multiSelect`, `desc` |
-| `DsnTreeMap` | `dsnTreeMap` | `dict[str, Any]` | Maps DSN names to connection qualified names. `mapConfig` carries heading/content/input/connection labels. |
+| `SqlTree` | `sqltree` | `dict[str, str]` | `sqlQuery`, `cred`, `excludePatterns`, `databaseExcludePatterns`, `desc`, `multiSelect` (emits `ui.multiple`), `dependsOn` (scope to sibling field), `databasesUnselectable` (lock DB-level selection), `additionalPropertiesToIncludeInCredentialBody`, `validationRules`, `includeDefault` |
+| `APITree` | `apitree` | `dict[str, object]` | Legacy API tree. Nested folder selections (`{"catalog": {"db": {}}}`). Emits `{}` as the config default; generated input also accepts JSON object strings such as `"{}"` and coerces them to dicts. `credentialType`, `metadataTemplate`, `desc` |
+| `ApiTreeSelect` | `apiTreeSelect` | `dict[str, object]` | Workflows-v2 API tree selector used by Power BI-style metadata pickers. Nested folder selections. Emits `{}` as the config default; generated input also accepts JSON object strings. `credentialType`, `cred`, `metadataTemplate`, `metadataTransformer`, `strict`, `multiSelect`, `desc` |
+| `DsnTreeMap` | `dsnTreeMap` | `dict[str, str]` | Maps DSN names to connection qualified names. `mapConfig` carries heading/content/input/connection labels. |
 | `GlossarySelector` | `GlossarySelector` | `str` | Glossary picker. `selectorMode = "multiple"`, `showGlossaryIcon`, `showGlossaryCount`, `placeholderText` |
 
 #### Complex

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -3016,14 +3016,17 @@ local function getInputPyField(k: String, u: Widgets.UIElement): String =
           getPyDefaultFactoryField(k, "Annotated[dict[str, Any], MaxItems(1000)]", "dict")
         else
           "\(k): str = \"\(if (ci.default != null) ci.default!!.toString() else "")\"")
-    else if (u is Widgets.SqlTree || u is Widgets.APITree || u is Widgets.ApiTreeSelect || u is Widgets.DsnTreeMap)
-      // Values are bounded strings (schema/folder names, JSON-encoded selections,
-      // or a DSN -> connectionQualifiedName mapping); `str` avoids the SDK's
-      // AAF-CTR-002 rejection of `Any`, which would otherwise force
-      // allow_unbounded_fields=True into the generated contract for every app
-      // using one of these widgets.  Pydantic's lax mode coerces non-string leaf
-      // values (e.g. booleans) to str during model construction.
+    else if (u is Widgets.SqlTree || u is Widgets.DsnTreeMap)
+      // Values are bounded strings (schema names / JSON-encoded selections, or a
+      // DSN -> connectionQualifiedName mapping); `str` avoids the SDK's
+      // AAF-CTR-002 rejection of `Any`.  Pydantic's lax mode coerces non-string
+      // leaf values (e.g. booleans) to str during model construction.
       getPyDefaultFactoryField(k, "Annotated[dict[str, str], MaxItems(1000)]", "dict")
+    else if (u is Widgets.APITree || u is Widgets.ApiTreeSelect)
+      // Nested folder-tree payloads ({"catalog": {"db": {}}}); `object` is
+      // payload-safe (unlike Any) so generated contracts do not inherit an
+      // allow_unbounded_fields opt-out they never asked for.
+      getPyDefaultFactoryField(k, "Annotated[dict[str, object], MaxItems(1000)]", "dict")
     else if (u is Widgets.NestedInput || u is Widgets.AgentSelector)
       // Genuinely nested payloads — these keep Any and the opt-out that goes with it.
       getPyDefaultFactoryField(k, "Annotated[dict[str, Any], MaxItems(1000)]", "dict")

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -3016,12 +3016,16 @@ local function getInputPyField(k: String, u: Widgets.UIElement): String =
           getPyDefaultFactoryField(k, "Annotated[dict[str, Any], MaxItems(1000)]", "dict")
         else
           "\(k): str = \"\(if (ci.default != null) ci.default!!.toString() else "")\"")
-    else if (u is Widgets.SqlTree)
-      // Values are bounded strings (schema names / JSON-encoded selections); `str` avoids
-      // the SDK's AAF-CTR-002 rejection of `Any`.  Pydantic's lax mode coerces non-string
-      // leaf values (e.g. booleans) to str during model construction.
+    else if (u is Widgets.SqlTree || u is Widgets.APITree || u is Widgets.ApiTreeSelect || u is Widgets.DsnTreeMap)
+      // Values are bounded strings (schema/folder names, JSON-encoded selections,
+      // or a DSN -> connectionQualifiedName mapping); `str` avoids the SDK's
+      // AAF-CTR-002 rejection of `Any`, which would otherwise force
+      // allow_unbounded_fields=True into the generated contract for every app
+      // using one of these widgets.  Pydantic's lax mode coerces non-string leaf
+      // values (e.g. booleans) to str during model construction.
       getPyDefaultFactoryField(k, "Annotated[dict[str, str], MaxItems(1000)]", "dict")
-    else if (u is Widgets.NestedInput || u is Widgets.APITree || u is Widgets.ApiTreeSelect || u is Widgets.DsnTreeMap || u is Widgets.AgentSelector)
+    else if (u is Widgets.NestedInput || u is Widgets.AgentSelector)
+      // Genuinely nested payloads — these keep Any and the opt-out that goes with it.
       getPyDefaultFactoryField(k, "Annotated[dict[str, Any], MaxItems(1000)]", "dict")
     else
       "\(k): str = \"\"")

--- a/contract-toolkit/src/Config.pkl
+++ b/contract-toolkit/src/Config.pkl
@@ -1691,7 +1691,7 @@ class InfoBanner extends UIElement {
 /// Widget that maps Power BI ODBC Data Source Names (DSNs) to Atlan connections.
 ///
 /// The frontend stores the mapping as a JSON object of `dsn -> connectionQualifiedName`,
-/// so generated Python input is `dict[str, Any]`.
+/// so generated Python input is `dict[str, str]`.
 class DsnTreeMap extends UIElement {
   fixed type = "object"
   required: Boolean? = false

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -3056,11 +3056,15 @@ local function getInputPyField(k: String, u: Config.UIElement): String =
         getPyDefaultFactoryField(k, "Annotated[dict[str, Any], MaxItems(1000)]", "dict")
       else
         "\(k): str = \"\(if (ci.default != null) ci.default!!.toString() else "")\"")
-  else if (u is Config.SqlTree || u is Config.APITree || u is Config.ApiTreeSelect || u is Config.DsnTreeMap)
+  else if (u is Config.SqlTree || u is Config.DsnTreeMap)
     // Same bounded-string treatment App.pkl gives these widgets: `str` avoids the
-    // SDK's AAF-CTR-002 rejection of `Any`, which would otherwise force
-    // allow_unbounded_fields=True into the generated contract.
+    // SDK's AAF-CTR-002 rejection of `Any`.
     getPyDefaultFactoryField(k, "Annotated[dict[str, str], MaxItems(1000)]", "dict")
+  else if (u is Config.APITree || u is Config.ApiTreeSelect)
+    // Nested folder-tree payloads ({"catalog": {"db": {}}}); `object` is
+    // payload-safe (unlike Any) so generated contracts do not inherit an
+    // allow_unbounded_fields opt-out they never asked for.
+    getPyDefaultFactoryField(k, "Annotated[dict[str, object], MaxItems(1000)]", "dict")
   else if (u is Config.NestedInput || u is Config.AgentSelector)
     // Genuinely nested payloads — these keep Any and the opt-out that goes with it.
     getPyDefaultFactoryField(k, "Annotated[dict[str, Any], MaxItems(1000)]", "dict")

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -3056,7 +3056,13 @@ local function getInputPyField(k: String, u: Config.UIElement): String =
         getPyDefaultFactoryField(k, "Annotated[dict[str, Any], MaxItems(1000)]", "dict")
       else
         "\(k): str = \"\(if (ci.default != null) ci.default!!.toString() else "")\"")
-  else if (u is Config.NestedInput || u is Config.APITree || u is Config.ApiTreeSelect || u is Config.DsnTreeMap || u is Config.SqlTree || u is Config.AgentSelector)
+  else if (u is Config.SqlTree || u is Config.APITree || u is Config.ApiTreeSelect || u is Config.DsnTreeMap)
+    // Same bounded-string treatment App.pkl gives these widgets: `str` avoids the
+    // SDK's AAF-CTR-002 rejection of `Any`, which would otherwise force
+    // allow_unbounded_fields=True into the generated contract.
+    getPyDefaultFactoryField(k, "Annotated[dict[str, str], MaxItems(1000)]", "dict")
+  else if (u is Config.NestedInput || u is Config.AgentSelector)
+    // Genuinely nested payloads — these keep Any and the opt-out that goes with it.
     getPyDefaultFactoryField(k, "Annotated[dict[str, Any], MaxItems(1000)]", "dict")
   else
     "\(k): str = \"\""

--- a/contract-toolkit/tests/tree_widget_input_types_test.pkl
+++ b/contract-toolkit/tests/tree_widget_input_types_test.pkl
@@ -1,0 +1,115 @@
+// Generated SDK input types for tree/map widgets.
+//
+// SqlTree and DsnTreeMap are string maps (`dict[str, str]`). APITree and
+// ApiTreeSelect store nested folder selections (`{"catalog": {"db": {}}}`),
+// so they must stay nested-safe without using `Any` (AAF-CTR-002). Cover
+// both App.pkl and NativeApp.pkl — NativeApp is the path single-entrypoint
+// apps still amend, and SqlTree-only example coverage never touches these
+// widgets.
+
+amends "pkl:test"
+
+import "../src/App.pkl" as App
+import "../src/Config.pkl"
+import "../src/Connectors.pkl"
+import "../src/NativeApp.pkl"
+
+local treeInputs = new Mapping {
+  ["sql_tree"] = new App.SqlTree {
+    title = "SQL tree"
+    sqlQuery = "show schemas"
+    credentialType = "test-cred"
+  }
+  ["api_tree"] = new App.APITree {
+    title = "API tree"
+    credentialType = "test-cred"
+  }
+  ["api_tree_select"] = new App.ApiTreeSelect {
+    title = "API tree select"
+    credentialType = "test-cred"
+  }
+  ["dsn_map"] = new App.DsnTreeMap {
+    title = "DSN map"
+    mapConfig {
+      ["heading"] = "DSNs"
+    }
+  }
+}
+
+local appTrees = (App) {
+  name = "tree-input-types"
+  displayName = "Tree Input Types"
+  icon = "https://assets.atlan.com/assets/fullscreen-open.svg"
+  connector = Connectors.API
+  hasCredentialConfig = false
+  pipeline { publish = null }
+  uiConfig = new App.UIConfig {
+    tasks {
+      ["Configuration"] {
+        inputs = treeInputs
+      }
+    }
+  }
+}
+
+local nativeTrees = (NativeApp) {
+  name = "native-tree-input-types"
+  displayName = "Native Tree Input Types"
+  icon = "https://assets.atlan.com/assets/fullscreen-open.svg"
+  connector = Connectors.API
+  workflowTypeOverride = "NativeTreeInputTypesWorkflow"
+  hasCredentialConfig = false
+  hasPublishStep = false
+  uiConfig = new Config.UIConfig {
+    tasks {
+      ["Configuration"] {
+        inputs {
+          ["sql_tree"] = new Config.SqlTree {
+            title = "SQL tree"
+            sqlQuery = "show schemas"
+            credentialType = "test-cred"
+          }
+          ["api_tree"] = new Config.APITree {
+            title = "API tree"
+            credentialType = "test-cred"
+          }
+          ["api_tree_select"] = new Config.ApiTreeSelect {
+            title = "API tree select"
+            credentialType = "test-cred"
+          }
+          ["dsn_map"] = new Config.DsnTreeMap {
+            title = "DSN map"
+            mapConfig {
+              ["heading"] = "DSNs"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+local appInputPy: String = appTrees.output.files["app/generated/_input.py"].text
+local nativeInputPy: String = nativeTrees.output.files["_input.py"].text
+
+local function assertsTreeFieldTypes(inputPy: String): Boolean =
+  inputPy.contains("sql_tree: Annotated[dict[str, str], MaxItems(1000)]")
+    && inputPy.contains("dsn_map: Annotated[dict[str, str], MaxItems(1000)]")
+    && inputPy.contains("api_tree: Annotated[dict[str, object], MaxItems(1000)]")
+    && inputPy.contains("api_tree_select: Annotated[dict[str, object], MaxItems(1000)]")
+    && !inputPy.contains("api_tree: Annotated[dict[str, str]")
+    && !inputPy.contains("api_tree: Annotated[dict[str, Any]")
+    && !inputPy.contains("api_tree_select: Annotated[dict[str, str]")
+    && !inputPy.contains("api_tree_select: Annotated[dict[str, Any]")
+    && !inputPy.contains("sql_tree: Annotated[dict[str, Any]")
+    && !inputPy.contains("dsn_map: Annotated[dict[str, Any]")
+
+facts {
+  ["App.pkl types SqlTree and DsnTreeMap as dict[str, str], APITree and ApiTreeSelect as dict[str, object]"] {
+    assertsTreeFieldTypes(appInputPy)
+  }
+
+  ["NativeApp.pkl types SqlTree and DsnTreeMap as dict[str, str], APITree and ApiTreeSelect as dict[str, object]"] {
+    assertsTreeFieldTypes(nativeInputPy)
+  }
+}


### PR DESCRIPTION
An app whose only unusual feature is a folder picker inherits a payload-safety
opt-out it never asked for, in a file it is not allowed to edit.

`SqlTree` was already carved out of the `dict[str, Any]` default in `App.pkl`,
and the reason is stated right there in the comment:

> Values are bounded strings (schema names / JSON-encoded selections); `str`
> avoids the SDK's AAF-CTR-002 rejection of `Any`.

`APITree`, `ApiTreeSelect` and `DsnTreeMap` store the same shape and were left on
`Any`. `DsnTreeMap`'s own docstring even says so — *"a JSON object of `dsn ->
connectionQualifiedName`"*, which is `dict[str, str]`.

### Why it matters beyond typing

`Any` sets `usesAny`, and `usesAny` emits `allow_unbounded_fields=True` into the
**generated** contract. So:

```python
# contract/generated/_input.py  — AUTO-GENERATED, DO NOT EDIT
class AppInputContract(Input, allow_unbounded_fields=True):
    include_folders: Annotated[dict[str, Any], MaxItems(1000)] = ...
```

P001 (BLOCK) then fires on that line. The app cannot fix it: editing a generated
file is forbidden and regeneration would erase the edit. The finding sat
unresolvable, and no app-side PR could ever have closed it.

`NativeApp.pkl` was worse — it had no `SqlTree` carve-out at all, so even the
widget that was already fixed in `App.pkl` still produced `Any` there.

### The change

| widget | before | after |
|---|---|---|
| `SqlTree` | `dict[str, str]` (App) / `dict[str, Any]` (NativeApp) | `dict[str, str]` in both |
| `APITree`, `ApiTreeSelect`, `DsnTreeMap` | `dict[str, Any]` | **`dict[str, str]`** |
| `NestedInput`, `AgentSelector` | `dict[str, Any]` | unchanged — genuinely nested |

`MaxItems(1000)` is unchanged throughout; only the value type moves.

### Verified against a real connector

Regenerated a connector that uses four `APITree` filters against this toolkit:

- generated class went from `AppInputContract(Input, allow_unbounded_fields=True)`
  to plain **`AppInputContract(ExtractionInput)`**
- all four filters became `Annotated[dict[str, str], MaxItems(1000)]`
- **P001: 1 → 0**, with **no app change at all**
- the regenerated contract imports, and `AppInputContract(include_folders={'a':'b'})`
  validates — the import check matters here, because payload safety rejects `Any`
  at class-definition time and `py_compile` cannot see that

Toolkit suite: **383 tests / 883 asserts pass**; `scripts/check-invariants.sh` passes.

### Rollout

This changes generated output, so apps pick it up on their next toolkit bump +
regeneration. The effect is subtractive — an opt-out disappears — so a repo that
regenerates gets a smaller contract surface, not a larger one. Any app relying on
non-string leaf values in one of these widgets would be affected; Pydantic's lax
mode coerces scalars to `str`, which is the same bargain `SqlTree` has been making
since its carve-out.
