### PR TITLE
fix(contract-toolkit): key the SDR default-emit guards on the emitted arg, not the kebab field spelling

### DIFF
--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -156,6 +156,16 @@ when unset, so existing generated output is unchanged.
 
 Automation Engine DAG template. Auto-derived from the declared workflow params and the typed `pipeline` block. Heracles substitutes `{{param}}` placeholders with form values before sending to AE.
 
+The extract node's `inputs.args` always carries the SDR routing pair `agent_json`
+and `extraction_method` — Heracles/AE derives the agent task queue and the
+credential-routing spec from both together. When the contract models either one
+itself — a form field whose Python name is the arg (`extraction-method` or
+`extraction_method`), or a `manifestTopLevelArgs` entry — the arg is templated from
+that field. Otherwise the toolkit emits the `{{agent-json}}` /
+`{{extraction-method}}` placeholder, so an app with a single fixed extraction path
+still satisfies conformance `P029` without a hidden widget. See
+[`docs/reference.md`](docs/reference.md) → *SDR routing pair in the extract node*.
+
 Default pipeline: `extract → publish`. Opt out of publish with
 `pipeline.publish = null`. Add parseQueries, popularity, or lineage steps by
 setting the corresponding `pipeline.*` field. Opt in to notifications

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -855,10 +855,37 @@ Credential files are hoisted by matching `connectorConfigName`. If two entrypoin
 |---|---|---|---|
 | `workflowConfigName` | String | `name` | Workflow configmap name / output filename. |
 | `credentialFieldName` | String? | `"{name}_credential"` | Credential ref field in Input class. Null to omit. |
-| `manifestTopLevelArgs` | Mapping<String, String> | `{"credential_guid": "credential-guid", "connection": "connection"}` | Explicit top-level extract args. |
+| `manifestTopLevelArgs` | Mapping<String, String> | `{"credential_guid": "credential-guid", "connection": "connection"}` | Explicit top-level extract args. An entry here also counts as "the contract models this arg" for the SDR routing pair — see [SDR routing pair in the extract node](#sdr-routing-pair-in-the-extract-node). |
 | `publishTagPipelineEnabled` | Boolean\|String? | auto | Value for `PublishNode`'s `tag_pipeline_enabled`. Auto-wired when `enable-tags` or `enable-tag-sync` is in the form. |
 | `publishTagAttachmentsPrefix` | String? | auto | Value for `PublishNode`'s `tag_attachments_prefix`. |
 | `notifications` | Boolean | `false` | Top-level app on/off. When set to `true`, appends a run-level notification node (`NotificationNode`, key `notifications`) that fires when the workflow run reaches any terminal state (success or failure). The node depends on the reserved run-level `workflow_complete` tag (a `DependencyCondition` with no `nodeId`), so AE runs it once per run as a finalizer and dispatches the `notification-app`, which fans alerts to the tenant's enabled integrations and decides delivery per integration (`failureOnly`: failure-only vs. all runs). Also skipped when `extraNodes` defines a `notifications` key. See [NotificationNode](#notificationnode). |
+
+#### SDR routing pair in the extract node
+
+The extract node's `inputs.args` always carries `agent_json` and
+`extraction_method`. Heracles/AE derives the agent task queue **and** fills the
+credential-routing spec from the two together at dispatch, so a manifest with only
+one of them leaves a self-deployed-runtime (SDR) run unable to tell direct from
+agent — the gap conformance `P029` reports.
+
+For each of the two args the toolkit asks one question: *will the contract's own
+form fields already emit this arg?* That is true when
+
+- a `uiConfig` property's Python name (`toPyName`, dashes → underscores) is the
+  arg — so `extraction-method` and `extraction_method` both count, as do
+  `agent-json` and `agent_json`; or
+- a `manifestTopLevelArgs` entry names the arg and its form field exists — e.g.
+  `["extraction_method"] = "extraction-method"`, or a renamed field such as
+  `["extraction_method"] = "mode"`.
+
+If so, the arg is templated from that field (`"{{extraction-method}}"`,
+`"{{extraction_method}}"`, `"{{mode}}"`, …) and emitted exactly once. If not, the
+toolkit emits the default placeholder — `"{{agent-json}}"` /
+`"{{extraction-method}}"` — so an app with a single fixed extraction path needs no
+hidden widget to satisfy `P029`. The test is on the *emitted arg*, never on one
+spelling of the form-field key: a guard keyed on the kebab spelling alone made the
+guard and the properties loop both emit `extraction_method` for a snake_case
+widget, and Pkl rejected the duplicate member (FND-96 / FND-1437).
 
 ---
 
@@ -1010,7 +1037,7 @@ Developers amend this module. It defines the app's identity, credentials, workfl
 | `workflowConfigName` | String | `name` | Workflow configmap name / output filename. |
 | `additionalOutputFiles` | Mapping<String, FileOutput> | `{}` | Explicit opt-in files to emit with this contract, for example a customized `AgentConfig.pkl` output. |
 | `extraNodes` | Mapping<String, DAGNode> | `{}` | Custom DAG nodes. Use `DAGNode` for arbitrary workflows, `PublishNode` for the standard Atlas publish step, `QueryIntelligenceNode` for native QI, `PopularityNode` for popularity metrics, `LineageNode` for the Lineage app, or `LineagePublishNode` for lineage publish. Key `"publish"` replaces auto-generated publish. |
-| `manifestTopLevelArgs` | Mapping<String, String> | `{"credential_guid": "credential-guid", "connection": "connection"}` | Explicit top-level extract args. These remain top-level in either manifest shape. |
+| `manifestTopLevelArgs` | Mapping<String, String> | `{"credential_guid": "credential-guid", "connection": "connection"}` | Explicit top-level extract args. These remain top-level in either manifest shape. An entry here also counts as "the contract models this arg" for the SDR routing pair (`agent_json`, `extraction_method`) — same rules as [App.pkl](#sdr-routing-pair-in-the-extract-node). |
 
 ### Credential Config
 

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -2819,6 +2819,23 @@ local workflowTypeResolved: String =
     .replaceAll(Regex("([a-z0-9])([A-Z])"), "$1-$2")
     .toLowerCase()
 
+/// Whether the contract itself sources extract-node arg `argName` — through a
+/// `manifestTopLevelArgs` entry naming it whose form field exists, or through a
+/// uiConfig property whose Python name (`toPyName`) is it.
+///
+/// The default-emit guards for the SDR routing pair (`agent_json`,
+/// `extraction_method`) use this so they key on the arg the two loops in
+/// `generateExtractNode` will emit — not on one spelling of the form-field key.
+/// `extraction-method`, `extraction_method` and a `manifestTopLevelArgs`-renamed
+/// field all spell the same manifest arg; a guard on the kebab spelling alone
+/// emitted a second copy for the snake_case shape, and Pkl rejects the duplicate
+/// member, failing generation outright (atlan-openapi-app; FND-96).
+local function modelsExtractArg(argName: String): Boolean =
+  uiConfig != null && (
+    manifestTopLevelArgs.toMap().any((arg, formField) -> arg == argName && uiConfig!!.properties.containsKey(formField))
+    || uiConfig!!.properties.keys.any((formField) -> toPyName(formField) == argName)
+  )
+
 local function generateExtractNode(): Mapping<String, Any> =
   let (step = pipeline.extract!!)
   let (_extractEhCheck = validateWorkflowNodeErrorHandling(step.errorHandling, "pipeline.extract.errorHandling"))
@@ -2848,21 +2865,24 @@ local function generateExtractNode(): Mapping<String, Any> =
         ["app_name"] = name
         ["credential"] = "{{credential}}"
         // SDR / agent-mode credential slot. Emitted whenever the app does not
-        // model `agent-json` — the gap that silently broke MSSQL's SDR rollout
-        // (atlan-mssql-app#177). When the app DOES model `agent-json`, the loop
-        // below emits it (AgentSelector constrains includeInManifest to true, so the
-        // loop always fires); this guard skips to avoid a duplicate key.
-        when (uiConfig == null || !uiConfig!!.properties.containsKey("agent-json")) {
+        // model `agent_json` — the gap that silently broke MSSQL's SDR rollout
+        // (atlan-mssql-app#177). When the app DOES model it, the loops below emit
+        // it (AgentSelector constrains includeInManifest to true, so the loop
+        // always fires); this guard skips to avoid a duplicate key. "Models it" is
+        // `modelsExtractArg`: decided on the emitted arg, so `agent-json`,
+        // `agent_json` and a `manifestTopLevelArgs`-renamed field all count.
+        when (!modelsExtractArg("agent_json")) {
           ["agent_json"] = "{{agent-json}}"
         }
         // The other half of the SDR routing pair. Heracles/AE derives the agent
         // task queue AND fills the credential-routing spec from `agent_json` +
         // `extraction_method` together at dispatch, so emitting only the first
         // leaves an SDR-declaring app half-wired — the same shape as the
-        // agent-json gap above, and what P029 reports. Emitted only when the app
-        // does not model `extraction-method` itself; when it does, the loop below
-        // emits it and this guard avoids a duplicate key.
-        when (uiConfig == null || !uiConfig!!.properties.containsKey("extraction-method")) {
+        // agent-json gap above, and what P029 reports (FND-96). Emitted only when
+        // the app does not model `extraction_method` itself (the same
+        // `modelsExtractArg` test); when it does, the loops below emit it and
+        // this guard avoids a duplicate key.
+        when (!modelsExtractArg("extraction_method")) {
           ["extraction_method"] = "{{extraction-method}}"
         }
         for (argName, formField in manifestTopLevelArgs) {

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -2860,6 +2860,21 @@ local function renderNodeArgs(node: DAGNode): Mapping<String, Any> =
     }
   }
 
+/// Whether the contract itself sources extract-node arg `argName` — through a
+/// `manifestTopLevelArgs` entry naming it whose form field exists, or through a
+/// uiConfig property whose Python name (`toPyName`) is it.
+///
+/// The default-emit guards for the SDR routing pair (`agent_json`,
+/// `extraction_method`) use this so they key on the arg the loops in
+/// `generateExtractNode` will emit — not on one spelling of the form-field key.
+/// `extraction-method`, `extraction_method` and a `manifestTopLevelArgs`-renamed
+/// field all spell the same manifest arg; a guard on the kebab spelling alone
+/// emitted a second copy for the snake_case shape, and Pkl rejects the duplicate
+/// member, failing generation outright (atlan-openapi-app; FND-96).
+local function modelsExtractArg(argName: String): Boolean =
+  manifestTopLevelArgs.toMap().any((arg, formField) -> arg == argName && uiConfig.properties.containsKey(formField))
+  || uiConfig.properties.keys.any((formField) -> toPyName(formField) == argName)
+
 local function generateExtractNode(): Mapping<String, Any> =
   let (_extractEhCheck = validateWorkflowNodeErrorHandling(extractNodeErrorHandling, "extractNodeErrorHandling"))
   let (topLevelFormFields = manifestTopLevelArgs.toMap().values.toList())
@@ -2889,21 +2904,24 @@ local function generateExtractNode(): Mapping<String, Any> =
         ["app_name"] = name
         ["credential"] = "{{credential}}"
         // SDR / agent-mode credential slot. Emitted whenever the app does not
-        // model `agent-json` — the gap that silently broke MSSQL's SDR rollout
-        // (atlan-mssql-app#177). When the app DOES model `agent-json`, the loops
-        // below emit it (AgentSelector constrains includeInManifest to true, so the
-        // loops always fire); this guard skips to avoid a duplicate key.
-        when (!uiConfig.properties.containsKey("agent-json")) {
+        // model `agent_json` — the gap that silently broke MSSQL's SDR rollout
+        // (atlan-mssql-app#177). When the app DOES model it, the loops below emit
+        // it (AgentSelector constrains includeInManifest to true, so the loops
+        // always fire); this guard skips to avoid a duplicate key. "Models it" is
+        // `modelsExtractArg`: decided on the emitted arg, so `agent-json`,
+        // `agent_json` and a `manifestTopLevelArgs`-renamed field all count.
+        when (!modelsExtractArg("agent_json")) {
           ["agent_json"] = "{{agent-json}}"
         }
         // The other half of the SDR routing pair. Heracles/AE derives the agent
         // task queue AND fills the credential-routing spec from `agent_json` +
         // `extraction_method` together at dispatch, so emitting only the first
         // leaves an SDR-declaring app half-wired — the same shape as the
-        // agent-json gap above, and what P029 reports. Emitted only when the app
-        // does not model `extraction-method` itself; when it does, the loop below
-        // emits it and this guard avoids a duplicate key.
-        when (!uiConfig.properties.containsKey("extraction-method")) {
+        // agent-json gap above, and what P029 reports (FND-96). Emitted only when
+        // the app does not model `extraction_method` itself (the same
+        // `modelsExtractArg` test); when it does, the loops below emit it and
+        // this guard avoids a duplicate key.
+        when (!modelsExtractArg("extraction_method")) {
           ["extraction_method"] = "{{extraction-method}}"
         }
         for (argName, formField in manifestTopLevelArgs) {

--- a/contract-toolkit/tests/default_emit_guard_spelling_test.pkl
+++ b/contract-toolkit/tests/default_emit_guard_spelling_test.pkl
@@ -1,0 +1,72 @@
+/// Tests that the extract-node default-emit guards for the SDR routing pair
+/// (`agent_json`, `extraction_method`) key on the manifest arg the loops will
+/// emit — not on one spelling of the form-field key.
+///
+/// Three ways an app can model the arg itself, all of which must emit the slot
+/// exactly once (guard skips, loop emits):
+///   1. snake_case form-field key (`extraction_method`) — the openapi shape;
+///      `toPyName` maps it onto the same arg as the kebab spelling (FND-96).
+///   2. kebab key routed through `manifestTopLevelArgs` — the tableau shape.
+///   3. an unrelated form-field name (`mode`) routed through
+///      `manifestTopLevelArgs` — proves the guard reads the emitted arg name.
+///
+/// The kebab-key branches live in `agent_json_default_emit_test.pkl` and
+/// `extraction_method_default_emit_test.pkl`.
+amends "pkl:test"
+
+import "pkl:json"
+import "fixtures/app_extraction_method_snake.pkl" as snakeApp
+import "fixtures/app_extraction_method_toplevel_mapped.pkl" as mappedApp
+import "fixtures/app_extraction_method_renamed_field.pkl" as renamedApp
+import "fixtures/native_app_extraction_method_snake.pkl" as snakeNative
+
+local function extractArgs(app, manifestKey: String) =
+  let (text = app.output.files[manifestKey].text)
+  let (manifest = new json.Parser { useMapping = true }.parse(text))
+    manifest["dag"]["extract"]["inputs"]["args"]
+
+local function occurrences(app, manifestKey: String, arg: String): Int =
+  app.output.files[manifestKey].text.split("\"\(arg)\"").length - 1
+
+local snakeAppArgs = extractArgs(snakeApp, "app/generated/manifest.json")
+local mappedAppArgs = extractArgs(mappedApp, "app/generated/manifest.json")
+local renamedAppArgs = extractArgs(renamedApp, "app/generated/manifest.json")
+local snakeNativeArgs = extractArgs(snakeNative, "manifest.json")
+
+facts {
+  // 1. snake_case keys (App.pkl): the properties loop emits both args under
+  //    their snake spelling; the guards must not add a second copy.
+  ["App.pkl snake_case extraction_method key emits the slot once, templated from the app's own field"] {
+    snakeAppArgs["extraction_method"] == "{{extraction_method}}"
+    occurrences(snakeApp, "app/generated/manifest.json", "extraction_method") == 1
+  }
+  ["App.pkl snake_case agent_json key emits the slot once, templated from the app's own field"] {
+    snakeAppArgs["agent_json"] == "{{agent_json}}"
+    occurrences(snakeApp, "app/generated/manifest.json", "agent_json") == 1
+  }
+
+  // 2. kebab key routed through manifestTopLevelArgs (App.pkl): the top-level
+  //    loop emits it; the properties loop and the guard both skip.
+  ["App.pkl manifestTopLevelArgs-mapped extraction-method emits the slot once"] {
+    mappedAppArgs["extraction_method"] == "{{extraction-method}}"
+    occurrences(mappedApp, "app/generated/manifest.json", "extraction_method") == 1
+  }
+
+  // 3. unrelated form-field name routed through manifestTopLevelArgs (App.pkl):
+  //    no form-field key spells "extraction method" at all, yet the arg is
+  //    emitted — the guard must read the emitted arg, not a field name.
+  ["App.pkl extraction_method sourced from a renamed form field emits the slot once"] {
+    renamedAppArgs["extraction_method"] == "{{mode}}"
+    occurrences(renamedApp, "app/generated/manifest.json", "extraction_method") == 1
+  }
+
+  // 1. snake_case keys (NativeApp.pkl).
+  ["NativeApp.pkl snake_case extraction_method key emits the slot once"] {
+    snakeNativeArgs["extraction_method"] == "{{extraction_method}}"
+    occurrences(snakeNative, "manifest.json", "extraction_method") == 1
+  }
+  ["NativeApp.pkl snake_case agent_json key emits the slot once"] {
+    snakeNativeArgs["agent_json"] == "{{agent_json}}"
+    occurrences(snakeNative, "manifest.json", "agent_json") == 1
+  }
+}

--- a/contract-toolkit/tests/fixtures/app_extraction_method_renamed_field.pkl
+++ b/contract-toolkit/tests/fixtures/app_extraction_method_renamed_field.pkl
@@ -1,0 +1,34 @@
+/// Fixture: App.pkl contract whose `extraction_method` manifest arg is sourced
+/// from a form field with an unrelated name (`mode`) via `manifestTopLevelArgs`.
+///
+/// Neither spelling of "extraction method" appears among the form-field keys,
+/// yet the top-level-args loop still emits `extraction_method`. Proves the
+/// default-emit guard keys on the *emitted arg name*, not on the presence of a
+/// particular form-field key.
+amends "../../src/App.pkl"
+
+name = "extraction-method-renamed-field"
+displayName = "Extraction Method (renamed form field)"
+icon = "https://assets.atlan.com/assets/fullscreen-exit.svg"
+hasCredentialConfig = false
+
+manifestTopLevelArgs {
+  ["extraction_method"] = "mode"
+}
+
+uiConfig = new UIConfig {
+  tasks {
+    ["Configuration"] {
+      inputs {
+        ["mode"] = new TextInput {
+          title = "Extraction mode"
+          hide = true
+          default = "direct"
+        }
+        ["connection"] = new ConnectionCreator {
+          placeholderText = "Connection Name"
+        }
+      }
+    }
+  }
+}

--- a/contract-toolkit/tests/fixtures/app_extraction_method_snake.pkl
+++ b/contract-toolkit/tests/fixtures/app_extraction_method_snake.pkl
@@ -1,0 +1,36 @@
+/// Fixture: App.pkl contract that models the SDR routing pair under snake_case
+/// form-field keys — `extraction_method` and `agent_json` — instead of the
+/// kebab `extraction-method` / `agent-json` most of the fleet uses.
+///
+/// This is the shape atlan-openapi-app ships (a hidden, constant
+/// `extraction_method` TextInput; see FND-96). `toPyName` maps both spellings
+/// onto the same manifest arg, so the default-emit guards must key on the arg
+/// the loops will emit, not on one spelling of the form-field key — otherwise
+/// guard + loop both emit and Pkl rejects the duplicate member.
+amends "../../src/App.pkl"
+
+name = "extraction-method-snake"
+displayName = "Extraction Method (snake_case keys)"
+icon = "https://assets.atlan.com/assets/fullscreen-exit.svg"
+hasCredentialConfig = false
+
+uiConfig = new UIConfig {
+  tasks {
+    ["Configuration"] {
+      inputs {
+        ["extraction_method"] = new TextInput {
+          title = "Extraction method"
+          hide = true
+          default = "direct"
+        }
+        ["agent_json"] = new TextInput {
+          title = "Agent JSON"
+          hide = true
+        }
+        ["connection"] = new ConnectionCreator {
+          placeholderText = "Connection Name"
+        }
+      }
+    }
+  }
+}

--- a/contract-toolkit/tests/fixtures/app_extraction_method_toplevel_mapped.pkl
+++ b/contract-toolkit/tests/fixtures/app_extraction_method_toplevel_mapped.pkl
@@ -1,0 +1,35 @@
+/// Fixture: App.pkl contract that models `extraction-method` (kebab) AND routes
+/// it through `manifestTopLevelArgs` — the shape atlan-tableau-app,
+/// atlan-salesforce-app and atlan-ukg-app ship.
+///
+/// The top-level-args loop emits `extraction_method` and the properties loop
+/// skips it (the form field is in `topLevelFormFields`), so the default-emit
+/// guard must skip too. Pins that the guard treats a top-level mapping as
+/// "the app models this arg".
+amends "../../src/App.pkl"
+
+name = "extraction-method-toplevel-mapped"
+displayName = "Extraction Method (manifestTopLevelArgs)"
+icon = "https://assets.atlan.com/assets/fullscreen-exit.svg"
+hasCredentialConfig = false
+
+manifestTopLevelArgs {
+  ["extraction_method"] = "extraction-method"
+}
+
+uiConfig = new UIConfig {
+  tasks {
+    ["Configuration"] {
+      inputs {
+        ["extraction-method"] = new TextInput {
+          title = "Extraction method"
+          hide = true
+          default = "direct"
+        }
+        ["connection"] = new ConnectionCreator {
+          placeholderText = "Connection Name"
+        }
+      }
+    }
+  }
+}

--- a/contract-toolkit/tests/fixtures/native_app_extraction_method_snake.pkl
+++ b/contract-toolkit/tests/fixtures/native_app_extraction_method_snake.pkl
@@ -1,0 +1,48 @@
+/// Fixture: NativeApp that models the SDR routing pair under snake_case
+/// form-field keys (`extraction_method`, `agent_json`) — the NativeApp.pkl
+/// counterpart of `app_extraction_method_snake.pkl`. Pair of
+/// `native_app_extraction_method.pkl`, which models the kebab spelling.
+amends "../../src/NativeApp.pkl"
+
+import "../../src/Connectors.pkl"
+import "../../src/Config.pkl"
+
+name = "native-app-extraction-method-snake"
+connector = Connectors.POSTGRES
+icon = "https://assets.atlan.com/assets/postgres.svg"
+workflowType = "PostgresWorkflow"
+
+credentialCommonFields {
+  new FieldSpec { name = "host"; displayName = "Host"; width = 6 }
+}
+
+credentialAuthOptions {
+  ["basic"] = new AuthOption {
+    label = "Basic"
+    fields {
+      new FieldSpec { name = "username"; displayName = "Username"; width = 4 }
+      new FieldSpec { name = "password"; sensitive = true; displayName = "Password"; width = 4 }
+    }
+  }
+}
+
+uiConfig = new Config.UIConfig {
+  tasks {
+    ["Credential"] {
+      inputs {
+        ["extraction_method"] = new Config.TextInput {
+          title = "Extraction method"
+          defaultValue = "direct"
+          hide = true
+        }
+        ["agent_json"] = new Config.TextInput {
+          title = "Agent JSON"
+          hide = true
+        }
+        ["credential-guid"] = new Config.CredentialInput {
+          credType = "atlan-connectors-native-app-extraction-method-snake"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Changelog
- `App.pkl` / `NativeApp.pkl`: the extract-node default-emit guards for the SDR routing pair (`agent_json`, `extraction_method`) now key on the **emitted arg name** via a shared `modelsExtractArg(argName)` predicate, instead of on the kebab spelling of the form-field key. An app that models the widget as `extraction_method` (snake_case), or routes it through `manifestTopLevelArgs` under any field name, is recognised and the slot is emitted exactly once, templated from the app's own field. Kebab-modelled apps are byte-identical to before.
- New `tests/default_emit_guard_spelling_test.pkl` + four fixtures (snake App, snake NativeApp, top-level-mapped, renamed field) — red before the fix with the exact CI error, green after.
- Docs: README manifest section + `docs/reference.md` gain a *SDR routing pair in the extract node* subsection describing the "does the contract already emit this arg?" rule; both `manifestTopLevelArgs` rows link to it.

### Why

#3633 (FND-96) made the extract node always carry `extraction_method`, guarded by *skip when the app models `extraction-method`*. The guard tested one spelling of the form-field key; the loop below emits `toPyName(formField)`. `atlan-openapi-app` models the widget as `extraction_method` (a hidden constant `TextInput` — its FND-96 workaround), so the guard missed it, the properties loop emitted the same arg, and Pkl rejected the duplicate:

```
–– Pkl Error ––
Duplicate definition of member `"extraction_method"`.
2875 | [toPyName(paramKey)] = "{{" + paramKey + "}}"
at com.atlan.app.contract.App#generateExtractNode.<function#3>["inputs"]["args"]
```

Surfaced on the first post-merge consumer dispatch: [openapi `Tests / Integration` run 33725482112](https://github.com/atlanhq/atlan-openapi-app/actions/runs/33725482112/job/100553446265), SDK-level toolkit override step. metabase and mysql passed the same dispatch — they model the kebab key, as does every other fleet app (≈40 repos checked). The `agent_json` guard from #2312 had the identical latent bug for a snake `agent_json` key; fixed here too.

Forward fix, not a revert: `app-contract-toolkit` is still `0.24.0` and no tag contains #3633, so nothing pinned in the fleet is affected — only SDK-level consumer dispatches against `main`.

### Additional context (e.g. screenshots, logs, links)
- Linear: FND-1437 (this fix), FND-96 (the auto-emit it corrects; its openapi cleanup follow-up still stands and becomes trivial once a toolkit release includes both).
- Fleet shapes the new predicate recognises, all of which spell the same manifest arg:
  - kebab widget `extraction-method` — mysql, metabase, looker, clickhouse, … (unchanged behaviour)
  - kebab widget + `manifestTopLevelArgs { ["extraction_method"] = "extraction-method" }` — tableau, salesforce, ukg, microstrategy (unchanged behaviour)
  - snake widget `extraction_method` — openapi (**was crashing; now emits once as `{{extraction_method}}`**)
  - `manifestTopLevelArgs { ["extraction_method"] = "<other field>" }` — none today (**was crashing; now emits once**)
- Verified locally: `pkl test tests/*.pkl` 395/395; `regenerate-all.sh` produces zero diff in `examples/`; `check-invariants.sh` passes; openapi `contract/app.pkl` evaluated with this branch's `contract-toolkit/src` as the local dependency override (the CI recipe) → exit 0, `extraction_method` appears once.

### Checklist
- [x] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.
