### PR TITLE
fix(storage): consolidate parquet into one file per chunk, not one per buffer

### DIFF
--- a/application_sdk/storage/formats/parquet.py
+++ b/application_sdk/storage/formats/parquet.py
@@ -855,19 +855,35 @@ class ParquetFileWriter(Writer):
             # Offloaded: a consolidation folder holds a full buffer's worth of
             # chunks, so reading them all back and concatenating is seconds of
             # blocking disk I/O plus CPU. Inline it starves the auto-heartbeat
-            # for that span (ADR-0010).
-            def _read_and_concat() -> "pd.DataFrame":
-                return pd.concat(
+            # for that span (ADR-0010). The in-memory size estimate rides the
+            # same hop: it walks every column once.
+            def _read_and_concat() -> "tuple[pd.DataFrame, int]":
+                frame = pd.concat(
                     [pd.read_parquet(f) for f in temp_files], ignore_index=True
                 )
+                return frame, int(frame.memory_usage(deep=True).sum())
 
-            combined_df = await run_in_thread(_read_and_concat)
+            combined_df, estimated_bytes = await run_in_thread(_read_and_concat)
 
-            # Write consolidated chunks respecting max_file_size_bytes
+            # One consolidated file per folder is the point of consolidating:
+            # the folder *is* the chunk (``consolidation_threshold`` ==
+            # ``chunk_size`` rows). Only ``max_file_size_bytes`` splits it, and
+            # against the in-memory estimate — larger than the snappy parquet
+            # that lands, so a split errs towards fewer rows, never a file over
+            # the cap. This loop used to slice by ``buffer_size`` instead, so
+            # every chunk became ``chunk_size / buffer_size`` files — twenty at
+            # the defaults. A 93M-row run staged ~18,700 objects that way, and
+            # its hand-off then paid one set of round trips per object
+            # (FND-1339).
+            total_rows = len(combined_df)
+            bytes_per_row = max(1, estimated_bytes // max(1, total_rows))
+            rows_per_file = max(
+                1, min(total_rows, self.max_file_size_bytes // bytes_per_row)
+            )
             partitions = 0
             chunk_part_start = 0
-            for i in range(0, len(combined_df), self.buffer_size):
-                chunk = combined_df.iloc[i : i + self.buffer_size]
+            for i in range(0, total_rows, rows_per_file):
+                chunk = combined_df.iloc[i : i + rows_per_file]
                 consolidated_file_path = self._get_consolidated_file_path(
                     folder_index=self.chunk_count,
                     chunk_part=chunk_part_start + partitions,

--- a/tests/unit/storage/formats/test_writer_progress_hooks.py
+++ b/tests/unit/storage/formats/test_writer_progress_hooks.py
@@ -151,12 +151,13 @@ async def test_consolidation_path_marks_accumulation_and_consolidation(
     writer.consolidation_threshold = 2 * _BUFFER
     await writer.write_batches(batches())
 
-    # Four accumulated chunks, and four consolidated files (two folders hit the
-    # 200-record threshold; each consolidates into 200/buffer_size = 2 files).
-    # The consolidation path bypasses _flush_buffer entirely, so without its own
-    # hooks this whole stream would be one quiet window.
+    # Four accumulated chunks, and two consolidated files (two folders hit the
+    # 200-record threshold; each consolidates into one file — FND-1339 stopped
+    # the consolidation loop re-slicing by buffer_size). The consolidation path
+    # bypasses _flush_buffer entirely, so without its own hooks this whole
+    # stream would be one quiet window.
     assert progress_marks.count("writer.accumulate_chunk") == 4
-    assert progress_marks.count("writer.consolidate_chunk") == 4
+    assert progress_marks.count("writer.consolidate_chunk") == 2
     assert progress_marks.count("writer.flush_buffer") == 0
 
 

--- a/tests/unit/storage/formats/writers/test_parquet_writer.py
+++ b/tests/unit/storage/formats/writers/test_parquet_writer.py
@@ -1314,3 +1314,82 @@ class TestWriteChunkNullColumns:
         assert ticks >= 5, f"event loop stalled during the write ({ticks} ticks)"
         table = pq.read_table(file_name)
         assert table.num_rows == 3
+
+
+class TestConsolidationFileCount:
+    """FND-1339: a consolidated chunk is one parquet file, not chunk/buffer files.
+
+    Consolidation exists to turn the per-``buffer_size`` accumulation chunks
+    into one file per ``chunk_size`` rows. The loop that wrote the consolidated
+    output sliced by ``buffer_size`` again, so every chunk became
+    ``chunk_size / buffer_size`` objects (20 at the defaults) — and every one of
+    them cost the hand-off a set of round trips.
+    """
+
+    @pytest.mark.asyncio
+    async def test_one_chunk_consolidates_to_one_file(self, tmp_path: Path):
+        writer = ParquetFileWriter(
+            path=str(tmp_path / "out"),
+            typename="rows",
+            chunk_size=1000,
+            buffer_size=10,
+            use_consolidation=True,
+            defer_uploads=True,
+        )
+
+        await writer.write_batches(
+            iter([pd.DataFrame({"id": list(range(1000)), "v": ["x"] * 1000})])
+        )
+        result = await writer.close()
+
+        assert result.total_record_count == 1000
+        assert writer.chunk_count == 1
+        assert writer.partitions == [1]
+        files = sorted(Path(writer.path).rglob("*.parquet"))
+        assert len(files) == 1, [f.name for f in files]
+        assert len(pd.read_parquet(files[0])) == 1000
+
+    @pytest.mark.asyncio
+    async def test_two_chunks_consolidate_to_two_files(self, tmp_path: Path):
+        writer = ParquetFileWriter(
+            path=str(tmp_path / "out"),
+            typename="rows",
+            chunk_size=200,
+            buffer_size=10,
+            use_consolidation=True,
+            defer_uploads=True,
+        )
+
+        await writer.write_batches(iter([pd.DataFrame({"id": list(range(250))})]))
+        await writer.close()
+
+        assert writer.chunk_count == 2
+        assert writer.partitions == [1, 1]
+        files = sorted(Path(writer.path).rglob("*.parquet"))
+        assert len(files) == 2, [f.name for f in files]
+        assert sum(len(pd.read_parquet(f)) for f in files) == 250
+
+    @pytest.mark.asyncio
+    async def test_max_file_size_still_splits_a_wide_chunk(self, tmp_path: Path):
+        writer = ParquetFileWriter(
+            path=str(tmp_path / "out"),
+            typename="rows",
+            chunk_size=1000,
+            buffer_size=100,
+            use_consolidation=True,
+            defer_uploads=True,
+        )
+        # A cap far below one chunk's in-memory size forces the split the cap
+        # exists for; it is the only thing that may split a consolidated chunk.
+        writer.max_file_size_bytes = 4 * 1024
+
+        await writer.write_batches(
+            iter([pd.DataFrame({"id": list(range(1000)), "v": ["y" * 20] * 1000})])
+        )
+        await writer.close()
+
+        assert writer.chunk_count == 1
+        assert writer.partitions[0] > 1
+        files = sorted(Path(writer.path).rglob("*.parquet"))
+        assert len(files) == writer.partitions[0]
+        assert sum(len(pd.read_parquet(f)) for f in files) == 1000


### PR DESCRIPTION
### Changelog
- `ParquetFileWriter(use_consolidation=True)` now writes **one parquet file per consolidated chunk** (`chunk_size` rows) instead of `chunk_size / buffer_size` files per chunk (20 at the defaults: 100k / 5k).
- `max_file_size_bytes` remains the only split, applied against the in-memory estimate of the combined frame (larger than the snappy parquet that lands), so a wide-row chunk still splits and never exceeds the cap.
- `chunk_count`, `total_record_count` and `partitions` keep their meaning; `partitions` reads `[1, 1, ...]` for ordinary chunks.

### Why
The consolidation loop re-sliced the combined frame by `buffer_size`, defeating the point of consolidating. A production agent-mode run that wrote 93M intermediate rows staged **~18,700 parquet objects**; its hand-off to Atlan's bucket then paid one set of gateway round trips per object and took **2h53m**. With one file per chunk the same tree is ~950 objects. Twelve fleet apps still pass `use_consolidation=True` (SAP ERP, SAP BW, SAP HANA, hive, oracle, postgres, presto, redshift, teradata, trino, kafka, adls, iceberg, mode), so the fix lands fleet-wide on the next SDK bump.

Companion to #3638 (directory-upload round trips and fan-out); the two multiply: fewer objects × fewer requests per object × wider fan-out. Investigation and measurements: FND-1339.

### Additional context (e.g. screenshots, logs, links)
- `ParquetFileWriter` is on the v4.0 removal path; this is a fix to the deprecated code because the fleet still runs it, not an endorsement. The recommended writer remains `RollingFileWriter` (size-based rollover).
- Reviewer note: consumers that glob `**/*.parquet` see fewer, larger files (up to `chunk_size` rows each, ~tens of MB for typical connector rows). Readers already handle both shapes; the old 5,000-row files were an accident of the loop, not a contract.

### Checklist
- [x] Additional tests added (`tests/unit/storage/formats/writers/test_parquet_writer.py::TestConsolidationFileCount`: one chunk → one file, two chunks → two files, the size cap still splits)
- [ ] All CI checks passed
- [x] Relevant documentation updated (inline; the writer is deprecated and undocumented beyond its docstring)

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.
