### PR TITLE
ci(loop): install PyYAML on the phase runner — every review has failed on import since #3604

### DIFF
--- a/.github/scripts/tests/test_loop_runner_deps.py
+++ b/.github/scripts/tests/test_loop_runner_deps.py
@@ -1,0 +1,83 @@
+"""The phase job must install what the phase scripts import.
+
+`sdk-loop-phase.yml` runs `.github/scripts/sdk_loop_phase.py` under the
+runner's `python3`, not under `uv run`. CI runs the same scripts' tests under
+`uv run pytest`, which has every project dependency. So a third-party import
+added to a loop script is green in CI and `ModuleNotFoundError` in production —
+which is exactly what happened when the verdict renderer landed with
+`import yaml`: every `@sdk-loop` review failed at import for a day and nothing
+went red anywhere.
+
+This test derives the third-party import set from the scripts themselves and
+asserts the workflow installs each one. A hand-maintained list here would be
+updated in the same commit that forgets the workflow.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+SCRIPTS = REPO / ".github/scripts"
+WORKFLOW = REPO / ".github/workflows/sdk-loop-phase.yml"
+
+#: Every module the phase job may end up importing. `sdk_review_*` because
+#: `sdk_loop_prep` imports `sdk_review_approve` and the phase imports the
+#: prep module.
+PATTERNS = ("sdk_loop*.py", "sdk_review*.py")
+
+
+def _third_party_imports() -> dict[str, set[str]]:
+    stdlib = set(sys.stdlib_module_names)
+    local = {p.stem for p in SCRIPTS.glob("*.py")}
+    found: dict[str, set[str]] = {}
+    for pattern in PATTERNS:
+        for path in sorted(SCRIPTS.glob(pattern)):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                names: list[str] = []
+                if isinstance(node, ast.Import):
+                    names = [a.name.split(".")[0] for a in node.names]
+                elif (
+                    isinstance(node, ast.ImportFrom) and node.module and node.level == 0
+                ):
+                    names = [node.module.split(".")[0]]
+                for name in names:
+                    if name not in stdlib and name not in local:
+                        found.setdefault(name, set()).add(path.name)
+    return found
+
+
+#: Import name -> the distribution the workflow has to install.
+DIST_FOR = {"yaml": "pyyaml"}
+
+
+def test_the_phase_job_installs_what_the_scripts_import() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8").lower()
+    install_lines = [ln for ln in workflow.splitlines() if "pip install" in ln]
+    assert install_lines, "sdk-loop-phase.yml has no pip install step at all"
+    installed = " ".join(install_lines)
+
+    missing = []
+    for module, files in sorted(_third_party_imports().items()):
+        dist = DIST_FOR.get(module, module).lower()
+        if dist not in installed:
+            missing.append(
+                f"{module} ({dist}) — imported by {', '.join(sorted(files))}"
+            )
+    assert not missing, (
+        "the phase job would fail on import in production:\n  "
+        + "\n  ".join(missing)
+        + "\nAdd the distribution to the `pip install` step in sdk-loop-phase.yml."
+    )
+
+
+def test_every_third_party_import_has_a_known_distribution() -> None:
+    """An import name that is not its distribution name (`yaml` → `pyyaml`)
+    needs the mapping, or the test above compares the wrong string."""
+    unmapped = sorted(
+        m for m in _third_party_imports() if m not in DIST_FOR and m != m.lower()
+    )
+    assert not unmapped, f"add these to DIST_FOR: {unmapped}"

--- a/.github/workflows/sdk-loop-phase.yml
+++ b/.github/workflows/sdk-loop-phase.yml
@@ -208,6 +208,15 @@ jobs:
         with:
           python-version: '3.14'
 
+      # The phase scripts run under the runner's python3, NOT `uv run` — and
+      # since the verdict renderer landed they import PyYAML. CI never saw the
+      # gap because pytest runs under uv, which has the project's deps; the
+      # workflow does not. Every review after that merge failed on import until
+      # this line. test_the_phase_job_installs_what_the_scripts_import derives
+      # the list from the scripts, so the next new import fails CI, not prod.
+      - name: Install what .github/scripts import
+        run: pip install "pyyaml>=6.0.2,<7.0.0"
+
       # A loop is up to 17 phase jobs, each on a fresh runner, so anything
       # installed per job is paid for 17 times. Cache the global npm store so
       # only the first job of a run pays the download.


### PR DESCRIPTION
**Production is down for `@sdk-loop`.** Every review since #3604 merged (2026-09-02 11:50) has ended Review 1 with:

```
ModuleNotFoundError: No module named 'yaml'
```

Last green loop: 2026-09-01 10:17. Since the merge: 3 failures, 0 successes.

## Why nothing went red

`sdk-loop-phase.yml` runs the phase scripts under the runner's `python3`, not `uv run`. `sdk_loop_phase.py` now imports `sdk_loop_findings` (#3604), which imports `yaml`. CI runs the same scripts' tests under `uv run pytest`, which has every project dependency — so the gap is invisible in CI **by construction**. It shows only on a runner, on a real PR.

Found by triggering the loop on the redesign PRs themselves.

## The fix

The repo's own pattern for `.github/scripts` deps (`release.yaml`: `pip install semver packaging`): one `pip install "pyyaml>=6.0.2,<7.0.0"` step after `setup-python`.

**The test is the point.** `test_loop_runner_deps.py` derives the third-party import set from the loop scripts via `ast` and asserts the workflow installs each distribution. A hand-maintained list would be updated in the same commit that forgets the workflow. Mutation-checked: removing the install line fails it.

**Merge first** — then re-run `@sdk-loop` on #3606, #3624, #3629 and #3583, which all failed on this.