### PR TITLE
ci(leak-gate): stop scanning tests/ and .github/ for hardcoded secrets (FND-678)

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -657,6 +657,10 @@ jobs:
   #   1. Hardcoded secrets (gitleaks) — BLOCKING. A committed secret (API key,
   #      token, private key) fails the job, which trips prepare's `!failure()`
   #      and skips build + publish. High precision; honors .gitleaks.toml.
+  #      Scans shipped application source only: `tests/`, `test/` and `.github/`
+  #      are pruned before the scan (FND-678) because hermetic fixtures are made
+  #      of credential-shaped strings that no value-shaped detector can tell from
+  #      a leak.
   #   2. Creds-into-logs (scan.py) — WARN-ONLY. Flags credentials reaching
   #      log/print/format/CLI sinks (the APP-1602 audit class). Pure-regex
   #      detection has an irreducible false-positive rate (it cannot always tell
@@ -741,6 +745,32 @@ jobs:
           # Scan the working tree, not git history: a publish checkout is a
           # single shallow commit. Drop .git so gitleaks doesn't walk internals.
           rm -rf .git
+          # Test fixtures and CI wiring are out of scope for THIS layer (FND-678).
+          # Hermetic fixtures are *built* out of credential-shaped strings — a
+          # generated golden dossier of fake API keys is indistinguishable from a
+          # leak to a value-shaped detector, and blocked atlan-microstrategy-app's
+          # publish on 148 `generic-api-key` hits in a single file. Every app
+          # would otherwise owe the same hand-written `.gitleaks.toml`, one
+          # false-positive shape at a time, on a config schema that fails silently
+          # on the pinned 8.21.2 (FND-679).
+          #
+          # This is a deliberate narrowing of the gate, not a false-positive
+          # filter: a real credential committed under these paths is no longer
+          # reported by gitleaks. It is the tradeoff chosen for the noise. Pruning
+          # rather than allowlisting keeps this immune to gitleaks config-schema
+          # skew and needs no merge with an app's own `.gitleaks.toml` below.
+          #
+          # Prune a COPY, never `app/` itself: the warn-only creds-into-logs layer
+          # below scans `--root app` afterwards, and deleting in place would
+          # silently narrow that layer too. Scanning `.` from inside the copy keeps
+          # reported paths repo-relative (`app/foo.py`), so the summary and Slack
+          # locations are unchanged.
+          SCAN_DIR=/tmp/gitleaks-scan
+          rm -rf "$SCAN_DIR"
+          mkdir -p "$SCAN_DIR"
+          cp -a . "$SCAN_DIR"/
+          rm -rf "$SCAN_DIR/tests" "$SCAN_DIR/test" "$SCAN_DIR/.github"
+          cd "$SCAN_DIR"
           CONFIG_ARGS=()
           if [ -f .gitleaks.toml ]; then
             echo "Using app-level .gitleaks.toml allowlist"
@@ -765,7 +795,7 @@ jobs:
             {
               echo "### ❌ Publish blocked — hardcoded secret(s) detected"
               echo ""
-              echo "gitleaks found ${COUNT} hardcoded secret(s) in the source. Locations only (values withheld):"
+              echo "gitleaks found ${COUNT} hardcoded secret(s) in shipped application source (\`tests/\`, \`test/\` and \`.github/\` are not scanned). Locations only (values withheld):"
               echo ""
               jq -r '.[] | "- `\(.File):\(.StartLine)` — rule: \(.RuleID)"' /tmp/gitleaks-report.json 2>/dev/null || true
               echo ""

--- a/docs/standards/credential-leak-gate.md
+++ b/docs/standards/credential-leak-gate.md
@@ -29,12 +29,49 @@ are spent:
 
 | Layer | Tool | Posture | On finding |
 |-------|------|---------|------------|
-| **Hardcoded secrets** | [`gitleaks`](https://github.com/gitleaks/gitleaks) over the working tree | **Blocking** | any committed secret (API key, token, private key, …) **fails the publish** |
+| **Hardcoded secrets** | [`gitleaks`](https://github.com/gitleaks/gitleaks) over the shipped source | **Blocking** | any committed secret (API key, token, private key, …) **fails the publish** |
 | **Creds-into-logs** | `scan.py` regex scanner (`.github/scripts/credential-leak-gate/`) | **Warn-only** | CRITICAL/HIGH findings annotate the run summary + ping Slack; publish proceeds |
 
 `MEDIUM`/`LOW` creds-into-logs findings (e.g. `helm --set password=` in an e2e
 script, or anything under a `tests/` path) are counted but not surfaced as
 warnings.
+
+### What the gitleaks layer does not scan
+
+The **gitleaks layer** scans a pruned copy of the checkout with `tests/`,
+`test/` and `.github/` removed (FND-678). Nothing under those paths can block a
+publish. The copy matters: the warn-only creds-into-logs layer still scans the
+full `app/` tree afterwards, so this narrowing applies to the blocking layer
+only.
+
+Hermetic fixtures are *built out of* credential-shaped strings, and a
+value-shaped detector cannot tell a generated golden dossier of fake API keys
+from a leak: one such file blocked `atlan-microstrategy-app`'s publish with 148
+`generic-api-key` findings. The alternative — every app carrying a hand-written
+`.gitleaks.toml`, extended one false-positive shape at a time — puts the fleet's
+release path behind a config schema that **fails silently** on the pinned
+gitleaks 8.21.2 (see FND-679: the plural `[[allowlists]]` form is parsed and
+ignored, with no warning and no non-zero exit).
+
+This is a deliberate **narrowing of the gate**, not a false-positive filter. Be
+explicit about the cost: a real credential committed under `tests/` or
+`.github/` is no longer reported by this gate. Measured on the pinned 8.21.2
+against a synthetic tree, pruning took a scan from 152 findings to 2 — it
+dropped 148 fixture false positives *and* 2 genuine planted tokens that lived
+under those paths.
+
+What still covers those paths:
+
+- **The creds-into-logs layer in this same job** — it scans `--root app`, the
+  unpruned tree, and is unaffected.
+- **`S001 HardcodedCredential` / `S002 RawEnvCredentialAccess`** (conformance
+  S-series) read test sources and are not affected by this pruning.
+- **The nightly `credential-leak-scan`** in `atlanhq/connector-pulse` still
+  walks the whole tree, including tests and CI wiring.
+
+Pruning a copy rather than allowlisting is what makes this immune to gitleaks
+config-schema skew, and means it needs no merge with an app-level
+`.gitleaks.toml`.
 
 ## How blocking works
 
@@ -109,8 +146,29 @@ and severity.
 ## Acting on a finding
 
 **Hardcoded secret (gitleaks) — blocks:** remove the secret, **rotate** any
-value that was committed, and re-run. Genuine false positives go in an app-level
-`.gitleaks.toml` config (the gate passes `--config .gitleaks.toml` when present).
+value that was committed, and re-run. Because `tests/`, `test/` and `.github/`
+are not scanned at all, a finding here is in **shipped application source** —
+treat it as real before reaching for an allowlist.
+
+For a genuine false positive in shipped source, an app-level `.gitleaks.toml`
+is still honoured (the gate passes `--config .gitleaks.toml` when present).
+Write it as a **single singular `[allowlist]` table** with `regexTarget =
+"line"`: the pinned 8.21.2 silently ignores the plural `[[allowlists]]` array
+form, so a config written that way validates against a modern local binary and
+does nothing in CI (FND-679). Prefer scoping an entry by the *value shape* over
+the file path, so a real secret added to the same file is still caught:
+
+```toml
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Well-known local-emulator constant, grants access to nothing"
+regexTarget = "line"
+regexes = [
+  '''AccountName=devstoreaccount1''',
+]
+```
 
 **Creds-into-logs (`scan.py`) — warning, does not block:** route the credential
 through the SDK redaction helper before the sink, or drop the log line.


### PR DESCRIPTION
Closes FND-678.

## Problem

The credential-leak gate's gitleaks layer is **blocking**, and hermetic test
fixtures are *built out of* credential-shaped strings. A value-shaped detector
cannot tell a generated golden dossier of fake API keys from a real leak.

`atlan-microstrategy-app` is blocked right now: **148 `generic-api-key` findings
in one file**, `tests/golden/tenant-a/extracted/dossiers/0.json`. Same class of
failure as `atlan-openapi-app#381`, which had to hand-write a `.gitleaks.toml`
to get a release out.

## Change

The gitleaks layer scans a **pruned copy** of the checkout with `tests/`,
`test/` and `.github/` removed. The warn-only creds-into-logs layer is
untouched.

Pruning a **copy**, not the checkout, is the load-bearing detail: `scan.py` runs
`--root app` later in the same job, so deleting in place would have silently
narrowed that layer too. Scanning `.` from inside the copy keeps reported paths
repo-relative (`app/foo.py`), so run-summary and Slack locations are unchanged.

## Why pruning, not an allowlist

Chris's suggestion on the ticket offered inline suppression as the "even better"
option. Two reasons it isn't, for the failure we actually have:

- **Inline `gitleaks:allow` can't apply to generated fixtures.** The findings
  cluster ~50-per-line on lines 1-3 of a machine-generated golden file.
  Annotations there get clobbered on the next regeneration.
- **Per-app `.gitleaks.toml` puts the release path behind a silent config trap.**
  The gate pins gitleaks 8.21.2, which parses the plural `[[allowlists]]` form
  and then ignores it — no warning, no non-zero exit (FND-679). A config that
  validates against a modern local binary can do nothing in CI.

Pruning is immune to config-schema skew and needs no merge with an app's own
`.gitleaks.toml` (still honoured for shipped-source false positives).

## This narrows the gate — stating the cost plainly

A real credential committed under `tests/` or `.github/` is **no longer reported
by this gate**. That is the accepted tradeoff, not a side effect.

Note this is broader than the ticket's `.github/test/` — it excludes all of
`.github/`, so workflow files are no longer scanned for hardcoded secrets by
this layer.

Still covering those paths: the creds-into-logs layer in this same job (scans
the unpruned tree), conformance `S001`/`S002`, and the nightly
`credential-leak-scan` in `connector-pulse`.

## Verification

Run against the **pinned 8.21.2** (downloaded and checksum-verified against
`gitleaks_8.21.2_checksums.txt`, not a local `brew` build), on a synthetic tree
reproducing the microstrategy fixture shape:

| Case | Result |
|---|---|
| Baseline, no change | 152 findings (148 fixture noise + 4 real) |
| Fixture noise only — the microstrategy situation | **exit 0**, gate passes |
| Real `ghp_` + `generic-api-key` in shipped app source | **exit 1**, both still reported, paths repo-relative |
| `app/` after the step | `tests/` and `.github/` still present — layer 2 keeps full coverage |
| Cost, measured | the 2 genuine tokens planted under `tests/` and `.github/` are no longer reported |

`uv run pre-commit run --files <changed>` passes, including actionlint.

## Not in this PR

The plural-`[[allowlists]]` detector is FND-679 with its own named holdouts
(`atlan-postgres-app`, `atlan-sdr-conformance-app` are inert-but-latent). Kept
separate.

Chris also floated helpers that generate to a naming standard plus conformance
rules enforcing it — offered with "I'm skeptical" and a question mark, so not
built here.
