### PR TITLE
feat(conformance): centralize connector review kit

### DIFF
--- a/packages/conformance/conformance/bootstrap/args.py
+++ b/packages/conformance/conformance/bootstrap/args.py
@@ -71,6 +71,7 @@ TRISTATE_FLAGS = (
 # by omission — see ``_sync_gitignore`` and ``_sync_contract_ledger``.
 PRESENCE_FLAGS = {
     "--resync": "resync",
+    "--connector-review-kit": "connector_review_kit",
 }
 
 # Flags that used to exist, mapped to why they are gone. A caller still
@@ -351,6 +352,12 @@ options:
                               app's own ignores) and contract_schema.lock.json
                               (append-only, owned by `gen-contract-ledger`, with B005/
                               B006 tracking its drift).
+  --connector-review-kit      install or update the centrally-managed local connector
+                              review kit (skill, non-blocking reminder, and rule-fetch
+                              script). This is
+                              opt-in so a normal bootstrap run never changes local
+                              Claude configuration. Existing unmarked review blocks
+                              stop for manual migration rather than being overwritten.
   --json                       after the normal output, print one final JSON line:
                               {"skipped": bool, "touched": [...], "unchanged": [...]}.
                               `touched` lists every path this invocation actually wrote

--- a/packages/conformance/conformance/bootstrap/args.py
+++ b/packages/conformance/conformance/bootstrap/args.py
@@ -63,12 +63,19 @@ TRISTATE_FLAGS = (
 # ``--resync=1``.
 #
 # ``--resync`` is deliberately one blanket flag rather than a per-file
-# ``--resync-<name>`` or a target list: it covers every write-if-absent
-# scaffold whose canonical can be re-rendered from values read back off the
-# file itself, and both current members (tests.yaml, renovate.json) carry the
+# ``--resync-<name>`` or a target list: it covers everything bootstrap owns
+# that a bare re-run deliberately leaves alone, and its members carry the
 # same risk profile, so there is nothing for a caller to choose between. The
 # two write-if-absent files it does NOT cover are excluded structurally, not
 # by omission — see ``_sync_gitignore`` and ``_sync_contract_ledger``.
+#
+# ``--resync`` therefore implies ``--connector-review-kit``: the kit is
+# centrally managed and its merges preserve per-repo content (a marked block
+# in CLAUDE.md, an additive hook entry in .claude/settings.json), so it is a
+# structural catch-up target like the scaffolds. The flag survives on its own
+# for the repo that wants the kit *without* resyncing tests.yaml/renovate.json,
+# and ``main()`` still distinguishes the two: an unmergeable review block is
+# fatal when the kit was asked for by name, and skipped when it was implied.
 PRESENCE_FLAGS = {
     "--resync": "resync",
     "--connector-review-kit": "connector_review_kit",
@@ -256,7 +263,8 @@ disk in every caller repo. All of these always overwrite (re-running eradicates 
 tests.yaml, renovate.json, and contract_schema.lock.json are write-if-absent by default;
 pass --enforce true|false (or --renovate-automerge true|false) to also update
 renovate.json's enforcement mode, and --resync to pull the resyncable scaffolds'
-structure forward without disturbing their per-repo values.
+structure forward without disturbing their per-repo values — which also installs or
+updates the local connector review kit (see --connector-review-kit).
 
 The tests gate is not one of these levers. `tests / Tests Gate` becoming a required,
 unbypassable status check on the default branch is a GitHub branch-protection setting
@@ -325,7 +333,8 @@ options:
   --resync                    re-render the resyncable write-if-absent scaffolds from
                               their canonical templates, so structural catch-up lands
                               in a repo scaffolded by an older bootstrap. Covers
-                              tests.yaml and renovate.json. Off by default: these are
+                              tests.yaml and renovate.json, and implies
+                              --connector-review-kit. Off by default: these are
                               write-if-absent precisely so apps can customise them, and
                               a bare re-run must never clobber that.
                               Each re-render reuses the per-repo values read back off
@@ -352,12 +361,24 @@ options:
                               app's own ignores) and contract_schema.lock.json
                               (append-only, owned by `gen-contract-ledger`, with B005/
                               B006 tracking its drift).
+                              The connector review kit rides along under different
+                              rules — it is centrally owned rather than read back off
+                              disk, so it re-renders whole, and its two merge targets
+                              (a marked block in CLAUDE.md, one hook entry in
+                              .claude/settings.json) preserve everything around them.
+                              A target that can't be merged safely skips the kit with a
+                              message and leaves the rest of the resync to finish,
+                              rather than failing the run.
   --connector-review-kit      install or update the centrally-managed local connector
                               review kit (skill, non-blocking reminder, and rule-fetch
-                              script). This is
-                              opt-in so a normal bootstrap run never changes local
+                              script). Implied by --resync; pass it alone to adopt the
+                              kit without resyncing tests.yaml/renovate.json. Otherwise
+                              opt-in, so a bare bootstrap run never changes local
                               Claude configuration. Existing unmarked review blocks
-                              stop for manual migration rather than being overwritten.
+                              stop for manual migration rather than being overwritten:
+                              passed by name that is an error (exit 2, nothing
+                              written); implied by --resync it is a skip, so one
+                              hand-edited CLAUDE.md cannot block a fleet resync.
   --json                       after the normal output, print one final JSON line:
                               {"skipped": bool, "touched": [...], "unchanged": [...]}.
                               `touched` lists every path this invocation actually wrote

--- a/packages/conformance/conformance/bootstrap/command.py
+++ b/packages/conformance/conformance/bootstrap/command.py
@@ -421,6 +421,30 @@ _RETIRED_CONNECTOR_REVIEW_HOOK_COMMANDS = frozenset(
     }
 )
 _CONNECTOR_REVIEW_REMINDER_COMMAND = ".claude/hooks/connector-review-reminder.sh"
+_KNOWN_LEGACY_CONNECTOR_REVIEW_BLOCK = """\
+## Mandatory pre-commit review (L1–L4)
+
+Before ANY `git commit`, the current changes MUST pass the `connector-review`
+skill: the L1 conformance suite plus every applicable L2/L3/L4 review rule.
+A PreToolUse hook blocks unreviewed commits; editing after a review invalidates
+it, so re-review after fixes.
+
+- L2/L4 rules: fetched from `atlanhq/application-sdk@main` into
+  `.mothership/.cache/review-rulesets/` by `scripts/fetch-review-rules.sh`.
+- L3 rules: `.mothership/review-rulesets/connector-app/` (this repo).
+- Never restate rule text in this file or in prompts — the rule files are the
+  only authority. If a rule seems wrong, change it in its source repo.
+- Local review is fast feedback. The PR-label CI review remains authoritative.
+- Emergency bypass (humans only, discouraged): `SKIP_CONNECTOR_REVIEW=1`.
+"""
+
+
+def _is_retired_connector_review_hook(command: object) -> bool:
+    """Match the old fixed hook paths, including project-directory prefixes."""
+    return isinstance(command, str) and any(
+        command == path or command.endswith(f"/{path}")
+        for path in _RETIRED_CONNECTOR_REVIEW_HOOK_COMMANDS
+    )
 
 
 def _merge_connector_review_settings(dest: pathlib.Path) -> str | None:
@@ -459,7 +483,7 @@ def _merge_connector_review_settings(dest: pathlib.Path) -> str | None:
                 for hook in entry_hooks
                 if not (
                     isinstance(hook, dict)
-                    and hook.get("command") in _RETIRED_CONNECTOR_REVIEW_HOOK_COMMANDS
+                    and _is_retired_connector_review_hook(hook.get("command"))
                 )
             ]
             if len(kept_hooks) == len(entry_hooks):
@@ -514,7 +538,10 @@ def _merge_connector_review_claude(dest: pathlib.Path) -> str:
     if begin == -1 and end == -1:
         if "## Mandatory pre-commit review" in text:
             legacy_begin = text.index("## Mandatory pre-commit review")
-            if "\n## " in text[legacy_begin + 1 :]:
+            if (
+                text[legacy_begin:].rstrip()
+                != _KNOWN_LEGACY_CONNECTOR_REVIEW_BLOCK.rstrip()
+            ):
                 raise ConnectorReviewMergeError(
                     dest, "unmarked connector-review block; migrate it manually first"
                 )

--- a/packages/conformance/conformance/bootstrap/command.py
+++ b/packages/conformance/conformance/bootstrap/command.py
@@ -556,7 +556,7 @@ def _merge_connector_review_claude(dest: pathlib.Path) -> str:
 def _sync_connector_review_kit(
     root: pathlib.Path, settings: str | None, claude: str
 ) -> list[tuple[pathlib.Path, str]]:
-    """Write the opt-in review kit after its merge targets were preflighted."""
+    """Write the review kit after its merge targets were preflighted."""
     changes: list[tuple[pathlib.Path, str]] = []
     for dest_rel, template_name, executable in MANAGED_CONNECTOR_REVIEW_FILES:
         dest = root / dest_rel
@@ -671,12 +671,19 @@ def main(argv: list[str]) -> int:
     # a write-mode toggle, not a template variable, and render() takes an exact
     # keyword set.
     resync = kwargs.pop("resync") == "true"
-    connector_review_kit = kwargs.pop("connector_review_kit") == "true"
+    # --resync is "pull forward everything bootstrap owns that a bare re-run
+    # leaves alone", and the review kit is exactly that: centrally owned, and
+    # merged rather than clobbered, so it belongs to the same catch-up. The
+    # flag stays meaningful on its own for a repo adopting the kit without
+    # resyncing its scaffolds, and which of the two happened decides how an
+    # unmergeable target is reported below.
+    kit_requested = kwargs.pop("connector_review_kit") == "true"
+    connector_review_kit = kit_requested or resync
     apply_bootstrap_autodetection(kwargs, root)
 
-    # Validate shared config before bootstrap writes anything. The kit is
-    # intentionally opt-in and must never overwrite a hand-maintained review
-    # block or malformed settings file during a fleet rollout.
+    # Validate shared config before bootstrap writes anything. The kit must
+    # never overwrite a hand-maintained review block or a malformed settings
+    # file during a fleet rollout.
     connector_review_settings: str | None = None
     connector_review_claude = ""
     if connector_review_kit:
@@ -686,8 +693,22 @@ def main(argv: list[str]) -> int:
             )
             connector_review_claude = _merge_connector_review_claude(root / "CLAUDE.md")
         except ConnectorReviewMergeError as error:
-            print(f"error: {error}", file=sys.stderr)
-            return 2
+            # Asked for by name: the whole invocation was about the kit, so
+            # fail loudly and write nothing.
+            if kit_requested:
+                print(f"error: {error}", file=sys.stderr)
+                return 2
+            # Implied by --resync: the kit is one target among several
+            # independent ones, so skip it the way a scaffold whose values
+            # can't be read back is skipped (see _resync_scaffold) and let the
+            # rest of the resync land. Otherwise one hand-edited CLAUDE.md
+            # would block a repo's tests.yaml/renovate.json catch-up too.
+            print(
+                f"skipped: {error}; the connector review kit was left untouched"
+                " (migrate the block by hand, then re-run with"
+                " --connector-review-kit)"
+            )
+            connector_review_kit = False
 
     # Resolve the two 0-touch levers, each independently expressible:
     #

--- a/packages/conformance/conformance/bootstrap/command.py
+++ b/packages/conformance/conformance/bootstrap/command.py
@@ -12,7 +12,9 @@ the actual write-phase helpers (``_bootstrap_file``, the self-guard, and the
 from __future__ import annotations
 
 import json
+import os
 import pathlib
+import sys
 import tomllib
 from collections.abc import Callable
 
@@ -27,8 +29,10 @@ from conformance.bootstrap.extract import (
 )
 from conformance.bootstrap.render import (
     MANAGED_ACTION_FILES,
+    MANAGED_CONNECTOR_REVIEW_FILES,
     MANAGED_WORKFLOWS,
-    RETIRED_WORKFLOWS,
+    RETIRED_CONNECTOR_REVIEW_FILES,
+    RETIRED_FILES,
     render,
 )
 
@@ -45,7 +49,9 @@ _TOUCHED_STATUSES = frozenset(
 )
 
 
-def _bootstrap_file(dest: pathlib.Path, content: str) -> str:
+def _bootstrap_file(
+    dest: pathlib.Path, content: str, *, executable: bool = False
+) -> str:
     """Write *content* to *dest*, creating parent directories as needed.
 
     Always-overwrite-managed — bootstrap owns these files and re-running is
@@ -64,19 +70,26 @@ def _bootstrap_file(dest: pathlib.Path, content: str) -> str:
     to fold into the ``--json`` touched-files manifest without a caller
     having to re-derive it from stdout text.
     """
+    expected_mode = 0o755
     if dest.exists():
         try:
             unchanged = dest.read_text(encoding="utf-8") == content
         except (OSError, UnicodeDecodeError):
             unchanged = False
-        if unchanged:
+        mode_matches = not executable or (dest.stat().st_mode & 0o777) == expected_mode
+        if unchanged and mode_matches:
             print(f"ok (up to date): {dest}")
             return "unchanged"
-        dest.write_text(content, encoding="utf-8")
+        if not unchanged:
+            dest.write_text(content, encoding="utf-8")
+        if executable:
+            os.chmod(dest, expected_mode)
         print(f"updated: {dest}")
         return "updated"
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_text(content, encoding="utf-8")
+    if executable:
+        os.chmod(dest, expected_mode)
     print(f"installed: {dest}")
     return "installed"
 
@@ -97,7 +110,7 @@ def _retire_file(dest: pathlib.Path) -> str:
     if not dest.exists():
         return "absent"
     dest.unlink()
-    print(f"removed: {dest}  (retired workflow — no longer managed)")
+    print(f"removed: {dest}  (retired managed file)")
     return "removed"
 
 
@@ -390,6 +403,164 @@ def _sync_gitignore(root: pathlib.Path) -> list[tuple[pathlib.Path, str]]:
     return [(gitignore_dest, "exists")]
 
 
+_CONNECTOR_REVIEW_BEGIN = "<!-- BEGIN APPLICATION SDK CONNECTOR REVIEW -->"
+_CONNECTOR_REVIEW_END = "<!-- END APPLICATION SDK CONNECTOR REVIEW -->"
+
+
+class ConnectorReviewMergeError(ValueError):
+    """A connector-review config cannot be safely merged."""
+
+    def __init__(self, dest: pathlib.Path, reason: str) -> None:
+        super().__init__(f"cannot safely merge {dest}: {reason}")
+
+
+_RETIRED_CONNECTOR_REVIEW_HOOK_COMMANDS = frozenset(
+    {
+        ".claude/hooks/check-review-before-commit.sh",
+        ".claude/hooks/review-rules-freshness.sh",
+    }
+)
+_CONNECTOR_REVIEW_REMINDER_COMMAND = ".claude/hooks/connector-review-reminder.sh"
+
+
+def _merge_connector_review_settings(dest: pathlib.Path) -> str | None:
+    """Replace retired kit hooks with one non-blocking reminder."""
+    if not dest.exists():
+        settings: dict[str, object] = {}
+        original = ""
+    else:
+        try:
+            original = dest.read_text(encoding="utf-8")
+            loaded = json.loads(original)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ConnectorReviewMergeError(dest, str(error)) from error
+        if not isinstance(loaded, dict):
+            raise ConnectorReviewMergeError(dest, "root must be a JSON object")
+        settings = loaded
+
+    hooks = settings.get("hooks")
+    if hooks is None:
+        hooks = {}
+        settings["hooks"] = hooks
+    if not isinstance(hooks, dict):
+        raise ConnectorReviewMergeError(dest, "'hooks' must be a JSON object")
+    changed = False
+    for event, entries in hooks.items():
+        if not isinstance(entries, list):
+            raise ConnectorReviewMergeError(dest, f"hooks.{event} must be an array")
+        retained = []
+        for entry in entries:
+            if not isinstance(entry, dict) or not isinstance(entry.get("hooks"), list):
+                retained.append(entry)
+                continue
+            entry_hooks = entry["hooks"]
+            kept_hooks = [
+                hook
+                for hook in entry_hooks
+                if not (
+                    isinstance(hook, dict)
+                    and hook.get("command") in _RETIRED_CONNECTOR_REVIEW_HOOK_COMMANDS
+                )
+            ]
+            if len(kept_hooks) == len(entry_hooks):
+                retained.append(entry)
+            elif kept_hooks:
+                retained.append({**entry, "hooks": kept_hooks})
+                changed = True
+            else:
+                changed = True
+        if retained != entries:
+            hooks[event] = retained
+    reminder_entries = hooks.setdefault("SessionStart", [])
+    if not isinstance(reminder_entries, list):
+        raise ConnectorReviewMergeError(dest, "hooks.SessionStart must be an array")
+    if not any(
+        isinstance(entry, dict)
+        and any(
+            isinstance(hook, dict)
+            and hook.get("command") == _CONNECTOR_REVIEW_REMINDER_COMMAND
+            for hook in entry.get("hooks", [])
+            if isinstance(entry.get("hooks"), list)
+        )
+        for entry in reminder_entries
+    ):
+        reminder_entries.append(
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": _CONNECTOR_REVIEW_REMINDER_COMMAND,
+                        "timeout": 10,
+                    }
+                ]
+            }
+        )
+        changed = True
+    return json.dumps(settings, indent=2) + "\n" if changed else original
+
+
+def _merge_connector_review_claude(dest: pathlib.Path) -> str:
+    """Return CLAUDE.md with one replaceable, centrally-owned review block."""
+    block = render("connector-review-claude.md")
+    if not dest.exists():
+        return block
+    try:
+        text = dest.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        raise ConnectorReviewMergeError(dest, str(error)) from error
+
+    begin = text.find(_CONNECTOR_REVIEW_BEGIN)
+    end = text.find(_CONNECTOR_REVIEW_END)
+    if begin == -1 and end == -1:
+        if "## Mandatory pre-commit review" in text:
+            legacy_begin = text.index("## Mandatory pre-commit review")
+            if "\n## " in text[legacy_begin + 1 :]:
+                raise ConnectorReviewMergeError(
+                    dest, "unmarked connector-review block; migrate it manually first"
+                )
+            return f"{text[:legacy_begin].rstrip()}\n\n{block}"
+        return f"{text.rstrip()}\n\n{block}"
+    if begin == -1 or end == -1 or end < begin:
+        raise ConnectorReviewMergeError(dest, "malformed managed review block")
+    end += len(_CONNECTOR_REVIEW_END)
+    return f"{text[:begin]}{block.rstrip()}\n{text[end:].lstrip()}"
+
+
+def _sync_connector_review_kit(
+    root: pathlib.Path, settings: str | None, claude: str
+) -> list[tuple[pathlib.Path, str]]:
+    """Write the opt-in review kit after its merge targets were preflighted."""
+    changes: list[tuple[pathlib.Path, str]] = []
+    for dest_rel, template_name, executable in MANAGED_CONNECTOR_REVIEW_FILES:
+        dest = root / dest_rel
+        changes.append(
+            (dest, _bootstrap_file(dest, render(template_name), executable=executable))
+        )
+
+    for dest_rel in RETIRED_CONNECTOR_REVIEW_FILES:
+        dest = root / dest_rel
+        if _retire_file(dest) == "removed":
+            changes.append((dest, "removed"))
+
+    if settings is not None:
+        settings_dest = root / ".claude" / "settings.json"
+        changes.append((settings_dest, _bootstrap_file(settings_dest, settings)))
+
+    claude_dest = root / "CLAUDE.md"
+    changes.append((claude_dest, _bootstrap_file(claude_dest, claude)))
+
+    gitignore_dest = root / ".gitignore"
+    ignore_line = ".mothership/.cache/"
+    text = gitignore_dest.read_text(encoding="utf-8") if gitignore_dest.exists() else ""
+    if ignore_line in text.splitlines():
+        print(f"ok (exists): {gitignore_dest}  (connector-review cache ignored)")
+        changes.append((gitignore_dest, "exists"))
+    else:
+        updated = f"{text.rstrip()}\n{ignore_line}\n" if text else f"{ignore_line}\n"
+        changes.append((gitignore_dest, _bootstrap_file(gitignore_dest, updated)))
+    return changes
+
+
 def _sync_contract_ledger(root: pathlib.Path) -> list[tuple[pathlib.Path, str]]:
     """contract_schema.lock.json — write-if-absent scaffold.
 
@@ -473,7 +644,23 @@ def main(argv: list[str]) -> int:
     # a write-mode toggle, not a template variable, and render() takes an exact
     # keyword set.
     resync = kwargs.pop("resync") == "true"
+    connector_review_kit = kwargs.pop("connector_review_kit") == "true"
     apply_bootstrap_autodetection(kwargs, root)
+
+    # Validate shared config before bootstrap writes anything. The kit is
+    # intentionally opt-in and must never overwrite a hand-maintained review
+    # block or malformed settings file during a fleet rollout.
+    connector_review_settings: str | None = None
+    connector_review_claude = ""
+    if connector_review_kit:
+        try:
+            connector_review_settings = _merge_connector_review_settings(
+                root / ".claude" / "settings.json"
+            )
+            connector_review_claude = _merge_connector_review_claude(root / "CLAUDE.md")
+        except ConnectorReviewMergeError as error:
+            print(f"error: {error}", file=sys.stderr)
+            return 2
 
     # Resolve the two 0-touch levers, each independently expressible:
     #
@@ -523,8 +710,8 @@ def main(argv: list[str]) -> int:
     # Only an actual deletion is recorded: a repo that never had the file (or
     # already dropped it) has no such path, and listing it under `unchanged`
     # would put a file that does not and will not exist into the manifest.
-    for name in RETIRED_WORKFLOWS:
-        dest = root / ".github" / "workflows" / name
+    for dest_rel in RETIRED_FILES:
+        dest = root / dest_rel
         if _retire_file(dest) == "removed":
             _record(dest, "removed")
 
@@ -547,6 +734,11 @@ def main(argv: list[str]) -> int:
         _record(path, status)
     for path, status in _sync_contract_ledger(root):
         _record(path, status)
+    if connector_review_kit:
+        for path, status in _sync_connector_review_kit(
+            root, connector_review_settings, connector_review_claude
+        ):
+            _record(path, status)
 
     if emit_json:
         print(

--- a/packages/conformance/conformance/bootstrap/render.py
+++ b/packages/conformance/conformance/bootstrap/render.py
@@ -70,7 +70,14 @@ MANAGED_WORKFLOWS: tuple[str, ...] = (
 # shim's shape was wrong outright.  Every call therefore failed at startup:
 # conclusion ``failure``, zero jobs, no check run, no logs.  Retired rather
 # than repointed — the check is not wanted on connectors.
-RETIRED_WORKFLOWS: tuple[str, ...] = ("docstring-coverage.yaml",)
+# Retirements are repo-root-relative so the same mechanism can remove a
+# previously-managed hook or script, not only a workflow.
+RETIRED_FILES: tuple[str, ...] = (".github/workflows/docstring-coverage.yaml",)
+RETIRED_WORKFLOWS: tuple[str, ...] = tuple(
+    path.removeprefix(".github/workflows/")
+    for path in RETIRED_FILES
+    if path.startswith(".github/workflows/")
+)
 
 # Non-workflow files that must also be vendored into every consumer repo,
 # keyed by (repo-root-relative dest path, template filename in templates/).
@@ -111,6 +118,27 @@ MANAGED_ACTION_FILES: tuple[tuple[str, str], ...] = (
     (".github/scripts/probe_code_scanning.py", "probe_code_scanning.py"),
 )
 
+# Opt-in local connector-review kit. These paths are owned by bootstrap after
+# the fleet rollout invokes ``bootstrap --connector-review-kit``.
+# (destination, template, must be executable)
+MANAGED_CONNECTOR_REVIEW_FILES: tuple[tuple[str, str, bool], ...] = (
+    ("scripts/fetch-review-rules.sh", "fetch-review-rules.sh", True),
+    (
+        ".claude/hooks/connector-review-reminder.sh",
+        "connector-review-reminder.sh",
+        True,
+    ),
+    (".claude/skills/connector-review/SKILL.md", "connector-review.md", False),
+)
+
+# Retire the marker and PreToolUse gate only when the opt-in kit is requested.
+# They were self-attestation: an agent could write PASS without proving review.
+RETIRED_CONNECTOR_REVIEW_FILES: tuple[str, ...] = (
+    "scripts/write-connector-review-marker.sh",
+    ".claude/hooks/check-review-before-commit.sh",
+    ".claude/hooks/review-rules-freshness.sh",
+)
+
 
 def _load_template(name: str) -> str:
     """Read a template file from the embedded templates directory."""
@@ -126,7 +154,10 @@ def _load_template(name: str) -> str:
 # variable-start delimiter (Jinja matches it starting at the *second* `<`,
 # then fails deep in the following line looking for the closing ` >>`).
 _STATIC_TEMPLATES: frozenset[str] = frozenset(
-    template_name for _, template_name in MANAGED_ACTION_FILES
+    [
+        *(template_name for _, template_name in MANAGED_ACTION_FILES),
+        *(template_name for _, template_name, _ in MANAGED_CONNECTOR_REVIEW_FILES),
+    ]
 )
 
 

--- a/packages/conformance/conformance/bootstrap/render.py
+++ b/packages/conformance/conformance/bootstrap/render.py
@@ -118,8 +118,9 @@ MANAGED_ACTION_FILES: tuple[tuple[str, str], ...] = (
     (".github/scripts/probe_code_scanning.py", "probe_code_scanning.py"),
 )
 
-# Opt-in local connector-review kit. These paths are owned by bootstrap after
-# the fleet rollout invokes ``bootstrap --connector-review-kit``.
+# Local connector-review kit. These paths are owned by bootstrap once a repo
+# opts in, via ``bootstrap --connector-review-kit`` or the ``bootstrap
+# --resync`` that implies it.
 # (destination, template, must be executable)
 MANAGED_CONNECTOR_REVIEW_FILES: tuple[tuple[str, str, bool], ...] = (
     ("scripts/fetch-review-rules.sh", "fetch-review-rules.sh", True),

--- a/packages/conformance/conformance/bootstrap/templates/connector-review-claude.md
+++ b/packages/conformance/conformance/bootstrap/templates/connector-review-claude.md
@@ -1,0 +1,11 @@
+<!-- BEGIN APPLICATION SDK CONNECTOR REVIEW -->
+## Mandatory pre-commit review (L2-L4 rules; L1 in PR CI)
+
+Before any `git commit`, run the `connector-review` skill for the applicable
+L2-L4 rules. It is local review guidance, not a marker-based commit gate.
+
+L1 conformance runs in CI on every pull-request update; the repository's CI
+configuration remains authoritative for enforcement.
+Shared L2/L4 rules are fetched into `.mothership/.cache/review-rulesets/` and
+L3 rules live in `.mothership/review-rulesets/connector-app/`.
+<!-- END APPLICATION SDK CONNECTOR REVIEW -->

--- a/packages/conformance/conformance/bootstrap/templates/connector-review-reminder.sh
+++ b/packages/conformance/conformance/bootstrap/templates/connector-review-reminder.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# SessionStart reminder only: L2-L4 review is guidance, never a commit gate.
+echo "Before your next git commit, run /connector-review for the applicable L2-L4 rules."
+exit 0

--- a/packages/conformance/conformance/bootstrap/templates/connector-review.md
+++ b/packages/conformance/conformance/bootstrap/templates/connector-review.md
@@ -1,0 +1,21 @@
+---
+name: connector-review
+description: Review the current connector change before commit against applicable L2-L4 rules.
+---
+
+# Connector review
+
+Review only the current diff. Rule files are the authority; do not restate them.
+
+1. Scope: use `git diff HEAD --name-only` and `git diff --cached --name-only`.
+   If both are empty, use `git diff origin/main...HEAD --name-only`.
+2. Run `scripts/fetch-review-rules.sh`. Read matching L2/L4 rules from
+   `.mothership/.cache/review-rulesets/` and L3 rules from
+   `.mothership/review-rulesets/connector-app/`. If the shared cache is unavailable,
+   state that L2/L4 were not reviewed.
+3. For each selected rule, report `checked`, `not_applicable`, or a finding. Then do
+   one independent correctness pass over the changed code.
+4. L1 conformance runs in CI on every pull-request update. Do not run L1 locally or
+   write a review marker. CI enforcement remains repository-specific.
+5. Report findings with evidence and a concrete fix. This local review is guidance;
+   it never blocks a commit through a self-written PASS marker.

--- a/packages/conformance/conformance/bootstrap/templates/fetch-review-rules.sh
+++ b/packages/conformance/conformance/bootstrap/templates/fetch-review-rules.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Fetch shared L2/L4 review rules into the local, gitignored cache.
+set -euo pipefail
+
+sdk_repo="atlanhq/application-sdk"
+cache_dir=".mothership/.cache/review-rulesets"
+lock_file=".mothership/.cache/rules.lock"
+
+sha="$(gh api "repos/${sdk_repo}/commits/main" --jq .sha 2>/dev/null || true)"
+if [ -z "${sha}" ]; then
+  if [ -f "${lock_file}" ]; then
+    echo "WARN: cannot reach GitHub; keeping cached review rules." >&2
+    exit 0
+  fi
+  echo "ERROR: no shared rules cache and GitHub is unavailable." >&2
+  exit 1
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+for ruleset in connector-app platform; do
+  gh api "repos/${sdk_repo}/contents/.mothership/review-rulesets/${ruleset}?ref=${sha}" \
+    --jq '.[] | select(.type == "file") | .path' | while read -r path; do
+      mkdir -p "${tmp}/${ruleset}"
+      gh api "repos/${sdk_repo}/contents/${path}?ref=${sha}" --jq .content | \
+        python3 -c 'import base64, sys; sys.stdout.buffer.write(base64.b64decode(sys.stdin.buffer.read()))' \
+        > "${tmp}/${ruleset}/$(basename "${path}")"
+    done
+  rules_dir=".mothership/review-rulesets/${ruleset}/rules"
+  gh api "repos/${sdk_repo}/contents/${rules_dir}?ref=${sha}" \
+    --jq '.[] | select(.type == "file") | .path' | while read -r path; do
+      mkdir -p "${tmp}/${ruleset}/rules"
+      gh api "repos/${sdk_repo}/contents/${path}?ref=${sha}" --jq .content | \
+        python3 -c 'import base64, sys; sys.stdout.buffer.write(base64.b64decode(sys.stdin.buffer.read()))' \
+        > "${tmp}/${ruleset}/rules/$(basename "${path}")"
+    done
+done
+
+mkdir -p "$(dirname "${cache_dir}")"
+rm -rf "${cache_dir}"
+mv "${tmp}" "${cache_dir}"
+trap - EXIT
+printf '{"sdk_repo":"%s","sha":"%s","fetched_at":"%s"}\n' \
+  "${sdk_repo}" "${sha}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "${lock_file}"
+echo "Fetched L2/L4 review rules at ${sdk_repo}@${sha}"

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -8,8 +8,10 @@ tests exercise the same code path a caller would use.
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import re
+import subprocess
 
 import pytest
 from conformance.bootstrap import extract as extract_mod
@@ -18,7 +20,9 @@ from conformance.bootstrap.autodetect import derive_app_name_from_dir
 from conformance.bootstrap.command import _bootstrap_file
 from conformance.bootstrap.render import (
     MANAGED_ACTION_FILES,
+    MANAGED_CONNECTOR_REVIEW_FILES,
     MANAGED_WORKFLOWS,
+    RETIRED_CONNECTOR_REVIEW_FILES,
     RETIRED_WORKFLOWS,
     render,
 )
@@ -90,6 +94,18 @@ def test_bootstrap_file_does_not_rewrite_unchanged_content(
     assert dest.stat().st_mtime_ns == mtime_before
 
 
+def test_bootstrap_file_corrects_managed_executable_mode(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A re-run fixes a non-executable hook even when its bytes already match."""
+    dest = tmp_path / "hook.sh"
+    dest.write_text("#!/usr/bin/env bash\n")
+    os.chmod(dest, 0o644)
+
+    assert _bootstrap_file(dest, dest.read_text(), executable=True) == "updated"
+    assert os.stat(dest).st_mode & 0o777 == 0o755
+
+
 # ---------------------------------------------------------------------------
 # parse_bootstrap_args
 # ---------------------------------------------------------------------------
@@ -118,6 +134,7 @@ def test_parse_bootstrap_args_defaults() -> None:
         # Presence flag: "false" unless --resync is passed, so a bare
         # re-run never rewrites the write-if-absent tests.yaml scaffold.
         "resync": "false",
+        "connector_review_kit": "false",
     }
 
 
@@ -2455,6 +2472,121 @@ def test_cmd_bootstrap_rerun_with_no_changes_reports_no_managed_file_as_updated(
         assert f"ok (up to date): {tmp_path / dest_rel}" in out
     skill_md = tmp_path / ".claude" / "skills" / "remediate" / "SKILL.md"
     assert f"ok (up to date): {skill_md}" in out
+
+
+def test_cmd_bootstrap_installs_connector_review_kit_additively(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The opt-in kit retires only its old state and preserves user settings."""
+    claude = tmp_path / "CLAUDE.md"
+    claude.write_text("# App notes\n")
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir()
+    settings.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {"matcher": "keep-me"},
+                        {
+                            "hooks": [
+                                {"command": ".claude/hooks/review-rules-freshness.sh"}
+                            ]
+                        },
+                    ],
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [
+                                {
+                                    "command": ".claude/hooks/check-review-before-commit.sh"
+                                },
+                                {"command": "scripts/keep-me.sh"},
+                            ],
+                        }
+                    ],
+                }
+            }
+        )
+        + "\n"
+    )
+    for dest_rel in RETIRED_CONNECTOR_REVIEW_FILES:
+        dest = tmp_path / dest_rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text("legacy\n")
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text("custom-cache/\n")
+
+    monkeypatch.chdir(tmp_path)
+    assert _cmd_bootstrap(["--connector-review-kit"]) == 0
+
+    for dest_rel, template_name, executable in MANAGED_CONNECTOR_REVIEW_FILES:
+        dest = tmp_path / dest_rel
+        assert dest.read_text() == render(template_name)
+        if executable:
+            assert os.stat(dest).st_mode & 0o777 == 0o755
+
+    merged_settings = json.loads(settings.read_text())
+    assert merged_settings["hooks"]["SessionStart"][0] == {"matcher": "keep-me"}
+    assert merged_settings["hooks"]["SessionStart"][1]["hooks"][0]["command"] == (
+        ".claude/hooks/connector-review-reminder.sh"
+    )
+    assert merged_settings["hooks"]["PreToolUse"] == [
+        {"matcher": "Bash", "hooks": [{"command": "scripts/keep-me.sh"}]}
+    ]
+    for dest_rel in RETIRED_CONNECTOR_REVIEW_FILES:
+        assert not (tmp_path / dest_rel).exists()
+    assert "# App notes" in claude.read_text()
+    assert "BEGIN APPLICATION SDK CONNECTOR REVIEW" in claude.read_text()
+    assert (
+        "write-connector-review-marker"
+        not in (tmp_path / ".claude/skills/connector-review/SKILL.md").read_text()
+    )
+    assert ".mothership/.cache/" in gitignore.read_text().splitlines()
+
+
+def test_cmd_bootstrap_connector_review_kit_migrates_eof_legacy_block(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The known old kit block was appended at EOF, so it can be replaced safely."""
+    (tmp_path / "CLAUDE.md").write_text("## Mandatory pre-commit review (L1-L4)\n")
+    monkeypatch.chdir(tmp_path)
+
+    assert _cmd_bootstrap(["--connector-review-kit"]) == 0
+    text = (tmp_path / "CLAUDE.md").read_text()
+    assert "L1-L4)" not in text
+    assert "BEGIN APPLICATION SDK CONNECTOR REVIEW" in text
+    settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+    assert settings["hooks"]["SessionStart"][0]["hooks"][0]["command"] == (
+        ".claude/hooks/connector-review-reminder.sh"
+    )
+
+
+def test_conformance_template_runs_on_every_pr_update() -> None:
+    """A GitHub pull_request workflow receives each push to an open PR."""
+    assert "pull_request: {}" in render("conformance.yaml")
+
+
+@pytest.mark.parametrize(
+    "_dest_rel,template_name",
+    [
+        (dest_rel, template_name)
+        for dest_rel, template_name, executable in MANAGED_CONNECTOR_REVIEW_FILES
+        if executable
+    ],
+)
+def test_connector_review_shell_template_is_valid(
+    _dest_rel: str, template_name: str, tmp_path: pathlib.Path
+) -> None:
+    """Every centrally-written hook/script must pass the shell parser first."""
+    script = tmp_path / template_name
+    script.write_text(render(template_name))
+    proc = subprocess.run(
+        ["bash", "-n", str(script)], capture_output=True, check=False, text=True
+    )
+    assert proc.returncode == 0, proc.stderr
 
 
 # ---------------------------------------------------------------------------

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -266,6 +266,26 @@ def test_cmd_bootstrap_writes_skill_md(
     assert dest.read_text() == render("remediate.md")
 
 
+@pytest.mark.parametrize("argv", [[], ["--resync"]])
+def test_cmd_bootstrap_restores_a_drifted_remediate_skill(
+    argv: list[str], tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The remediate skill is always-overwrite, so it needs no --resync opt-in.
+
+    It is the one managed file a caller most expects --resync to cover, and it
+    is covered more strongly than that: a bare re-run already eradicates its
+    drift. Locked under both argvs so nobody "adds it to --resync" by making
+    it write-if-absent first.
+    """
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    dest = tmp_path / ".claude" / "skills" / "remediate" / "SKILL.md"
+    dest.write_text("# hand-edited, missing everything newer\n")
+
+    _cmd_bootstrap(argv)
+    assert dest.read_text() == render("remediate.md")
+
+
 def _seed_conformance_pyproject(repo_root: pathlib.Path) -> None:
     """Create a minimal packages/conformance/pyproject.toml naming this exact
     package, matching what the real SDK monorepo checkout has on disk."""
@@ -2589,6 +2609,77 @@ def test_cmd_bootstrap_connector_review_kit_preserves_unverified_legacy_suffix(
     assert _cmd_bootstrap(["--connector-review-kit"]) == 2
     assert claude.read_text().endswith("### App notes\nKeep this.\n")
     assert not (tmp_path / ".claude" / "skills" / "connector-review").exists()
+
+
+def test_resync_installs_the_connector_review_kit(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--resync is the fleet's structural catch-up, so it carries the kit too."""
+    monkeypatch.chdir(tmp_path)
+
+    assert _cmd_bootstrap(["--resync"]) == 0
+
+    for dest_rel, template_name, _executable in MANAGED_CONNECTOR_REVIEW_FILES:
+        assert (tmp_path / dest_rel).read_text() == render(template_name)
+    assert (
+        "BEGIN APPLICATION SDK CONNECTOR REVIEW" in (tmp_path / "CLAUDE.md").read_text()
+    )
+    settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+    assert settings["hooks"]["SessionStart"][0]["hooks"][0]["command"] == (
+        ".claude/hooks/connector-review-reminder.sh"
+    )
+
+
+def test_bare_rerun_never_installs_the_connector_review_kit(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only --connector-review-kit or the --resync that implies it may opt in.
+
+    The other half of the contract: --resync gained the kit, a bare re-run
+    must still leave local Claude configuration alone.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    assert _cmd_bootstrap([]) == 0
+
+    for dest_rel, _template_name, _executable in MANAGED_CONNECTOR_REVIEW_FILES:
+        assert not (tmp_path / dest_rel).exists()
+    assert not (tmp_path / "CLAUDE.md").exists()
+    assert not (tmp_path / ".claude" / "settings.json").exists()
+
+
+def test_resync_skips_an_unmergeable_kit_without_failing_the_run(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """One hand-edited CLAUDE.md must not block a repo's scaffold catch-up.
+
+    Passed by name the same block is a hard error (exit 2) — see
+    test_cmd_bootstrap_connector_review_kit_preserves_unverified_legacy_suffix.
+    Implied by --resync it is a skip, so the tests.yaml/renovate.json
+    re-render still lands.
+    """
+    claude = tmp_path / "CLAUDE.md"
+    claude.write_text(
+        _KNOWN_LEGACY_CONNECTOR_REVIEW_BLOCK + "\n### App notes\nKeep this.\n"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    assert _cmd_bootstrap(["--resync"]) == 0
+
+    out = capsys.readouterr().out
+    assert "skipped: cannot safely merge" in out
+    assert "--connector-review-kit" in out
+    assert claude.read_text().endswith("### App notes\nKeep this.\n")
+    assert not (tmp_path / ".claude" / "skills" / "connector-review").exists()
+    assert not (tmp_path / ".claude" / "settings.json").exists()
+    # The rest of the resync is unaffected.
+    assert (tmp_path / ".github" / "workflows" / "tests.yaml").read_text() == render(
+        "tests.yaml", app_name=derive_app_name_from_dir(tmp_path)
+    )
 
 
 @pytest.mark.parametrize(

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -17,7 +17,10 @@ import pytest
 from conformance.bootstrap import extract as extract_mod
 from conformance.bootstrap.args import BOOTSTRAP_USAGE, FLAGS, parse_bootstrap_args
 from conformance.bootstrap.autodetect import derive_app_name_from_dir
-from conformance.bootstrap.command import _bootstrap_file
+from conformance.bootstrap.command import (
+    _KNOWN_LEGACY_CONNECTOR_REVIEW_BLOCK,
+    _bootstrap_file,
+)
 from conformance.bootstrap.render import (
     MANAGED_ACTION_FILES,
     MANAGED_CONNECTOR_REVIEW_FILES,
@@ -2491,7 +2494,12 @@ def test_cmd_bootstrap_installs_connector_review_kit_additively(
                         {"matcher": "keep-me"},
                         {
                             "hooks": [
-                                {"command": ".claude/hooks/review-rules-freshness.sh"}
+                                {
+                                    "command": (
+                                        '"$CLAUDE_PROJECT_DIR"/'
+                                        ".claude/hooks/review-rules-freshness.sh"
+                                    )
+                                }
                             ]
                         },
                     ],
@@ -2500,7 +2508,10 @@ def test_cmd_bootstrap_installs_connector_review_kit_additively(
                             "matcher": "Bash",
                             "hooks": [
                                 {
-                                    "command": ".claude/hooks/check-review-before-commit.sh"
+                                    "command": (
+                                        '"$CLAUDE_PROJECT_DIR"/'
+                                        ".claude/hooks/check-review-before-commit.sh"
+                                    )
                                 },
                                 {"command": "scripts/keep-me.sh"},
                             ],
@@ -2551,7 +2562,7 @@ def test_cmd_bootstrap_connector_review_kit_migrates_eof_legacy_block(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The known old kit block was appended at EOF, so it can be replaced safely."""
-    (tmp_path / "CLAUDE.md").write_text("## Mandatory pre-commit review (L1-L4)\n")
+    (tmp_path / "CLAUDE.md").write_text(_KNOWN_LEGACY_CONNECTOR_REVIEW_BLOCK)
     monkeypatch.chdir(tmp_path)
 
     assert _cmd_bootstrap(["--connector-review-kit"]) == 0
@@ -2564,9 +2575,20 @@ def test_cmd_bootstrap_connector_review_kit_migrates_eof_legacy_block(
     )
 
 
-def test_conformance_template_runs_on_every_pr_update() -> None:
-    """A GitHub pull_request workflow receives each push to an open PR."""
-    assert "pull_request: {}" in render("conformance.yaml")
+def test_cmd_bootstrap_connector_review_kit_preserves_unverified_legacy_suffix(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the complete known EOF block may be replaced automatically."""
+    claude = tmp_path / "CLAUDE.md"
+    claude.write_text(
+        _KNOWN_LEGACY_CONNECTOR_REVIEW_BLOCK + "\n### App notes\nKeep this.\n"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    assert _cmd_bootstrap(["--connector-review-kit"]) == 2
+    assert claude.read_text().endswith("### App notes\nKeep this.\n")
+    assert not (tmp_path / ".claude" / "skills" / "connector-review").exists()
 
 
 @pytest.mark.parametrize(

--- a/packages/conformance/tests/test_bootstrap_scaffold_lint.py
+++ b/packages/conformance/tests/test_bootstrap_scaffold_lint.py
@@ -29,7 +29,12 @@ import sys
 import tomllib
 
 import pytest
-from conformance.bootstrap.render import MANAGED_ACTION_FILES, MANAGED_WORKFLOWS, render
+from conformance.bootstrap.render import (
+    MANAGED_ACTION_FILES,
+    MANAGED_CONNECTOR_REVIEW_FILES,
+    MANAGED_WORKFLOWS,
+    render,
+)
 from conformance.cli import _cmd_bootstrap
 
 # The strictest ruff lint selection seen in the fleet, plus "I" (import
@@ -63,8 +68,10 @@ _PY_SCAFFOLDS = tuple(
 # test_force_written_system_deps_file_is_whitespace_clean below.
 _TEMPLATE_RENDERED_FORCE_WRITTEN = (
     *MANAGED_ACTION_FILES,
+    *((dest, template) for dest, template, _ in MANAGED_CONNECTOR_REVIEW_FILES),
     *((f".github/workflows/{name}", name) for name in MANAGED_WORKFLOWS),
     (".claude/skills/remediate/SKILL.md", "remediate.md"),
+    ("CLAUDE.md", "connector-review-claude.md"),
 )
 
 # Per-repo render parameters to check the templates under, beyond the


### PR DESCRIPTION
### Changelog
- Add an opt-in `bootstrap --connector-review-kit` rollout for the shared connector-review skill and rule fetcher.
- Retire the marker-based pre-commit gate and remove only its managed hook entries while preserving unrelated settings.
- Add a non-blocking session reminder; L1 remains the CI check for every open-PR update.

### Additional context (e.g. screenshots, logs, links)
- Validated with 372 bootstrap, drift, and scaffold tests plus targeted pre-commit.

### Checklist
- [x] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? Please share additional details.