### PR TITLE
fix(contract-toolkit): emit extraction_method alongside agent_json (P029)

### DIFF
--- a/contract-toolkit/examples/artifact-schemas/app/generated/manifest.json
+++ b/contract-toolkit/examples/artifact-schemas/app/generated/manifest.json
@@ -15,6 +15,7 @@
           "app_name": "artifact-schemas-example",
           "credential": "{{credential}}",
           "agent_json": "{{agent-json}}",
+          "extraction_method": "{{extraction-method}}",
           "lookback_days": "{{lookback-days}}"
         }
       },

--- a/contract-toolkit/examples/behind-the-scenes/app/generated/manifest.json
+++ b/contract-toolkit/examples/behind-the-scenes/app/generated/manifest.json
@@ -15,6 +15,7 @@
           "app_name": "behind-the-scenes",
           "credential": "{{credential}}",
           "agent_json": "{{agent-json}}",
+          "extraction_method": "{{extraction-method}}",
           "target": "{{target}}"
         }
       },

--- a/contract-toolkit/examples/bundle/app/generated/crawler/manifest.json
+++ b/contract-toolkit/examples/bundle/app/generated/crawler/manifest.json
@@ -15,6 +15,7 @@
           "app_name": "crawler",
           "credential": "{{credential}}",
           "agent_json": "{{agent-json}}",
+          "extraction_method": "{{extraction-method}}",
           "credential_guid": "{{credential-guid}}",
           "connection": "{{connection}}",
           "include_filter": "{{include-filter}}",

--- a/contract-toolkit/examples/bundle/app/generated/miner/manifest.json
+++ b/contract-toolkit/examples/bundle/app/generated/miner/manifest.json
@@ -15,6 +15,7 @@
           "app_name": "miner",
           "credential": "{{credential}}",
           "agent_json": "{{agent-json}}",
+          "extraction_method": "{{extraction-method}}",
           "credential_guid": "{{credential-guid}}",
           "lookback_days": "{{lookback-days}}",
           "max_queries": "{{max-queries}}"

--- a/contract-toolkit/examples/connection-ref/app/generated/manifest.json
+++ b/contract-toolkit/examples/connection-ref/app/generated/manifest.json
@@ -15,6 +15,7 @@
           "app_name": "connection-ref",
           "credential": "{{credential}}",
           "agent_json": "{{agent-json}}",
+          "extraction_method": "{{extraction-method}}",
           "connection": "{{connection}}",
           "connections": "{{connections}}"
         }

--- a/contract-toolkit/examples/deploy/app/generated/manifest.json
+++ b/contract-toolkit/examples/deploy/app/generated/manifest.json
@@ -15,6 +15,7 @@
           "app_name": "deploy",
           "credential": "{{credential}}",
           "agent_json": "{{agent-json}}",
+          "extraction_method": "{{extraction-method}}",
           "target": "{{target}}"
         }
       },

--- a/contract-toolkit/examples/fanin/app/generated/manifest.json
+++ b/contract-toolkit/examples/fanin/app/generated/manifest.json
@@ -15,6 +15,7 @@
           "app_name": "fanin",
           "credential": "{{credential}}",
           "agent_json": "{{agent-json}}",
+          "extraction_method": "{{extraction-method}}",
           "credential_guid": "{{credential-guid}}"
         }
       },

--- a/contract-toolkit/examples/full/app/generated/manifest.json
+++ b/contract-toolkit/examples/full/app/generated/manifest.json
@@ -15,6 +15,7 @@
           "app_name": "full-featured",
           "credential": "{{credential}}",
           "agent_json": "{{agent-json}}",
+          "extraction_method": "{{extraction-method}}",
           "credential_guid": "{{credential-guid}}",
           "connection": "{{connection}}",
           "include_filter": "{{include_filter}}",

--- a/contract-toolkit/examples/minimal/app/generated/manifest.json
+++ b/contract-toolkit/examples/minimal/app/generated/manifest.json
@@ -15,6 +15,7 @@
           "app_name": "minimal",
           "credential": "{{credential}}",
           "agent_json": "{{agent-json}}",
+          "extraction_method": "{{extraction-method}}",
           "target": "{{target}}"
         }
       },

--- a/contract-toolkit/examples/pools/app/generated/manifest.json
+++ b/contract-toolkit/examples/pools/app/generated/manifest.json
@@ -15,6 +15,7 @@
           "app_name": "pools-example",
           "credential": "{{credential}}",
           "agent_json": "{{agent-json}}",
+          "extraction_method": "{{extraction-method}}",
           "target": "{{target}}"
         }
       },

--- a/contract-toolkit/examples/scheduled/app/generated/manifest.json
+++ b/contract-toolkit/examples/scheduled/app/generated/manifest.json
@@ -15,6 +15,7 @@
           "app_name": "scheduled",
           "credential": "{{credential}}",
           "agent_json": "{{agent-json}}",
+          "extraction_method": "{{extraction-method}}",
           "target": "{{target}}"
         }
       },

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -2855,6 +2855,16 @@ local function generateExtractNode(): Mapping<String, Any> =
         when (uiConfig == null || !uiConfig!!.properties.containsKey("agent-json")) {
           ["agent_json"] = "{{agent-json}}"
         }
+        // The other half of the SDR routing pair. Heracles/AE derives the agent
+        // task queue AND fills the credential-routing spec from `agent_json` +
+        // `extraction_method` together at dispatch, so emitting only the first
+        // leaves an SDR-declaring app half-wired — the same shape as the
+        // agent-json gap above, and what P029 reports. Emitted only when the app
+        // does not model `extraction-method` itself; when it does, the loop below
+        // emits it and this guard avoids a duplicate key.
+        when (uiConfig == null || !uiConfig!!.properties.containsKey("extraction-method")) {
+          ["extraction_method"] = "{{extraction-method}}"
+        }
         for (argName, formField in manifestTopLevelArgs) {
           when (argName != "app_name" && uiConfig != null && uiConfig!!.properties.containsKey(formField) && uiConfig!!.properties[formField].includeInManifest) {
             [argName] = "{{" + formField + "}}"

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -2896,6 +2896,16 @@ local function generateExtractNode(): Mapping<String, Any> =
         when (!uiConfig.properties.containsKey("agent-json")) {
           ["agent_json"] = "{{agent-json}}"
         }
+        // The other half of the SDR routing pair. Heracles/AE derives the agent
+        // task queue AND fills the credential-routing spec from `agent_json` +
+        // `extraction_method` together at dispatch, so emitting only the first
+        // leaves an SDR-declaring app half-wired — the same shape as the
+        // agent-json gap above, and what P029 reports. Emitted only when the app
+        // does not model `extraction-method` itself; when it does, the loop below
+        // emits it and this guard avoids a duplicate key.
+        when (!uiConfig.properties.containsKey("extraction-method")) {
+          ["extraction_method"] = "{{extraction-method}}"
+        }
         for (argName, formField in manifestTopLevelArgs) {
           when (argName != "app_name" && uiConfig.properties.containsKey(formField) && uiConfig.properties[formField].includeInManifest) {
             [argName] = "{{" + formField + "}}"

--- a/contract-toolkit/tests/extraction_method_default_emit_test.pkl
+++ b/contract-toolkit/tests/extraction_method_default_emit_test.pkl
@@ -1,0 +1,66 @@
+/// Tests for the extract-node `extraction_method` default-emit guard (PR #3633).
+///
+/// `extraction_method` is the other half of the SDR routing pair with
+/// `agent_json`. Heracles/AE derives the agent task queue AND fills the
+/// credential-routing spec from both fields together at dispatch, so an app
+/// that declares SDR but does not model `extraction-method` must still emit
+/// the slot — the gap P029 reports.
+///
+/// Two guard branches on each of App.pkl and NativeApp.pkl:
+///   1. app does NOT model `extraction-method` → guard emits the slot
+///   2. app models `extraction-method`         → loop emits it exactly once
+amends "pkl:test"
+
+import "pkl:json"
+import "fixtures/default_pipeline.pkl" as noExtractionMethodApp
+import "../examples/agent-e2e/app.pkl" as modeledExtractionMethodApp
+import "fixtures/native_app_pipeline.pkl" as noExtractionMethodNative
+import "fixtures/native_app_extraction_method.pkl" as modeledExtractionMethodNative
+
+local function extractArgs(app, manifestKey: String) =
+  let (text = app.output.files[manifestKey].text)
+  let (manifest = new json.Parser { useMapping = true }.parse(text))
+    manifest["dag"]["extract"]["inputs"]["args"]
+
+local noAppArgs = extractArgs(noExtractionMethodApp, "app/generated/manifest.json")
+local modeledAppArgs = extractArgs(modeledExtractionMethodApp, "app/generated/manifest.json")
+local noNativeArgs = extractArgs(noExtractionMethodNative, "manifest.json")
+local modeledNativeArgs = extractArgs(modeledExtractionMethodNative, "manifest.json")
+
+local modeledAppManifestText =
+  modeledExtractionMethodApp.output.files["app/generated/manifest.json"].text
+local modeledNativeManifestText =
+  modeledExtractionMethodNative.output.files["manifest.json"].text
+
+facts {
+  // App.pkl branch 1: app does not model `extraction-method` → guard emits.
+  ["App.pkl without a modeled extraction-method still gets extraction_method in extract args"] {
+    noAppArgs["extraction_method"] == "{{extraction-method}}"
+  }
+
+  // App.pkl branch 2: app models `extraction-method` → the properties loop
+  // emits it; the guard skips to avoid a duplicate key.
+  ["App.pkl modeling extraction-method gets extraction_method in extract args"] {
+    modeledAppArgs["extraction_method"] == "{{extraction-method}}"
+  }
+
+  // App.pkl branch 2 (no duplicate): the slot appears exactly once.
+  ["App.pkl modeled extraction-method emits the extraction_method slot exactly once"] {
+    modeledAppManifestText.split("\"extraction_method\"").length == 2
+  }
+
+  // NativeApp.pkl branch 1: app does not model `extraction-method` → guard emits.
+  ["NativeApp.pkl without a modeled extraction-method still gets extraction_method in extract args"] {
+    noNativeArgs["extraction_method"] == "{{extraction-method}}"
+  }
+
+  // NativeApp.pkl branch 2: app models `extraction-method` → the loop emits it.
+  ["NativeApp.pkl modeling extraction-method gets extraction_method in extract args"] {
+    modeledNativeArgs["extraction_method"] == "{{extraction-method}}"
+  }
+
+  // NativeApp.pkl branch 2 (no duplicate): the slot appears exactly once.
+  ["NativeApp.pkl modeled extraction-method emits the extraction_method slot exactly once"] {
+    modeledNativeManifestText.split("\"extraction_method\"").length == 2
+  }
+}

--- a/contract-toolkit/tests/fixtures/native_app_extraction_method.pkl
+++ b/contract-toolkit/tests/fixtures/native_app_extraction_method.pkl
@@ -1,0 +1,43 @@
+/// Fixture: NativeApp that models `extraction-method` so the properties loop
+/// emits it and the default-emit guard skips (no duplicate key).
+/// Pair of `native_app_pipeline.pkl`, which does not model the widget.
+amends "../../src/NativeApp.pkl"
+
+import "../../src/Connectors.pkl"
+import "../../src/Config.pkl"
+
+name = "native-app-extraction-method"
+connector = Connectors.POSTGRES
+icon = "https://assets.atlan.com/assets/postgres.svg"
+workflowType = "PostgresWorkflow"
+
+credentialCommonFields {
+  new FieldSpec { name = "host"; displayName = "Host"; width = 6 }
+}
+
+credentialAuthOptions {
+  ["basic"] = new AuthOption {
+    label = "Basic"
+    fields {
+      new FieldSpec { name = "username"; displayName = "Username"; width = 4 }
+      new FieldSpec { name = "password"; sensitive = true; displayName = "Password"; width = 4 }
+    }
+  }
+}
+
+uiConfig = new Config.UIConfig {
+  tasks {
+    ["Credential"] {
+      inputs {
+        ["extraction-method"] = new Config.TextInput {
+          title = "Extraction method"
+          defaultValue = "direct"
+          hide = true
+        }
+        ["credential-guid"] = new Config.CredentialInput {
+          credType = "atlan-connectors-native-app-extraction-method"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
`agent_json` already has a defensive fallback, and the comment says why it exists:

```pkl
// SDR / agent-mode credential slot. Emitted whenever the app does not
// model `agent-json` — the gap that silently broke MSSQL's SDR rollout
// (atlan-mssql-app#177).
when (!uiConfig.properties.containsKey("agent-json")) {
  ["agent_json"] = "{{agent-json}}"
}
```

`extraction_method` never got the same treatment. It only reaches the manifest
through the loop over `uiConfig.properties`, so an app that declares
`self_deployed_runtime: true` but has no `extraction-method` widget emits exactly
one half of the routing pair.

That is what P029 reports, and it is not cosmetic: Heracles/AE derives the agent
task queue **and** fills the credential-routing spec from `agent_json` +
`extraction_method` *together* at dispatch. Half-wired means an SDR run cannot
tell direct from agent.

### Why the toolkit and not the apps

Three connectors are affected. The obvious app-side fix is to add an
`extraction-method` `ConditionalInput` to each contract — but that is a ~40-line
UI widget per app that also turns on the Self-Deployed Runtime *option in the
form*, which is a product decision, not a conformance fix. The reference apps
(`mysql`, `metabase`) have the widget because they chose to offer SDR.

The manifest arg is a different thing from the form field: it is dispatch wiring,
and the toolkit already accepts that responsibility for `agent_json`. This just
makes the pair symmetric.

I also checked the obvious alternative first — the affected apps are on toolkit
0.19.2/0.22.0 while `mysql` is on 0.24.0, so a version bump looked plausible.
Bumping and regenerating did **not** add the field; the widget was the only
source. That is what pointed at this guard.

### Verified

Regenerated a connector that was missing it, against this toolkit:

| | before | after |
|---|---|---|
| `agent_json` | `{{agent-json}}` | `{{agent-json}}` |
| `extraction_method` | *absent* | **`{{extraction-method}}`** |
| P029 | 1 | **0** |

No app change. When the app *does* model `extraction-method`, the existing loop
emits it and this guard skips — exactly as `agent_json` behaves today.

Toolkit suite: **383 tests / 883 asserts pass**.

### One thing for whoever rolls this out

Regenerating these apps also rewrites `atlan.yaml`, and on one of them that
**deletes six lines of comment recording a production incident** about heartbeat
timeouts. That is pre-existing toolkit-version drift, not caused by this change —
but any repo adopting a newer toolkit should diff `atlan.yaml` before committing.

