### PR TITLE
feat(storage): cut directory-upload round trips and widen small-object fan-out

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -143,7 +143,73 @@ def _resolve_transformed_target(local_path: str) -> "Path | None":
     return None
 
 
-async def _warn_on_invalid_transformed_assets(local_path: str, app_name: str) -> None:
+def _current_activity_attempt() -> int:
+    """This activity attempt, or 1 outside an activity context."""
+    try:
+        return activity.info().attempt
+    except RuntimeError:  # conformance: ignore[E007] "not in activity context" is temporalio's signal for a direct call (tests, run_dev), an expected state rather than an error worth a log line
+        return 1
+
+
+def _transformed_asset_validation_budget() -> float:
+    """Wall-clock bound for one upload's warn-only validation scan.
+
+    ``VALIDATE_ASSETS_TIMEOUT_SECONDS``, capped at half the activity's
+    start-to-close timeout when one is set. The two used to share a 600s
+    default, so a scan over a large transformed layer could spend the whole
+    activity budget before the first byte moved (FND-1339). Half leaves the
+    transfer at least as much time as the scan even when an app keeps the SDK
+    default bound; outside an activity context the configured value stands.
+    """
+    from application_sdk.constants import (  # noqa: PLC0415 — deferred-constant import mirrors upload()'s pattern
+        VALIDATE_ASSETS_TIMEOUT_SECONDS,
+    )
+
+    budget = VALIDATE_ASSETS_TIMEOUT_SECONDS
+    try:
+        bound = activity.info().start_to_close_timeout
+    except RuntimeError:  # conformance: ignore[E007] "not in activity context" is temporalio's signal for a direct call (tests, run_dev), an expected state rather than an error worth a log line
+        return budget
+    if bound is not None:
+        budget = min(budget, bound.total_seconds() / 2)
+    return budget
+
+
+def _start_transformed_asset_validation(
+    local_path: str, app_name: str
+) -> "asyncio.Task[None] | None":
+    """Kick off the warn-only asset validation *alongside* the transfer.
+
+    Returns the task, or ``None`` on a retry attempt. The scan is deterministic
+    over the same local tree and attempt 1 already emitted its outcome row, so
+    re-running it would spend the retry's budget on work that cannot change
+    the result; the retry's time goes to the transfer (FND-1339).
+    """
+    attempt = _current_activity_attempt()
+    if attempt > 1:
+        _task_logger.info(
+            "Skipping transformed-asset validation on retry attempt %d: attempt 1 "
+            "emitted its outcome and the scan is deterministic over the same "
+            "tree; this attempt's budget goes to the transfer",
+            attempt,
+        )
+        return None
+    return asyncio.create_task(
+        _warn_on_invalid_transformed_assets(
+            local_path, app_name, timeout=_transformed_asset_validation_budget()
+        )
+    )
+
+
+def _cancel_transformed_asset_validation(task: "asyncio.Task[None] | None") -> None:
+    """Drop a still-running scan when the hand-off it accompanied has failed."""
+    if task is not None and not task.done():
+        task.cancel()
+
+
+async def _warn_on_invalid_transformed_assets(
+    local_path: str, app_name: str, *, timeout: "float | None" = None
+) -> None:
     """Best-effort, warn-only validation of transformed asset NDJSON before upload.
 
     BLDX-1555 defense-in-depth at the SDR→Atlan boundary. When ``local_path``
@@ -230,7 +296,7 @@ async def _warn_on_invalid_transformed_assets(local_path: str, app_name: str) ->
         ModelSource(model=Asset),
         label="Transformed-asset validation",
         logger=_task_logger,
-        timeout=VALIDATE_ASSETS_TIMEOUT_SECONDS,
+        timeout=VALIDATE_ASSETS_TIMEOUT_SECONDS if timeout is None else timeout,
     )
 
     if report is None:
@@ -1375,12 +1441,6 @@ class App(ABC):
         if ENABLE_ATLAN_UPLOAD and upstream is None:
             raise UpstreamObjectStoreNotConfiguredError()
 
-        # BLDX-1555 defense-in-depth: validate transformed assets against the
-        # pyatlan_v9 backbone before the handoff. Warn-only, best-effort, and
-        # run in an isolated child process (CNCT-85) so a native decode fault
-        # kills only the child and never blocks or crashes the event loop.
-        await _warn_on_invalid_transformed_assets(input.local_path, self._app_name)
-
         # Build the ordered list of (store, label, fatal) upload targets.
         # See ADR-0014 §"BLDX-1464 dual-write" for the full routing decision.
         if (
@@ -1416,72 +1476,100 @@ class App(ABC):
             else None
         )
 
+        # BLDX-1555 defense-in-depth: validate transformed assets against the
+        # pyatlan_v9 backbone. Warn-only, best-effort, and run in an isolated
+        # child process (CNCT-85) so a native decode fault kills only the child
+        # and never blocks or crashes the event loop. It runs *alongside* the
+        # transfer rather than ahead of it (FND-1339): a scan over millions of
+        # records used to hold every byte back for up to its whole budget —
+        # the same 600s this activity defaults to — so a large hand-off could
+        # time out before its first PUT. Started here, after every check that
+        # can raise before the transfer, so a refused hand-off never leaves an
+        # orphaned scan behind.
+        validation = _start_transformed_asset_validation(
+            input.local_path, self._app_name
+        )
+
         # Fan-out: iterate targets in order. Fatal failures are deferred until all
         # remaining targets complete so the upstream write always runs and a copy
         # lands somewhere. If both writes fail the deployment error is chained as
         # __cause__ of the upstream error so neither traceback is lost.
         result: UploadOutput | None = None
         deferred_required_error: Exception | None = None
-        for target_store, label, fatal in targets:
-            # FND-536: every leg — including the deployment leg — gets the
-            # deployment store as its fallback source. Withholding it there made
-            # a deployment→deployment copy inexpressible: with ``local_path``
-            # absent (cross-pod / ref-only, the shape the P042 bridges use)
-            # ``transfer.upload`` could not take its deployment-store fallback
-            # branch and raised "local_path does not exist", which is a spurious
-            # WARNING under ``best_effort`` and fails the run under ``required``.
-            # Passing it costs nothing on the local-present paths: the directory
-            # reconcile is gated on a *distinct* source store, the single-file
-            # path never reads it, and ``_upload_from_store`` short-circuits a
-            # same-store copy of an identical key without any sidecar GET.
-            source_store = self.context.storage
-            try:
-                out = await _upload(
-                    input.local_path,
-                    input.storage_path,
-                    storage_subdir=input.storage_subdir,
-                    skip_if_exists=input.skip_if_exists,
-                    raise_on_empty=input.raise_on_empty,
-                    store=target_store,
-                    _source_ref=source_ref,
-                    _source_store=source_store,
-                    _app_prefix=app_prefix,
-                    _tier=input.tier,
-                )
-            except Exception as exc:
-                if fatal:
-                    _task_logger.error(
-                        "Object-store upload to %s store failed for prefix %s; "
-                        "will fail run after remaining targets complete",
-                        label,
-                        app_prefix,
-                        exc_info=True,
+        try:
+            for target_store, label, fatal in targets:
+                # FND-536: every leg — including the deployment leg — gets the
+                # deployment store as its fallback source. Withholding it there
+                # made a deployment→deployment copy inexpressible: with
+                # ``local_path`` absent (cross-pod / ref-only, the shape the P042
+                # bridges use) ``transfer.upload`` could not take its
+                # deployment-store fallback branch and raised "local_path does
+                # not exist", which is a spurious WARNING under ``best_effort``
+                # and fails the run under ``required``. Passing it costs nothing
+                # on the local-present paths: the directory reconcile is gated
+                # on a *distinct* source store, the single-file path never reads
+                # it, and ``_upload_from_store`` short-circuits a same-store copy
+                # of an identical key without any sidecar GET.
+                source_store = self.context.storage
+                try:
+                    out = await _upload(
+                        input.local_path,
+                        input.storage_path,
+                        storage_subdir=input.storage_subdir,
+                        skip_if_exists=input.skip_if_exists,
+                        raise_on_empty=input.raise_on_empty,
+                        store=target_store,
+                        _source_ref=source_ref,
+                        _source_store=source_store,
+                        _app_prefix=app_prefix,
+                        _tier=input.tier,
                     )
-                    if deferred_required_error is not None:
-                        # Both writes failed: chain the earlier error as __cause__ so
-                        # neither traceback is lost when the exception is surfaced.
-                        exc.__cause__ = deferred_required_error
-                    deferred_required_error = exc
-                else:
-                    _task_logger.warning(
-                        "Object-store upload to %s store failed for prefix %s "
-                        "(non-fatal); continuing to next target",
-                        label,
-                        app_prefix,
-                        exc_info=True,
-                    )
-                continue
-            result = out  # last successful write is authoritative (upstream in SDR)
+                except Exception as exc:
+                    if fatal:
+                        _task_logger.error(
+                            "Object-store upload to %s store failed for prefix %s; "
+                            "will fail run after remaining targets complete",
+                            label,
+                            app_prefix,
+                            exc_info=True,
+                        )
+                        if deferred_required_error is not None:
+                            # Both writes failed: chain the earlier error as
+                            # __cause__ so neither traceback is lost when the
+                            # exception is surfaced.
+                            exc.__cause__ = deferred_required_error
+                        deferred_required_error = exc
+                    else:
+                        _task_logger.warning(
+                            "Object-store upload to %s store failed for prefix %s "
+                            "(non-fatal); continuing to next target",
+                            label,
+                            app_prefix,
+                            exc_info=True,
+                        )
+                    continue
+                result = out  # last successful write is authoritative (upstream in SDR)
 
-        if deferred_required_error is not None:
-            raise deferred_required_error
-        if result is None:
-            # Unreachable under current target-construction logic (the single-target
-            # branch is always fatal=True), but guards against future changes.
-            raise _InternalError(
-                message="App.upload fan-out captured no result — this is a programming error",
-                invariant="upload fan-out must produce at least one result",
-            )
+            if deferred_required_error is not None:
+                raise deferred_required_error
+            if result is None:
+                # Unreachable under current target-construction logic (the
+                # single-target branch is always fatal=True), but guards against
+                # future changes.
+                raise _InternalError(
+                    message="App.upload fan-out captured no result — this is a programming error",
+                    invariant="upload fan-out must produce at least one result",
+                )
+        except BaseException:
+            # The hand-off is failing (or was cancelled); a warn-only scan
+            # accompanying it has nothing left to inform and must not outlive it.
+            _cancel_transformed_asset_validation(validation)
+            raise
+
+        if validation is not None:
+            # The transfer is done; give the scan the rest of its own bound so
+            # its outcome row still lands. It never raises (see its docstring).
+            await validation
         return result
 
     @task(timeout_seconds=600, retry_max_attempts=3)

--- a/application_sdk/common/_listing.py
+++ b/application_sdk/common/_listing.py
@@ -169,3 +169,18 @@ def safe_list_directory(path: Path) -> list[Path]:
     """
     _flush_directory_metadata(path)
     return list(_scandir_recursive(path))
+
+
+def file_sizes(paths: list[Path]) -> list[int]:
+    """Return ``st_size`` for every path, in order.
+
+    One blocking pass over a listing so a transfer can size its fan-out per
+    file without a ``stat`` on the event loop for each of thousands of files.
+    Run it via ``run_in_thread``, like :func:`safe_list_directory`.
+
+    Raises:
+        OSError: If any path cannot be stat-ed (removed between listing and
+            sizing, permission denied). Surfaced, not swallowed, for the same
+            reason :func:`safe_list_directory` surfaces traversal errors.
+    """
+    return [p.stat().st_size for p in paths]

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -266,6 +266,28 @@ MAX_CONCURRENT_STORAGE_TRANSFERS = int(
     os.getenv("ATLAN_MAX_CONCURRENT_STORAGE_TRANSFERS", "4")
 )
 
+#: Objects at or below this many bytes travel as one PUT (no multipart) and are
+#: buffered whole, so a directory transfer can keep many of them in flight for
+#: the price of one large object's part buffers. Directory uploads and
+#: ``FileReference`` persists use it to pick the fan-out tier per file
+#: (default 4 MiB). ``0`` disables the small-object tier so every file is
+#: bounded by ``ATLAN_MAX_CONCURRENT_STORAGE_TRANSFERS``. (FND-1339)
+STORAGE_SMALL_OBJECT_BYTES = int(
+    os.getenv("ATLAN_STORAGE_SMALL_OBJECT_BYTES", str(4 * 1024 * 1024))
+)
+
+#: Concurrent uploads for *small* objects within one directory transfer
+#: (default 32). A directory hand-off over a high-latency store is bound by
+#: round trips, not bandwidth: ``N`` small files at ``L`` seconds per request
+#: take ``N * L / fan-out`` regardless of their bytes, so the tier that holds
+#: no part buffers is the one that is safe to widen. Peak buffer memory for
+#: this tier is at most ``STORAGE_SMALL_OBJECT_BYTES`` times this value
+#: (128 MiB at the defaults); large objects keep
+#: ``MAX_CONCURRENT_STORAGE_TRANSFERS``. (FND-1339)
+MAX_CONCURRENT_SMALL_TRANSFERS = int(
+    os.getenv("ATLAN_MAX_CONCURRENT_SMALL_TRANSFERS", "32")
+)
+
 # FileReference chunked-download configuration
 #: File size threshold above which downloads use parallel range GETs (default 32 MiB)
 FILE_REF_CHUNKED_THRESHOLD_BYTES = int(

--- a/application_sdk/storage/_concurrency.py
+++ b/application_sdk/storage/_concurrency.py
@@ -25,3 +25,46 @@ async def _gather_with_semaphore(
             return await coro
 
     return list(await asyncio.gather(*[_run(c) for c in coros]))
+
+
+async def _gather_size_tiered(
+    sized_coros: Iterable[tuple[int, Coroutine[Any, Any, T]]],
+    *,
+    small_threshold: int,
+    small_limit: int,
+    large_limit: int,
+    return_exceptions: bool = False,
+) -> list[T | BaseException]:
+    """Run ``(size, coroutine)`` pairs concurrently with a per-size-tier bound.
+
+    A coroutine whose ``size`` is at or below *small_threshold* runs under a
+    semaphore of *small_limit* slots; anything larger runs under *large_limit*.
+    The two tiers exist because a transfer's cost has two different shapes: a
+    small object is buffered whole and costs a fixed number of round trips
+    regardless of its bytes, so a directory of thousands of them is
+    round-trip-bound and only a wide fan-out helps; a large object carries
+    multipart buffers (part size times part concurrency) for as long as it is
+    in flight, so its tier stays narrow to keep peak memory bounded. With
+    *small_threshold* ``<= 0`` every coroutine takes the large tier. (FND-1339)
+
+    Preserves input order in the returned list. With *return_exceptions*
+    ``False`` the first exception propagates (``asyncio.gather`` semantics);
+    with ``True`` each failure is returned in place so the caller decides.
+    """
+    small_sem = asyncio.Semaphore(max(1, small_limit))
+    large_sem = asyncio.Semaphore(max(1, large_limit))
+
+    async def _run(size: int, coro: Coroutine[Any, Any, T]) -> T:
+        sem = (
+            small_sem if 0 < small_threshold and size <= small_threshold else large_sem
+        )
+        async with sem:
+            return await coro
+
+    # conformance: ignore[E010] a bounded-gather primitive: the caller owns the results and checks them (every call site filters BaseException or lets the first propagate)
+    return list(
+        await asyncio.gather(
+            *[_run(size, coro) for size, coro in sized_coros],
+            return_exceptions=return_exceptions,
+        )
+    )

--- a/application_sdk/storage/ops.py
+++ b/application_sdk/storage/ops.py
@@ -731,6 +731,7 @@ async def _finalize_upload_integrity(
     digest: str | None,
     verify: bool | None,
     write_sidecar: bool | None,
+    defer_remote_verify: bool = False,
 ) -> None:
     """Validate a completed upload, then record its digest (FND-306).
 
@@ -756,6 +757,12 @@ async def _finalize_upload_integrity(
         digest: Streaming SHA-256, or ``None`` when hashing was off.
         verify: Per-call verification flag (``None`` → env default).
         write_sidecar: Per-call sidecar flag (``None`` → env default).
+        defer_remote_verify: When ``True``, run the local-truncation check but
+            skip the readback HEAD — the caller has taken over the readback
+            (a directory upload verifies every object against one listing of
+            its prefix instead of one HEAD each, FND-1339). Such a caller must
+            also hold the sidecar back (``write_sidecar=False``) until its own
+            readback has passed, or the ordering guarantee above is lost.
 
     Raises:
         StorageIntegrityError: If the local file shrank while being read.
@@ -766,29 +773,30 @@ async def _finalize_upload_integrity(
         integrity.check_local_file_stable(
             key, path, declared_size=declared_size, bytes_read=bytes_sent
         )
-        remote_meta = await get_file_meta(key, resolved, normalize=False)
-        if remote_meta is None:
-            # The writer reported success but the object is not there. The
-            # zero-byte case is the known one (some S3-style backends drop
-            # empty objects), and a size comparison would pass it — 0 sent,
-            # 0 found — so absence is checked separately from length.
-            from application_sdk.storage.errors import StorageError  # noqa: PLC0415
+        if not defer_remote_verify:
+            remote_meta = await get_file_meta(key, resolved, normalize=False)
+            if remote_meta is None:
+                # The writer reported success but the object is not there. The
+                # zero-byte case is the known one (some S3-style backends drop
+                # empty objects), and a size comparison would pass it — 0 sent,
+                # 0 found — so absence is checked separately from length.
+                from application_sdk.storage.errors import StorageError  # noqa: PLC0415
 
-            raise StorageError(
-                f"Upload of '{key}' reported success but the object is absent "
-                f"from the store afterwards ({bytes_sent} bytes sent from "
-                f"{path}). Some S3-style backends silently drop empty objects; "
-                f"others need read-your-writes consistency that this store "
-                f"does not offer.",
-                key=key,
+                raise StorageError(
+                    f"Upload of '{key}' reported success but the object is "
+                    f"absent from the store afterwards ({bytes_sent} bytes sent "
+                    f"from {path}). Some S3-style backends silently drop empty "
+                    f"objects; others need read-your-writes consistency that "
+                    f"this store does not offer.",
+                    key=key,
+                )
+            integrity.check_transfer_size(
+                "upload",
+                key,
+                expected=bytes_sent,
+                actual=remote_meta[0],
+                local_path=path,
             )
-        integrity.check_transfer_size(
-            "upload",
-            key,
-            expected=bytes_sent,
-            actual=remote_meta[0],
-            local_path=path,
-        )
 
     if digest is not None and integrity.sidecar_writes_enabled(write_sidecar):
         await integrity.write_digest_sidecar(store, key, digest)
@@ -805,6 +813,7 @@ async def upload_file(
     compute_hash: bool = True,
     verify: bool | None = None,
     write_sidecar: bool | None = None,
+    defer_remote_verify: bool = False,
 ) -> str | None:
     """Stream-upload a local file to *key* in the store.
 
@@ -859,6 +868,13 @@ async def upload_file(
         write_sidecar: Write the ``{key}.sha256`` sidecar.  ``None`` (default)
             follows ``ATLAN_STORAGE_WRITE_SIDECARS``.  Ignored when
             *compute_hash* is ``False`` (there is no digest to record).
+        defer_remote_verify: When ``True`` and verification is on, skip this
+            call's readback HEAD; the local-truncation check still runs.  For
+            callers that verify a whole batch against one listing of the
+            target prefix instead of one HEAD per object — the shape
+            :func:`application_sdk.storage.transfer.upload` uses for
+            directories (FND-1339).  Pair it with ``write_sidecar=False`` and
+            write the sidecars once that readback has passed.
 
     Returns:
         Hex-encoded SHA-256 digest of the uploaded file if *compute_hash* is
@@ -1014,6 +1030,7 @@ async def upload_file(
         digest=digest,
         verify=verify,
         write_sidecar=write_sidecar,
+        defer_remote_verify=defer_remote_verify,
     )
 
     if not retain_local_copy:

--- a/application_sdk/storage/reference.py
+++ b/application_sdk/storage/reference.py
@@ -47,7 +47,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from application_sdk._runtime.offload import run_in_thread
-from application_sdk.common._listing import safe_list_directory
+from application_sdk.common._listing import file_sizes, safe_list_directory
 from application_sdk.common.atomic import atomic_write
 from application_sdk.contracts.types import FileReference
 from application_sdk.storage._locks import PathLockRegistry
@@ -222,15 +222,24 @@ async def persist_file_reference(
             await upload_file(file_key, file_path, store, normalize=False)
 
         try:
-            from application_sdk.constants import (  # noqa: PLC0415
-                MAX_CONCURRENT_STORAGE_TRANSFERS,
+            from application_sdk import (  # noqa: PLC0415 — read at call time so the deployment's env (and tests) govern
+                constants as _constants,
             )
             from application_sdk.storage._concurrency import (  # noqa: PLC0415
-                _gather_with_semaphore,
+                _gather_size_tiered,
             )
 
-            sem = asyncio.Semaphore(MAX_CONCURRENT_STORAGE_TRANSFERS)
-            await _gather_with_semaphore([_upload_one(fp) for fp in files], sem)
+            # Small objects fan out wider than large ones (FND-1339): a
+            # directory of many small files is round-trip-bound, while each
+            # large object already holds part-size x part-concurrency of
+            # buffer, so only the small tier is safe to widen.
+            sizes = await run_in_thread(file_sizes, files)
+            await _gather_size_tiered(
+                [(size, _upload_one(fp)) for fp, size in zip(files, sizes)],
+                small_threshold=_constants.STORAGE_SMALL_OBJECT_BYTES,
+                small_limit=_constants.MAX_CONCURRENT_SMALL_TRANSFERS,
+                large_limit=_constants.MAX_CONCURRENT_STORAGE_TRANSFERS,
+            )
         except Exception as exc:
             # conformance: ignore[L018,L009] structured failure event; keys promoted to indexed OTLP attributes via _KNOWN_EXTRA_KEYS; distinct transfer-boundary telemetry not re-emitted by caller
             logger.error(

--- a/application_sdk/storage/transfer.py
+++ b/application_sdk/storage/transfer.py
@@ -38,29 +38,43 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
+import sys
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from application_sdk._runtime.offload import run_in_thread
 from application_sdk._runtime.progress import current_progress_tracker
-from application_sdk.common._listing import safe_list_directory
-from application_sdk.constants import MAX_CONCURRENT_STORAGE_TRANSFERS
+from application_sdk.common._listing import file_sizes, safe_list_directory
 from application_sdk.contracts.types import FileReference, StorageTier
 from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.storage._concurrency import _gather_size_tiered
 
 # The batch key listers are imported at top level, unlike the other
 # storage-sibling imports in this module which are lazy: ``batch`` depends only
 # on ``storage.ops`` / ``storage.integrity`` and never on ``transfer``, so
 # ``transfer → batch`` is unconditionally acyclic — the import is safe
 # regardless of module load order.
-from application_sdk.storage.batch import list_data_keys, list_data_objects, list_keys
+from application_sdk.storage.batch import (
+    list_data_keys,
+    list_data_objects,
+    list_keys,
+    list_keys_with_meta,
+)
 
 # Sidecar naming, digest computation and the read/write of ``{key}.sha256`` all
 # live in ``storage.integrity``, which ``ops`` calls on every transfer. This
 # module holds no copy of them: a second implementation of the digest protocol
 # is how the reader and the writer drift apart.
-from application_sdk.storage.integrity import read_expected_digest, sha256_file
+from application_sdk.storage.integrity import (
+    check_transfer_size,
+    read_expected_digest,
+    sha256_file,
+    sidecar_key,
+    sidecar_writes_enabled,
+    verification_enabled,
+    write_digest_sidecar,
+)
 
 _logger = get_logger(__name__)
 
@@ -78,12 +92,28 @@ async def _upload_one(
     store_key: str,
     *,
     skip_if_exists: bool,
-) -> tuple[bool, str]:
-    """Upload a single file.  Returns ``(transferred, reason)``.
+    sidecar_present: bool | None = None,
+    defer_remote_verify: bool = False,
+    write_sidecar: bool | None = None,
+) -> tuple[bool, str, str | None]:
+    """Upload a single file.  Returns ``(transferred, reason, digest)``.
 
     The ``{key}.sha256`` sidecar is written by ``upload_file`` itself, after it
     has validated that what landed in the store is what was sent — so it is not
-    written here (FND-306).
+    written here (FND-306). A directory upload holds both of those back
+    (``defer_remote_verify=True``, ``write_sidecar=False``) and does them once
+    for the whole batch against a listing; ``digest`` is returned so it can.
+
+    Args:
+        sidecar_present: What a listing of the target already established
+            about ``{store_key}.sha256`` — forwarded to
+            :func:`read_expected_digest` so the skip check costs no request
+            when the listing says there is nothing to compare against.
+            ``None`` keeps the per-file HEAD.
+        defer_remote_verify: Forwarded to ``upload_file``; the caller verifies
+            the object afterwards.
+        write_sidecar: Forwarded to ``upload_file``; ``False`` when the caller
+            writes sidecars itself after its readback.
     """
     from application_sdk.storage.ops import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
         upload_file,
@@ -91,23 +121,32 @@ async def _upload_one(
 
     if skip_if_exists:
         local_digest = await sha256_file(local_file)
-        remote_digest = await read_expected_digest(store, store_key)
+        remote_digest = await read_expected_digest(
+            store, store_key, sidecar_present=sidecar_present
+        )
         if remote_digest == local_digest:
             # A skip is still one file resolved. Directory uploads that skip
             # thousands of hash-matching files on an idempotent retry are doing
             # real work (a digest and a sidecar GET each) and must not read as
             # a stall.
             current_progress_tracker().mark_progress("storage.upload_file")
-            return False, "skipped:hash_match"
+            return False, "skipped:hash_match", local_digest
 
-    await upload_file(store_key, local_file, store, normalize=False)
+    digest = await upload_file(
+        store_key,
+        local_file,
+        store,
+        normalize=False,
+        defer_remote_verify=defer_remote_verify,
+        write_sidecar=write_sidecar,
+    )
     # Per-file boundary, on top of the per-part marks inside upload_file: this
     # is the label an operator wants in a stall message, since it says the
     # attempt was moving whole files rather than stuck mid-transfer on one.
     # (The sidecar write that used to sit here is upload_file's job now — see
     # the docstring above.)
     current_progress_tracker().mark_progress("storage.upload_file")
-    return True, "uploaded"
+    return True, "uploaded", digest
 
 
 async def _cross_store_sha256_match(
@@ -440,6 +479,80 @@ _FALLBACK_PREFIX_REQUIRED = (
 )
 
 
+def _fan_out_limits(max_concurrency: int | None) -> tuple[int, int, int]:
+    """``(small_limit, large_limit, small_threshold)`` for a directory transfer.
+
+    ``None`` sizes the fan-out per file from the deployment's constants: small
+    objects (at or below ``STORAGE_SMALL_OBJECT_BYTES``) run
+    ``MAX_CONCURRENT_SMALL_TRANSFERS`` wide, everything else
+    ``MAX_CONCURRENT_STORAGE_TRANSFERS``. An explicit *max_concurrency* is one
+    hard cap across everything in flight — a caller that asks for two means
+    two — so it collapses the tiers (threshold ``0``) rather than granting two
+    separate allowances. Read at call time, not import time, so a deployment's
+    environment (and a test's patch) is what governs.
+    """
+    from application_sdk import (  # noqa: PLC0415 — read at call time so the deployment's env (and tests) govern
+        constants as _constants,
+    )
+
+    if max_concurrency is not None:
+        return max_concurrency, max_concurrency, 0
+    return (
+        _constants.MAX_CONCURRENT_SMALL_TRANSFERS,
+        _constants.MAX_CONCURRENT_STORAGE_TRANSFERS,
+        _constants.STORAGE_SMALL_OBJECT_BYTES,
+    )
+
+
+async def _list_target_sizes(prefix: str, store: ObjectStore) -> dict[str, int]:
+    """``{key: size}`` for every object under *prefix* in *store*, sidecars included.
+
+    One listing (a request per thousand keys) answers, for a whole directory,
+    the two questions the per-object protocol used to spend a HEAD each on:
+    "is there a sidecar to compare against?" before the transfer, and "did
+    every object land at the size that was sent?" after it (FND-1339).
+    """
+    items = await list_keys_with_meta(prefix.rstrip("/") + "/", store, normalize=False)
+    return {key: size for key, size, _ in items}
+
+
+async def _verify_uploaded_against_listing(
+    prefix: str,
+    store: ObjectStore,
+    uploaded: list[tuple[str, int, str | None, Path]],
+) -> None:
+    """The directory-mode readback: one listing in place of a HEAD per object.
+
+    Same two checks as :func:`application_sdk.storage.ops._finalize_upload_integrity`
+    makes per object — the object is there, and it is the size that was sent —
+    and the same error classes, so a caller cannot tell which shape ran except
+    by the request count. Absence is checked separately from length because a
+    zero-byte object that a backend silently dropped would pass a bare size
+    comparison (0 sent, 0 found).
+
+    Raises:
+        StorageError: If any transferred object is missing from the listing or
+            listed at a different size than was sent (retryable).
+    """
+    listed = await _list_target_sizes(prefix, store)
+    for key, expected, _digest, local_path in uploaded:
+        actual = listed.get(key)
+        if actual is None:
+            from application_sdk.storage.errors import StorageError  # noqa: PLC0415
+
+            raise StorageError(
+                f"Upload of '{key}' reported success but the object is absent "
+                f"from the store's listing afterwards ({expected} bytes sent "
+                f"from {local_path}). Some S3-style backends silently drop "
+                f"empty objects; others need read-your-writes consistency that "
+                f"this store does not offer.",
+                key=key,
+            )
+        check_transfer_size(
+            "upload", key, expected=expected, actual=actual, local_path=local_path
+        )
+
+
 async def _list_source_data_keys(
     source_storage_path: str, source_store: ObjectStore
 ) -> tuple[str, list[str]]:
@@ -486,9 +599,17 @@ async def upload(
     _source_store: ObjectStore | None = None,
     _app_prefix: str = "",
     _tier: StorageTier = StorageTier.RETAINED,
-    max_concurrency: int = MAX_CONCURRENT_STORAGE_TRANSFERS,
+    max_concurrency: int | None = None,
 ) -> UploadOutput:
     """Upload a local file or directory to the object store.
+
+    **Round trips (directory mode, FND-1339).** A directory hand-off over a
+    high-latency store is bound by requests, not bytes. Each file costs one
+    PUT and one sidecar PUT; the skip check and the readback that used to add
+    a HEAD each per file are answered for the whole directory by two listings
+    of the target prefix (a request per thousand keys). Small objects fan out
+    on their own wider tier — see *max_concurrency* — because they are
+    buffered whole and hold no multipart part buffers.
 
     When *storage_path* is ``None`` and *_app_prefix* is provided the key /
     prefix is auto-namespaced as ``{_app_prefix}/{filename}`` (files) or
@@ -547,8 +668,13 @@ async def upload(
             fallback source.  Always ``self.context.storage`` when called via
             ``App.upload()``.
         _app_prefix: Internal prefix injected by the ``App.upload`` task.
-        max_concurrency: Maximum parallel uploads for directory mode
-            (default :data:`~application_sdk.constants.MAX_CONCURRENT_STORAGE_TRANSFERS`).
+        max_concurrency: Hard cap on parallel uploads in directory mode.
+            ``None`` (default) sizes the fan-out per file: objects at or below
+            :data:`~application_sdk.constants.STORAGE_SMALL_OBJECT_BYTES` run
+            :data:`~application_sdk.constants.MAX_CONCURRENT_SMALL_TRANSFERS`
+            wide, larger ones
+            :data:`~application_sdk.constants.MAX_CONCURRENT_STORAGE_TRANSFERS`.
+            An explicit value is one hard cap across everything in flight.
 
     Returns:
         :class:`~application_sdk.contracts.storage.UploadOutput`
@@ -610,7 +736,7 @@ async def upload(
         key = _derive_target_key(
             storage_path, _app_prefix, storage_subdir, src.name, normalize_key
         )
-        transferred, reason = await _upload_one(
+        transferred, reason, _ = await _upload_one(
             resolved, src, key, skip_if_exists=skip_if_exists
         )
         return _make_upload_output(str(src), key, 1, _tier, int(transferred), reason)
@@ -683,7 +809,6 @@ async def upload(
                 "stream-uploaded-per-file workaround pattern.",
                 local_path=local_path,
             )
-        sem = asyncio.Semaphore(max_concurrency)
         keys = [
             f"{prefix}/{str(fp.relative_to(src)).replace(os.sep, '/')}"
             if prefix
@@ -691,14 +816,48 @@ async def upload(
             for fp in files
         ]
 
-        async def _bounded_upload(file_path: Path, fkey: str) -> bool:
-            async with sem:
-                ok, _ = await _upload_one(
-                    resolved, file_path, fkey, skip_if_exists=skip_if_exists
-                )
-                return ok
+        # ── Round-trip budget (FND-1339) ─────────────────────────────────
+        # A directory hand-off over a high-latency store is bound by requests,
+        # not bytes: every file used to cost four *dependent* round trips — a
+        # sidecar HEAD for the skip check, the PUT, a readback HEAD, the
+        # sidecar PUT — at a fan-out of four. Two listings of the target prefix
+        # now stand in for the two HEADs of every file: one before the
+        # transfer answers "is there a sidecar to compare against?" for the
+        # skip check, one after confirms every object landed at the size that
+        # was sent. Listing needs a rooted prefix — at the store root there is
+        # no narrow listing to make — so that shape keeps the per-object
+        # checks.
+        can_list_target = bool(prefix)
+        target_before: dict[str, int] | None = None
+        if can_list_target and skip_if_exists:
+            target_before = await _list_target_sizes(prefix, resolved)
+        defer_verify = can_list_target and verification_enabled(None)
+        sizes = await run_in_thread(file_sizes, files)
+        # Every object this call transferred, as (key, local size, digest,
+        # local path): the set the deferred readback and sidecar pass cover.
+        uploaded: list[tuple[str, int, str | None, Path]] = []
 
-        async def _bounded_reconcile(source_key: str, target_key: str) -> bool:
+        async def _upload_local(file_path: Path, fkey: str, size: int) -> bool:
+            sidecar_present = (
+                None if target_before is None else sidecar_key(fkey) in target_before
+            )
+            ok, _, digest = await _upload_one(
+                resolved,
+                file_path,
+                fkey,
+                skip_if_exists=skip_if_exists,
+                sidecar_present=sidecar_present,
+                defer_remote_verify=defer_verify,
+                # Held back until the listing has confirmed the object; a
+                # sidecar must never advertise a digest for an object this
+                # same upload then rejects.
+                write_sidecar=False if defer_verify else None,
+            )
+            if ok:
+                uploaded.append((fkey, size, digest, file_path))
+            return ok
+
+        async def _reconcile(source_key: str, target_key: str) -> bool:
             # source_resolved is non-None whenever reconcile_pairs is populated
             # (guarded where reconcile_pairs is built). Explicit check rather than
             # ``assert`` so it is not stripped under ``python -O`` and narrows the
@@ -707,20 +866,31 @@ async def upload(
                 raise RuntimeError(
                     "reconcile requires a resolved source store but none was set"
                 )
-            async with sem:
-                ok, _ = await _upload_from_store(
-                    source_resolved,
-                    source_key,
-                    resolved,
-                    target_key,
-                    source_listed=True,  # came from _list_source_data_keys
-                )
-                return ok
+            ok, _ = await _upload_from_store(
+                source_resolved,
+                source_key,
+                resolved,
+                target_key,
+                source_listed=True,  # came from _list_source_data_keys
+            )
+            return ok
 
+        small_limit, large_limit, small_threshold = _fan_out_limits(max_concurrency)
         # conformance: ignore[E010] results checked immediately below: errs filters BaseException, first is re-raised and rest are logged
-        results = await asyncio.gather(
-            *[_bounded_upload(fp, k) for fp, k in zip(files, keys)],
-            *[_bounded_reconcile(sk, tk) for sk, tk in reconcile_pairs],
+        results = await _gather_size_tiered(
+            [
+                (size, _upload_local(fp, k, size))
+                for fp, k, size in zip(files, keys, sizes)
+            ]
+            + [
+                # A streamed copy's size is unknown without a HEAD, and it
+                # holds part buffers like any large object: narrow tier.
+                (sys.maxsize, _reconcile(sk, tk))
+                for sk, tk in reconcile_pairs
+            ],
+            small_threshold=small_threshold,
+            small_limit=small_limit,
+            large_limit=large_limit,
             return_exceptions=True,
         )
         errs = [r for r in results if isinstance(r, BaseException)]
@@ -728,6 +898,23 @@ async def upload(
             for extra in errs[1:]:
                 _logger.error("concurrent upload failure (suppressed)", exc_info=extra)
             raise errs[0]
+        if defer_verify and uploaded:
+            await _verify_uploaded_against_listing(prefix, resolved, uploaded)
+            if sidecar_writes_enabled(None):
+                # Sidecars only now, after the listing has confirmed every
+                # object — the same ordering the per-object protocol keeps.
+                # write_digest_sidecar is best-effort and logs its own
+                # failures, so there are no results to check here.
+                await _gather_size_tiered(
+                    [
+                        (0, write_digest_sidecar(resolved, key, digest))
+                        for key, _, digest, _ in uploaded
+                        if digest is not None
+                    ],
+                    small_threshold=small_threshold,
+                    small_limit=small_limit,
+                    large_limit=large_limit,
+                )
         n = sum(1 for ok in results if ok)
         total_files = len(files) + len(reconcile_pairs)
         reason = "uploaded" if n > 0 else "skipped:hash_match"
@@ -768,7 +955,10 @@ async def upload(
             )
             if not fallback_prefix:
                 raise StorageError(_FALLBACK_PREFIX_REQUIRED)
-            sem = asyncio.Semaphore(max_concurrency)
+            # Streamed copies hold part buffers like any large object, so the
+            # fallback keeps the narrow tier (an explicit cap still wins).
+            _, large_limit, _ = _fan_out_limits(max_concurrency)
+            sem = asyncio.Semaphore(large_limit)
 
             async def _bounded_fallback(source_key: str) -> bool:
                 async with sem:

--- a/docs/concepts/file-reference.md
+++ b/docs/concepts/file-reference.md
@@ -284,7 +284,10 @@ async def transform(self, input: TransformInput) -> TransformOutput:
         process(parquet_file)
 ```
 
-The SDK uploads every file in the directory recursively (bounded concurrency),
+The SDK uploads every file in the directory recursively (bounded concurrency:
+small objects fan out `ATLAN_MAX_CONCURRENT_SMALL_TRANSFERS` wide, large ones
+`ATLAN_MAX_CONCURRENT_STORAGE_TRANSFERS` — see
+[Directory uploads](storage.md#directory-uploads-round-trips-not-bytes)),
 preserves the directory structure under the storage prefix, and recreates it on
 download. `file_count` on the durable ref tells you how many files were uploaded.
 

--- a/docs/concepts/storage.md
+++ b/docs/concepts/storage.md
@@ -208,7 +208,9 @@ Both are called automatically by the default `on_complete()` implementation. Do 
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ATLAN_MAX_CONCURRENT_STORAGE_TRANSFERS` | `4` | Max concurrent upload/download operations |
+| `ATLAN_MAX_CONCURRENT_STORAGE_TRANSFERS` | `4` | Max concurrent transfers for large objects and for downloads (each large upload holds part size × part concurrency of buffer) |
+| `ATLAN_MAX_CONCURRENT_SMALL_TRANSFERS` | `32` | Max concurrent uploads for small objects within one directory transfer — the round-trip-bound tier (see [Directory uploads](#directory-uploads-round-trips-not-bytes)) |
+| `ATLAN_STORAGE_SMALL_OBJECT_BYTES` | `4194304` (4 MiB) | Size at or below which an object takes the small tier; `0` disables the tier |
 | `ATLAN_TEMPORARY_PATH` | `./local/tmp/` | Base path for local temporary files |
 | `ATLAN_CLEANUP_BASE_PATHS` | _(empty)_ | Extra prefixes to clean up (comma-separated) |
 | `ATLAN_OBSTORE_READ_TIMEOUT` | `90s` | Progress-based liveness bound — fail only if no bytes arrive for this long |
@@ -240,10 +242,40 @@ persist, `upload_prefix`, and the writer chunk uploads):
 1. the local file must not shrink between the opening `stat` and the read
    reaching EOF — a file truncated under the reader would put a prefix of the
    intended artifact in the store (`StorageIntegrityError`);
-2. a HEAD after the writer closes must report the byte count that was sent —
-   this is what catches a backend silently dropping the object (`StorageError`,
-   retryable);
-3. the SHA-256 computed during the upload pass is written to `{key}.sha256`.
+2. a readback after the writer closes must report the byte count that was
+   sent — this is what catches a backend silently dropping the object
+   (`StorageError`, retryable). A single-file upload reads back with a HEAD;
+   a directory upload reads the whole batch back from **one listing of its
+   prefix** (see below), with the same two checks and the same error classes;
+3. the SHA-256 computed during the upload pass is written to `{key}.sha256` —
+   only after the readback has passed, so a sidecar never advertises an
+   object the same upload then rejected.
+
+### Directory uploads: round trips, not bytes
+
+A directory hand-off over a high-latency store — an agent pushing a run's
+artifacts through the tenant's blobstorage gateway, say — is bound by the
+number of requests, not by bandwidth: `N` files at `L` seconds per request
+take `N × L / fan-out` regardless of their bytes. Every file used to cost four
+*dependent* round trips (a sidecar HEAD for the `skip_if_exists` check, the
+PUT, the readback HEAD, the sidecar PUT) at a fan-out of four, so a run that
+staged twenty thousand small parquet files spent close to three hours in the
+hand-off (FND-1339). The directory path now spends:
+
+- **one listing of the target prefix before the transfer**, when
+  `skip_if_exists` is set, to learn which sidecars exist — a file whose sidecar
+  is absent is uploaded without any probe, one whose sidecar is present costs
+  a single GET to compare digests;
+- **one PUT per object**, plus **one sidecar PUT per object**;
+- **one listing after the transfer** as the readback for every object at once.
+
+That is two round trips per object plus a request per thousand keys, and
+small objects fan out on their own tier (`ATLAN_MAX_CONCURRENT_SMALL_TRANSFERS`,
+default 32) because they are buffered whole and hold no multipart part
+buffers; large objects keep the narrow tier. Object *count* is still the
+variable that scales the cost, so writers should roll output by size
+(`RollingFileWriter`, 50 MB by default) rather than by row count — a tree of
+250 objects hands off in seconds where 20,000 take minutes at any fan-out.
 
 **On download** (`download_file` / `download_file_chunked`, and therefore
 `App.download`, `FileReference` materialize, `download_prefix`, and the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -194,7 +194,9 @@ Used by `RedisCapacityPool` for distributed slot locking. Leave empty if you use
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ATLAN_MAX_CONCURRENT_STORAGE_TRANSFERS` | `4` | Maximum concurrent object-store uploads/downloads. |
+| `ATLAN_MAX_CONCURRENT_STORAGE_TRANSFERS` | `4` | Maximum concurrent object-store transfers for large objects and for downloads. Large uploads each hold `ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES` × `ATLAN_STORAGE_UPLOAD_MAX_CONCURRENCY` of buffer, so this stays narrow. |
+| `ATLAN_MAX_CONCURRENT_SMALL_TRANSFERS` | `32` | Concurrent uploads for *small* objects within one directory transfer (`App.upload` of a directory, `FileReference` directory persist). A directory hand-off over a high-latency store is bound by round trips, not bandwidth — `N` small files at `L` seconds per request take `N × L / fan-out` — and small objects hold no part buffers, so this is the tier that is safe to widen. Peak buffer memory is at most `ATLAN_STORAGE_SMALL_OBJECT_BYTES` × this value. |
+| `ATLAN_STORAGE_SMALL_OBJECT_BYTES` | `4194304` (4 MiB) | Objects at or below this size take the small-object tier above. `0` disables the tier so every file is bounded by `ATLAN_MAX_CONCURRENT_STORAGE_TRANSFERS`. |
 | `ATLAN_OBSTORE_READ_TIMEOUT` | `90s` | **Progress-based** liveness bound: a transfer fails only if no bytes arrive for this long (the timer resets on every successful read). The primary timeout — a slow-but-progressing transfer survives; a genuine stall fails fast. |
 | `ATLAN_OBSTORE_TIMEOUT` | `30m` | **Overall-request** wall-clock backstop per object-store request. Scales with file size, not throughput, so it is deliberately generous; `ATLAN_OBSTORE_READ_TIMEOUT` is the real liveness bound. |
 | `ATLAN_STORAGE_RESUME_DOWNLOADS` | `true` | Kill-switch for resumable chunked downloads. When enabled, an interrupted chunked download keeps its in-flight part file and checkpoint sidecar (`.sdk-partial/{name}.part` and `.sdk-partial/{name}.transfer-state` beside the destination), and a retry fetches only the missing ranges. Set to `false` to restore delete-partial-on-failure behaviour. |

--- a/tests/unit/app/test_base.py
+++ b/tests/unit/app/test_base.py
@@ -2049,3 +2049,111 @@ class TestInlineImportContracts:
         from application_sdk.observability.correlation import (  # noqa: F401
             get_correlation_context,
         )
+
+
+# =============================================================================
+# App.upload() — asset validation runs alongside the transfer (FND-1339)
+# =============================================================================
+class TestUploadValidationAlongsideTransfer:
+    """The warn-only scan overlaps the transfer and dies with a failed one."""
+
+    def setup_method(self) -> None:
+        from application_sdk.app.registry import TaskRegistry
+
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+    def teardown_method(self) -> None:
+        from application_sdk.app.registry import TaskRegistry
+
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+    @staticmethod
+    def _app() -> App:
+        from application_sdk.app.context import AppContext
+
+        class _UpApp(App):
+            async def run(self, input: _BLDXInput) -> _BLDXOutput:
+                return _BLDXOutput()
+
+        app = _UpApp()
+        app._context = AppContext(
+            app_name=app._app_name,
+            app_version="1",
+            run_id="run-1",
+            _storage=object(),  # type: ignore[arg-type]
+        )
+        return app
+
+    async def test_scan_overlaps_the_transfer_and_is_awaited(self) -> None:
+        import asyncio
+
+        from application_sdk.app import base as base_module
+        from application_sdk.contracts.storage import UploadInput, UploadOutput
+
+        events: list[str] = []
+        scan_started = asyncio.Event()
+
+        async def fake_scan(local_path, app_name, *, timeout=None):
+            events.append("scan:start")
+            scan_started.set()
+            await asyncio.sleep(0.05)
+            events.append("scan:end")
+
+        async def fake_transfer(*args, **kwargs):
+            # Bytes move while the scan is already running — it no longer gates them.
+            await scan_started.wait()
+            events.append("transfer")
+            return UploadOutput()
+
+        app = self._app()
+        with (
+            mock.patch.object(
+                base_module, "_warn_on_invalid_transformed_assets", fake_scan
+            ),
+            mock.patch(
+                "application_sdk.storage.transfer.upload", side_effect=fake_transfer
+            ),
+        ):
+            await app.upload(UploadInput(local_path="/tmp/out"))
+
+        assert events == ["scan:start", "transfer", "scan:end"]
+
+    async def test_failed_transfer_cancels_the_scan(self) -> None:
+        import asyncio
+
+        from application_sdk.app import base as base_module
+        from application_sdk.contracts.storage import UploadInput
+
+        scan_started = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def hanging_scan(local_path, app_name, *, timeout=None):
+            scan_started.set()
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        async def failing_transfer(*args, **kwargs):
+            # Let the scan get under way first, so the cancel has something to
+            # interrupt rather than a task that never started.
+            await scan_started.wait()
+            raise RuntimeError("boom")
+
+        app = self._app()
+        with (
+            mock.patch.object(
+                base_module, "_warn_on_invalid_transformed_assets", hanging_scan
+            ),
+            mock.patch(
+                "application_sdk.storage.transfer.upload",
+                side_effect=failing_transfer,
+            ),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            await app.upload(UploadInput(local_path="/tmp/out"))
+
+        await asyncio.wait_for(cancelled.wait(), timeout=1)

--- a/tests/unit/app/test_upload_asset_validation.py
+++ b/tests/unit/app/test_upload_asset_validation.py
@@ -453,3 +453,110 @@ class TestWarnOnInvalidTransformedAssets:
         with patch.object(base_module, "_task_logger") as logger_after:
             await _warn_on_invalid_transformed_assets(str(dirs[0]), APP)
             logger_after.warning.assert_not_called()
+
+
+class TestValidationAlongsideTransfer:
+    """FND-1339: the scan no longer gates the transfer's budget.
+
+    ``App.upload`` starts the scan as a task and moves bytes while it runs;
+    retry attempts skip it; its bound is capped at half the activity's own so a
+    600s scan can never eat a 600s activity before the first PUT.
+    """
+
+    def test_retry_attempt_skips_the_scan(self, monkeypatch) -> None:
+        info = MagicMock(attempt=2, start_to_close_timeout=None)
+        monkeypatch.setattr(base_module.activity, "info", lambda: info)
+
+        assert base_module._start_transformed_asset_validation("/tmp/x", APP) is None
+        assert base_module._current_activity_attempt() == 2
+
+    async def test_first_attempt_starts_a_task_with_the_capped_budget(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        from datetime import timedelta
+
+        info = MagicMock(attempt=1, start_to_close_timeout=timedelta(seconds=100))
+        monkeypatch.setattr(base_module.activity, "info", lambda: info)
+        seen: dict[str, float | None] = {}
+
+        async def fake_warn(local_path, app_name, *, timeout=None):
+            seen["timeout"] = timeout
+
+        monkeypatch.setattr(
+            base_module, "_warn_on_invalid_transformed_assets", fake_warn
+        )
+
+        task = base_module._start_transformed_asset_validation(str(tmp_path), APP)
+
+        assert task is not None
+        await task
+        assert seen["timeout"] == 50.0
+
+    def test_budget_outside_an_activity_is_the_configured_value(
+        self, monkeypatch
+    ) -> None:
+        from application_sdk.constants import VALIDATE_ASSETS_TIMEOUT_SECONDS
+
+        def not_in_activity():
+            raise RuntimeError("Not in activity context")
+
+        monkeypatch.setattr(base_module.activity, "info", not_in_activity)
+
+        assert (
+            base_module._transformed_asset_validation_budget()
+            == VALIDATE_ASSETS_TIMEOUT_SECONDS
+        )
+        assert base_module._current_activity_attempt() == 1
+
+    def test_budget_is_the_configured_value_under_a_generous_activity_bound(
+        self, monkeypatch
+    ) -> None:
+        from datetime import timedelta
+
+        from application_sdk.constants import VALIDATE_ASSETS_TIMEOUT_SECONDS
+
+        info = MagicMock(attempt=1, start_to_close_timeout=timedelta(seconds=10_000))
+        monkeypatch.setattr(base_module.activity, "info", lambda: info)
+
+        assert (
+            base_module._transformed_asset_validation_budget()
+            == VALIDATE_ASSETS_TIMEOUT_SECONDS
+        )
+
+    async def test_explicit_timeout_reaches_the_isolated_scan(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        out = tmp_path / "transformed" / "table"
+        out.mkdir(parents=True)
+        (out / "entities.json").write_bytes(b"{}\n")
+        runner = MagicMock()
+
+        async def fake_run_best_effort(*args, **kwargs):
+            runner(*args, **kwargs)
+            return None
+
+        monkeypatch.setattr(base_module, "run_best_effort", fake_run_best_effort)
+
+        await _warn_on_invalid_transformed_assets(str(tmp_path), APP, timeout=7.5)
+
+        assert runner.call_args.kwargs["timeout"] == 7.5
+
+    async def test_default_timeout_is_the_configured_value(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        from application_sdk.constants import VALIDATE_ASSETS_TIMEOUT_SECONDS
+
+        out = tmp_path / "transformed" / "table"
+        out.mkdir(parents=True)
+        (out / "entities.json").write_bytes(b"{}\n")
+        runner = MagicMock()
+
+        async def fake_run_best_effort(*args, **kwargs):
+            runner(*args, **kwargs)
+            return None
+
+        monkeypatch.setattr(base_module, "run_best_effort", fake_run_best_effort)
+
+        await _warn_on_invalid_transformed_assets(str(tmp_path), APP)
+
+        assert runner.call_args.kwargs["timeout"] == VALIDATE_ASSETS_TIMEOUT_SECONDS

--- a/tests/unit/storage/test_integrity.py
+++ b/tests/unit/storage/test_integrity.py
@@ -924,3 +924,72 @@ class TestAllPathsConverge:
         await transfer.download("conv/rt/", str(dest), store=store)
         assert (dest / "a.json").read_bytes() == b'{"a": 1}'
         assert (dest / "b.json").read_bytes() == b'{"b": 2}'
+
+
+class TestDeferredRemoteVerify:
+    """``upload_file(defer_remote_verify=True)``: local check on, readback HEAD off.
+
+    The directory upload path verifies a whole batch against one listing of
+    its prefix (FND-1339); this is the per-file primitive it leans on.
+    """
+
+    @staticmethod
+    def _count_heads(monkeypatch) -> list[str]:
+        import application_sdk.storage.ops as ops_mod
+
+        heads: list[str] = []
+        real = ops_mod.get_file_meta
+
+        async def meta(key, *a, **kw):
+            heads.append(key)
+            return await real(key, *a, **kw)
+
+        monkeypatch.setattr(ops_mod, "get_file_meta", meta)
+        return heads
+
+    async def test_default_still_reads_back_with_a_head(
+        self, store, tmp_path, monkeypatch
+    ) -> None:
+        from application_sdk.storage.ops import upload_file
+
+        heads = self._count_heads(monkeypatch)
+        f = tmp_path / "c.bin"
+        f.write_bytes(b"x" * 100)
+
+        await upload_file("k/c.bin", f, store)
+
+        assert heads == ["k/c.bin"]
+
+    async def test_deferred_skips_the_head_but_keeps_digest_and_sidecar(
+        self, store, tmp_path, monkeypatch
+    ) -> None:
+        from application_sdk.storage.ops import _get_bytes, upload_file
+
+        heads = self._count_heads(monkeypatch)
+        f = tmp_path / "a.bin"
+        f.write_bytes(b"x" * 100)
+
+        digest = await upload_file("k/a.bin", f, store, defer_remote_verify=True)
+
+        assert digest == hashlib.sha256(b"x" * 100).hexdigest()
+        assert heads == []
+        sidecar = await _get_bytes("k/a.bin.sha256", store, normalize=False)
+        assert sidecar is not None
+        assert sidecar.decode().strip() == digest
+
+    async def test_deferred_with_write_sidecar_false_holds_the_sidecar_back(
+        self, store, tmp_path, monkeypatch
+    ) -> None:
+        from application_sdk.storage.ops import exists, upload_file
+
+        self._count_heads(monkeypatch)
+        f = tmp_path / "b.bin"
+        f.write_bytes(b"y" * 50)
+
+        digest = await upload_file(
+            "k/b.bin", f, store, defer_remote_verify=True, write_sidecar=False
+        )
+
+        assert digest == hashlib.sha256(b"y" * 50).hexdigest()
+        assert await exists("k/b.bin", store, normalize=False) is True
+        assert await exists("k/b.bin.sha256", store, normalize=False) is False

--- a/tests/unit/storage/test_reference.py
+++ b/tests/unit/storage/test_reference.py
@@ -651,7 +651,11 @@ class TestDirectoryPersistConcurrent:
         assert sidecar.decode().strip() == _hash_bytes(b"aaa")
 
     async def test_concurrent_uploads_respect_semaphore(self, store, tmp_path) -> None:
-        """Upload concurrency is bounded by MAX_CONCURRENT_STORAGE_TRANSFERS."""
+        """Upload concurrency is bounded by the transfer constants.
+
+        Both tiers are pinned to 2 here; the tiers themselves are exercised by
+        ``test_small_files_take_the_wider_tier`` below (FND-1339).
+        """
         from unittest.mock import patch
 
         import application_sdk.storage.ops as ops_mod
@@ -675,7 +679,10 @@ class TestDirectoryPersistConcurrent:
         with patch.object(ops_mod, "upload_file", side_effect=tracking_upload):
             from application_sdk import constants
 
-            with patch.object(constants, "MAX_CONCURRENT_STORAGE_TRANSFERS", 2):
+            with (
+                patch.object(constants, "MAX_CONCURRENT_STORAGE_TRANSFERS", 2),
+                patch.object(constants, "MAX_CONCURRENT_SMALL_TRANSFERS", 2),
+            ):
                 ref = FileReference(
                     local_path=str(tmp_path), tier=StorageTier.TRANSIENT
                 )
@@ -683,6 +690,46 @@ class TestDirectoryPersistConcurrent:
 
         assert result.file_count == 6
         assert max_active <= 2, f"Expected max 2 concurrent uploads, got {max_active}"
+
+    async def test_small_files_take_the_wider_tier(self, store, tmp_path) -> None:
+        """A directory of small files persists on the small-object tier (FND-1339)."""
+        import asyncio
+        from unittest.mock import patch
+
+        import application_sdk.storage.ops as ops_mod
+
+        for i in range(12):
+            (tmp_path / f"f{i}.bin").write_bytes(b"x" * 16)
+
+        max_active = 0
+        active = 0
+        real_upload = ops_mod.upload_file
+
+        async def tracking_upload(*args, **kwargs):
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            try:
+                await asyncio.sleep(0.02)  # hold the slot so the peak is observable
+                return await real_upload(*args, **kwargs)
+            finally:
+                active -= 1
+
+        with patch.object(ops_mod, "upload_file", side_effect=tracking_upload):
+            from application_sdk import constants
+
+            with (
+                patch.object(constants, "MAX_CONCURRENT_STORAGE_TRANSFERS", 1),
+                patch.object(constants, "MAX_CONCURRENT_SMALL_TRANSFERS", 4),
+                patch.object(constants, "STORAGE_SMALL_OBJECT_BYTES", 1024),
+            ):
+                ref = FileReference(
+                    local_path=str(tmp_path), tier=StorageTier.TRANSIENT
+                )
+                result = await persist_file_reference(store, ref)
+
+        assert result.file_count == 12
+        assert 1 < max_active <= 4, f"Expected the small tier (2..4), got {max_active}"
 
 
 class TestPersistFileReferenceListingRace:

--- a/tests/unit/storage/test_transfer.py
+++ b/tests/unit/storage/test_transfer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import sys
 from pathlib import Path
@@ -10,7 +11,10 @@ from unittest.mock import patch
 import pytest
 
 from application_sdk.contracts.storage import UploadOutput
+from application_sdk.storage.batch import list_keys
+from application_sdk.storage.errors import StorageError
 from application_sdk.storage.factory import create_memory_store
+from application_sdk.storage.ops import _get_bytes
 from application_sdk.storage.transfer import download, upload
 
 _IS_WINDOWS = sys.platform == "win32"
@@ -135,12 +139,10 @@ class TestUploadDirectory:
 
         _original = transfer_mod._upload_one
 
-        async def _failing_upload_one(st, local_file, store_key, *, skip_if_exists):
+        async def _failing_upload_one(st, local_file, store_key, **kwargs):
             if "fail.txt" in str(local_file):
                 raise RuntimeError("simulated upload failure")
-            return await _original(
-                st, local_file, store_key, skip_if_exists=skip_if_exists
-            )
+            return await _original(st, local_file, store_key, **kwargs)
 
         monkeypatch.setattr(transfer_mod, "_upload_one", _failing_upload_one)
 
@@ -1041,3 +1043,263 @@ class TestUploadSameStoreCopy:
         exists_spy.assert_not_called()
         assert out.ref.file_count == 2
         assert out.synced == 0
+
+
+# =============================================================================
+# FND-1339: a directory upload is round-trip-bound — spend listings, not HEADs
+# =============================================================================
+
+
+def _make_tree(root: Path, n: int, size: int = 64) -> list[Path]:
+    paths: list[Path] = []
+    for i in range(n):
+        d = root / "raw" / f"t{i % 3}"
+        d.mkdir(parents=True, exist_ok=True)
+        p = d / f"chunk-{i}.parquet"
+        p.write_bytes(bytes([i % 251]) * size)
+        paths.append(p)
+    return paths
+
+
+class _RequestLog:
+    """Records the per-object requests the directory path is meant to avoid.
+
+    ``heads`` covers both HEAD shapes the old protocol spent per file (the
+    sidecar-existence probe of the skip check and the readback), ``listings``
+    the prefix listings that replace them, ``puts`` the data-object uploads.
+    """
+
+    def __init__(self, monkeypatch) -> None:
+        import application_sdk.storage.ops as ops_mod
+        from application_sdk.storage import transfer as transfer_mod
+
+        self.heads: list[str] = []
+        self.listings: list[str] = []
+        self.puts: list[str] = []
+        real_exists, real_meta = ops_mod.exists, ops_mod.get_file_meta
+        real_list = transfer_mod.list_keys_with_meta
+        real_upload = ops_mod.upload_file
+
+        async def exists(key, *a, **kw):
+            self.heads.append(key)
+            return await real_exists(key, *a, **kw)
+
+        async def meta(key, *a, **kw):
+            self.heads.append(key)
+            return await real_meta(key, *a, **kw)
+
+        async def listing(prefix, *a, **kw):
+            self.listings.append(prefix)
+            return await real_list(prefix, *a, **kw)
+
+        async def upload_file(key, *a, **kw):
+            self.puts.append(key)
+            return await real_upload(key, *a, **kw)
+
+        monkeypatch.setattr(ops_mod, "exists", exists)
+        monkeypatch.setattr(ops_mod, "get_file_meta", meta)
+        monkeypatch.setattr(transfer_mod, "list_keys_with_meta", listing)
+        monkeypatch.setattr(ops_mod, "upload_file", upload_file)
+
+
+class TestUploadDirectoryRoundTrips:
+    """Two listings per directory in place of two HEADs per file."""
+
+    async def test_first_upload_lists_twice_and_never_heads(
+        self, store, tmp_path, monkeypatch
+    ) -> None:
+        paths = _make_tree(tmp_path, 12)
+        log = _RequestLog(monkeypatch)
+
+        out = await upload(str(tmp_path), "runs/r1", store=store, skip_if_exists=True)
+
+        assert out.ref.file_count == 12
+        assert out.synced is True
+        assert out.reason == "uploaded"
+        assert log.heads == []
+        # One listing answers the skip check, one is the readback.
+        assert log.listings == ["runs/r1/", "runs/r1/"]
+        assert len(log.puts) == 12
+        keys = set(await list_keys("runs/r1/", store, normalize=False))
+        for p in paths:
+            key = f"runs/r1/{p.relative_to(tmp_path).as_posix()}"
+            assert key in keys
+            assert f"{key}.sha256" in keys
+            sidecar = await _get_bytes(f"{key}.sha256", store, normalize=False)
+            assert sidecar is not None
+            assert sidecar.decode().strip() == _hash_bytes(p.read_bytes())
+
+    async def test_retry_skips_every_file_with_one_listing_and_no_puts(
+        self, store, tmp_path, monkeypatch
+    ) -> None:
+        _make_tree(tmp_path, 8)
+        await upload(str(tmp_path), "runs/r2", store=store, skip_if_exists=True)
+        log = _RequestLog(monkeypatch)
+
+        out = await upload(str(tmp_path), "runs/r2", store=store, skip_if_exists=True)
+
+        assert out.synced is False
+        assert out.reason == "skipped:hash_match"
+        assert log.puts == []
+        assert log.heads == []
+        # Nothing transferred, so there is nothing to read back: skip check only.
+        assert log.listings == ["runs/r2/"]
+
+    async def test_changed_file_alone_is_reuploaded_and_read_back(
+        self, store, tmp_path, monkeypatch
+    ) -> None:
+        paths = _make_tree(tmp_path, 8)
+        await upload(str(tmp_path), "runs/r3", store=store, skip_if_exists=True)
+        paths[3].write_bytes(b"changed" * 8)
+        log = _RequestLog(monkeypatch)
+
+        out = await upload(str(tmp_path), "runs/r3", store=store, skip_if_exists=True)
+
+        changed_key = f"runs/r3/{paths[3].relative_to(tmp_path).as_posix()}"
+        assert out.synced is True
+        assert log.puts == [changed_key]
+        assert log.heads == []
+        assert log.listings == ["runs/r3/", "runs/r3/"]
+        sidecar = await _get_bytes(f"{changed_key}.sha256", store, normalize=False)
+        assert sidecar is not None
+        assert sidecar.decode().strip() == _hash_bytes(b"changed" * 8)
+
+    async def test_readback_catches_a_dropped_object_and_withholds_sidecars(
+        self, store, tmp_path, monkeypatch
+    ) -> None:
+        _make_tree(tmp_path, 4)
+        from application_sdk.storage import transfer as transfer_mod
+
+        real = transfer_mod._list_target_sizes
+        calls = {"n": 0}
+
+        async def dropping(prefix, st):
+            calls["n"] += 1
+            listed = await real(prefix, st)
+            if calls["n"] >= 2:  # the post-transfer readback, not the skip check
+                listed.pop("runs/r4/raw/t0/chunk-0.parquet")
+            return listed
+
+        monkeypatch.setattr(transfer_mod, "_list_target_sizes", dropping)
+
+        with pytest.raises(StorageError, match="absent from the store's listing"):
+            await upload(str(tmp_path), "runs/r4", store=store, skip_if_exists=True)
+
+        # The objects landed, but no sidecar may advertise a batch the readback
+        # rejected — same ordering guarantee as the per-object protocol.
+        keys = set(await list_keys("runs/r4/", store, normalize=False))
+        assert len(keys) == 4
+        assert not any(k.endswith(".sha256") for k in keys)
+
+    async def test_readback_catches_a_size_mismatch(
+        self, store, tmp_path, monkeypatch
+    ) -> None:
+        _make_tree(tmp_path, 4)
+        from application_sdk.storage import transfer as transfer_mod
+
+        real = transfer_mod._list_target_sizes
+
+        async def short_by_one(prefix, st):
+            listed = await real(prefix, st)
+            key = "runs/r5/raw/t1/chunk-1.parquet"
+            if key in listed:
+                listed[key] -= 1
+            return listed
+
+        monkeypatch.setattr(transfer_mod, "_list_target_sizes", short_by_one)
+
+        with pytest.raises(StorageError, match="Incomplete upload"):
+            await upload(str(tmp_path), "runs/r5", store=store)
+
+    async def test_verification_off_writes_sidecars_inline_and_skips_readback(
+        self, store, tmp_path, monkeypatch
+    ) -> None:
+        _make_tree(tmp_path, 4)
+        from application_sdk import constants
+
+        monkeypatch.setattr(constants, "STORAGE_VERIFY_TRANSFERS", False)
+        log = _RequestLog(monkeypatch)
+
+        out = await upload(str(tmp_path), "runs/r6", store=store, skip_if_exists=True)
+
+        assert out.synced is True
+        assert log.heads == []
+        assert log.listings == ["runs/r6/"]  # skip check only; nothing to read back
+        keys = set(await list_keys("runs/r6/", store, normalize=False))
+        assert sum(k.endswith(".sha256") for k in keys) == 4
+
+
+class TestUploadDirectoryFanOut:
+    """Small objects fan out on their own tier; large ones keep the narrow one."""
+
+    @staticmethod
+    def _track(monkeypatch, threshold: int) -> dict[str, int]:
+        import application_sdk.storage.ops as ops_mod
+
+        active = {"small": 0, "large": 0, "all": 0}
+        peak = {"small": 0, "large": 0, "all": 0}
+        real_upload = ops_mod.upload_file
+
+        async def tracking(key, local_path, *a, **kw):
+            tier = "small" if Path(local_path).stat().st_size <= threshold else "large"
+            for t in (tier, "all"):
+                active[t] += 1
+                peak[t] = max(peak[t], active[t])
+            try:
+                await asyncio.sleep(0.02)  # hold the slot so peaks are observable
+                return await real_upload(key, local_path, *a, **kw)
+            finally:
+                for t in (tier, "all"):
+                    active[t] -= 1
+
+        monkeypatch.setattr(ops_mod, "upload_file", tracking)
+        return peak
+
+    async def test_small_objects_fan_out_wider_than_large_ones(
+        self, store, tmp_path, monkeypatch
+    ) -> None:
+        from application_sdk import constants
+
+        monkeypatch.setattr(constants, "MAX_CONCURRENT_STORAGE_TRANSFERS", 2)
+        monkeypatch.setattr(constants, "MAX_CONCURRENT_SMALL_TRANSFERS", 6)
+        monkeypatch.setattr(constants, "STORAGE_SMALL_OBJECT_BYTES", 100)
+        _make_tree(tmp_path / "small", 18, size=10)
+        _make_tree(tmp_path / "large", 6, size=1000)
+        peak = self._track(monkeypatch, threshold=100)
+
+        out = await upload(str(tmp_path), "runs/r7", store=store)
+
+        assert out.ref.file_count == 24
+        assert peak["large"] <= 2
+        assert 2 < peak["small"] <= 6
+
+    async def test_explicit_max_concurrency_caps_both_tiers(
+        self, store, tmp_path, monkeypatch
+    ) -> None:
+        from application_sdk import constants
+
+        monkeypatch.setattr(constants, "MAX_CONCURRENT_SMALL_TRANSFERS", 32)
+        monkeypatch.setattr(constants, "STORAGE_SMALL_OBJECT_BYTES", 100)
+        _make_tree(tmp_path / "small", 8, size=10)
+        _make_tree(tmp_path / "large", 4, size=1000)
+        peak = self._track(monkeypatch, threshold=100)
+
+        out = await upload(str(tmp_path), "runs/r8", store=store, max_concurrency=1)
+
+        assert out.ref.file_count == 12
+        assert peak["all"] == 1
+
+    async def test_zero_threshold_disables_the_small_tier(
+        self, store, tmp_path, monkeypatch
+    ) -> None:
+        from application_sdk import constants
+
+        monkeypatch.setattr(constants, "MAX_CONCURRENT_STORAGE_TRANSFERS", 2)
+        monkeypatch.setattr(constants, "MAX_CONCURRENT_SMALL_TRANSFERS", 16)
+        monkeypatch.setattr(constants, "STORAGE_SMALL_OBJECT_BYTES", 0)
+        _make_tree(tmp_path, 10, size=10)
+        peak = self._track(monkeypatch, threshold=0)
+
+        await upload(str(tmp_path), "runs/r9", store=store)
+
+        assert peak["all"] <= 2


### PR DESCRIPTION
### Changelog
- **Directory uploads spend two prefix listings instead of two HEADs per file.** Before the transfer, one listing of the target prefix answers the `skip_if_exists` check for every file (`read_expected_digest` already took `sidecar_present`; it is now fed from the listing). After the transfer, one listing is the readback for every object at once: same two checks as the per-object HEAD in `_finalize_upload_integrity` (present, and the size that was sent), same error classes. Sidecars are written only after that readback passes, so the "never advertise an object this upload rejected" ordering is preserved.
- **Size-tiered fan-out for directory transfers** (`transfer.upload` and `FileReference` directory persist). Objects at or below `ATLAN_STORAGE_SMALL_OBJECT_BYTES` (4 MiB) run `ATLAN_MAX_CONCURRENT_SMALL_TRANSFERS` (32) wide; larger objects keep `ATLAN_MAX_CONCURRENT_STORAGE_TRANSFERS` (4) because each holds part-size × part-concurrency of buffer. An explicit `max_concurrency` stays one hard cap across everything in flight. `0` disables the tier.
- `upload_file(defer_remote_verify=...)`: local-truncation check on, readback HEAD off, for callers that take over the readback. Single-file uploads are unchanged.
- **`App.upload`: the warn-only transformed-asset validation runs alongside the transfer** instead of ahead of it, is skipped on retry attempts (deterministic over the same tree; attempt 1 emitted its outcome), and its bound is capped at half the activity's start-to-close timeout. The two used to share a 600s default, so a scan over millions of records could spend the whole activity budget before the first PUT.
- Docs: `configuration.md`, `storage.md` (new *Directory uploads: round trips, not bytes* section), `file-reference.md`.

### Why
A directory hand-off over a high-latency store is bound by requests, not bytes. Every file cost four *dependent* round trips (sidecar HEAD, PUT, readback HEAD, sidecar PUT) drained four at a time. A production agent-mode run that staged ~19k small parquet files spent **2h53m** in `App.upload` at ~0.5 s per request through the tenant blobstorage gateway; two earlier runs of the same connector died in it after 3 × 600s. The SDK's own work was ~10 ms per file (measured against a local store); the rest was round trips.

Measured against an S3-compatible stub that logs requests and injects 100 ms each (200 files):

| Config | Requests | Per file | 4-wide | 32-wide |
|---|---|---|---|---|
| before this PR (`skip_if_exists`, verify, sidecars) | 800 (HEAD sidecar, PUT, HEAD object, PUT sidecar) | 4.0 | 23.7s | 4.5s |
| after this PR, same flags | 2 listings + 200 PUT + 200 PUT sidecar | ~2.0 | | small tier default |

Net for the SAP-shaped tree: 4 → 2 requests per object plus one request per thousand keys, at up to 8× the fan-out for the round-trip-bound tier. Object *count* is still what scales the cost; the writer-side follow-up (roll by size, fix the 5,000-row consolidation slices) is a separate PR.

### Additional context (e.g. screenshots, logs, links)
- Investigation and measurements: FND-1339 (Linear).
- Follow-ups, not in this PR: `ParquetFileWriter` consolidation slicing at `chunk_size`; `RollingFileWriter` minimum-bytes guard on the time rollover; a per-prefix integrity manifest to drop the sidecar PUT as well (touches the reader side, needs its own design note).
- Behaviour notes for reviewers:
  - Directory uploads to a store root (empty prefix) keep the per-object checks; there is no narrow listing to make there.
  - `ATLAN_STORAGE_VERIFY_TRANSFERS=false` still means no readback at all; with it on, directory mode's readback is the listing. Listing consistency assumptions match the HEAD's (read-after-write).
  - Peak buffer memory for the small tier is bounded by threshold × fan-out (128 MiB at defaults); the large tier is unchanged.
  - Validation skip-on-retry means an attempt-1 that died mid-scan emits no outcome row; the transfer is what the retry is for.

### Checklist
- [x] Additional tests added (`tests/unit/storage/test_transfer.py`: request log + fan-out tiers; `test_integrity.py`: deferred readback; `test_reference.py`: tiered persist; `tests/unit/app/test_base.py` + `test_upload_asset_validation.py`: validation alongside the transfer, cancel on failure, retry skip, budget cap)
- [ ] All CI checks passed
- [x] Relevant documentation updated

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.
