### PR TITLE
ci(loop): a review-only dispatch, so the A/B can review merged PRs without anything pushing

### DIFF
--- a/.github/scripts/gen_sdk_loop_workflow.py
+++ b/.github/scripts/gen_sdk_loop_workflow.py
@@ -31,6 +31,7 @@ OUT = pathlib.Path(".github/workflows/sdk-loop.yml")
 HEADER = """# @sdk-loop — drive a PR to merge-ready without supervision.
 #
 #   fence -> review 1 -> resolve 1 -> review 2 -> ... -> review 8 -> finalize
+#   fence -> review 1 -> finalize                    (workflow_dispatch review_only)
 #
 # One workflow run, one job per phase, up to 8 review/resolve pairs. The review
 # phase runs on xai/grok-4.6 — the same model the existing lanes review with
@@ -94,6 +95,14 @@ on:
       pr:
         description: 'PR number to drive'
         required: true
+      review_only:
+        description: >-
+          Review once and stop. Accepts a merged or closed PR, runs no
+          resolver, casts no approval. The A/B's instrument: it reviews PRs
+          whose human outcome is already known.
+        type: boolean
+        required: false
+        default: false
 
 # Keyed on the PR alone: loops on different PRs never contend. `cancel-in-
 # progress: false` because cancelling could kill a resolve phase mid-push —
@@ -137,6 +146,12 @@ jobs:
       head_ref: ${{ steps.fence.outputs.head_ref }}
       base_sha: ${{ steps.fence.outputs.base_sha }}
       reason: ${{ steps.fence.outputs.reason }}
+      # 'true' | 'false', on both triggers. The round gates read THIS, not
+      # `inputs.review_only`: `inputs` is empty on an issue_comment run, and a
+      # dispatch boolean arrives as a string, so `!inputs.review_only` would be
+      # false for the literal 'false'. The fence normalises once; every gate
+      # compares against one string.
+      review_only: ${{ steps.fence.outputs.review_only }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -153,6 +168,7 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           WORKFLOW_FILE: sdk-loop.yml
+          REVIEW_ONLY: ${{ inputs.review_only }}
         run: python3 .github/scripts/sdk_loop_fence.py
 
       # The same acknowledgement the other two lanes give: an emoji within
@@ -205,12 +221,20 @@ def prep_job() -> str:
     reported and left alone.
 
     Deterministic for a healthy PR — a few `gh` reads and no model at all.
+
+    Skipped on a review-only run, for two reasons that are the same reason:
+    it pushes, and its fast track cancels the review. A review-only run's PR
+    is usually merged, so a push lands on a branch nobody is driving, and the
+    review is the one thing the run exists to produce. Review 1 already falls
+    back to the fence's baseline when prep did not run.
     """
     return """
   prep:
     name: Prep
     needs: [fence]
-    if: needs.fence.outputs.proceed == 'true'
+    if: >-
+      needs.fence.outputs.proceed == 'true' &&
+      needs.fence.outputs.review_only != 'true'
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -260,8 +284,11 @@ def review_job(n: int) -> str:
         prev_res, prev_rev = f"resolve-{n - 1}", f"review-{n - 1}"
         # Continue when the previous resolve made progress, or when either
         # phase of the previous pair lost the branch and needs a fresh review.
+        # `!= 'true'`, not `== 'false'`: a fence from before this output
+        # existed emits nothing, and '' must keep looping.
         gate = (
-            f"!cancelled() && needs.fence.outputs.proceed == 'true' && ("
+            f"!cancelled() && needs.fence.outputs.proceed == 'true' && "
+            f"needs.fence.outputs.review_only != 'true' && ("
             f"needs.{prev_res}.outputs.outcome == 'ok' || "
             f"needs.{prev_res}.outputs.outcome == 'reaim' || "
             f"needs.{prev_rev}.outputs.outcome == 'reaim')"
@@ -299,6 +326,7 @@ def review_job(n: int) -> str:
       prior_sha: {prior_sha}
       spent_so_far: {spent}
       reaims_so_far: {reaims}
+      review_only: ${{{{ needs.fence.outputs.review_only || 'false' }}}}
 """
 
 
@@ -308,6 +336,10 @@ def resolve_job(n: int) -> str:
     `outcome == 'ok'` is exactly NEEDS_FIXES. A clean verdict, a terminal
     verdict, a re-aim and a failure all skip this job, which is what makes
     "resolve only if required" true rather than aspirational.
+
+    A review-only run skips it whatever the verdict: that run exists to
+    measure the review, and its PR is usually merged — the one branch the
+    resolver must never push to.
     """
     prev = f"review-{n}"
     prev_res = f"resolve-{n - 1}" if n > 1 else None
@@ -322,7 +354,8 @@ def resolve_job(n: int) -> str:
     name: Resolve {n}
     needs: {needs}
     if: >-
-      !cancelled() && needs.{prev}.outputs.outcome == 'ok'
+      !cancelled() && needs.fence.outputs.review_only != 'true' &&
+      needs.{prev}.outputs.outcome == 'ok'
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -349,6 +382,10 @@ def _stop_expr() -> str:
     # run that did exactly what it was supposed to. Guarded to the one value:
     # prep's ordinary outcomes describe branch hygiene, not why a run ended.
     parts = ["needs.prep.outputs.outcome == 'fast_track' && 'fast_track'"]
+    # A review-only run has one review outcome and no resolve. Left to the
+    # round scan, an 'ok' (NEEDS_FIXES) review would be reported as the reason
+    # the run stopped — true of the verdict, false of the run. Name the mode.
+    parts.append("needs.fence.outputs.review_only == 'true' && 'review_only'")
     for n in range(MAX_ROUNDS, 0, -1):
         parts.append("needs.resolve-%d.outputs.outcome" % n)
         parts.append("needs.review-%d.outputs.outcome" % n)

--- a/.github/scripts/sdk_loop_fence.py
+++ b/.github/scripts/sdk_loop_fence.py
@@ -24,6 +24,8 @@ Environment:
     RUN_ID              this workflow run, so it can exclude itself
     GHA_RUN_URL         link included in whatever it posts
     WORKFLOW_FILE       e.g. sdk-loop.yml
+    REVIEW_ONLY         'true' on a review-only dispatch: a closed or merged PR is
+                        accepted, and the chain stops after Review 1
 """
 
 from __future__ import annotations
@@ -111,11 +113,32 @@ def decide(
     return FenceDecision(proceed=True, reason="ok")
 
 
+def admit_state(state: str | None, review_only: bool) -> str | None:
+    """Why a PR in this state may not be driven — or None to proceed.
+
+    The full loop refuses anything but OPEN: its resolver pushes, and a push
+    to a merged or closed branch is work nobody asked for. A review-only run
+    admits any state, because nothing after Review 1 runs — the review reads
+    the diff against base, which a merged PR still has.
+    """
+    if state == "OPEN" or review_only:
+        return None
+    return f"the PR is {str(state).lower()}, not open."
+
+
 MARK_START = "<!-- SDK_LOOP_STARTED -->"
 MARK_DECLINE = "<!-- SDK_LOOP_DECLINED -->"
 
 
-def start_comment(pr: str, run_url: str, sha: str) -> str:
+def start_comment(pr: str, run_url: str, sha: str, review_only: bool = False) -> str:
+    if review_only:
+        return (
+            f"{MARK_START}\n"
+            f"🔁 **`@sdk-loop`** review-only run on `{sha[:8]}`.\n\n"
+            "One review, no fixes, no approval: the verdict is posted for "
+            "comparison and nothing on this PR changes because of it.\n\n"
+            f"[Watch it run]({run_url})"
+        )
     return (
         f"{MARK_START}\n"
         f"🔁 **`@sdk-loop`** started on `{sha[:8]}`.\n\n"
@@ -206,8 +229,14 @@ def main(argv: list[str] | None = None) -> int:
             "headRefName,headRefOid,baseRefName,isDraft,state",
         ]
     )
-    if pr.get("state") != "OPEN":
-        reason = f"the PR is {str(pr.get('state')).lower()}, not open."
+    # A review-only run is the A/B's instrument: it reviews a PR whose human
+    # outcome is already known, so the PR is usually merged. That is safe
+    # precisely because nothing after Review 1 runs — the resolver never sees
+    # a branch it could push to. The full loop still refuses a closed PR:
+    # pushing fixes to a merged branch is work nobody asked for.
+    review_only = os.environ.get("REVIEW_ONLY", "").strip().lower() == "true"
+    reason = admit_state(pr.get("state"), review_only)
+    if reason:
         emit_outputs(proceed="false", reason=reason)
         post_comment(repo, pr_number, decline_comment(reason, run_url))
         return 0
@@ -220,8 +249,17 @@ def main(argv: list[str] | None = None) -> int:
         base_sha=pr["headRefOid"],
         base_ref=pr["baseRefName"],
         comment_id=os.environ.get("COMMENT_ID", ""),
+        # A string, like every other output, and defined on BOTH triggers. The
+        # chain gates read this rather than `inputs.review_only` directly: on
+        # an issue_comment run `inputs` is empty, and a dispatch boolean
+        # arrives as the string 'false', which a bare `if:` reads as true.
+        review_only="true" if review_only else "false",
     )
-    post_comment(repo, pr_number, start_comment(pr_number, run_url, pr["headRefOid"]))
+    post_comment(
+        repo,
+        pr_number,
+        start_comment(pr_number, run_url, pr["headRefOid"], review_only=review_only),
+    )
     print(f"baseline {pr['headRefOid'][:8]} on {pr['headRefName']}")
     return 0
 

--- a/.github/scripts/sdk_loop_fence.py
+++ b/.github/scripts/sdk_loop_fence.py
@@ -120,6 +120,11 @@ def admit_state(state: str | None, review_only: bool) -> str | None:
     to a merged or closed branch is work nobody asked for. A review-only run
     admits any state, because nothing after Review 1 runs — the review reads
     the diff against base, which a merged PR still has.
+
+    Admission does not require the head *ref* to still exist. This repo
+    deletes the branch on merge; Review 1 fences on `headRefOid` (`base_sha`)
+    and `live_head` falls back to the pull object's `.head.sha` if the ref
+    is already gone.
     """
     if state == "OPEN" or review_only:
         return None

--- a/.github/scripts/sdk_loop_finalize.py
+++ b/.github/scripts/sdk_loop_finalize.py
@@ -42,6 +42,12 @@ STOP_TEXT = {
         "from base — so the verdict was re-stamped on the live head and no round "
         "ran. Push a change and the next `@sdk-loop` reviews it properly."
     ),
+    "review_only": (
+        "**Review only.** One review ran and stopped by request: no fixes were "
+        "attempted, no approval was cast, and the verdict carries the A/B marker "
+        "so nothing downstream acts on it. Compare it with the review the PR "
+        "actually received."
+    ),
     "no_progress": (
         "**Stalled.** A resolve round changed nothing and contested nothing, so "
         "another identical round could not do better."

--- a/.github/scripts/sdk_loop_findings.py
+++ b/.github/scripts/sdk_loop_findings.py
@@ -47,6 +47,11 @@ from typing import Any, Iterable, Sequence
 import yaml
 from sdk_loop_by_design import ByDesign
 
+#: Stamped on a review-only run's verdict. The approval workflow refuses to
+#: act on it and telemetry filters on it, so an A/B row can never approve a
+#: merged PR or be counted as a real review.
+MARK_AB = "<!-- SDK_LOOP_AB -->"
+
 #: Canonical severity data. Never read by a model — see the file's own header.
 SEVERITY_DATA = (
     Path(__file__).resolve().parents[2] / ".mothership/pr-loop/data/severity.yaml"
@@ -423,6 +428,7 @@ def render_markers(
     *,
     answers_trigger: str | None = None,
     toolkit_artifact_hash: str | None = None,
+    review_only: bool = False,
 ) -> str:
     """The five-marker block, in the frozen order.
 
@@ -456,6 +462,11 @@ def render_markers(
         lines.append(f"<!-- ANSWERS_TRIGGER: {trigger} -->")
     if toolkit_artifact_hash:
         lines.append(f"<!-- TOOLKIT_ARTIFACT_HASH: {toolkit_artifact_hash} -->")
+    if review_only:
+        # Last, and additive: every existing parser reads the markers above by
+        # regex, not by position, so an extra trailing line changes nothing for
+        # them. The approval path reads THIS one and stands down.
+        lines.append(MARK_AB)
     return "\n".join(lines)
 
 
@@ -509,6 +520,7 @@ def render_summary(
     model: str = "",
     run_url: str = "",
     heading_subject: str = "SDK",
+    review_only: bool = False,
 ) -> str:
     """The whole verdict comment.
 
@@ -523,6 +535,7 @@ def render_summary(
             reviewed_head,
             answers_trigger=answers_trigger,
             toolkit_artifact_hash=toolkit_artifact_hash,
+            review_only=review_only,
         ),
         f"## {heading_subject} {kind} (@sdk-loop): PR #{pr_number} — {pr_title}",
         "",

--- a/.github/scripts/sdk_loop_live.py
+++ b/.github/scripts/sdk_loop_live.py
@@ -237,6 +237,7 @@ def deliver(
     run_url: str,
     needs_human: bool = False,
     conflicting: bool = False,
+    review_only: bool = False,
 ) -> LiveResult:
     """From the reviewer's file to the comment `main()` will post.
 
@@ -314,6 +315,7 @@ def deliver(
         answers_trigger=answers_trigger,
         model=model,
         run_url=run_url,
+        review_only=review_only,
     )
     return LiveResult(
         body=body,

--- a/.github/scripts/sdk_loop_phase.py
+++ b/.github/scripts/sdk_loop_phase.py
@@ -885,6 +885,7 @@ def main(argv: list[str] | None = None) -> int:
                 answers_trigger=os.environ.get("COMMENT_ID") or None,
                 model=REVIEW_MODEL,
                 run_url=os.environ.get("GHA_RUN_URL", ""),
+                review_only=os.environ.get("REVIEW_ONLY", "").lower() == "true",
             )
             if live.should_post:
                 url = post_comment(repo, pr, live.body, _sh)

--- a/.github/scripts/sdk_loop_phase.py
+++ b/.github/scripts/sdk_loop_phase.py
@@ -160,16 +160,39 @@ def _sh(args: list[str], runner: Callable[..., Any] = subprocess.run, **kw: Any)
 
 
 def live_head(
-    repo: str, head_ref: str, runner: Callable[..., Any] = subprocess.run
+    repo: str,
+    head_ref: str,
+    runner: Callable[..., Any] = subprocess.run,
+    pr: str | int | None = None,
 ) -> str:
-    """The branch's current sha, read from the remote, never from the checkout."""
+    """The branch's current sha, read from the remote, never from the checkout.
+
+    This repo deletes the head branch on merge (`delete_branch_on_merge`).
+    A review-only run is aimed at exactly those PRs, so the ref lookup 404s
+    while the pull object still names the reviewed commit as `.head.sha`.
+    Fall back to that rather than failing Review 1 — the only job the run has.
+    """
     proc = _sh(
         ["gh", "api", f"repos/{repo}/git/ref/heads/{head_ref}", "--jq", ".object.sha"],
         runner=runner,
     )
-    if proc.returncode != 0:
+    sha = (proc.stdout or "").strip()
+    if proc.returncode == 0 and sha:
+        return sha
+    pr_id = pr if pr is not None else os.environ.get("PR_NUMBER", "")
+    if not pr_id:
         raise RuntimeError(f"could not read {head_ref}: {proc.stderr.strip()}")
-    return (proc.stdout or "").strip()
+    pull = _sh(
+        ["gh", "api", f"repos/{repo}/pulls/{pr_id}", "--jq", ".head.sha"],
+        runner=runner,
+    )
+    sha = (pull.stdout or "").strip()
+    if pull.returncode != 0 or not sha:
+        detail = proc.stderr.strip()
+        if pull.returncode != 0:
+            detail = f"{detail}; pull {pr_id}: {pull.stderr.strip()}".strip("; ")
+        raise RuntimeError(f"could not read {head_ref}: {detail}")
+    return sha
 
 
 # --------------------------------------------------------------------------
@@ -653,8 +676,14 @@ def main(argv: list[str] | None = None) -> int:
     baseline = os.environ["BASE_SHA"]
     ours = [s for s in os.environ.get("OURS", "").split(",") if s]
     ledger = DismissalLedger.from_json(os.environ.get("LEDGER"))
+    review_only = os.environ.get("REVIEW_ONLY", "").strip().lower() == "true"
 
-    state = head_state(live_head(repo, head_ref), baseline, ours)
+    # Review-only fences on the sha the fence already pinned (headRefOid).
+    # The branch ref is often already gone; looking it up would 404 and kill
+    # the only job this run has. The full loop still reads the live ref so a
+    # push from outside this run is visible.
+    live = baseline if review_only else live_head(repo, head_ref)
+    state = head_state(live, baseline, ours)
     reaims = int(os.environ.get("REAIMS_SO_FAR") or 0)
     if state.moved_by_other and reaim_exhausted(reaims):
         # Stop rather than spend another round on a target that keeps moving.
@@ -885,7 +914,7 @@ def main(argv: list[str] | None = None) -> int:
                 answers_trigger=os.environ.get("COMMENT_ID") or None,
                 model=REVIEW_MODEL,
                 run_url=os.environ.get("GHA_RUN_URL", ""),
-                review_only=os.environ.get("REVIEW_ONLY", "").lower() == "true",
+                review_only=review_only,
             )
             if live.should_post:
                 url = post_comment(repo, pr, live.body, _sh)

--- a/.github/scripts/sdk_review_approve.py
+++ b/.github/scripts/sdk_review_approve.py
@@ -138,6 +138,10 @@ Runner = Callable[..., subprocess.CompletedProcess]
 Sleeper = Callable[[float], None]
 
 APPROVED = "approved"
+#: Mirrors sdk_loop_findings.MARK_AB. Duplicated rather than imported: this
+#: script runs under `python3` on a bare runner and must stay import-free of
+#: the loop lane, whose modules pull in PyYAML.
+MARK_AB = "<!-- SDK_LOOP_AB -->"
 SKIPPED = "skipped"
 FAILED = "failed"
 
@@ -823,6 +827,17 @@ def stamp_verdict(
                 f"posting)."
             )
             return StampOutcome(SKIPPED, 0, "no summary comment")
+
+    # Before the verdict is even read. A review-only run stamps this on its
+    # comment so the A/B can review merged PRs; the verdict is a measurement,
+    # not a decision, and nothing here — label, approval, status — may act on
+    # it. Checked first so no later guard can be argued into approving it.
+    if MARK_AB in body:
+        print(
+            f"PR #{pr_number}: verdict carries {MARK_AB} — a review-only run. "
+            "Nothing to stamp."
+        )
+        return StampOutcome(SKIPPED, 0, "review-only verdict")
 
     verdict = extract_verdict(body)
     if not verdict:

--- a/.github/scripts/tests/test_sdk_loop_review_only.py
+++ b/.github/scripts/tests/test_sdk_loop_review_only.py
@@ -22,6 +22,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import gen_sdk_loop_workflow as gen  # noqa: E402
 import sdk_loop_finalize as finalize  # noqa: E402
 import sdk_loop_live as live  # noqa: E402
+import sdk_loop_phase  # noqa: E402
 import sdk_loop_refute as refute  # noqa: E402
 import sdk_review_approve as approve  # noqa: E402
 from _gha_expr import evaluate  # noqa: E402
@@ -65,6 +66,8 @@ def test_the_full_loop_still_refuses_a_pr_that_is_not_open(state: str) -> None:
 
 @pytest.mark.parametrize("state", ["MERGED", "CLOSED", "OPEN"])
 def test_a_review_only_run_admits_any_state(state: str) -> None:
+    """Admission is the PR object, not the branch. This repo deletes the head
+    ref on merge; Review 1 still has `headRefOid` as `base_sha`."""
     assert admit_state(state, review_only=True) is None
 
 
@@ -243,3 +246,88 @@ def test_the_approve_script_mirrors_the_marker_it_cannot_import() -> None:
     """sdk_review_approve runs on a bare runner and must not import the loop
     lane. The constant is duplicated; this is what keeps the copies equal."""
     assert approve.MARK_AB == MARK_AB
+
+
+# ---------------------------------------------------------------------------
+# Deleted head ref — this repo has delete_branch_on_merge
+# ---------------------------------------------------------------------------
+
+
+class _Proc:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_live_head_falls_back_to_the_pull_object_when_the_ref_is_gone() -> None:
+    """Five recently merged PRs in this repo 404 on git/ref/heads/{head}.
+    `.head.sha` on the pull object survives; Review 1 must use it."""
+    seen: list[str] = []
+
+    def runner(args, **_kw):
+        joined = " ".join(str(a) for a in args)
+        seen.append(joined)
+        if "git/ref/heads/" in joined:
+            return _Proc(1, "", "Not Found")
+        if "pulls/42" in joined:
+            return _Proc(0, SHA + "\n")
+        raise AssertionError(joined)
+
+    assert sdk_loop_phase.live_head("o/r", "gone-branch", runner=runner, pr=42) == SHA
+    assert any("git/ref/heads/gone-branch" in s for s in seen)
+    assert any("pulls/42" in s for s in seen)
+
+
+def test_live_head_still_raises_when_the_pull_object_is_gone_too() -> None:
+    def runner(args, **_kw):
+        joined = " ".join(str(a) for a in args)
+        if "git/ref/heads/" in joined:
+            return _Proc(1, "", "Not Found")
+        return _Proc(1, "", "pull 404")
+
+    with pytest.raises(RuntimeError, match="could not read gone-branch"):
+        sdk_loop_phase.live_head("o/r", "gone-branch", runner=runner, pr=42)
+
+
+def test_review_only_main_does_not_look_up_the_deleted_head_ref(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """The right-now crash: Review 1 calls live_head before the agent, the
+    branch is already deleted, the job dies with no verdict. Review-only
+    fences on BASE_SHA (the fence's headRefOid) and never asks the ref."""
+    captured: dict[str, object] = {}
+
+    def fake_run_agent(model, prompt, cwd, timeout_s, **kwargs):
+        captured["ran"] = True
+        return sdk_loop_phase.AgentResult(exit_code=0, stdout="", stderr="")
+
+    def boom(repo, head_ref, runner=None, pr=None):
+        raise AssertionError(f"live_head looked up {head_ref!r} — the ref is gone")
+
+    class _Done:
+        returncode = 0
+        stdout = ""
+
+    monkeypatch.setattr(sdk_loop_phase, "run_agent", fake_run_agent)
+    monkeypatch.setattr(sdk_loop_phase, "live_head", boom)
+    monkeypatch.setattr(
+        sdk_loop_phase, "pr_files", lambda r, p: [".github/workflows/x.yaml"]
+    )
+    monkeypatch.setattr(sdk_loop_phase, "diff_lines", lambda r, p: 85)
+    monkeypatch.setattr(sdk_loop_phase, "_sh", lambda *a, **k: _Done())
+    monkeypatch.setattr(sdk_loop_phase, "opencode_usage", lambda w: {})
+    monkeypatch.setenv("PHASE", "review")
+    monkeypatch.setenv("ROUND", "1")
+    monkeypatch.setenv("REPO", "o/r")
+    monkeypatch.setenv("PR_NUMBER", "1")
+    monkeypatch.setenv("HEAD_REF", "deleted-on-merge")
+    monkeypatch.setenv("BASE_SHA", SHA)
+    monkeypatch.setenv("REVIEW_ONLY", "true")
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("LITELLM_BASE_URL", "https://gateway.example")
+    sdk_loop_phase.main([])
+    # Reaching the agent at all means live_head was not called — boom() would
+    # have raised before run_agent. The later "no findings.json" failure is
+    # the stub, not the deleted-ref crash this test pins.
+    assert captured.get("ran") is True

--- a/.github/scripts/tests/test_sdk_loop_review_only.py
+++ b/.github/scripts/tests/test_sdk_loop_review_only.py
@@ -1,0 +1,245 @@
+"""A review-only run: one review, no fixes, no approval — on a PR in any state.
+
+The A/B measures the new lane against the reviews PRs actually received, so
+it has to run on merged PRs. Everything the full loop does after Review 1
+exists to change the branch — prep pushes, the resolver pushes, the approval
+workflow approves. Every one of those is wrong on a merged PR, so every one
+of them must provably not run. These tests are that proof, lifted from the
+generated workflow and the real scripts rather than from the intent.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import gen_sdk_loop_workflow as gen  # noqa: E402
+import sdk_loop_finalize as finalize  # noqa: E402
+import sdk_loop_live as live  # noqa: E402
+import sdk_loop_refute as refute  # noqa: E402
+import sdk_review_approve as approve  # noqa: E402
+from _gha_expr import evaluate  # noqa: E402
+from sdk_loop_fence import admit_state, start_comment  # noqa: E402
+from sdk_loop_findings import MARK_AB, load_severity, render_markers  # noqa: E402
+from sdk_loop_pack import build_pack  # noqa: E402
+from sdk_loop_routing import load_routing  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+WORKFLOW = REPO / ".github/workflows/sdk-loop.yml"
+PHASE_WORKFLOW = REPO / ".github/workflows/sdk-loop-phase.yml"
+SHA = "a" * 40
+
+
+def _jobs() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+
+
+def _ctx(review_only: str, **outcomes: str) -> dict:
+    """A run where the fence admitted the PR and Review 1 found work."""
+    needs = {
+        "fence": {"outputs": {"proceed": "true", "review_only": review_only}},
+        "prep": {"outputs": {"outcome": ""}},
+        "review-1": {"outputs": {"outcome": "ok"}},
+    }
+    for job, outcome in outcomes.items():
+        needs[job] = {"outputs": {"outcome": outcome}}
+    return {"needs": needs}
+
+
+# ---------------------------------------------------------------------------
+# The fence admits a merged PR only for a review-only run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("state", ["MERGED", "CLOSED"])
+def test_the_full_loop_still_refuses_a_pr_that_is_not_open(state: str) -> None:
+    reason = admit_state(state, review_only=False)
+    assert reason and state.lower() in reason
+
+
+@pytest.mark.parametrize("state", ["MERGED", "CLOSED", "OPEN"])
+def test_a_review_only_run_admits_any_state(state: str) -> None:
+    assert admit_state(state, review_only=True) is None
+
+
+def test_an_open_pr_is_admitted_either_way() -> None:
+    assert admit_state("OPEN", review_only=False) is None
+
+
+def test_the_start_comment_says_nothing_will_change() -> None:
+    """The author of a merged PR sees a bot start on it. The first line must
+    say the run is a measurement, before any verdict arrives to alarm them."""
+    body = start_comment("42", "http://x/runs/9", SHA, review_only=True)
+    assert "review-only" in body
+    assert "no fixes" in body and "no approval" in body
+    full = start_comment("42", "http://x/runs/9", SHA)
+    assert "review-only" not in full
+
+
+# ---------------------------------------------------------------------------
+# The chain stops after Review 1 — proven on the generated gates
+# ---------------------------------------------------------------------------
+
+
+def test_the_fence_exports_the_flag_the_gates_read() -> None:
+    jobs = _jobs()
+    assert "review_only" in jobs["fence"]["outputs"]
+    env = jobs["fence"]["steps"][-2]["env"]  # the fence step, before the reaction
+    assert env["REVIEW_ONLY"] == "${{ inputs.review_only }}"
+
+
+def test_the_dispatch_input_exists_and_defaults_off() -> None:
+    wf = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    inp = wf[True]["workflow_dispatch"]["inputs"]["review_only"]  # `on:` parses as True
+    assert inp["type"] == "boolean"
+    assert inp["default"] is False
+
+
+def test_review_one_runs_on_a_review_only_run() -> None:
+    ctx = _ctx("true")
+    assert evaluate(_jobs()["review-1"]["if"], ctx) is True
+
+
+def test_prep_does_not_run_on_a_review_only_run() -> None:
+    """Prep pushes and its fast track cancels the review. Both are wrong on a
+    PR nobody is driving."""
+    assert evaluate(_jobs()["prep"]["if"], _ctx("true")) is False
+    assert evaluate(_jobs()["prep"]["if"], _ctx("false")) is True
+
+
+def test_nothing_after_review_one_runs_on_a_review_only_run() -> None:
+    """Every resolve and every later review, with the outcomes that would
+    normally continue the chain. The resolver is what pushes; if any of these
+    evaluates true the A/B can rewrite a merged branch."""
+    jobs = _jobs()
+    ctx = _ctx("true", **{f"resolve-{n}": "ok" for n in range(1, gen.MAX_ROUNDS + 1)})
+    for n in range(1, gen.MAX_ROUNDS + 1):
+        ctx["needs"][f"review-{n}"] = {"outputs": {"outcome": "ok"}}
+    for n in range(1, gen.MAX_ROUNDS + 1):
+        assert evaluate(jobs[f"resolve-{n}"]["if"], ctx) is False, f"resolve-{n}"
+        if n > 1:
+            assert evaluate(jobs[f"review-{n}"]["if"], ctx) is False, f"review-{n}"
+
+
+def test_the_full_loop_is_unchanged_when_the_flag_is_off() -> None:
+    jobs = _jobs()
+    ctx = _ctx("false", **{"resolve-1": "ok"})
+    assert evaluate(jobs["resolve-1"]["if"], ctx) is True
+    assert evaluate(jobs["review-2"]["if"], ctx) is True
+
+
+def test_a_fence_that_predates_the_flag_still_loops() -> None:
+    """An empty output — a fence from before this existed — must read as the
+    full loop, not as review-only. `!= 'true'`, never `== 'false'`."""
+    jobs = _jobs()
+    ctx = _ctx("", **{"resolve-1": "ok"})
+    assert evaluate(jobs["resolve-1"]["if"], ctx) is True
+    assert evaluate(jobs["review-2"]["if"], ctx) is True
+    assert evaluate(jobs["prep"]["if"], ctx) is True
+
+
+def test_the_flag_reaches_the_review_phase() -> None:
+    """The verdict marker is rendered inside the phase, so the phase has to be
+    told. Round 1 passes the fence's flag; the phase declares the input and
+    exports it to the script."""
+    review_1 = _jobs()["review-1"]["with"]
+    assert "needs.fence.outputs.review_only" in review_1["review_only"]
+    phase = yaml.safe_load(PHASE_WORKFLOW.read_text(encoding="utf-8"))
+    assert "review_only" in phase[True]["workflow_call"]["inputs"]
+    run_step = next(s for s in phase["jobs"]["phase"]["steps"] if s.get("id") == "run")
+    assert run_step["env"]["REVIEW_ONLY"] == "${{ inputs.review_only }}"
+
+
+def test_the_summary_names_the_mode_not_the_verdict() -> None:
+    """Left to the round scan, a NEEDS_FIXES review would be reported as why
+    the run stopped. The run stopped because it was asked to."""
+    stop = _jobs()["finalize"]["steps"][-1]["env"]["STOP_REASON"]
+    assert stop.index("review_only == 'true' && 'review_only'") < stop.index(
+        "needs.review-1.outputs.outcome"
+    )
+    assert "review_only" in finalize.STOP_TEXT
+    assert "no approval" in finalize.STOP_TEXT["review_only"]
+
+
+# ---------------------------------------------------------------------------
+# The verdict carries the marker, and the approval path stands down on it
+# ---------------------------------------------------------------------------
+
+
+def test_the_marker_is_last_and_additive() -> None:
+    """Every existing parser reads its marker by regex. The A/B marker is a
+    trailing line, so a review-only verdict parses exactly as before for
+    everyone who does not know about it."""
+    plain = render_markers("NEEDS_FIXES", SHA)
+    flagged = render_markers("NEEDS_FIXES", SHA, review_only=True)
+    assert flagged.startswith(plain)
+    assert flagged.splitlines()[-1] == MARK_AB
+    assert MARK_AB not in plain
+
+
+def test_deliver_stamps_the_marker_on_a_review_only_verdict() -> None:
+    diff = (
+        "diff --git a/application_sdk/x.py b/application_sdk/x.py\n"
+        "--- a/application_sdk/x.py\n+++ b/application_sdk/x.py\n"
+        "@@ -0,0 +1 @@\n+x = 1\n"
+    )
+    pack = build_pack(repo=REPO, diff=diff, scope="full", routing=load_routing())
+    payload = (
+        '{"pack_id":"p","status":"complete","reviewed_files":["application_sdk/x.py"],'
+        '"findings":[],"strengths":[],"notes":""}'
+    )
+    kw = dict(
+        payload_text=payload,
+        pack=pack,
+        sev=load_severity(),
+        by_design=None,
+        challenge=None,
+        challenge_brief="# Refuter",
+        challenge_mode=refute.CROSS_FAMILY,
+        diff=diff,
+        redgreen_report=None,
+        pr=1,
+        pr_title="t",
+        reviewed_head=SHA,
+        answers_trigger=None,
+        model="m",
+        run_url="",
+    )
+    assert MARK_AB in live.deliver(**kw, review_only=True).body
+    assert MARK_AB not in live.deliver(**kw).body
+
+
+def test_the_approval_path_refuses_a_review_only_verdict(monkeypatch) -> None:
+    """READY_TO_MERGE on a merged PR would otherwise label, approve and set a
+    status. The guard runs before the verdict is read, so no later rule can
+    be argued into acting."""
+    calls: list[list[str]] = []
+
+    def gh(argv, **_kw):
+        calls.append(list(argv))
+        raise AssertionError(f"approve reached gh: {argv}")
+
+    for key, value in {
+        "REPO": "o/r",
+        "PR_NUMBER": "1",
+        "COMMENT_BODY": render_markers("READY_TO_MERGE", SHA, review_only=True),
+        "APPROVER_TOKEN": "t",
+    }.items():
+        monkeypatch.setenv(key, value)
+    outcome = approve.stamp_verdict(runner=gh)
+    assert outcome.action == approve.SKIPPED
+    assert "review-only" in outcome.detail
+    assert outcome.exit_code == 0
+    assert calls == []
+
+
+def test_the_approve_script_mirrors_the_marker_it_cannot_import() -> None:
+    """sdk_review_approve runs on a bare runner and must not import the loop
+    lane. The constant is duplicated; this is what keeps the copies equal."""
+    assert approve.MARK_AB == MARK_AB

--- a/.github/workflows/sdk-loop-phase.yml
+++ b/.github/workflows/sdk-loop-phase.yml
@@ -67,6 +67,11 @@ on:
         required: false
         default: ''
         description: 'Consecutive re-aims so far. A re-aim is not progress, so it gets a budget of its own.'
+      review_only:
+        type: string
+        required: false
+        default: 'false'
+        description: "'true' on a review-only run: the verdict carries the A/B marker so nothing approves on it."
     secrets:
       LITELLM_API_KEY:
         required: true
@@ -317,6 +322,7 @@ jobs:
           PRIOR_SHA: ${{ inputs.prior_sha }}
           SPENT_SO_FAR: ${{ inputs.spent_so_far }}
           REAIMS_SO_FAR: ${{ inputs.reaims_so_far }}
+          REVIEW_ONLY: ${{ inputs.review_only }}
           SDK_LOOP_MAX_TOKENS: ${{ vars.SDK_LOOP_MAX_TOKENS }}
           # $HEAD_SHA is referenced 9 times by the playbook (the
           # moved-since-dispatch guard, the delta diff range, the commit-status

--- a/.github/workflows/sdk-loop.yml
+++ b/.github/workflows/sdk-loop.yml
@@ -1,6 +1,7 @@
 # @sdk-loop — drive a PR to merge-ready without supervision.
 #
 #   fence -> review 1 -> resolve 1 -> review 2 -> ... -> review 8 -> finalize
+#   fence -> review 1 -> finalize                    (workflow_dispatch review_only)
 #
 # One workflow run, one job per phase, up to 8 review/resolve pairs. The review
 # phase runs on xai/grok-4.6 — the same model the existing lanes review with
@@ -64,6 +65,14 @@ on:
       pr:
         description: 'PR number to drive'
         required: true
+      review_only:
+        description: >-
+          Review once and stop. Accepts a merged or closed PR, runs no
+          resolver, casts no approval. The A/B's instrument: it reviews PRs
+          whose human outcome is already known.
+        type: boolean
+        required: false
+        default: false
 
 # Keyed on the PR alone: loops on different PRs never contend. `cancel-in-
 # progress: false` because cancelling could kill a resolve phase mid-push —
@@ -107,6 +116,12 @@ jobs:
       head_ref: ${{ steps.fence.outputs.head_ref }}
       base_sha: ${{ steps.fence.outputs.base_sha }}
       reason: ${{ steps.fence.outputs.reason }}
+      # 'true' | 'false', on both triggers. The round gates read THIS, not
+      # `inputs.review_only`: `inputs` is empty on an issue_comment run, and a
+      # dispatch boolean arrives as a string, so `!inputs.review_only` would be
+      # false for the literal 'false'. The fence normalises once; every gate
+      # compares against one string.
+      review_only: ${{ steps.fence.outputs.review_only }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -123,6 +138,7 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           WORKFLOW_FILE: sdk-loop.yml
+          REVIEW_ONLY: ${{ inputs.review_only }}
         run: python3 .github/scripts/sdk_loop_fence.py
 
       # The same acknowledgement the other two lanes give: an emoji within
@@ -142,7 +158,9 @@ jobs:
   prep:
     name: Prep
     needs: [fence]
-    if: needs.fence.outputs.proceed == 'true'
+    if: >-
+      needs.fence.outputs.proceed == 'true' &&
+      needs.fence.outputs.review_only != 'true'
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -170,12 +188,14 @@ jobs:
       prior_sha: ''
       spent_so_far: ''
       reaims_so_far: ''
+      review_only: ${{ needs.fence.outputs.review_only || 'false' }}
 
   resolve-1:
     name: Resolve 1
     needs: [fence, review-1]
     if: >-
-      !cancelled() && needs.review-1.outputs.outcome == 'ok'
+      !cancelled() && needs.fence.outputs.review_only != 'true' &&
+      needs.review-1.outputs.outcome == 'ok'
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -192,7 +212,7 @@ jobs:
     name: Review 2
     needs: [fence, review-1, resolve-1]
     if: >-
-      !cancelled() && needs.fence.outputs.proceed == 'true' && (needs.resolve-1.outputs.outcome == 'ok' || needs.resolve-1.outputs.outcome == 'reaim' || needs.review-1.outputs.outcome == 'reaim')
+      !cancelled() && needs.fence.outputs.proceed == 'true' && needs.fence.outputs.review_only != 'true' && (needs.resolve-1.outputs.outcome == 'ok' || needs.resolve-1.outputs.outcome == 'reaim' || needs.review-1.outputs.outcome == 'reaim')
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -206,12 +226,14 @@ jobs:
       prior_sha: ${{ needs.review-1.outputs.reviewed_head }}
       spent_so_far: ${{ needs.resolve-1.outputs.spent_total || needs.review-1.outputs.spent_total }}
       reaims_so_far: ${{ needs.review-1.outputs.reaims }}
+      review_only: ${{ needs.fence.outputs.review_only || 'false' }}
 
   resolve-2:
     name: Resolve 2
     needs: [fence, review-2, resolve-1]
     if: >-
-      !cancelled() && needs.review-2.outputs.outcome == 'ok'
+      !cancelled() && needs.fence.outputs.review_only != 'true' &&
+      needs.review-2.outputs.outcome == 'ok'
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -228,7 +250,7 @@ jobs:
     name: Review 3
     needs: [fence, review-2, resolve-2]
     if: >-
-      !cancelled() && needs.fence.outputs.proceed == 'true' && (needs.resolve-2.outputs.outcome == 'ok' || needs.resolve-2.outputs.outcome == 'reaim' || needs.review-2.outputs.outcome == 'reaim')
+      !cancelled() && needs.fence.outputs.proceed == 'true' && needs.fence.outputs.review_only != 'true' && (needs.resolve-2.outputs.outcome == 'ok' || needs.resolve-2.outputs.outcome == 'reaim' || needs.review-2.outputs.outcome == 'reaim')
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -242,12 +264,14 @@ jobs:
       prior_sha: ${{ needs.review-2.outputs.reviewed_head }}
       spent_so_far: ${{ needs.resolve-2.outputs.spent_total || needs.review-2.outputs.spent_total }}
       reaims_so_far: ${{ needs.review-2.outputs.reaims }}
+      review_only: ${{ needs.fence.outputs.review_only || 'false' }}
 
   resolve-3:
     name: Resolve 3
     needs: [fence, review-3, resolve-2]
     if: >-
-      !cancelled() && needs.review-3.outputs.outcome == 'ok'
+      !cancelled() && needs.fence.outputs.review_only != 'true' &&
+      needs.review-3.outputs.outcome == 'ok'
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -264,7 +288,7 @@ jobs:
     name: Review 4
     needs: [fence, review-3, resolve-3]
     if: >-
-      !cancelled() && needs.fence.outputs.proceed == 'true' && (needs.resolve-3.outputs.outcome == 'ok' || needs.resolve-3.outputs.outcome == 'reaim' || needs.review-3.outputs.outcome == 'reaim')
+      !cancelled() && needs.fence.outputs.proceed == 'true' && needs.fence.outputs.review_only != 'true' && (needs.resolve-3.outputs.outcome == 'ok' || needs.resolve-3.outputs.outcome == 'reaim' || needs.review-3.outputs.outcome == 'reaim')
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -278,12 +302,14 @@ jobs:
       prior_sha: ${{ needs.review-3.outputs.reviewed_head }}
       spent_so_far: ${{ needs.resolve-3.outputs.spent_total || needs.review-3.outputs.spent_total }}
       reaims_so_far: ${{ needs.review-3.outputs.reaims }}
+      review_only: ${{ needs.fence.outputs.review_only || 'false' }}
 
   resolve-4:
     name: Resolve 4
     needs: [fence, review-4, resolve-3]
     if: >-
-      !cancelled() && needs.review-4.outputs.outcome == 'ok'
+      !cancelled() && needs.fence.outputs.review_only != 'true' &&
+      needs.review-4.outputs.outcome == 'ok'
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -300,7 +326,7 @@ jobs:
     name: Review 5
     needs: [fence, review-4, resolve-4]
     if: >-
-      !cancelled() && needs.fence.outputs.proceed == 'true' && (needs.resolve-4.outputs.outcome == 'ok' || needs.resolve-4.outputs.outcome == 'reaim' || needs.review-4.outputs.outcome == 'reaim')
+      !cancelled() && needs.fence.outputs.proceed == 'true' && needs.fence.outputs.review_only != 'true' && (needs.resolve-4.outputs.outcome == 'ok' || needs.resolve-4.outputs.outcome == 'reaim' || needs.review-4.outputs.outcome == 'reaim')
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -314,12 +340,14 @@ jobs:
       prior_sha: ${{ needs.review-4.outputs.reviewed_head }}
       spent_so_far: ${{ needs.resolve-4.outputs.spent_total || needs.review-4.outputs.spent_total }}
       reaims_so_far: ${{ needs.review-4.outputs.reaims }}
+      review_only: ${{ needs.fence.outputs.review_only || 'false' }}
 
   resolve-5:
     name: Resolve 5
     needs: [fence, review-5, resolve-4]
     if: >-
-      !cancelled() && needs.review-5.outputs.outcome == 'ok'
+      !cancelled() && needs.fence.outputs.review_only != 'true' &&
+      needs.review-5.outputs.outcome == 'ok'
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -336,7 +364,7 @@ jobs:
     name: Review 6
     needs: [fence, review-5, resolve-5]
     if: >-
-      !cancelled() && needs.fence.outputs.proceed == 'true' && (needs.resolve-5.outputs.outcome == 'ok' || needs.resolve-5.outputs.outcome == 'reaim' || needs.review-5.outputs.outcome == 'reaim')
+      !cancelled() && needs.fence.outputs.proceed == 'true' && needs.fence.outputs.review_only != 'true' && (needs.resolve-5.outputs.outcome == 'ok' || needs.resolve-5.outputs.outcome == 'reaim' || needs.review-5.outputs.outcome == 'reaim')
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -350,12 +378,14 @@ jobs:
       prior_sha: ${{ needs.review-5.outputs.reviewed_head }}
       spent_so_far: ${{ needs.resolve-5.outputs.spent_total || needs.review-5.outputs.spent_total }}
       reaims_so_far: ${{ needs.review-5.outputs.reaims }}
+      review_only: ${{ needs.fence.outputs.review_only || 'false' }}
 
   resolve-6:
     name: Resolve 6
     needs: [fence, review-6, resolve-5]
     if: >-
-      !cancelled() && needs.review-6.outputs.outcome == 'ok'
+      !cancelled() && needs.fence.outputs.review_only != 'true' &&
+      needs.review-6.outputs.outcome == 'ok'
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -372,7 +402,7 @@ jobs:
     name: Review 7
     needs: [fence, review-6, resolve-6]
     if: >-
-      !cancelled() && needs.fence.outputs.proceed == 'true' && (needs.resolve-6.outputs.outcome == 'ok' || needs.resolve-6.outputs.outcome == 'reaim' || needs.review-6.outputs.outcome == 'reaim')
+      !cancelled() && needs.fence.outputs.proceed == 'true' && needs.fence.outputs.review_only != 'true' && (needs.resolve-6.outputs.outcome == 'ok' || needs.resolve-6.outputs.outcome == 'reaim' || needs.review-6.outputs.outcome == 'reaim')
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -386,12 +416,14 @@ jobs:
       prior_sha: ${{ needs.review-6.outputs.reviewed_head }}
       spent_so_far: ${{ needs.resolve-6.outputs.spent_total || needs.review-6.outputs.spent_total }}
       reaims_so_far: ${{ needs.review-6.outputs.reaims }}
+      review_only: ${{ needs.fence.outputs.review_only || 'false' }}
 
   resolve-7:
     name: Resolve 7
     needs: [fence, review-7, resolve-6]
     if: >-
-      !cancelled() && needs.review-7.outputs.outcome == 'ok'
+      !cancelled() && needs.fence.outputs.review_only != 'true' &&
+      needs.review-7.outputs.outcome == 'ok'
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -408,7 +440,7 @@ jobs:
     name: Review 8
     needs: [fence, review-7, resolve-7]
     if: >-
-      !cancelled() && needs.fence.outputs.proceed == 'true' && (needs.resolve-7.outputs.outcome == 'ok' || needs.resolve-7.outputs.outcome == 'reaim' || needs.review-7.outputs.outcome == 'reaim')
+      !cancelled() && needs.fence.outputs.proceed == 'true' && needs.fence.outputs.review_only != 'true' && (needs.resolve-7.outputs.outcome == 'ok' || needs.resolve-7.outputs.outcome == 'reaim' || needs.review-7.outputs.outcome == 'reaim')
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -422,12 +454,14 @@ jobs:
       prior_sha: ${{ needs.review-7.outputs.reviewed_head }}
       spent_so_far: ${{ needs.resolve-7.outputs.spent_total || needs.review-7.outputs.spent_total }}
       reaims_so_far: ${{ needs.review-7.outputs.reaims }}
+      review_only: ${{ needs.fence.outputs.review_only || 'false' }}
 
   resolve-8:
     name: Resolve 8
     needs: [fence, review-8, resolve-7]
     if: >-
-      !cancelled() && needs.review-8.outputs.outcome == 'ok'
+      !cancelled() && needs.fence.outputs.review_only != 'true' &&
+      needs.review-8.outputs.outcome == 'ok'
     uses: ./.github/workflows/sdk-loop-phase.yml
     secrets: inherit
     with:
@@ -457,6 +491,6 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ needs.fence.outputs.pr }}
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          STOP_REASON: ${{ needs.prep.outputs.outcome == 'fast_track' && 'fast_track' || needs.resolve-8.outputs.outcome || needs.review-8.outputs.outcome || needs.resolve-7.outputs.outcome || needs.review-7.outputs.outcome || needs.resolve-6.outputs.outcome || needs.review-6.outputs.outcome || needs.resolve-5.outputs.outcome || needs.review-5.outputs.outcome || needs.resolve-4.outputs.outcome || needs.review-4.outputs.outcome || needs.resolve-3.outputs.outcome || needs.review-3.outputs.outcome || needs.resolve-2.outputs.outcome || needs.review-2.outputs.outcome || needs.resolve-1.outputs.outcome || needs.review-1.outputs.outcome || 'failed' }}
+          STOP_REASON: ${{ needs.prep.outputs.outcome == 'fast_track' && 'fast_track' || needs.fence.outputs.review_only == 'true' && 'review_only' || needs.resolve-8.outputs.outcome || needs.review-8.outputs.outcome || needs.resolve-7.outputs.outcome || needs.review-7.outputs.outcome || needs.resolve-6.outputs.outcome || needs.review-6.outputs.outcome || needs.resolve-5.outputs.outcome || needs.review-5.outputs.outcome || needs.resolve-4.outputs.outcome || needs.review-4.outputs.outcome || needs.resolve-3.outputs.outcome || needs.review-3.outputs.outcome || needs.resolve-2.outputs.outcome || needs.review-2.outputs.outcome || needs.resolve-1.outputs.outcome || needs.review-1.outputs.outcome || 'failed' }}
           ROUNDS_JSON: '[{"number":0,"phase":"prep","outcome":"${{ needs.prep.outputs.outcome }}","verdict":"","sha":"${{ needs.prep.outputs.new_base_sha }}","detail":"${{ needs.prep.outputs.detail }}","cost":"","usage":""},{"number":1,"phase":"review","outcome":"${{ needs.review-1.outputs.outcome }}","verdict":"${{ needs.review-1.outputs.verdict }}","sha":"${{ needs.review-1.outputs.new_base_sha }}","detail":"${{ needs.review-1.outputs.detail }}","cost":"${{ needs.review-1.outputs.cost }}","usd":"${{ needs.review-1.outputs.usd }}","usage":"${{ needs.review-1.outputs.usage }}"},{"number":1,"phase":"resolve","outcome":"${{ needs.resolve-1.outputs.outcome }}","verdict":"${{ needs.resolve-1.outputs.verdict }}","sha":"${{ needs.resolve-1.outputs.new_base_sha }}","detail":"${{ needs.resolve-1.outputs.detail }}","cost":"${{ needs.resolve-1.outputs.cost }}","usd":"${{ needs.resolve-1.outputs.usd }}","usage":"${{ needs.resolve-1.outputs.usage }}"},{"number":2,"phase":"review","outcome":"${{ needs.review-2.outputs.outcome }}","verdict":"${{ needs.review-2.outputs.verdict }}","sha":"${{ needs.review-2.outputs.new_base_sha }}","detail":"${{ needs.review-2.outputs.detail }}","cost":"${{ needs.review-2.outputs.cost }}","usd":"${{ needs.review-2.outputs.usd }}","usage":"${{ needs.review-2.outputs.usage }}"},{"number":2,"phase":"resolve","outcome":"${{ needs.resolve-2.outputs.outcome }}","verdict":"${{ needs.resolve-2.outputs.verdict }}","sha":"${{ needs.resolve-2.outputs.new_base_sha }}","detail":"${{ needs.resolve-2.outputs.detail }}","cost":"${{ needs.resolve-2.outputs.cost }}","usd":"${{ needs.resolve-2.outputs.usd }}","usage":"${{ needs.resolve-2.outputs.usage }}"},{"number":3,"phase":"review","outcome":"${{ needs.review-3.outputs.outcome }}","verdict":"${{ needs.review-3.outputs.verdict }}","sha":"${{ needs.review-3.outputs.new_base_sha }}","detail":"${{ needs.review-3.outputs.detail }}","cost":"${{ needs.review-3.outputs.cost }}","usd":"${{ needs.review-3.outputs.usd }}","usage":"${{ needs.review-3.outputs.usage }}"},{"number":3,"phase":"resolve","outcome":"${{ needs.resolve-3.outputs.outcome }}","verdict":"${{ needs.resolve-3.outputs.verdict }}","sha":"${{ needs.resolve-3.outputs.new_base_sha }}","detail":"${{ needs.resolve-3.outputs.detail }}","cost":"${{ needs.resolve-3.outputs.cost }}","usd":"${{ needs.resolve-3.outputs.usd }}","usage":"${{ needs.resolve-3.outputs.usage }}"},{"number":4,"phase":"review","outcome":"${{ needs.review-4.outputs.outcome }}","verdict":"${{ needs.review-4.outputs.verdict }}","sha":"${{ needs.review-4.outputs.new_base_sha }}","detail":"${{ needs.review-4.outputs.detail }}","cost":"${{ needs.review-4.outputs.cost }}","usd":"${{ needs.review-4.outputs.usd }}","usage":"${{ needs.review-4.outputs.usage }}"},{"number":4,"phase":"resolve","outcome":"${{ needs.resolve-4.outputs.outcome }}","verdict":"${{ needs.resolve-4.outputs.verdict }}","sha":"${{ needs.resolve-4.outputs.new_base_sha }}","detail":"${{ needs.resolve-4.outputs.detail }}","cost":"${{ needs.resolve-4.outputs.cost }}","usd":"${{ needs.resolve-4.outputs.usd }}","usage":"${{ needs.resolve-4.outputs.usage }}"},{"number":5,"phase":"review","outcome":"${{ needs.review-5.outputs.outcome }}","verdict":"${{ needs.review-5.outputs.verdict }}","sha":"${{ needs.review-5.outputs.new_base_sha }}","detail":"${{ needs.review-5.outputs.detail }}","cost":"${{ needs.review-5.outputs.cost }}","usd":"${{ needs.review-5.outputs.usd }}","usage":"${{ needs.review-5.outputs.usage }}"},{"number":5,"phase":"resolve","outcome":"${{ needs.resolve-5.outputs.outcome }}","verdict":"${{ needs.resolve-5.outputs.verdict }}","sha":"${{ needs.resolve-5.outputs.new_base_sha }}","detail":"${{ needs.resolve-5.outputs.detail }}","cost":"${{ needs.resolve-5.outputs.cost }}","usd":"${{ needs.resolve-5.outputs.usd }}","usage":"${{ needs.resolve-5.outputs.usage }}"},{"number":6,"phase":"review","outcome":"${{ needs.review-6.outputs.outcome }}","verdict":"${{ needs.review-6.outputs.verdict }}","sha":"${{ needs.review-6.outputs.new_base_sha }}","detail":"${{ needs.review-6.outputs.detail }}","cost":"${{ needs.review-6.outputs.cost }}","usd":"${{ needs.review-6.outputs.usd }}","usage":"${{ needs.review-6.outputs.usage }}"},{"number":6,"phase":"resolve","outcome":"${{ needs.resolve-6.outputs.outcome }}","verdict":"${{ needs.resolve-6.outputs.verdict }}","sha":"${{ needs.resolve-6.outputs.new_base_sha }}","detail":"${{ needs.resolve-6.outputs.detail }}","cost":"${{ needs.resolve-6.outputs.cost }}","usd":"${{ needs.resolve-6.outputs.usd }}","usage":"${{ needs.resolve-6.outputs.usage }}"},{"number":7,"phase":"review","outcome":"${{ needs.review-7.outputs.outcome }}","verdict":"${{ needs.review-7.outputs.verdict }}","sha":"${{ needs.review-7.outputs.new_base_sha }}","detail":"${{ needs.review-7.outputs.detail }}","cost":"${{ needs.review-7.outputs.cost }}","usd":"${{ needs.review-7.outputs.usd }}","usage":"${{ needs.review-7.outputs.usage }}"},{"number":7,"phase":"resolve","outcome":"${{ needs.resolve-7.outputs.outcome }}","verdict":"${{ needs.resolve-7.outputs.verdict }}","sha":"${{ needs.resolve-7.outputs.new_base_sha }}","detail":"${{ needs.resolve-7.outputs.detail }}","cost":"${{ needs.resolve-7.outputs.cost }}","usd":"${{ needs.resolve-7.outputs.usd }}","usage":"${{ needs.resolve-7.outputs.usage }}"},{"number":8,"phase":"review","outcome":"${{ needs.review-8.outputs.outcome }}","verdict":"${{ needs.review-8.outputs.verdict }}","sha":"${{ needs.review-8.outputs.new_base_sha }}","detail":"${{ needs.review-8.outputs.detail }}","cost":"${{ needs.review-8.outputs.cost }}","usd":"${{ needs.review-8.outputs.usd }}","usage":"${{ needs.review-8.outputs.usage }}"},{"number":8,"phase":"resolve","outcome":"${{ needs.resolve-8.outputs.outcome }}","verdict":"${{ needs.resolve-8.outputs.verdict }}","sha":"${{ needs.resolve-8.outputs.new_base_sha }}","detail":"${{ needs.resolve-8.outputs.detail }}","cost":"${{ needs.resolve-8.outputs.cost }}","usd":"${{ needs.resolve-8.outputs.usd }}","usage":"${{ needs.resolve-8.outputs.usage }}"}]'
         run: python3 .github/scripts/sdk_loop_finalize.py

--- a/.mothership/pr-loop/CONTRACT.md
+++ b/.mothership/pr-loop/CONTRACT.md
@@ -20,6 +20,7 @@ drifts from the first.
 | `<!-- REVIEWED_HEAD: <40-hex> -->` | always | the next round, to scope its delta; `sdk_review_approve.py`, to refuse a verdict for a stale sha |
 | `<!-- ANSWERS_TRIGGER: <digits> -->` | comment triggers only | the resolver's push guard, to tell this round's verdict from an earlier one landing late |
 | `<!-- TOOLKIT_ARTIFACT_HASH: <sha256> -->` | toolkit scopes only | the next round, to carry consumer validation forward |
+| `<!-- SDK_LOOP_AB -->` | review-only runs only | `sdk_review_approve.py`, to stand down before reading the verdict; A/B telemetry, to keep measurement rows out of the real ones |
 
 `X` is one of `READY_TO_MERGE`, `NEEDS_FIXES`, `BLOCKED`, `NEEDS_HUMAN`,
 `NEEDS_REBASE`. There is no sixth token.
@@ -43,6 +44,38 @@ renderer owns it; nothing asks a model to honour it.
 It follows that **every tier rendered into `### Findings` blocks the merge**.
 That is why `severity.yaml` routes `LOW` and `INFO` to prose instead: a tier
 that cannot be actioned would wedge the loop forever.
+
+## Review-only runs
+
+`workflow_dispatch` with `review_only: true` runs the fence and Review 1 and
+nothing else. It exists for the A/B, which reviews PRs whose human outcome is
+already known — so the PR is usually merged, and every job after Review 1 is
+one that changes the branch:
+
+| Job | Full loop | Review-only | Why it must not run |
+|---|---|---|---|
+| prep | pushes mechanical fixes; fast-tracks an unchanged diff | skipped | a push lands on a branch nobody is driving; a fast track cancels the one review the run exists to produce |
+| resolve-*n* | pushes fixes | skipped | the resolver on a merged branch |
+| review-*n* ≥ 2 | re-reviews after a resolve | skipped | nothing to re-review |
+| approve-on-verdict | labels, `sdk-review` status, `atlan-ci` approval | stands down on `SDK_LOOP_AB` | an approval on a merged PR is noise at best and a false audit trail at worst |
+
+The gates read the **fence's** `review_only` output, never `inputs.review_only`
+directly: `inputs` is empty on an `issue_comment` run, and a dispatch boolean
+arrives as the string `'false'`, which a bare `if:` reads as true. The fence
+normalises once and every gate compares one string. Gates test `!= 'true'` so a
+fence from before the output existed keeps looping.
+
+The fence admits a closed or merged PR **only** under `review_only`. The full
+loop still refuses one — its resolver pushes.
+
+**The control lane.** `@sdk-review` (mothership) has no state check and would
+run on a merged PR via dispatch, but that is the wrong control: its verdict is
+authored by `mothership-ai[bot]`, so `approve-on-verdict` would act on it, and
+it would review today's rules against a diff from weeks ago. Control rows for
+the A/B come from the **review comments already on those PRs** — the review
+each PR actually received, at the time, with the rules as they stood. That is
+what the human outcome was measured against, so it is the only fair baseline.
+Nothing in this lane needs to dispatch the other one.
 
 ## Merge authority
 

--- a/.mothership/pr-loop/CONTRACT.md
+++ b/.mothership/pr-loop/CONTRACT.md
@@ -68,6 +68,12 @@ fence from before the output existed keeps looping.
 The fence admits a closed or merged PR **only** under `review_only`. The full
 loop still refuses one — its resolver pushes.
 
+This repo deletes the head branch on merge. Admission is about the PR object,
+not the ref: Review 1 fences on `headRefOid` (the fence's `base_sha`) and
+`live_head` falls back to `pulls/{pr}.head.sha` when `git/ref/heads/{head}`
+404s, so the only job a review-only run has does not die looking up a branch
+GitHub has already deleted.
+
 **The control lane.** `@sdk-review` (mothership) has no state check and would
 run on a merged PR via dispatch, but that is the wrong control: its verdict is
 authored by `mothership-ai[bot]`, so `approve-on-verdict` would act on it, and


### PR DESCRIPTION
Closes FND-1428. Unblocks FND-1397 (run the A/B).

## Why

The A/B measures the new lane against the reviews PRs **actually received**, so it has to run on **merged** PRs. Two things stopped that:

- `sdk_loop_fence.py` refused any PR that was not `OPEN`
- `workflow_dispatch` took only `pr`, so every run was the full chain — and **the resolver would have pushed fixes to a merged branch**

## What

`workflow_dispatch` gains **`review_only`** (boolean, default `false`). When set:

| Job | Full loop | Review-only |
|---|---|---|
| fence | refuses non-OPEN | admits merged / closed; exports `review_only='true'` |
| prep | pushes mechanical fixes; fast-tracks an unchanged diff | **skipped** |
| review-1 | runs | runs — verdict carries a trailing `<!-- SDK_LOOP_AB -->` |
| resolve-*n* | pushes fixes | **skipped** |
| review-*n* ≥ 2 | re-reviews | **skipped** |
| approve-on-verdict | labels · `sdk-review` status · `atlan-ci` approval | **stands down** on the marker, before it reads the verdict |
| finalize | names the stop reason | says `review_only`, not "NEEDS_FIXES stopped the run" |

**Prep is skipped too** — the ticket didn't ask, but it holds write scope and pushes, and its fast track *cancels the review* when the diff is unchanged. On a merged PR the first is a push nobody asked for and the second skips the one review the run exists to produce. Review 1 already falls back to the fence's baseline when prep didn't run.

## Two decisions worth reading

**Gates read the fence's output, never `inputs.review_only`.** `inputs` is empty on an `issue_comment` run, and a dispatch boolean arrives as the string `'false'` — which a bare `if:` reads as *true*. The fence normalises once; every gate compares one string. Gates test `!= 'true'` so a fence from before this output existed keeps looping (tested).

**The control lane is not dispatched.** `@sdk-review` (mothership) has no state check and *would* run on a merged PR — but its `mothership-ai[bot]` verdict would fire `approve-on-verdict`, and it would review today's rules against a weeks-old diff. Control rows come from the **review comments already on those PRs**: the review each one actually received, with the rules as they stood, which is what the human outcome was measured against. Documented in `CONTRACT.md`.

## Tests — 20 new, `test_sdk_loop_review_only.py`

Evaluated against the **generated** `sdk-loop.yml` with the real GHA expression evaluator, not against intent:

- fence: full loop refuses MERGED/CLOSED; review-only admits any state; start comment says "no fixes, no approval"
- chain: review-1 runs · prep does not · **every** resolve-1..8 and review-2..8 evaluate `false` with the outcomes that would normally continue · flag off → unchanged · flag **absent** (old fence) → unchanged
- plumbing: dispatch input exists and defaults off · fence env + output · round-1 `with:` → phase `workflow_call` input → `REVIEW_ONLY` env on the run step
- marker: last and additive (a flagged block `startswith` the plain one) · `deliver()` stamps it · `sdk_review_approve.stamp_verdict` returns SKIPPED **without a single `gh` call** · the approve script's mirrored constant equals `sdk_loop_findings.MARK_AB`
- summary: `review_only` term precedes the round scan in `STOP_REASON`; `STOP_TEXT` has the entry

**459 pass** across the loop suites. Generator `--check` clean. The two fast-track workflow tests still pass.

## How to run one

```
gh workflow run sdk-loop.yml -f pr=<merged PR> -f review_only=true
```
