### PR TITLE
fix(testing): let HttpFakeSource serve TLS

### DIFF
--- a/application_sdk/testing/fake_source.py
+++ b/application_sdk/testing/fake_source.py
@@ -59,6 +59,7 @@ from __future__ import annotations
 
 import base64
 import re
+import ssl
 import threading
 import time
 from collections.abc import Callable, Iterable, Mapping, Sequence
@@ -370,10 +371,12 @@ class HttpFakeSource:
         connection_timeout: float = _CONNECTION_TIMEOUT_SECONDS,
         bind_host: str = _LOOPBACK,
         port: int = 0,
+        ssl_context: ssl.SSLContext | None = None,
     ) -> None:
         self.name = name
         self.bind_host = bind_host
         self.requested_port = port
+        self.ssl_context = ssl_context
         self.default_content_type = default_content_type
         self.not_found_body = (
             {"error": "not found"} if not_found_body is None else not_found_body
@@ -452,7 +455,8 @@ class HttpFakeSource:
             # (a compose service name, say) out of band — there is nothing here
             # from which that name could be derived.
             host_text = _LOOPBACK
-        return f"http://{host_text}:{port}"
+        scheme = "https" if self.ssl_context is not None else "http"
+        return f"{scheme}://{host_text}:{port}"
 
     @property
     def port(self) -> int:
@@ -526,12 +530,24 @@ class HttpFakeSource:
         fixture wants. A caller serving the fake to peers — a container on a
         compose network reaching it by service name — passes a wildcard
         ``bind_host`` and usually a fixed ``port``.
+
+        Passing an ``ssl_context`` serves TLS instead of plain HTTP. That is
+        needed by connectors whose client forces an ``https://`` scheme onto
+        whatever host it is given — a plain-HTTP fake is simply unreachable for
+        those, however correct its routes are.
         """
         if self._server is not None:
             return self
         server = _FakeSourceServer(
             (self.bind_host, self.requested_port), _make_handler_class(self)
         )
+        if self.ssl_context is not None:
+            # Wrap the listening socket, so every accepted connection is a TLS
+            # one. Done here rather than per-request because the handler class
+            # is shared and knows nothing about transport.
+            server.socket = self.ssl_context.wrap_socket(
+                server.socket, server_side=True
+            )
         thread = threading.Thread(
             target=server.serve_forever,
             name=f"{self.name}-server",

--- a/application_sdk/testing/fake_source.py
+++ b/application_sdk/testing/fake_source.py
@@ -582,9 +582,11 @@ class HttpFakeSource:
                 # serve_forever, and therefore stop(), inside accept(). TLS 1.2
                 # is the floor: a test fake has no reason to speak 1.0/1.1, and
                 # leaving them enabled trips CodeQL py/insecure-protocol.
-                if self.ssl_context.minimum_version < ssl.TLSVersion.TLSv1_2:
-                    self.ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
-                server.socket = self.ssl_context.wrap_socket(
+                tls = self.ssl_context
+                tls.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+                if tls.minimum_version < ssl.TLSVersion.TLSv1_2:
+                    tls.minimum_version = ssl.TLSVersion.TLSv1_2
+                server.socket = tls.wrap_socket(  # codeql[py/insecure-protocol]
                     server.socket, server_side=True, do_handshake_on_connect=False
                 )
             thread = threading.Thread(

--- a/application_sdk/testing/fake_source.py
+++ b/application_sdk/testing/fake_source.py
@@ -579,7 +579,11 @@ class HttpFakeSource:
                 # Wrap the listening socket so every accepted connection is TLS.
                 # Handshake is deferred to get_request (do_handshake_on_connect=
                 # False) so a TCP peer that never speaks TLS cannot stall
-                # serve_forever, and therefore stop(), inside accept().
+                # serve_forever, and therefore stop(), inside accept(). TLS 1.2
+                # is the floor: a test fake has no reason to speak 1.0/1.1, and
+                # leaving them enabled trips CodeQL py/insecure-protocol.
+                if self.ssl_context.minimum_version < ssl.TLSVersion.TLSv1_2:
+                    self.ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
                 server.socket = self.ssl_context.wrap_socket(
                     server.socket, server_side=True, do_handshake_on_connect=False
                 )

--- a/application_sdk/testing/fake_source.py
+++ b/application_sdk/testing/fake_source.py
@@ -317,10 +317,39 @@ class _FakeSourceServer(ThreadingHTTPServer):
 
     daemon_threads = True
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *args: Any,
+        handshake_timeout: float | None = None,
+        **kwargs: Any,
+    ) -> None:
         self._handler_threads: set[threading.Thread] = set()
         self._handler_lock = threading.Lock()
+        self.handshake_timeout = handshake_timeout
         super().__init__(*args, **kwargs)
+
+    def get_request(self) -> tuple[Any, Any]:
+        """Accept one connection, then handshake TLS under ``handshake_timeout``.
+
+        The listening socket is wrapped with ``do_handshake_on_connect=False``, so
+        ``accept()`` returns as soon as TCP completes. Handshake then happens here
+        with the same timeout that bounds :meth:`HttpFakeSource.stop`. Without that,
+        a peer that connects and never speaks TLS parks ``serve_forever`` inside
+        ``SSLSocket.accept()``, and ``shutdown()`` waits forever on it.
+        """
+        request, client_address = super().get_request()
+        handshake = getattr(request, "do_handshake", None)
+        if handshake is None or self.handshake_timeout is None:
+            return request, client_address
+        previous = request.gettimeout()
+        try:
+            request.settimeout(self.handshake_timeout)
+            handshake()
+        except BaseException:
+            request.close()
+            raise
+        request.settimeout(previous)
+        return request, client_address
 
     def process_request_thread(self, request: Any, client_address: Any) -> None:
         current = threading.current_thread()
@@ -539,21 +568,30 @@ class HttpFakeSource:
         if self._server is not None:
             return self
         server = _FakeSourceServer(
-            (self.bind_host, self.requested_port), _make_handler_class(self)
+            (self.bind_host, self.requested_port),
+            _make_handler_class(self),
+            handshake_timeout=(
+                self.connection_timeout if self.ssl_context is not None else None
+            ),
         )
-        if self.ssl_context is not None:
-            # Wrap the listening socket, so every accepted connection is a TLS
-            # one. Done here rather than per-request because the handler class
-            # is shared and knows nothing about transport.
-            server.socket = self.ssl_context.wrap_socket(
-                server.socket, server_side=True
+        try:
+            if self.ssl_context is not None:
+                # Wrap the listening socket so every accepted connection is TLS.
+                # Handshake is deferred to get_request (do_handshake_on_connect=
+                # False) so a TCP peer that never speaks TLS cannot stall
+                # serve_forever, and therefore stop(), inside accept().
+                server.socket = self.ssl_context.wrap_socket(
+                    server.socket, server_side=True, do_handshake_on_connect=False
+                )
+            thread = threading.Thread(
+                target=server.serve_forever,
+                name=f"{self.name}-server",
+                daemon=True,
             )
-        thread = threading.Thread(
-            target=server.serve_forever,
-            name=f"{self.name}-server",
-            daemon=True,
-        )
-        thread.start()
+            thread.start()
+        except BaseException:
+            server.server_close()
+            raise
         self._server = server
         self._thread = thread
         return self

--- a/tests/unit/testing/test_fake_source.py
+++ b/tests/unit/testing/test_fake_source.py
@@ -274,6 +274,32 @@ class TestLifecycle:
         with source:
             assert source.base_url.startswith("http://")
 
+    def test_failed_tls_wrap_releases_the_bound_port(self) -> None:
+        """A wrap_socket failure after bind must not leak the listening socket.
+
+        ``_FakeSourceServer`` binds immediately. If wrap then raises, ``_server``
+        is never stored and ``stop()`` cannot close the port — unless start()
+        closes the server on the way out.
+        """
+        probe = socket.socket()
+        probe.bind(("127.0.0.1", 0))
+        chosen = probe.getsockname()[1]
+        probe.close()
+
+        # PROTOCOL_TLS_CLIENT raises after bind: check_hostname needs a hostname
+        # that a server-side wrap never has.
+        source = HttpFakeSource(
+            port=chosen, ssl_context=ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        )
+        with pytest.raises(ValueError, match="check_hostname"):
+            source.start()
+
+        rebound = socket.socket()
+        try:
+            rebound.bind(("127.0.0.1", chosen))
+        finally:
+            rebound.close()
+
     def test_base_url_before_start_is_an_error_not_a_hang(self) -> None:
         source = HttpFakeSource()
         with pytest.raises(FakeSourceNotRunningError, match="not running"):
@@ -911,6 +937,29 @@ class TestThreadTeardown:
     ) -> None:
         HttpFakeSource().stop()
         assert warnings == []
+
+    def test_stop_returns_when_a_tcp_peer_never_handshakes(
+        self, tmp_path: Path
+    ) -> None:
+        """A TCP connect that never speaks TLS must not stall stop() in shutdown()."""
+        cert, key = _self_signed_cert(tmp_path, "127.0.0.1")
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ctx.load_cert_chain(certfile=str(cert), keyfile=str(key))
+        source = HttpFakeSource(ssl_context=ctx, connection_timeout=0.2)
+        source.start()
+        peer = socket.create_connection(("127.0.0.1", source.port), timeout=5)
+        try:
+            # Let serve_forever accept and enter the TLS handshake so this
+            # actually covers the hang, not just an idle accept loop.
+            time.sleep(0.05)
+            started = time.monotonic()
+            source.stop()
+            elapsed = time.monotonic() - started
+            budget = 0.2 + fake_source._JOIN_GRACE_SECONDS
+            assert elapsed <= budget
+        finally:
+            peer.close()
+            source.stop()
 
 
 class TestHyphenatedResponseHeaders:

--- a/tests/unit/testing/test_fake_source.py
+++ b/tests/unit/testing/test_fake_source.py
@@ -14,14 +14,18 @@ outbound traffic from the unit tier — stays enforced.
 
 from __future__ import annotations
 
+import datetime
 import http.client
+import ipaddress
 import json
 import socket
+import ssl
 import threading
 import time
 import urllib.error
 import urllib.request
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -40,6 +44,54 @@ from application_sdk.testing.fake_source import (
 )
 
 pytestmark = pytest.mark.allow_hosts(["127.0.0.1"])
+
+
+def _self_signed_cert(tmp_path: "Path", common_name: str) -> tuple["Path", "Path"]:
+    """Generate a throwaway self-signed cert/key pair for a TLS fake.
+
+    Generated per-test rather than committed: a checked-in key, even a test one,
+    trips secret scanners and teaches the wrong habit.
+    """
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    now = datetime.datetime.now(datetime.UTC)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=5))
+        .not_valid_after(now + datetime.timedelta(hours=1))
+        .add_extension(
+            # An IP SAN, not a DNS one: the unit tier allows connects to
+            # 127.0.0.1 only, and "localhost" resolves to ::1 first on this
+            # runner — which pytest-socket blocks with
+            # SocketConnectBlockedError naming "::1".
+            x509.SubjectAlternativeName(
+                [x509.IPAddress(ipaddress.ip_address(common_name))]
+            ),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    cert_path = tmp_path / "fake.crt"
+    key_path = tmp_path / "fake.key"
+    cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    return cert_path, key_path
+
 
 HYPHENATED = "X-Fake-AuthToken"
 
@@ -188,6 +240,39 @@ class TestLifecycle:
             assert source.base_url == f"http://127.0.0.1:{source.port}"
             with urllib.request.urlopen(f"{source.base_url}/ping", timeout=5) as resp:
                 assert json.loads(resp.read()) == {"ok": True}
+
+    def test_serves_tls_when_given_an_ssl_context(self, tmp_path: Path) -> None:
+        """A TLS fake is reachable over https and says so in base_url.
+
+        Connectors whose client forces an ``https://`` scheme onto whatever host
+        it is handed cannot reach a plain-HTTP fake at all, however correct its
+        routes are. The self-signed cert is generated here rather than committed,
+        so nothing in the repo looks like a real key.
+        """
+        cert, key = _self_signed_cert(tmp_path, "127.0.0.1")
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ctx.load_cert_chain(certfile=str(cert), keyfile=str(key))
+
+        source = HttpFakeSource(ssl_context=ctx)
+        source.route(r"/ping", lambda _r: FakeResponse.json_({"ok": True}))
+        with source:
+            assert source.base_url.startswith("https://")
+            client_ctx = ssl.create_default_context(cafile=str(cert))
+            conn = http.client.HTTPSConnection(
+                "127.0.0.1", source.port, context=client_ctx, timeout=5
+            )
+            conn.request("GET", "/ping")
+            resp = conn.getresponse()
+            assert resp.status == 200
+            assert json.loads(resp.read()) == {"ok": True}
+            conn.close()
+
+    def test_plain_http_stays_the_default(self) -> None:
+        """No ssl_context means no behaviour change for every existing caller."""
+        source = HttpFakeSource()
+        assert source.ssl_context is None
+        with source:
+            assert source.base_url.startswith("http://")
 
     def test_base_url_before_start_is_an_error_not_a_hang(self) -> None:
         source = HttpFakeSource()

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ test = [
 
 [[package]]
 name = "atlan-application-sdk-conformance"
-version = "0.26.0"
+version = "0.27.0"
 source = { directory = "packages/conformance" }
 dependencies = [
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ test = [
 
 [[package]]
 name = "atlan-application-sdk-conformance"
-version = "0.27.0"
+version = "0.26.0"
 source = { directory = "packages/conformance" }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Follow-up to #3654. That PR made the fake reachable from *another container*; this one makes it reachable by a client that insists on **https**.

## Why

Some connector clients normalise whatever host they are handed onto an `https://` scheme. `atlan-microstrategy-app`'s `parse_credentials` rewrites `http://` → `https://` outright:

```python
if host_str.lower().startswith("http://"):
    host_str = "https://" + host_str[len("http://"):]
elif not host_str.lower().startswith("https://"):
    host_str = "https://" + host_str
```

That is deliberate — its frontend stores only the host suffix behind a fixed scheme badge. But it means a plain-HTTP fake is unreachable for that connector no matter how correct its routes are. The symptom is not a connection error either; it surfaces as the app's own preflight verdict, `Preflight failed: Invalid or incomplete MicroStrategy credentials`, because the client cannot complete a TLS handshake against an HTTP listener and `_build_client` raises. That reads as a credential problem and sent me looking in the wrong place for a while.

The sourceless-testing playbook already lists this as a per-connector hazard ("some force `https://` in `parse_credentials`"), so it will recur across the source-less wave.

## What

`ssl_context` becomes an optional constructor argument. When given, the listening socket is wrapped once at `start()` — not per request, since the handler class is shared and knows nothing about transport — and `base_url` reports `https`. Omitted, **nothing changes for any existing caller.**

## The alternative I rejected

Disabling certificate verification in the connector. That would weaken a production code path to suit a test. Instead the fake presents a real certificate and the caller trusts it: `httpx.AsyncClient` in that client is constructed with `trust_env=True` and no explicit `verify`, so `SSL_CERT_FILE` is sufficient on the consuming side.

## Tests

Two, both behavioural:

- a TLS fake answers over https with a certificate the client actually validates
- the plain-HTTP default is unchanged (`ssl_context is None`, `base_url` starts `http://`)

The certificate is generated per-test rather than committed — a checked-in key, even a test one, trips secret scanners and teaches the wrong habit. It carries an **IP SAN for 127.0.0.1**, because the unit tier allows connects to that address only and `"localhost"` resolves to `::1` first on these runners, which `pytest-socket` blocks with `SocketConnectBlockedError` naming `::1`.

**112 pass** in `tests/unit/testing/test_fake_source.py`. Pre-commit clean.

Refs FND-1597, FND-825.

---

## Second fix in this PR: pin every DAG node the app under test owns

`_seed_dag_from_manifest` re-pointed exactly **one** node — the one literally named `extract` — at the worker under test, and substituted the tenant deployment name into every other node's queue:

```python
def _sub_queue(node_name: str, raw: str) -> str:
    if node_name == "extract":
        return extract_task_queue
    return raw.replace("{deployment_name}", deployment_name)
```

For a connector whose DAG carries more than one of its own nodes, that dispatches the rest to **whatever copy the tenant has installed** — not the version under test. Two canonical apps have exactly that shape:

| app | app-owned nodes | where the 2nd one sits |
|---|---|---|
| **metabase** | `extract`, `extract-lineage` | trailing side branch, *after* `publish` |
| **microstrategy** | `extract`, `process` | on the critical path — `publish` depends on it |

Which is why it went unnoticed: metabase loses lineage at worst, its assets are already published from the pinned `extract`. Microstrategy's second node is the transform step, so the tenant copy running it handed `publish` nothing. The observed run:

```
✅ AE run [224s] Succeeded — ✅ extract ✅ process ✅ publish ✅ qi
```

…while the worker under test had executed only `extract_all` (12 raw artifacts uploaded, confirmed in its log) and Atlas held **zero** assets. Every node green, nothing produced — a run can never be trusted to have exercised the code under test while this holds.

The selector is now the node's `app_name` — already substituted from `{app_name}` in the same loop iteration — compared against `connector_short_name`. Nodes of the app under test follow the worker; system apps (`publish`, `qi`, `lineage`) keep their tenant queues, which the existing `test_non_extract_queue_substitutes_deployment_name` still asserts. The new test pins a second app-owned node alongside `extract` and checks a `publish` node in the same DAG is left alone. 132 pass in `tests/unit/testing/e2e/`.

**This is the metabase fix as well.** No metabase code change is needed — it picks the correct behaviour up on its next SDK bump.

Refs FND-1597.

