### PR TITLE
fix(e2e): pin every DAG node on the extract node's task-queue template, not only `extract`

### DIFF
--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -2298,17 +2298,42 @@ class BaseE2ETest:
 
         deployment_name = self.resolved_tenant_deployment_name()
 
-        def _sub_queue(node_name: str, app_name: object, raw: str) -> str:
-            # Pin every node that belongs to the app under test — not only the
-            # one named "extract". A connector whose DAG has more than one of its
-            # own nodes (microstrategy: extract + process) otherwise runs half
-            # its pipeline on the version under test and the other half on
-            # whatever copy the tenant has installed, which can "succeed" while
-            # producing nothing: the run reports every node green and Atlas ends
-            # up empty. System apps (publish, qi, lineage) keep their tenant
-            # queues. ``inputs["app_name"]`` has already had ``{app_name}``
-            # substituted by the time this runs, so the comparison is exact.
-            if node_name == "extract" or app_name == self.connector_short_name:
+        # The extract node's task-queue template, read raw (before any
+        # ``{deployment_name}`` substitution) and before the loop below mutates
+        # anything. ``None`` when the manifest has no extract node or its queue
+        # is not a non-empty string — then only the node named "extract" is
+        # pinned, exactly as before.
+        extract_node = dag.get("extract")
+        extract_inputs = (
+            extract_node.get("inputs") if isinstance(extract_node, dict) else None
+        )
+        extract_template = (
+            extract_inputs.get("task_queue")
+            if isinstance(extract_inputs, dict)
+            else None
+        )
+        if not (isinstance(extract_template, str) and extract_template):
+            extract_template = None
+
+        def _sub_queue(node_name: str, raw: str) -> str:
+            # Pin every node whose raw task-queue template equals the extract
+            # node's to the worker under test — not only the node named
+            # "extract". The template is the routing truth: it is exactly the set
+            # of nodes the AE hands to the same worker deployment as extract. A
+            # connector whose DAG has more than one such node (microstrategy:
+            # extract + process; metabase: extract + extract-lineage) otherwise
+            # runs half its pipeline on the version under test and the other
+            # half on whatever copy the tenant has installed, which can "succeed"
+            # while producing nothing: every node green, Atlas empty.
+            #
+            # ``app_name`` is deliberately not consulted: it is not identity. In
+            # a real generated manifest the extract node can carry
+            # ``app_name=<x>-crawler`` while a sibling on the SAME queue template
+            # carries ``app_name=<x>`` (databricks), and the harness's hand-set
+            # ``connector_short_name`` may legitimately differ from both. System
+            # apps (publish, qi, lineage) have their own templates and keep their
+            # tenant queues.
+            if node_name == "extract" or raw == extract_template:
                 return extract_task_queue
             return raw.replace("{deployment_name}", deployment_name)
 
@@ -2326,7 +2351,7 @@ class BaseE2ETest:
                 )
             tq = inputs.get("task_queue")
             if isinstance(tq, str):
-                inputs["task_queue"] = _sub_queue(name, inputs.get("app_name"), tq)
+                inputs["task_queue"] = _sub_queue(name, tq)
 
         subs_dict = self._mustache_substitutions().model_dump(by_alias=True)
         for name, node in dag.items():

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -2298,8 +2298,17 @@ class BaseE2ETest:
 
         deployment_name = self.resolved_tenant_deployment_name()
 
-        def _sub_queue(node_name: str, raw: str) -> str:
-            if node_name == "extract":
+        def _sub_queue(node_name: str, app_name: object, raw: str) -> str:
+            # Pin every node that belongs to the app under test — not only the
+            # one named "extract". A connector whose DAG has more than one of its
+            # own nodes (microstrategy: extract + process) otherwise runs half
+            # its pipeline on the version under test and the other half on
+            # whatever copy the tenant has installed, which can "succeed" while
+            # producing nothing: the run reports every node green and Atlas ends
+            # up empty. System apps (publish, qi, lineage) keep their tenant
+            # queues. ``inputs["app_name"]`` has already had ``{app_name}``
+            # substituted by the time this runs, so the comparison is exact.
+            if node_name == "extract" or app_name == self.connector_short_name:
                 return extract_task_queue
             return raw.replace("{deployment_name}", deployment_name)
 
@@ -2317,7 +2326,7 @@ class BaseE2ETest:
                 )
             tq = inputs.get("task_queue")
             if isinstance(tq, str):
-                inputs["task_queue"] = _sub_queue(name, tq)
+                inputs["task_queue"] = _sub_queue(name, inputs.get("app_name"), tq)
 
         subs_dict = self._mustache_substitutions().model_dump(by_alias=True)
         for name, node in dag.items():

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -252,6 +252,59 @@ class TestSeedDagFromManifest:
         result = self.harness._seed_dag_from_manifest("atlan-openapi-agent-99")
         assert result["extract"]["inputs"]["task_queue"] == "atlan-openapi-agent-99"
 
+    def test_second_app_owned_node_is_pinned_to_the_worker_queue(
+        self, tmp_path: Path
+    ) -> None:
+        """Every node the app under test owns runs on the version under test.
+
+        A connector whose DAG carries more than one of its own nodes — metabase's
+        ``extract`` + ``extract-lineage``, microstrategy's ``extract`` +
+        ``process`` — must not have the second one substituted with the tenant
+        deployment name: that dispatches it to whatever copy the tenant has
+        installed, which can succeed while producing nothing (every node green,
+        Atlas empty). The selector is ``app_name``, not the node's name.
+        """
+        app = self.harness.connector_short_name
+        dag = {
+            "extract": {
+                "node_type": "workflow",
+                "app_name": app,
+                "app_task_queue": f"atlan-{app}-{{deployment_name}}",
+                "inputs": {
+                    "app_name": app,
+                    "task_queue": f"atlan-{app}-{{deployment_name}}",
+                    "args": {},
+                },
+            },
+            "process": {
+                "node_type": "workflow",
+                "app_name": app,
+                "app_task_queue": f"atlan-{app}-{{deployment_name}}",
+                "inputs": {
+                    "app_name": app,
+                    "task_queue": f"atlan-{app}-{{deployment_name}}",
+                    "args": {},
+                },
+            },
+            "publish": {
+                "node_type": "workflow",
+                "app_name": "publish",
+                "app_task_queue": "atlan-publish-{deployment_name}",
+                "inputs": {
+                    "app_name": "publish",
+                    "task_queue": "atlan-publish-{deployment_name}",
+                    "args": {},
+                },
+            },
+        }
+        self.harness.manifest_path = str(_write_manifest(tmp_path, dag))  # type: ignore[attr-defined]
+        result = self.harness._seed_dag_from_manifest("atlan-openapi-agent-1")
+        assert result["extract"]["inputs"]["task_queue"] == "atlan-openapi-agent-1"
+        # the app's own second node follows the worker, not the tenant
+        assert result["process"]["inputs"]["task_queue"] == "atlan-openapi-agent-1"
+        # a system app stays on the tenant's queue
+        assert result["publish"]["inputs"]["task_queue"] == "atlan-publish-production"
+
     def test_non_extract_queue_substitutes_deployment_name(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -204,6 +204,20 @@ def _write_manifest(tmp_path: Path, dag: dict[str, Any]) -> Path:
     return manifest
 
 
+def _manifest_node(app_name: str, task_queue: str) -> dict[str, Any]:
+    """A manifest DAG node in the shape the contract toolkit generates.
+
+    ``app_name`` and ``task_queue`` are both raw — the ``{deployment_name}``
+    placeholder is left for ``_seed_dag_from_manifest`` to resolve.
+    """
+    return {
+        "node_type": "workflow",
+        "app_name": app_name,
+        "app_task_queue": task_queue,
+        "inputs": {"app_name": app_name, "task_queue": task_queue, "args": {}},
+    }
+
+
 class TestSeedDagFromManifest:
     """Manifest loader: file resolution, queue patching, mustache substitution."""
 
@@ -252,58 +266,200 @@ class TestSeedDagFromManifest:
         result = self.harness._seed_dag_from_manifest("atlan-openapi-agent-99")
         assert result["extract"]["inputs"]["task_queue"] == "atlan-openapi-agent-99"
 
-    def test_second_app_owned_node_is_pinned_to_the_worker_queue(
+    # --- queue-template pinning -----------------------------------------------
+    #
+    # The selector is the node's raw ``inputs.task_queue`` template compared to
+    # the extract node's, never ``app_name`` and never ``connector_short_name``.
+    # The concrete harness under test has ``connector_short_name = "openapi"``;
+    # every fixture below deliberately uses OTHER app names so that a selector
+    # that quietly compared against the harness attribute would fail these.
+
+    def test_every_node_on_the_extract_queue_template_is_pinned(
         self, tmp_path: Path
     ) -> None:
-        """Every node the app under test owns runs on the version under test.
+        """microstrategy shape: ``extract`` + ``process`` share one template.
 
-        A connector whose DAG carries more than one of its own nodes — metabase's
-        ``extract`` + ``extract-lineage``, microstrategy's ``extract`` +
-        ``process`` — must not have the second one substituted with the tenant
-        deployment name: that dispatches it to whatever copy the tenant has
-        installed, which can succeed while producing nothing (every node green,
-        Atlas empty). The selector is ``app_name``, not the node's name.
+        Both follow the worker under test; the system apps (``publish``,
+        ``qi``) have their own templates and keep the tenant's queues. A
+        connector whose second app-owned node is on the critical path otherwise
+        runs its transform on whatever copy the tenant has installed, and the
+        run can report every node green while Atlas ends up empty.
         """
-        app = self.harness.connector_short_name
         dag = {
-            "extract": {
-                "node_type": "workflow",
-                "app_name": app,
-                "app_task_queue": f"atlan-{app}-{{deployment_name}}",
-                "inputs": {
-                    "app_name": app,
-                    "task_queue": f"atlan-{app}-{{deployment_name}}",
-                    "args": {},
-                },
-            },
-            "process": {
-                "node_type": "workflow",
-                "app_name": app,
-                "app_task_queue": f"atlan-{app}-{{deployment_name}}",
-                "inputs": {
-                    "app_name": app,
-                    "task_queue": f"atlan-{app}-{{deployment_name}}",
-                    "args": {},
-                },
-            },
-            "publish": {
-                "node_type": "workflow",
-                "app_name": "publish",
-                "app_task_queue": "atlan-publish-{deployment_name}",
-                "inputs": {
-                    "app_name": "publish",
-                    "task_queue": "atlan-publish-{deployment_name}",
-                    "args": {},
-                },
-            },
+            "extract": _manifest_node(
+                "microstrategy", "atlan-microstrategy-{deployment_name}"
+            ),
+            "process": _manifest_node(
+                "microstrategy", "atlan-microstrategy-{deployment_name}"
+            ),
+            "publish": _manifest_node("publish", "atlan-publish-{deployment_name}"),
+            "qi": _manifest_node(
+                "query-intelligence", "atlan-query-intelligence-{deployment_name}"
+            ),
         }
         self.harness.manifest_path = str(_write_manifest(tmp_path, dag))  # type: ignore[attr-defined]
         result = self.harness._seed_dag_from_manifest("atlan-openapi-agent-1")
         assert result["extract"]["inputs"]["task_queue"] == "atlan-openapi-agent-1"
-        # the app's own second node follows the worker, not the tenant
         assert result["process"]["inputs"]["task_queue"] == "atlan-openapi-agent-1"
-        # a system app stays on the tenant's queue
         assert result["publish"]["inputs"]["task_queue"] == "atlan-publish-production"
+        assert (
+            result["qi"]["inputs"]["task_queue"]
+            == "atlan-query-intelligence-production"
+        )
+
+    def test_differing_app_names_on_the_same_queue_template_are_both_pinned(
+        self, tmp_path: Path
+    ) -> None:
+        """databricks shape: the app-owned nodes do NOT share an ``app_name``.
+
+        ``extract`` carries ``app_name=databricks-crawler`` and the marker node
+        carries ``app_name=databricks``, yet both sit on
+        ``atlan-databricks-{deployment_name}``. An ``app_name``-based selector
+        misses the marker node (and neither name equals
+        ``connector_short_name``); the queue-template selector pins both.
+        """
+        template = "atlan-databricks-{deployment_name}"
+        dag = {
+            "extract": _manifest_node("databricks-crawler", template),
+            "promote-incremental-marker": _manifest_node("databricks", template),
+            "publish": _manifest_node("publish", "atlan-publish-{deployment_name}"),
+            "qi": _manifest_node(
+                "query-intelligence", "atlan-query-intelligence-{deployment_name}"
+            ),
+            "lineage-app": _manifest_node("lineage", "atlan-lineage-{deployment_name}"),
+            "lineage-publish": _manifest_node(
+                "publish", "atlan-publish-{deployment_name}"
+            ),
+        }
+        assert self.harness.connector_short_name not in {
+            "databricks-crawler",
+            "databricks",
+        }
+        self.harness.manifest_path = str(_write_manifest(tmp_path, dag))  # type: ignore[attr-defined]
+        result = self.harness._seed_dag_from_manifest("atlan-openapi-agent-1")
+        assert result["extract"]["inputs"]["task_queue"] == "atlan-openapi-agent-1"
+        assert (
+            result["promote-incremental-marker"]["inputs"]["task_queue"]
+            == "atlan-openapi-agent-1"
+        )
+        # the app_name placeholder substitution is untouched by the pinning
+        assert result["extract"]["inputs"]["app_name"] == "databricks-crawler"
+        assert (
+            result["promote-incremental-marker"]["inputs"]["app_name"] == "databricks"
+        )
+        # system apps stay on the tenant's queues
+        assert result["publish"]["inputs"]["task_queue"] == "atlan-publish-production"
+        assert (
+            result["qi"]["inputs"]["task_queue"]
+            == "atlan-query-intelligence-production"
+        )
+        assert (
+            result["lineage-app"]["inputs"]["task_queue"] == "atlan-lineage-production"
+        )
+        assert (
+            result["lineage-publish"]["inputs"]["task_queue"]
+            == "atlan-publish-production"
+        )
+
+    def test_same_app_name_on_a_different_queue_template_is_not_pinned(
+        self, tmp_path: Path
+    ) -> None:
+        """The decision is queue-based, not app_name-based.
+
+        A node that shares ``extract``'s ``app_name`` — here even the harness's
+        own ``connector_short_name`` — but is routed through a different queue
+        template is a different worker deployment and must keep the tenant's
+        queue.
+        """
+        app = self.harness.connector_short_name
+        dag = {
+            "extract": _manifest_node(app, f"atlan-{app}-{{deployment_name}}"),
+            "sidecar": _manifest_node(app, f"atlan-{app}-sidecar-{{deployment_name}}"),
+        }
+        self.harness.manifest_path = str(_write_manifest(tmp_path, dag))  # type: ignore[attr-defined]
+        result = self.harness._seed_dag_from_manifest("atlan-openapi-agent-1")
+        assert result["extract"]["inputs"]["task_queue"] == "atlan-openapi-agent-1"
+        assert (
+            result["sidecar"]["inputs"]["task_queue"]
+            == f"atlan-{app}-sidecar-production"
+        )
+
+    def test_only_extract_is_pinned_when_nothing_shares_its_template(
+        self, tmp_path: Path
+    ) -> None:
+        """mysql / openapi shape: ``extract`` is the app's only node."""
+        dag = {
+            "extract": _manifest_node("mysql", "atlan-mysql-{deployment_name}"),
+            "qi": _manifest_node(
+                "query-intelligence", "atlan-query-intelligence-{deployment_name}"
+            ),
+            "lineage-app": _manifest_node("lineage", "atlan-lineage-{deployment_name}"),
+            "publish": _manifest_node("publish", "atlan-publish-{deployment_name}"),
+            "lineage-publish": _manifest_node(
+                "publish", "atlan-publish-{deployment_name}"
+            ),
+        }
+        self.harness.manifest_path = str(_write_manifest(tmp_path, dag))  # type: ignore[attr-defined]
+        result = self.harness._seed_dag_from_manifest("atlan-openapi-agent-1")
+        pinned = {
+            name
+            for name, node in result.items()
+            if node["inputs"]["task_queue"] == "atlan-openapi-agent-1"
+        }
+        assert pinned == {"extract"}
+        for name in ("qi", "lineage-app", "publish", "lineage-publish"):
+            assert "{deployment_name}" not in result[name]["inputs"]["task_queue"]
+            assert result[name]["inputs"]["task_queue"].endswith("-production")
+
+    def test_no_extract_node_pins_nothing_extra(self, tmp_path: Path) -> None:
+        # Without an extract node there is no template to match against; every
+        # node gets the tenant deployment name, and nothing raises.
+        dag = {
+            "process": _manifest_node(
+                "microstrategy", "atlan-microstrategy-{deployment_name}"
+            ),
+            "publish": _manifest_node("publish", "atlan-publish-{deployment_name}"),
+        }
+        self.harness.manifest_path = str(_write_manifest(tmp_path, dag))  # type: ignore[attr-defined]
+        result = self.harness._seed_dag_from_manifest("atlan-openapi-agent-1")
+        assert (
+            result["process"]["inputs"]["task_queue"]
+            == "atlan-microstrategy-production"
+        )
+        assert result["publish"]["inputs"]["task_queue"] == "atlan-publish-production"
+
+    @pytest.mark.parametrize("extract_queue", [None, "", 42])
+    def test_extract_without_a_string_queue_falls_back(
+        self, tmp_path: Path, extract_queue: object
+    ) -> None:
+        # An extract node with no usable task_queue template cannot anchor the
+        # comparison: other nodes fall back to deployment-name substitution.
+        extract = _manifest_node(
+            "microstrategy", "atlan-microstrategy-{deployment_name}"
+        )
+        if extract_queue is None:
+            del extract["inputs"]["task_queue"]
+        else:
+            extract["inputs"]["task_queue"] = extract_queue
+        dag = {
+            "extract": extract,
+            "process": _manifest_node(
+                "microstrategy", "atlan-microstrategy-{deployment_name}"
+            ),
+        }
+        self.harness.manifest_path = str(_write_manifest(tmp_path, dag))  # type: ignore[attr-defined]
+        result = self.harness._seed_dag_from_manifest("atlan-openapi-agent-1")
+        assert (
+            result["process"]["inputs"]["task_queue"]
+            == "atlan-microstrategy-production"
+        )
+        if isinstance(extract_queue, str):
+            # the node named extract is always pinned when its queue is a
+            # string, exactly as before — an empty one just anchors nothing
+            assert result["extract"]["inputs"]["task_queue"] == "atlan-openapi-agent-1"
+        else:
+            # a non-string extract queue is left exactly as the manifest had it
+            assert result["extract"]["inputs"].get("task_queue") == extract_queue
 
     def test_non_extract_queue_substitutes_deployment_name(
         self, tmp_path: Path


### PR DESCRIPTION
`_seed_dag_from_manifest` re-pointed exactly **one** node — the one literally named `extract` — at the worker under test, and substituted the tenant deployment name into every other node's queue:

```python
def _sub_queue(node_name: str, raw: str) -> str:
    if node_name == "extract":
        return extract_task_queue
    return raw.replace("{deployment_name}", deployment_name)
```

For a connector whose DAG carries more than one of its own nodes, that dispatches the rest to **whatever copy the tenant has installed** — not the version under test. Two canonical apps have exactly that shape:

| app | app-owned nodes | where the 2nd one sits |
|---|---|---|
| **metabase** | `extract`, `extract-lineage` | trailing side branch, *after* `publish` |
| **microstrategy** | `extract`, `process` | on the critical path — `publish` depends on it |

That difference is why this went unnoticed. Metabase loses lineage at worst; its assets are already published from the pinned `extract`. Microstrategy's second node is the transform step, so the tenant copy running it hands `publish` nothing. The observed run on atlanhq/atlan-microstrategy-app#107:

```
✅ AE run [224s] Succeeded — ✅ extract ✅ process ✅ publish ✅ qi
```

…while the worker under test had executed only `extract_all` (12 raw artifacts uploaded, confirmed in its container log) and Atlas held **zero** assets. Every node green, nothing produced. A run cannot be trusted to have exercised the code under test while this holds — that's the whole point of pinning `extract` in the first place, applied to only half the app.

## The change: pin on the extract node's task-queue template

The selector is the node's **raw `inputs.task_queue` template** (before `{deployment_name}` substitution) compared to the extract node's. Every node whose template equals extract's is pinned to `extract_task_queue`; every other node gets `{deployment_name}` substituted as before, so `publish` / `qi` / `lineage` keep their tenant queues.

```python
extract_template = <extract node's raw inputs.task_queue, or None>

def _sub_queue(node_name: str, raw: str) -> str:
    if node_name == "extract" or raw == extract_template:
        return extract_task_queue
    return raw.replace("{deployment_name}", deployment_name)
```

If the manifest has no `extract` node, or its `task_queue` is not a non-empty string, `extract_template` is `None` and behaviour is exactly what it was: only the node named `extract` is pinned. Nothing raises.

### Why the queue template and not `app_name`

An earlier revision of this branch pinned on `inputs.app_name == connector_short_name`. That is wrong because **`app_name` is not identity**, and the harness attribute is hand-set. Read from the generated `app/generated/…/manifest.json` of the app repos on 2026-09-04:

| app | node | `inputs.app_name` | raw `inputs.task_queue` |
|---|---|---|---|
| databricks | `extract` | `databricks-crawler` | `atlan-databricks-{deployment_name}` |
| databricks | `promote-incremental-marker` | `databricks` | `atlan-databricks-{deployment_name}` |
| microstrategy | `extract`, `process` | `microstrategy` | `atlan-microstrategy-{deployment_name}` |
| microstrategy | `qi` | — | `atlan-query-intelligence-{deployment_name}` |
| microstrategy | `publish` | — | `atlan-publish-{deployment_name}` |
| metabase | `extract`, `extract-lineage` | `metabase` | `atlan-metabase-{deployment_name}` |
| metabase | `publish`, `qi`, `lineage-publish` | — | system templates |
| mysql | `extract` | `mysql` | `atlan-mysql-{deployment_name}` |
| mysql | `qi`, `lineage-app`, `publish`, `lineage-publish` | — | system templates |
| openapi | `extract` | `openapi` | `atlan-openapi-{deployment_name}` |

- **databricks** has two app-owned nodes with *different* `app_name`s (`databricks-crawler` vs `databricks`) on the *same* queue template. An `app_name` selector misses the marker node; the template selector catches it.
- An app can legitimately carry three different names — the `atlan.yaml` name, the registered `_app_name`, and the harness `connector_short_name` — so no comparison against `connector_short_name` is structurally guaranteed to match anything.
- The queue template is the routing truth: it is exactly "which nodes the AE will hand to the same worker deployment as extract". That is the property the pin exists to preserve.

`connector_short_name` and `app_name` play no part in the decision. The existing `{app_name}` placeholder substitution into `inputs.app_name` / `node.app_name` is untouched.

## Tests (`tests/unit/testing/e2e/test_base_e2e.py`, `TestSeedDagFromManifest`)

The concrete harness has `connector_short_name = "openapi"`; every fixture deliberately uses other app names so a selector that quietly compared against the harness attribute would fail them.

| test | shape | asserts |
|---|---|---|
| `test_every_node_on_the_extract_queue_template_is_pinned` | microstrategy: `extract` + `process`, same template; `publish`, `qi` system | both app nodes → worker queue; `publish` → `atlan-publish-production`; `qi` → `atlan-query-intelligence-production` |
| `test_differing_app_names_on_the_same_queue_template_are_both_pinned` | databricks: `extract` (`databricks-crawler`) + `promote-incremental-marker` (`databricks`), same template; `publish`/`qi`/`lineage-app`/`lineage-publish` system | both pinned though `app_name`s differ and neither equals `connector_short_name`; `app_name`s preserved; four system nodes untouched |
| `test_same_app_name_on_a_different_queue_template_is_not_pinned` | `extract` + `sidecar`, same `app_name` (even `== connector_short_name`), different template | `sidecar` is **not** pinned — decision is queue-based |
| `test_only_extract_is_pinned_when_nothing_shares_its_template` | mysql/openapi: `extract` + four system nodes | pinned set == `{"extract"}` |
| `test_no_extract_node_pins_nothing_extra` | no `extract` node | nothing pinned, nothing raises |
| `test_extract_without_a_string_queue_falls_back[None/""/42]` | `extract` with missing / empty / non-string `task_queue` | others fall back to deployment substitution; nothing raises |

`test_non_extract_queue_substitutes_deployment_name` and `test_app_name_placeholder_substituted` (existing) still pass unchanged.

615 pass in `tests/unit/testing/e2e/`. Pre-commit clean.

This is the metabase fix as well; no metabase code change is needed.

Cherry-picked from a commit that landed on #3657's branch after that PR had merged. Refs FND-1597.
