### PR TITLE
fix(testing): let HttpFakeSource bind beyond loopback

### DIFF
--- a/application_sdk/testing/fake_source.py
+++ b/application_sdk/testing/fake_source.py
@@ -96,6 +96,7 @@ logger = get_logger(__name__)
 T = TypeVar("T")
 
 _LOOPBACK = "127.0.0.1"
+_WILDCARD_HOSTS = frozenset({"0.0.0.0", "::", ""})  # noqa: S104 — compared against, never bound by default
 _METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")
 _CONNECTION_TIMEOUT_SECONDS = 5.0
 _JOIN_GRACE_SECONDS = 5.0
@@ -365,8 +366,12 @@ class HttpFakeSource:
         warn_unmatched: bool = True,
         name: str = "fake-source",
         connection_timeout: float = _CONNECTION_TIMEOUT_SECONDS,
+        bind_host: str = _LOOPBACK,
+        port: int = 0,
     ) -> None:
         self.name = name
+        self.bind_host = bind_host
+        self.requested_port = port
         self.default_content_type = default_content_type
         self.not_found_body = (
             {"error": "not found"} if not_found_body is None else not_found_body
@@ -424,7 +429,7 @@ class HttpFakeSource:
 
     @property
     def base_url(self) -> str:
-        """``http://127.0.0.1:<port>`` — the value a fixture yields.
+        """``http://<host>:<port>`` — the value a fixture yields.
 
         Only meaningful while the server is running; raises otherwise, because a
         base URL for a stopped server is a hang or a connection error later, far
@@ -437,6 +442,14 @@ class HttpFakeSource:
             )
         host, port = self._server.server_address[:2]
         host_text = host.decode() if isinstance(host, bytes) else str(host)
+        if host_text in _WILDCARD_HOSTS:
+            # A wildcard is an accept-on-every-interface instruction, not an
+            # address anything can dial. Report loopback, which is a real route
+            # to this server for every in-process caller. A peer on another host
+            # cannot use base_url at all and has to be told the reachable name
+            # (a compose service name, say) out of band — there is nothing here
+            # from which that name could be derived.
+            host_text = _LOOPBACK
         return f"http://{host_text}:{port}"
 
     @property
@@ -505,10 +518,18 @@ class HttpFakeSource:
             self._hits.clear()
 
     def start(self) -> Self:
-        """Bind an ephemeral loopback port and serve in a daemon thread."""
+        """Bind ``bind_host``/``port`` and serve in a daemon thread.
+
+        Defaults to an ephemeral loopback port, which is what an in-process
+        fixture wants. A caller serving the fake to peers — a container on a
+        compose network reaching it by service name — passes a wildcard
+        ``bind_host`` and usually a fixed ``port``.
+        """
         if self._server is not None:
             return self
-        server = _FakeSourceServer((_LOOPBACK, 0), _make_handler_class(self))
+        server = _FakeSourceServer(
+            (self.bind_host, self.requested_port), _make_handler_class(self)
+        )
         thread = threading.Thread(
             target=server.serve_forever,
             name=f"{self.name}-server",

--- a/application_sdk/testing/fake_source.py
+++ b/application_sdk/testing/fake_source.py
@@ -96,7 +96,7 @@ logger = get_logger(__name__)
 T = TypeVar("T")
 
 _LOOPBACK = "127.0.0.1"
-_WILDCARD_HOSTS = frozenset({"0.0.0.0", "::", ""})  # noqa: S104 — compared against, never bound by default
+_WILDCARD_HOSTS = frozenset({"0.0.0.0", ""})  # noqa: S104 — compared against, never bound by default. "::" is omitted: ThreadingHTTPServer is AF_INET, so bind_host="::" cannot start.
 _METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")
 _CONNECTION_TIMEOUT_SECONDS = 5.0
 _JOIN_GRACE_SECONDS = 5.0
@@ -352,8 +352,10 @@ class HttpFakeSource:
     or ``None`` for a 404 — so the common case stays a one-liner and the
     uncommon one is still expressible.
 
-    Binding is always loopback: the server is reachable from the test process and
-    from nothing else on the network.
+    Defaults to loopback on an ephemeral port: the server is then reachable from
+    the test process and from nothing else on the network. Pass a wildcard
+    ``bind_host`` (and usually a fixed ``port``) when peers on another host must
+    reach it — IPv4 wildcards only; ``ThreadingHTTPServer`` is AF_INET.
     """
 
     def __init__(

--- a/docs/guides/integration-fixtures.md
+++ b/docs/guides/integration-fixtures.md
@@ -113,6 +113,21 @@ What the connector supplies is the part that is genuinely per-source: the endpoi
 
 **Two counters, two scopes.** `reset_http_fake_sources` is autouse, so every test starts with a clean `requests`, `unmatched` and `hits(pattern)` — per-test questions. `unused_routes()` reads a separate lifetime counter the reset does not clear, because "is this route dead fixture weight?" can only be answered once the whole suite has run. Assert it from a session-scoped teardown, not from inside a test.
 
+### Serving the fake to a peer, not just in-process
+
+`start()` binds loopback on an ephemeral port by default, which is what a fixture wants and what `http_fake_source_factory` gives you. The e2e tier needs the other shape: the same fake, reachable by a *different container* on a compose network, so the connector under test dials it by service name instead of a vendor host.
+
+```python
+fake = HttpFakeSource(name="my-source", bind_host="0.0.0.0", port=8080)
+```
+
+Two things follow from a wildcard bind, both deliberate:
+
+- **`base_url` reports loopback, not the wildcard.** `0.0.0.0` is an accept-on-every-interface instruction, not an address anything can connect to; echoing it back would hand callers a URL that fails at connect time, far from its cause.
+- **A peer cannot use `base_url` at all.** There is nothing in the process from which its reachable name could be derived, so tell it out of band — the compose service name in the environment variable the connector already reads for its host.
+
+This is what lets one corpus and one fake back both tiers: the integration suite starts the fake in-process on loopback, and e2e runs the identical route table in a container. Reverse-engineering the source's envelopes is the expensive part, and it is done once.
+
 **Two assertions worth making in every fake-source suite.** `assert not fake.unmatched` catches an extract calling an endpoint the fake does not model — without it the test asserted against a 404. `assert not fake.unused_routes()` catches the reverse: a route carried in the fixture that nothing exercises.
 
 ### Why a star-import and not a `pytest11` plugin

--- a/tests/unit/testing/test_fake_source.py
+++ b/tests/unit/testing/test_fake_source.py
@@ -151,6 +151,44 @@ class TestLifecycle:
         assert fake.base_url.startswith("http://127.0.0.1:")
         assert fake.port > 0
 
+    def test_defaults_to_loopback_so_the_fixture_case_is_unchanged(self) -> None:
+        """The default bind is the loopback/ephemeral pair fixtures rely on."""
+        source = HttpFakeSource()
+        assert source.bind_host == "127.0.0.1"
+        assert source.requested_port == 0
+        with source:
+            assert source.base_url.startswith("http://127.0.0.1:")
+            assert source.port != 0
+
+    def test_serves_a_requested_port_when_one_is_given(self) -> None:
+        """A fixed port is what a peer reaching the fake by name must dial."""
+        probe = socket.socket()
+        probe.bind(("127.0.0.1", 0))
+        chosen = probe.getsockname()[1]
+        probe.close()
+
+        source = HttpFakeSource(port=chosen)
+        with source:
+            assert source.port == chosen
+            assert source.base_url == f"http://127.0.0.1:{chosen}"
+
+    def test_wildcard_bind_reports_a_dialable_base_url(self) -> None:
+        """A wildcard listens everywhere, so base_url must not echo it back.
+
+        ``0.0.0.0`` is an accept-on-every-interface instruction, not an address
+        anything can connect to. Reporting it verbatim would hand callers a URL
+        that fails at connect time, far from its cause, so base_url reports
+        loopback — a real route to this server — and the response below proves
+        the reported URL actually serves.
+        """
+        source = HttpFakeSource(bind_host="0.0.0.0")  # noqa: S104 — the case under test
+        source.route(r"/ping", lambda _r: FakeResponse.json_({"ok": True}))
+        with source:
+            assert "0.0.0.0" not in source.base_url
+            assert source.base_url == f"http://127.0.0.1:{source.port}"
+            with urllib.request.urlopen(f"{source.base_url}/ping", timeout=5) as resp:
+                assert json.loads(resp.read()) == {"ok": True}
+
     def test_base_url_before_start_is_an_error_not_a_hang(self) -> None:
         source = HttpFakeSource()
         with pytest.raises(FakeSourceNotRunningError, match="not running"):

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ test = [
 
 [[package]]
 name = "atlan-application-sdk-conformance"
-version = "0.26.0"
+version = "0.27.0"
 source = { directory = "packages/conformance" }
 dependencies = [
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ test = [
 
 [[package]]
 name = "atlan-application-sdk-conformance"
-version = "0.27.0"
+version = "0.26.0"
 source = { directory = "packages/conformance" }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
`HttpFakeSource.start()` hardcodes `(127.0.0.1, 0)`, so the fake can only be reached from inside the process that started it. This adds `bind_host` and `port` constructor arguments, defaulting to the same loopback/ephemeral pair — **every existing caller is unchanged.**

## Why

The loopback default is right for the integration tier: a fixture starts the fake, the worker runs in the same process, done. That is what #3496 built it for.

It does not cover e2e. There the connector runs as its own container and must dial the fake by service name on a compose network, which needs a listener on a routable interface. Without it, an e2e for a source-less connector has two options and both are bad:

- reverse-engineer the source's HTTP envelopes a second time in a standalone server — duplicating precisely what this primitive exists to stop; or
- wait on a vendor sandbox that is not coming.

Eight connectors in the source-less wave (FND-825) are in that position right now. Concretely, `atlanhq/atlan-microstrategy-app` has a working fake replaying a sanitized golden corpus through the real `extract_metadata` entrypoint, and its e2e draft is parked as "source deferred" waiting on a MicroStrategy Intelligence Server it does not need. This is the gap between those two facts.

## The one design decision

A wildcard bind makes `server_address` report `0.0.0.0`. Returning that verbatim from `base_url` would hand callers a URL that fails at connect time, far from its cause — a wildcard is an accept-on-every-interface instruction, not an address anything can dial.

So `base_url` reports loopback when the bind host is a wildcard, which is a real route to the server for every in-process caller. A peer on another host cannot use `base_url` at all, and deliberately gets no guess: nothing in the process can derive the name that would reach it, so it is told out of band via the environment variable the connector already reads for its host. That asymmetry is documented in the guide rather than left to be discovered.

## Tests

Three, covering the contract rather than the implementation:

- the default pair is still loopback/ephemeral (the regression that matters — every current caller depends on it)
- a requested port is honoured
- a wildcard bind yields a `base_url` that is both free of the wildcard *and* actually serves a request

110 pass in `tests/unit/testing/test_fake_source.py`. Pre-commit clean (ruff, ruff-format, isort, pyright).

Note the unit tier runs `--disable-socket`, and this file grants AF_INET back for loopback only — the wildcard test binds a wildcard but connects over loopback, so the no-outbound-traffic guard stays enforced.

## Docs

`docs/guides/integration-fixtures.md` gains a short section on serving the fake to a peer, including why `base_url` behaves as it does and why one corpus plus one fake can back both tiers — the envelope reverse-engineering is the expensive part and should be done once.

Refs FND-1597, FND-825.
