### PR TITLE
feat(testing): verify workflow-setup routes resolve on the tenant (FND-1667)

### DIFF
--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -741,6 +741,52 @@ runs:
           --base-url "$ATLAN_BASE_URL" \
           --expected "$EXPECTED"
 
+    # Does every entrypoint's workflow-setup page actually resolve? (FND-1667)
+    #
+    # The FND-1593 contract migration 404'd both of a connector's setup pages
+    # while every local and CI check stayed green: the generated artifacts were
+    # self-consistent, conformance was clean, and the freshness gate passed. The
+    # break lived only in the join between what the contract generates and what
+    # the tenant serves, and no gate looked there — a human opened the UI and
+    # found it. Any contract change that moves a marketplace card's identity
+    # does the same thing.
+    #
+    # WHY HERE, and not in `prepare-tenant`. Three constraints intersect at
+    # exactly this step, and only here:
+    #
+    #   * the app must be INSTALLED, so it has to follow prepare-tenant. The
+    #     `e2e` job that calls this action has prepare-tenant in its `needs:`,
+    #     so everything in this composite is strictly after the install.
+    #   * the SDK must be IMPORTABLE. The check reads the same three facts the
+    #     configmap endpoint serves from (`application_sdk.app.generated_tree`),
+    #     rather than re-deriving them into a second copy that could drift from
+    #     the server. prepare-tenant runs a bare `python3` with no `uv sync`, so
+    #     the SDK is not importable there; by this point in this action it is.
+    #   * the tenant CREDENTIALS must be resolved, which the calling job has
+    #     already exported into ATLAN_BASE_URL / ATLAN_API_KEY.
+    #
+    # Placed BEFORE the assertions rather than after, for the same reason as the
+    # version verify above: an app whose setup page will not load is not
+    # installed in any useful sense, so there is nothing to learn from running
+    # the DAG against it.
+    #
+    # Same `expected-app-version` gate as the version verify, which is precisely
+    # "this run installed the app under test". A caller that did not install is
+    # pointed at whatever version the tenant already served, and the served-form
+    # subset check would then report a stale image as a contract break.
+    #
+    # Everything reaches the shell through env:, nothing through `${{ }}` inside
+    # run:, per docs/standards/ci.md.
+    - name: Verify workflow-setup routes resolve
+      if: inputs.expected-app-version != ''
+      shell: bash
+      env:
+        SDR_E2E_ROOT: ${{ steps.action_root.outputs.path }}
+      run: |
+        set -euo pipefail
+        uv run python "$SDR_E2E_ROOT/verify_setup_routes.py" \
+          --base-url "$ATLAN_BASE_URL"
+
     - name: Run SDR integration tests
       id: tests
       shell: bash

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -758,7 +758,7 @@ runs:
     #     `e2e` job that calls this action has prepare-tenant in its `needs:`,
     #     so everything in this composite is strictly after the install.
     #   * the SDK must be IMPORTABLE. The check reads the same three facts the
-    #     configmap endpoint serves from (`application_sdk.app.generated_tree`),
+    #     configmap endpoint serves from (`application_sdk.app._generated_tree`),
     #     rather than re-deriving them into a second copy that could drift from
     #     the server. prepare-tenant runs a bare `python3` with no `uv sync`, so
     #     the SDK is not importable there; by this point in this action it is.

--- a/.github/actions/sdr-e2e/verify_setup_routes.py
+++ b/.github/actions/sdr-e2e/verify_setup_routes.py
@@ -14,7 +14,7 @@ tenant serves, and the SDK is on **both** sides of that join: the tenant's
 ``GET /workflows/v1/configmap/{id}`` in ``application_sdk.handler.service``.
 So the envelope the check unwraps, the rule deciding which generated ``*.json``
 is a setup form, and the bundle-vs-flat layout classification are all read from
-``application_sdk.app.generated_tree`` — the same authority the server reads. A
+``application_sdk.app._generated_tree`` — the same authority the server reads. A
 copy of any of those in this directory would let the server serve one file while
 the check compared against another, and that mismatch would read as a contract
 regression rather than as two divergent copies of one rule.

--- a/.github/actions/sdr-e2e/verify_setup_routes.py
+++ b/.github/actions/sdr-e2e/verify_setup_routes.py
@@ -22,22 +22,62 @@ regression rather than as two divergent copies of one rule.
 Run with ``uv run python`` rather than ``python3``: it needs the app's synced
 environment, which is where the SDK is importable. That is also why this step
 lives in this composite — see the step's own comment in ``action.yaml``.
+
+Version skew is the load-bearing detail here
+--------------------------------------------
+Both callers reference this action as ``@main``, so a change lands in every
+repo's next e2e run at once. But the SDK it imports is the **connector repo's
+own pinned version** — the harness is only repinned to a specific SDK ref on
+cross-repo dispatch (``harness-sdk-ref``), and on an ordinary connector PR the
+action's own comment says the harness "comes from the connector's OWN pinned
+SDK".
+
+So on the day this merges, the always-current action would be asking a
+per-app-pinned SDK for a module that only exists from one release onwards.
+Without the guard below that is a ``ModuleNotFoundError`` and a red e2e leg in
+every connector still pinned below it — a fleet-wide break caused purely by
+skew, with nothing wrong in any app.
+
+The guard is an **import probe, not a version comparison**: it asks the exact
+question that matters ("does the SDK on this runner carry the check?") rather
+than a proxy that needs a floor constant kept in step with a release number.
+The skew closes on its own as apps bump, with no second change here.
 """
 
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import os
 import sys
 from pathlib import Path
 
-from application_sdk.testing.setup_routes import (
-    DEFAULT_CATALOG_WAIT_SECONDS,
-    RouteCheckSkipped,
-    SetupRouteError,
-    TenantRoutes,
-    verify,
-)
+#: Set when the SDK on this runner predates the route check. Checked before the
+#: import so an older pin skips instead of crashing — see the module docstring.
+#:
+#: ``find_spec`` returns ``None`` for a submodule that does not exist, and
+#: raises ``ModuleNotFoundError`` when a PARENT is missing (no SDK synced at
+#: all, which is not this check's problem and which every other step in the leg
+#: will report). An ``ImportError`` from inside a module that DOES exist is
+#: deliberately not caught here: that is a real defect in a new-enough SDK and
+#: must surface as a failure rather than a skip.
+try:
+    _HAS_CHECK = (
+        importlib.util.find_spec("application_sdk.testing.setup_routes") is not None
+    )
+except ModuleNotFoundError:
+    _HAS_CHECK = False
+
+if _HAS_CHECK:
+    from application_sdk.testing.setup_routes import (
+        DEFAULT_CATALOG_WAIT_SECONDS,
+        RouteCheckSkipped,
+        SetupRouteError,
+        TenantRoutes,
+        verify,
+    )
+else:  # pragma: no cover — exercised by the wiring test in a stripped env
+    DEFAULT_CATALOG_WAIT_SECONDS = 120
 
 
 def _bearer() -> str:
@@ -94,6 +134,20 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     args = parser.parse_args(argv)
+
+    if not _HAS_CHECK:
+        # Skew, not a failure. Named as such so a reader does not go looking for
+        # a broken check: this app's pinned SDK simply predates it, and the skip
+        # disappears when the pin moves.
+        print(
+            "::notice::workflow-setup route check skipped: this app's pinned "
+            "atlan-application-sdk predates application_sdk.testing.setup_routes. "
+            "The check ships with the SDK and runs automatically once this repo's "
+            "SDK pin is bumped past the release that added it; nothing needs "
+            "doing in this repo.",
+            flush=True,
+        )
+        return 0
 
     try:
         lines = verify(

--- a/.github/actions/sdr-e2e/verify_setup_routes.py
+++ b/.github/actions/sdr-e2e/verify_setup_routes.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""CLI shell for the workflow-setup route check (FND-1667).
+
+All the logic lives in :mod:`application_sdk.testing.setup_routes`, which is
+pure and unit-tested offline. This file is the shell around it: argument
+parsing, reading the token from the environment, flushing progress, and turning
+its three outcomes into an exit code and a GitHub annotation.
+
+Why the shell is here and the logic is in the SDK
+-------------------------------------------------
+The check asserts a join between what an app's contract generates and what its
+tenant serves, and the SDK is on **both** sides of that join: the tenant's
+``/api/service/configmaps/<name>`` is Heracles proxying to the app pod's own
+``GET /workflows/v1/configmap/{id}`` in ``application_sdk.handler.service``.
+So the envelope the check unwraps, the rule deciding which generated ``*.json``
+is a setup form, and the bundle-vs-flat layout classification are all read from
+``application_sdk.app.generated_tree`` — the same authority the server reads. A
+copy of any of those in this directory would let the server serve one file while
+the check compared against another, and that mismatch would read as a contract
+regression rather than as two divergent copies of one rule.
+
+Run with ``uv run python`` rather than ``python3``: it needs the app's synced
+environment, which is where the SDK is importable. That is also why this step
+lives in this composite — see the step's own comment in ``action.yaml``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from application_sdk.testing.setup_routes import (
+    DEFAULT_CATALOG_WAIT_SECONDS,
+    RouteCheckSkipped,
+    SetupRouteError,
+    TenantRoutes,
+    verify,
+)
+
+
+def _bearer() -> str:
+    """Read the tenant token from the environment, never from argv.
+
+    ``ATLAN_API_KEY`` is what the e2e tenant resolver already exports for this
+    leg, so nothing new has to be threaded through a GitHub expression.
+    """
+    for name in ("ATLAN_API_KEY", "E2E_API_KEY"):
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+    raise SetupRouteError(
+        "no tenant token: set ATLAN_API_KEY (the e2e tenant resolver already "
+        "exports it for this leg). Read from the environment rather than passed "
+        "on argv, which is visible in process listings and in `set -x` output."
+    )
+
+
+def _progress(message: str) -> None:
+    """Print one poll-progress line, flushed.
+
+    Flushed explicitly because Python block-buffers stdout when it is not a
+    TTY, and a GitHub Actions step's ``run:`` is a pipe. Without the flush a
+    poll loop's progress is invisible until the step exits — so a step that is
+    patiently waiting looks identical to one that has hung, which is the
+    diagnosis-hostile failure this whole check exists to avoid.
+    """
+    print(message, flush=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify every entrypoint's workflow-setup page resolves on the tenant."
+    )
+    parser.add_argument("--base-url", required=True, help="https://<tenant>")
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="The app repo's working directory (holds atlan.yaml + app/generated).",
+    )
+    parser.add_argument(
+        "--generated-dir",
+        default="app/generated",
+        help="Generated contract directory, relative to --repo-root.",
+    )
+    parser.add_argument(
+        "--wait-seconds",
+        type=int,
+        default=DEFAULT_CATALOG_WAIT_SECONDS,
+        help=(
+            "How long to keep re-reading the marketplace catalog while it "
+            "reconciles after the install. 0 reads once."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        lines = verify(
+            Path(args.repo_root),
+            TenantRoutes(base_url=args.base_url, bearer=_bearer()),
+            generated_dir=args.generated_dir,
+            wait_seconds=args.wait_seconds,
+            on_progress=_progress,
+        )
+    except RouteCheckSkipped as exc:
+        # Not a failure. An app with no generated contract, and one whose
+        # entrypoints carry no marketplace card, both have no setup page to
+        # check — and without this the check would be a fleet-wide false
+        # positive on its first run. A notice rather than silence, so a skip is
+        # visible in the log instead of looking like a pass.
+        print(f"::notice::workflow-setup route check skipped: {exc}", flush=True)
+        return 0
+    except SetupRouteError as exc:
+        print(f"::error::{exc}", file=sys.stderr, flush=True)
+        return 1
+
+    for line in lines:
+        print(f"verified: {line}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_setup_routes_wiring.py
+++ b/.github/scripts/tests/test_setup_routes_wiring.py
@@ -21,6 +21,9 @@ without a runner.
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -230,3 +233,136 @@ def test_the_action_stash_copies_the_whole_directory(steps: list[dict]) -> None:
         "the stash names individual files now; add verify_setup_routes.py to it "
         "or restore the whole-directory copy"
     )
+
+
+# ── Version skew: the action is @main, the SDK is per-app-pinned ─────────────
+#
+# Both callers reference this action as `@main`, so a change here reaches every
+# repo's next e2e run at once. The SDK it imports is the CONNECTOR's own pinned
+# version — the harness is repinned only on cross-repo dispatch
+# (`harness-sdk-ref`), and the action's own comment says an ordinary connector
+# PR runs "the connector's OWN pinned SDK".
+#
+# So without a guard, merging this reds the e2e leg of every connector still
+# pinned below the release that adds the check — a fleet-wide break caused
+# purely by skew, with nothing wrong in any app. These tests are the guard's
+# regression net, and the subprocess one is the only one that proves the
+# property rather than describing it.
+
+
+def _run_shell(
+    env_extra: dict[str, str], *args: str
+) -> subprocess.CompletedProcess[str]:
+    """Run the CLI shell in a subprocess with a modified environment."""
+    env = dict(os.environ)
+    env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(_SHELL), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def _fake_older_sdk(root: Path) -> Path:
+    """An `application_sdk` package whose `testing` has no `setup_routes`.
+
+    This is what an older pinned SDK looks like to the probe: the package and
+    the subpackage import fine, and the submodule simply is not there.
+    """
+    package = root / "application_sdk"
+    (package / "testing").mkdir(parents=True)
+    (package / "__init__.py").write_text('__version__ = "3.0.0"\n')
+    (package / "testing" / "__init__.py").write_text("")
+    return root
+
+
+def test_an_older_pinned_sdk_skips_instead_of_crashing(tmp_path: Path) -> None:
+    """The fleet-safety property, proven by running the real shell.
+
+    A `ModuleNotFoundError` here would be a red e2e leg in every connector
+    pinned below the release that adds the check.
+    """
+    result = _run_shell(
+        {"PYTHONPATH": str(_fake_older_sdk(tmp_path)), "ATLAN_API_KEY": "unused"},
+        "--base-url",
+        "https://tenant.invalid",
+    )
+
+    assert result.returncode == 0, (
+        "the shell did not survive an SDK that predates the check:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "ModuleNotFoundError" not in result.stderr
+    assert "::notice::" in result.stdout
+
+
+def test_the_skip_notice_says_no_action_is_needed_in_the_app(tmp_path: Path) -> None:
+    """A skew skip must not read as a task for the connector's author.
+
+    The check ships with the SDK, so the skip clears itself when the pin moves.
+    Saying so is what stops someone opening an issue against their own repo.
+    """
+    result = _run_shell(
+        {"PYTHONPATH": str(_fake_older_sdk(tmp_path)), "ATLAN_API_KEY": "unused"},
+        "--base-url",
+        "https://tenant.invalid",
+    )
+
+    assert "predates" in result.stdout
+    assert "nothing needs" in result.stdout
+
+
+def test_the_skip_does_not_require_a_tenant_token(tmp_path: Path) -> None:
+    """The skew skip comes before the credential read.
+
+    An old-pin repo has no reason to have supplied one, and demanding it would
+    turn the skip back into the failure the guard exists to prevent.
+    """
+    env = {"PYTHONPATH": str(_fake_older_sdk(tmp_path))}
+    # Blank rather than absent: the resolver exports these, so an empty value is
+    # the realistic shape, and `_bearer` treats both the same way.
+    env["ATLAN_API_KEY"] = ""
+    env["E2E_API_KEY"] = ""
+
+    result = _run_shell(env, "--base-url", "https://tenant.invalid")
+
+    assert result.returncode == 0
+    assert "no tenant token" not in result.stdout + result.stderr
+
+
+def test_a_current_sdk_does_not_take_the_skip_path() -> None:
+    """The guard must not swallow the check on an SDK that DOES carry it.
+
+    A probe that answered "absent" for a present module would green every leg
+    forever — the worst outcome available here, since it looks identical to a
+    pass. Run with no PYTHONPATH shim, i.e. this repo's own SDK.
+    """
+    result = _run_shell({"ATLAN_API_KEY": ""}, "--base-url", "https://tenant.invalid")
+
+    assert "predates" not in result.stdout, (
+        "the shell reported an SDK that predates the check while running "
+        "against this repo's own SDK, which contains it"
+    )
+    # It gets as far as needing a credential, which proves it took the real path.
+    assert result.returncode == 1
+    assert "no tenant token" in result.stderr
+
+
+def test_the_probe_is_an_import_check_not_a_version_comparison() -> None:
+    """No release-number floor to keep in step with a changelog.
+
+    A version gate needs a constant bumped by hand at release time; get it
+    wrong in either direction and the check either crashes on old pins or
+    silently skips new ones. The import probe asks the question that actually
+    matters and closes on its own as apps bump.
+    """
+    source = _SHELL.read_text(encoding="utf-8")
+
+    assert "importlib.util.find_spec" in source
+    for version_gate in ("__version__", "packaging", "Version("):
+        assert version_gate not in source, (
+            f"{version_gate!r} suggests a version comparison; the guard is "
+            "deliberately an import probe (see the module docstring)"
+        )

--- a/.github/scripts/tests/test_setup_routes_wiring.py
+++ b/.github/scripts/tests/test_setup_routes_wiring.py
@@ -1,0 +1,232 @@
+"""Guards for the workflow-setup route check's wiring in sdr-e2e (FND-1667).
+
+The check itself is unit-tested in ``tests/unit/testing/test_setup_routes.py``,
+which proves it bites. These assertions protect the *placement*, and every one
+of them guards a failure mode that is silent rather than red:
+
+* placed in the wrong job, the SDK is not importable and the step dies on an
+  ``ImportError`` that reads like a broken check rather than a misplaced one
+* placed before the install, it reports a 404 for an app that simply is not
+  deployed yet — a false positive on every run
+* placed after the assertions, a connector whose setup page will not load still
+  runs a full DAG against it first
+* gated wrongly, it compares a committed contract against whatever version the
+  tenant already happened to serve, and reports a stale image as a contract
+  break
+
+Deliberately YAML-shape assertions: what is being protected is GitHub Actions'
+own step ordering and job-dependency semantics, which cannot be exercised
+without a runner.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_WORKFLOW = _REPO_ROOT / ".github/workflows/tests-reusable.yaml"
+_FULL_WORKFLOW = _REPO_ROOT / ".github/workflows/e2e-full-reusable.yaml"
+_SDR_ACTION = _REPO_ROOT / ".github/actions/sdr-e2e/action.yaml"
+_SHELL = _REPO_ROOT / ".github/actions/sdr-e2e/verify_setup_routes.py"
+
+_STEP_NAME = "Verify workflow-setup routes resolve"
+_VERSION_STEP_NAME = "Verify the tenant runs the version under test"
+_PYTEST_STEP_NAME = "Run SDR integration tests"
+
+
+@pytest.fixture(scope="module")
+def action() -> dict:  # type: ignore[type-arg]
+    return yaml.safe_load(_SDR_ACTION.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def steps(action: dict) -> list[dict]:  # type: ignore[type-arg]
+    return action["runs"]["steps"]
+
+
+def _index(steps: list[dict], name: str) -> int:  # type: ignore[type-arg]
+    for position, step in enumerate(steps):
+        if step.get("name") == name:
+            return position
+    raise AssertionError(f"no step named {name!r} in {_SDR_ACTION}")
+
+
+# ── It exists, and it runs the shell that exists ─────────────────────────────
+
+
+def test_the_step_exists(steps: list[dict]) -> None:  # type: ignore[type-arg]
+    _index(steps, _STEP_NAME)
+
+
+def test_the_shell_it_invokes_is_committed(steps: list[dict]) -> None:  # type: ignore[type-arg]
+    """The step's script must actually be in the action directory.
+
+    ``$SDR_E2E_ROOT`` resolves to a copy of this directory, so a step naming a
+    file that is not committed here fails at runtime with a bare "No such file",
+    several minutes into an e2e leg.
+    """
+    step = steps[_index(steps, _STEP_NAME)]
+
+    assert "verify_setup_routes.py" in step["run"]
+    assert _SHELL.is_file(), f"{_SHELL} is referenced by the step but not committed"
+
+
+def test_it_runs_under_uv_not_bare_python(steps: list[dict]) -> None:  # type: ignore[type-arg]
+    """`uv run python`, because the check imports the SDK.
+
+    The shell reads ``application_sdk.app.generated_tree`` — the same authority
+    the configmap endpoint serves from — rather than keeping a second copy of
+    the layout and form-selection rules. A bare ``python3`` has no SDK on the
+    path, so this would die on an ImportError. The action's other scripts use
+    ``python3`` precisely because they do NOT need the SDK, which makes this an
+    easy thing to "tidy" into breakage.
+    """
+    step = steps[_index(steps, _STEP_NAME)]
+
+    assert "uv run python" in step["run"]
+    assert "python3 " not in step["run"]
+
+
+# ── Ordering: after the install, before the assertions ───────────────────────
+
+
+def test_it_runs_after_the_version_verify(steps: list[dict]) -> None:  # type: ignore[type-arg]
+    """The version check is the cheaper, more fundamental failure.
+
+    A tenant running the wrong version would make the served-form subset check
+    report a stale image as a contract break, so the version mismatch has to be
+    the error the reader sees first.
+    """
+    assert _index(steps, _STEP_NAME) > _index(steps, _VERSION_STEP_NAME)
+
+
+def test_it_runs_before_the_assertions(steps: list[dict]) -> None:  # type: ignore[type-arg]
+    """An app whose setup page will not load is not usefully installed.
+
+    There is nothing to learn from running a full DAG against it, so this fails
+    the leg before the suite spends its budget.
+    """
+    assert _index(steps, _STEP_NAME) < _index(steps, _PYTEST_STEP_NAME)
+
+
+def test_the_calling_job_runs_after_prepare_tenant() -> None:
+    """The cards and configmaps exist only after the install.
+
+    This is what makes placing the step in this composite sound at all: the
+    ``e2e`` job that invokes it declares ``prepare-tenant`` in its ``needs:``,
+    so every step here is strictly after the install. Deleting that dependency
+    would leave this check reading a tenant nobody installed onto.
+    """
+    jobs = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+
+    assert "prepare-tenant" in jobs["e2e"]["needs"]
+
+
+# ── The gate ─────────────────────────────────────────────────────────────────
+
+
+def test_it_shares_the_install_paths_gate(steps: list[dict]) -> None:  # type: ignore[type-arg]
+    """Gated on `expected-app-version`, exactly like the version verify.
+
+    That input is non-empty precisely when THIS run installed the app under
+    test. A caller that did not install is pointed at whatever the tenant
+    already served, and the served-form subset check would then read a stale
+    image as a missing contract input — a false positive, on a check whose
+    entire value is that it does not produce those.
+    """
+    step = steps[_index(steps, _STEP_NAME)]
+    version_step = steps[_index(steps, _VERSION_STEP_NAME)]
+
+    assert step["if"] == version_step["if"]
+    assert "expected-app-version" in step["if"]
+
+
+# ── Injection discipline ─────────────────────────────────────────────────────
+
+
+def test_nothing_is_interpolated_into_the_run_block(steps: list[dict]) -> None:  # type: ignore[type-arg]
+    """Everything through `env:`, nothing through `${{ }}` inside `run:`.
+
+    docs/standards/ci.md, and the same finding sdk-review has raised against
+    this file's neighbours: ``github.head_ref`` is attacker-controlled on a fork
+    PR, and a crafted branch name interpolated into ``run:`` is spliced into the
+    script before bash sees a quote.
+    """
+    step = steps[_index(steps, _STEP_NAME)]
+
+    assert "${{" not in step["run"]
+
+
+def test_the_token_never_reaches_argv(steps: list[dict]) -> None:  # type: ignore[type-arg]
+    """The credential is read from the environment inside the shell.
+
+    argv is visible in process listings and in ``set -x`` output, so a token
+    passed as a flag leaks to anything that can read either.
+    """
+    step = steps[_index(steps, _STEP_NAME)]
+
+    assert "ATLAN_API_KEY" not in step["run"]
+    assert "--token" not in step["run"]
+    assert "--api-key" not in step["run"]
+
+
+# ── Both callers get it ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("workflow", [_WORKFLOW, _FULL_WORKFLOW])
+def test_both_callers_reach_this_action(workflow: Path) -> None:
+    """One insertion has to cover every e2e caller, or it covers one repo.
+
+    The check lives in this composite rather than in a job step precisely
+    because both reusable e2e workflows call it. If a caller stopped using the
+    action, its route coverage would vanish with no failing check to say so.
+    """
+    assert "actions/sdr-e2e" in workflow.read_text(encoding="utf-8")
+
+
+# ── No second copy of the shared rules ───────────────────────────────────────
+
+
+def test_the_shell_holds_no_check_logic() -> None:
+    """The shell parses arguments and prints; the logic is in the SDK.
+
+    The point of the placement is that there is ONE copy of "which generated
+    file is the form", "what layout is this tree" and "how is the served
+    envelope shaped" — read from the same module the configmap endpoint serves
+    from. A copy re-appearing here would let the server serve one file while the
+    check compared against another, and that mismatch would read as a contract
+    regression rather than as two divergent copies of one rule.
+    """
+    source = _SHELL.read_text(encoding="utf-8")
+
+    assert "from application_sdk.testing.setup_routes import" in source
+    # The vocabulary that must NOT be restated here.
+    for leaked in ("atlan-connectors-", "csa-connectors-", "manifest.json"):
+        assert leaked not in source, (
+            f"{leaked!r} appears in the CLI shell. That rule belongs to "
+            "application_sdk.app.generated_tree, which the configmap endpoint "
+            "also reads — a second copy here can drift from the server."
+        )
+
+
+def test_the_action_stash_copies_the_whole_directory(steps: list[dict]) -> None:  # type: ignore[type-arg]
+    """The shell reaches the runner via the action's own directory stash.
+
+    When this action is invoked as a LOCAL action, ``github.action_path`` sits
+    inside the workspace and ``setup-deps``' checkout wipes it, so every
+    post-setup step reads from a ``/tmp`` stash taken beforehand. That stash is
+    a whole-directory ``cp -R``, which is why adding a script needed no change
+    to it. Narrowing it to an explicit file list would silently strip this one
+    — the step would then fail minutes into an e2e leg with a bare "No such
+    file or directory".
+    """
+    stash = steps[_index(steps, "Stash action assets")]
+
+    assert "cp -R" in stash["run"]
+    assert "verify_setup_routes" not in stash["run"], (
+        "the stash names individual files now; add verify_setup_routes.py to it "
+        "or restore the whole-directory copy"
+    )

--- a/.github/scripts/tests/test_setup_routes_wiring.py
+++ b/.github/scripts/tests/test_setup_routes_wiring.py
@@ -80,7 +80,7 @@ def test_the_shell_it_invokes_is_committed(steps: list[dict]) -> None:  # type: 
 def test_it_runs_under_uv_not_bare_python(steps: list[dict]) -> None:  # type: ignore[type-arg]
     """`uv run python`, because the check imports the SDK.
 
-    The shell reads ``application_sdk.app.generated_tree`` — the same authority
+    The shell reads ``application_sdk.app._generated_tree`` — the same authority
     the configmap endpoint serves from — rather than keeping a second copy of
     the layout and form-selection rules. A bare ``python3`` has no SDK on the
     path, so this would die on an ImportError. The action's other scripts use
@@ -210,7 +210,7 @@ def test_the_shell_holds_no_check_logic() -> None:
     for leaked in ("atlan-connectors-", "csa-connectors-", "manifest.json"):
         assert leaked not in source, (
             f"{leaked!r} appears in the CLI shell. That rule belongs to "
-            "application_sdk.app.generated_tree, which the configmap endpoint "
+            "application_sdk.app._generated_tree, which the configmap endpoint "
             "also reads — a second copy here can drift from the server."
         )
 

--- a/application_sdk/app/_artifact_schema_guard.py
+++ b/application_sdk/app/_artifact_schema_guard.py
@@ -49,10 +49,11 @@ from __future__ import annotations
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, Literal, get_args, get_origin
+from typing import TYPE_CHECKING, Annotated, Any, get_args, get_origin
 
 import orjson
 
+from application_sdk.app.generated_tree import GeneratedLayout, generated_layout
 from application_sdk.constants import CONTRACT_GENERATED_DIR
 from application_sdk.contracts.types import FileReference
 from application_sdk.observability.logger_adaptor import get_logger
@@ -62,6 +63,10 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ARTIFACT_SCHEMA_REMOVAL_VERSION",
+    # Re-exported from application_sdk.app.generated_tree, which owns the
+    # classification. Kept as a name here because this module's docstrings and
+    # `_declared_artifact_schema_keys`'s signature are written in terms of it.
+    "GeneratedLayout",
     "warn_undeclared_artifact_schemas",
 ]
 
@@ -73,10 +78,6 @@ _logger = get_logger(__name__)
 ARTIFACT_SCHEMA_REMOVAL_VERSION = "4.0"
 
 _ARTIFACT_SCHEMAS_FILENAME = "artifact_schemas.json"
-
-#: Shape of the committed ``app/generated/`` tree — the authority on where an
-#: entry point's declarations live.  Mirrors conformance K016's contract scan.
-GeneratedLayout = Literal["multi", "single", "unknown"]
 
 
 @dataclass(frozen=True)
@@ -114,43 +115,15 @@ class _Declarations:
 
 
 def _generated_layout() -> GeneratedLayout:
-    """Classify the committed ``app/generated/`` tree by the shape it actually has.
+    """Classify this app's committed generated tree.
 
-    Mirrors the contract scan conformance K016 uses, deliberately: the two must
-    agree on where an entry point's declarations live, or the same app gets two
-    different answers about the same file.
-
-    ``multi``
-        One or more immediate subdirectories each holding a ``manifest.json``.
-        Each subdirectory name is an entry point's wire name.
-    ``single``
-        A ``manifest.json`` at the root of the generated dir and no per-entry-point
-        subdirectories.
-    ``unknown``
-        No generated tree, or one carrying no ``manifest.json`` anywhere (a repo
-        that has not generated yet).  Nothing can be inferred about the layout, and
-        the caller says so rather than guessing.
-
-    **Why the tree and not ``len(entry_points)``.**  The layout is a property of
-    what the toolkit emitted, not of how many ``@entrypoint`` methods Python
-    happens to see.  A **route/card-split** app (BLDX-1342) is exactly where those
-    two disagree: it has several ``@entrypoint``\\ s the DAG invokes by
-    ``workflow_type``, but one marketplace card and therefore one *flat*
-    generated tree.  Counting Python entry points calls it a bundle and sends its
-    author to ``app/generated/<wire-name>/artifact_schemas.json`` — a file the
-    toolkit will never write for that app, so following the warning cannot clear
-    it.
+    Thin wrapper over :func:`application_sdk.app.generated_tree.generated_layout`
+    applied to :data:`~application_sdk.constants.CONTRACT_GENERATED_DIR`, which
+    is the authority — ``handler.service``'s configmap fallback and the
+    tenant-side route check read the same classifier, so the same app cannot get
+    two different answers about the same tree.
     """
-    generated = Path(CONTRACT_GENERATED_DIR)
-    try:
-        children = list(generated.iterdir())
-    except OSError:
-        return "unknown"
-    if any((child / "manifest.json").is_file() for child in children if child.is_dir()):
-        return "multi"
-    if (generated / "manifest.json").is_file():
-        return "single"
-    return "unknown"
+    return generated_layout(Path(CONTRACT_GENERATED_DIR))
 
 
 def _declared_artifact_schema_keys(

--- a/application_sdk/app/_artifact_schema_guard.py
+++ b/application_sdk/app/_artifact_schema_guard.py
@@ -53,7 +53,7 @@ from typing import TYPE_CHECKING, Annotated, Any, get_args, get_origin
 
 import orjson
 
-from application_sdk.app.generated_tree import GeneratedLayout, generated_layout
+from application_sdk.app._generated_tree import GeneratedLayout, generated_layout
 from application_sdk.constants import CONTRACT_GENERATED_DIR
 from application_sdk.contracts.types import FileReference
 from application_sdk.observability.logger_adaptor import get_logger
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ARTIFACT_SCHEMA_REMOVAL_VERSION",
-    # Re-exported from application_sdk.app.generated_tree, which owns the
+    # Re-exported from application_sdk.app._generated_tree, which owns the
     # classification. Kept as a name here because this module's docstrings and
     # `_declared_artifact_schema_keys`'s signature are written in terms of it.
     "GeneratedLayout",
@@ -117,7 +117,7 @@ class _Declarations:
 def _generated_layout() -> GeneratedLayout:
     """Classify this app's committed generated tree.
 
-    Thin wrapper over :func:`application_sdk.app.generated_tree.generated_layout`
+    Thin wrapper over :func:`application_sdk.app._generated_tree.generated_layout`
     applied to :data:`~application_sdk.constants.CONTRACT_GENERATED_DIR`, which
     is the authority — ``handler.service``'s configmap fallback and the
     tenant-side route check read the same classifier, so the same app cannot get

--- a/application_sdk/app/_generated_tree.py
+++ b/application_sdk/app/_generated_tree.py
@@ -27,6 +27,11 @@ the same copy the server does.
 Deliberately dependency-light: stdlib only, no logger, no constants import. It
 is imported by the request path in ``handler.service`` and by a CI-time check,
 so it must cost nothing and pull nothing.
+
+Private (leading underscore), like its siblings ``_artifact_schema_guard`` and
+``_ep_registration``: these are the SDK's own rules about its own generated
+tree, not a surface a consumer app should pin against. Nothing here is
+re-exported from ``application_sdk.app``.
 """
 
 from __future__ import annotations

--- a/application_sdk/app/generated_tree.py
+++ b/application_sdk/app/generated_tree.py
@@ -1,0 +1,166 @@
+"""The shape of the committed ``app/generated/`` tree, in one place.
+
+Three facts about that tree were, until FND-1667, each written down twice:
+
+* **which layout the tree has** — a bundle nests one directory per entry point,
+  while a single-generated-contract app (including a route/card-split app with
+  several ``@entrypoint``\\ s behind one card) emits everything flat.
+  :func:`generated_layout` is the authority, and
+  :mod:`application_sdk.app._artifact_schema_guard` delegates to it.
+* **which of the sibling ``*.json`` files is a setup form** — as opposed to the
+  DAG ``manifest`` or a per-object-store-family credential template.
+  :func:`is_form_configmap` is the authority, and
+  :mod:`application_sdk.handler.service` delegates to it.
+* **where an entry point's form actually lives**, given the two above.
+  :func:`form_configmap` is the authority; the tenant-side route check in
+  :mod:`application_sdk.testing.setup_routes` is its first caller.
+
+Keeping them here is not tidying. The route check added in FND-1667 asserts a
+join between what an app's contract generates and what its tenant serves, and
+the SDK is on *both* sides of that join: ``handler.service.get_configmap`` is
+the endpoint the tenant's ``/api/service/configmaps/<name>`` proxies to. A
+check that re-derived "which file is the form" would be comparing one guess
+against another, and would drift from the server the moment the exclusion
+vocabulary grew a prefix. There is one copy of each fact, and the check reads
+the same copy the server does.
+
+Deliberately dependency-light: stdlib only, no logger, no constants import. It
+is imported by the request path in ``handler.service`` and by a CI-time check,
+so it must cost nothing and pull nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+__all__ = [
+    "CREDENTIAL_TEMPLATE_PREFIXES",
+    "GeneratedLayout",
+    "MANIFEST_STEM",
+    "form_configmap",
+    "generated_layout",
+    "is_form_configmap",
+]
+
+#: Stem of the DAG manifest that sits alongside the generated setup forms.
+MANIFEST_STEM = "manifest"
+
+#: Non-form JSON siblings that live in the generated dir next to the setup-form
+#: configmaps. Credential templates are emitted per object-store family
+#: (``atlan-connectors-*.json``, ``csa-connectors-*.json``).
+#:
+#: Centralised so the form-discovery exclusion vocabulary is named once instead
+#: of re-spelled at each site: adding the next connector-family prefix here
+#: updates the server's fallback (``handler.service.get_configmap``) and the
+#: tenant-side route check together. They disagreeing is the failure this
+#: constant exists to make impossible — the server would serve one file and the
+#: check would compare against another, and the mismatch would read as a
+#: contract regression rather than as two different exclusion lists.
+CREDENTIAL_TEMPLATE_PREFIXES = ("atlan-connectors-", "csa-connectors-")
+
+#: Shape of the committed ``app/generated/`` tree — the authority on where an
+#: entry point's generated artifacts live. Mirrors conformance K016's contract
+#: scan.
+GeneratedLayout = Literal["multi", "single", "unknown"]
+
+
+def is_form_configmap(stem: str) -> bool:
+    """Whether a generated JSON stem is a setup-form configmap.
+
+    True when *stem* is neither the DAG ``manifest`` nor a credential template.
+
+    Args:
+        stem: A generated file's name without its ``.json`` suffix.
+    """
+    return stem != MANIFEST_STEM and not stem.startswith(CREDENTIAL_TEMPLATE_PREFIXES)
+
+
+def generated_layout(generated: Path) -> GeneratedLayout:
+    """Classify the committed generated tree by the shape it actually has.
+
+    ``multi``
+        One or more immediate subdirectories each holding a ``manifest.json``.
+        Each subdirectory name is an entry point's wire name.
+    ``single``
+        A ``manifest.json`` at the root of *generated* and no per-entry-point
+        subdirectories.
+    ``unknown``
+        No generated tree, or one carrying no ``manifest.json`` anywhere (a repo
+        that has not generated yet). Nothing can be inferred about the layout,
+        and every caller says so rather than guessing.
+
+    **Why the tree and not the Python entry-point count.** The layout is a
+    property of what the toolkit emitted, not of how many ``@entrypoint``
+    methods Python happens to see. A **route/card-split** app (BLDX-1342) is
+    exactly where the two disagree: it has several ``@entrypoint``\\ s the DAG
+    invokes by ``workflow_type``, but one marketplace card and therefore one
+    *flat* generated tree. Counting Python entry points calls it a bundle and
+    sends every consumer looking under a wire-name subdirectory the toolkit
+    will never write for that app.
+
+    Args:
+        generated: The generated directory, usually ``app/generated``.
+    """
+    try:
+        children = list(generated.iterdir())
+    except OSError:
+        return "unknown"
+    if any((child / "manifest.json").is_file() for child in children if child.is_dir()):
+        return "multi"
+    if (generated / "manifest.json").is_file():
+        return "single"
+    return "unknown"
+
+
+def form_configmap(
+    generated: Path, entrypoint: str, *, layout: GeneratedLayout | None = None
+) -> Path | None:
+    """Return the setup-form configmap for *entrypoint*, or ``None``.
+
+    Which directory is searched follows the *layout*, not the caller's belief
+    about how many entry points exist — see :func:`generated_layout`:
+
+    ``multi``
+        ``<generated>/<entrypoint>/`` only. A bundle's forms are nested, and
+        falling back to the root would let the root-level credential template
+        or another entry point's form answer for this one.
+    ``single``
+        ``<generated>/`` only, and *entrypoint* is ignored: a flat tree has one
+        form serving every route behind the single card.
+    ``unknown``
+        The nested directory, then the flat one — best effort, since a repo
+        that has not generated has nothing to be right about.
+
+    Within the chosen directory the first stem that :func:`is_form_configmap`
+    accepts wins, in sorted order for determinism. That exclusion is what keeps
+    a flat app's ``atlan-connectors-<source>.json`` from being mistaken for its
+    form: sorted alphabetically the credential template comes *first*, so a
+    glob without the exclusion picks the wrong file on every single-entrypoint
+    connector.
+
+    Args:
+        generated: The generated directory, usually ``app/generated``.
+        entrypoint: The entry point's kebab-case wire name, which is also its
+            directory name in a bundle's generated tree.
+        layout: The tree's shape. Computed from *generated* when omitted.
+
+    Returns:
+        The form's path, or ``None`` when the chosen directories hold no file
+        that qualifies.
+    """
+    resolved = generated_layout(generated) if layout is None else layout
+    if resolved == "single":
+        search: tuple[Path, ...] = (generated,)
+    elif resolved == "multi":
+        search = (generated / entrypoint,)
+    else:
+        search = (generated / entrypoint, generated)
+
+    for directory in search:
+        if not directory.is_dir():
+            continue
+        for candidate in sorted(directory.glob("*.json")):
+            if is_form_configmap(candidate.stem):
+                return candidate
+    return None

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -56,8 +56,8 @@ from pydantic import ValidationError
 from temporalio.client import WorkflowFailureError
 
 from application_sdk._runtime.offload import run_in_thread
+from application_sdk.app._generated_tree import is_form_configmap
 from application_sdk.app.entrypoint import canonical_workflow_type
-from application_sdk.app.generated_tree import is_form_configmap
 from application_sdk.common.dispatch import resolve_dispatch_workflow_id
 from application_sdk.common.task_queue import (
     resolve_manifest_tokens,
@@ -443,7 +443,7 @@ _storage: ObjectStore | None = None
 CONTRACT_GENERATED_DIR = Path(_CONTRACT_GENERATED_DIR)
 
 # The form-discovery exclusion vocabulary lives in
-# `application_sdk.app.generated_tree`, which is the authority: this endpoint is
+# `application_sdk.app._generated_tree`, which is the authority: this endpoint is
 # what a tenant's /api/service/configmaps/<name> proxies to, and the FND-1667
 # route check compares what this serves against the app's committed contract.
 # A second copy of "which sibling JSON is a form" would let the server serve one

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -57,6 +57,7 @@ from temporalio.client import WorkflowFailureError
 
 from application_sdk._runtime.offload import run_in_thread
 from application_sdk.app.entrypoint import canonical_workflow_type
+from application_sdk.app.generated_tree import is_form_configmap
 from application_sdk.common.dispatch import resolve_dispatch_workflow_id
 from application_sdk.common.task_queue import (
     resolve_manifest_tokens,
@@ -441,21 +442,15 @@ _storage: ObjectStore | None = None
 # Directory where generated contract JSON files are stored
 CONTRACT_GENERATED_DIR = Path(_CONTRACT_GENERATED_DIR)
 
-# Non-form JSON siblings that live in CONTRACT_GENERATED_DIR next to the
-# generated setup-form configmaps. Credential templates are emitted per
-# object-store family (`atlan-connectors-*.json`, `csa-connectors-*.json`).
-# Centralised so the form-discovery exclusion vocabulary is named in one place
-# instead of re-spelled inline; `_is_form_configmap` applies it in the
-# get_configmap default-entrypoint fallback, so adding the next connector-family
-# prefix here updates that site without re-spelling the list. `list_configmaps`
-# still uses its own `manifest`-only exclusion (a separate, deliberate decision).
-_CREDENTIAL_TEMPLATE_PREFIXES = ("atlan-connectors-", "csa-connectors-")
-
-
-def _is_form_configmap(stem: str) -> bool:
-    """True when a generated JSON stem is a setup-form configmap, i.e. neither
-    the DAG ``manifest`` nor a credential template."""
-    return stem != "manifest" and not stem.startswith(_CREDENTIAL_TEMPLATE_PREFIXES)
+# The form-discovery exclusion vocabulary lives in
+# `application_sdk.app.generated_tree`, which is the authority: this endpoint is
+# what a tenant's /api/service/configmaps/<name> proxies to, and the FND-1667
+# route check compares what this serves against the app's committed contract.
+# A second copy of "which sibling JSON is a form" would let the server serve one
+# file while the check compared against another — and that mismatch would read
+# as a contract regression rather than as two divergent exclusion lists.
+# `list_configmaps` below still uses its own `manifest`-only exclusion (a
+# separate, deliberate decision).
 
 
 # Allowlist regex for entrypoint names: letter-start, then letters/digits/hyphens/underscores.
@@ -1947,7 +1942,7 @@ def _register_workflow_routes(
                 #
                 # Pick the form file by excluding the well-known non-form
                 # siblings (`manifest.json` and the `{atlan,csa}-connectors-*`
-                # credential templates) via `_is_form_configmap`. Sorted for
+                # credential templates) via `is_form_configmap`. Sorted for
                 # determinism.
                 for search_dir in (
                     CONTRACT_GENERATED_DIR / ep.name,
@@ -1956,7 +1951,7 @@ def _register_workflow_routes(
                     if not search_dir.is_dir():
                         continue
                     for json_file in sorted(search_dir.glob("*.json")):
-                        if not _is_form_configmap(json_file.stem):
+                        if not is_form_configmap(json_file.stem):
                             continue
                         target = json_file
                         break

--- a/application_sdk/testing/setup_routes.py
+++ b/application_sdk/testing/setup_routes.py
@@ -42,7 +42,7 @@ Both sides of the join are the SDK's
 ``/api/service/configmaps/<name>`` is Heracles proxying to the app pod's own
 ``GET /workflows/v1/configmap/{id}`` — :mod:`application_sdk.handler.service`.
 So the envelope this module unwraps and the file-selection rule it applies are
-read from :mod:`application_sdk.app.generated_tree`, the same authority the
+read from :mod:`application_sdk.app._generated_tree`, the same authority the
 server reads. Re-deriving either would compare one guess against another and
 drift the moment the exclusion vocabulary grew a prefix.
 
@@ -80,7 +80,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from application_sdk.app.generated_tree import form_configmap, generated_layout
+from application_sdk.app._generated_tree import form_configmap, generated_layout
 
 __all__ = [
     "DEFAULT_CATALOG_WAIT_SECONDS",
@@ -271,7 +271,7 @@ def read_entrypoints(
     """Read every entry point's committed workflow config.
 
     The entry-point *names* come from ``atlan.yaml`` and the *files* are located
-    through :func:`application_sdk.app.generated_tree.form_configmap`, so this
+    through :func:`application_sdk.app._generated_tree.form_configmap`, so this
     agrees with the endpoint that serves them by construction rather than by a
     second glob that could drift.
 

--- a/application_sdk/testing/setup_routes.py
+++ b/application_sdk/testing/setup_routes.py
@@ -1,0 +1,716 @@
+"""Does every entry point's workflow-setup page actually resolve on a tenant?
+
+FND-1667. The FND-1593 contract migration shipped a change that 404'd both of a
+connector's setup pages while **every local and CI check stayed green**: the
+generated artifacts were self-consistent, conformance was clean (K001/K002
+cleared), and the generated-artifact freshness gate passed. Nothing was stale or
+hand-edited. The break lived only in the *join* between what the contract
+generates and what the tenant serves, and no gate looked there. A human opened
+the UI and found it.
+
+That is a gap, not a one-off: any contract change that moves a marketplace
+card's identity breaks the setup page for a connector while leaving every
+mechanical check satisfied.
+
+What the UI does, and what this therefore asserts
+-------------------------------------------------
+``src/pages/workflows/setup/[id]/index.vue`` in ``atlan-frontend`` takes the
+URL's ``id`` segment and spends it on two independent lookups:
+
+* ``useMarketplaceAppById(id)`` — finds the card in
+  ``GET /api/service/marketplace/apps`` by ``app.id == id``
+* ``useConfigMapByName(id)`` — ``GET /api/service/configmaps/<id>`` for the
+  form schema
+
+The marketplace grid builds the link **from the card**, so the route resolves
+only when the card's ``id`` is a name the configmap endpoint also answers to.
+Setting ``Entrypoint.packageId`` moves the card's identity onto the marketplace
+package, and the path is then derived from the package name — pointing at a name
+no configmap exists for.
+
+Why it is not circular
+----------------------
+A check asserting ``GET configmaps/<known-good-name> == 200`` **would have
+passed straight through the regression** — that name never stopped working.
+What moved was the card pointing at it. So the card is located by facts that are
+*not* the thing under test (the app ``name`` and the ``entrypoint`` name, both
+from the committed ``atlan.yaml``) and only then is its ``id`` compared against
+the ``id`` in the committed generated workflow config.
+
+Both sides of the join are the SDK's
+------------------------------------
+``/api/service/configmaps/<name>`` is Heracles proxying to the app pod's own
+``GET /workflows/v1/configmap/{id}`` — :mod:`application_sdk.handler.service`.
+So the envelope this module unwraps and the file-selection rule it applies are
+read from :mod:`application_sdk.app.generated_tree`, the same authority the
+server reads. Re-deriving either would compare one guess against another and
+drift the moment the exclusion vocabulary grew a prefix.
+
+Skip, don't fail
+----------------
+An app with no marketplace card (the behind-the-scenes pattern) and an app that
+has not generated a contract both have no setup page to check. Reporting those
+as failures would make this a fleet-wide false positive on its first run, so
+they are skips that say why. Only a *join that is actually broken* fails.
+
+Where it runs
+-------------
+This module is logic only — no argument parsing, no printing, no exit codes.
+The CLI shell around it is ``verify_setup_routes.py`` in the ``sdr-e2e``
+composite action, which is the one place with the SDK synced, the tenant
+credentials exported and an ordering strictly after ``prepare-tenant``'s
+install. Keeping the shell there and the logic here is what makes the checks
+below provable offline, and it keeps this module free of the ``print`` the SDK
+rightly bans.
+
+The token never reaches this module from argv — the shell reads it from the
+environment, because argv is visible in process listings and in ``set -x``
+output. Nothing here logs it; failures name URLs and statuses only.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from application_sdk.app.generated_tree import form_configmap, generated_layout
+
+__all__ = [
+    "DEFAULT_CATALOG_WAIT_SECONDS",
+    "Card",
+    "Entrypoint",
+    "RouteCheckSkipped",
+    "SetupRouteError",
+    "TenantRoutes",
+    "declared_inputs",
+    "input_shortfall",
+    "locate_cards",
+    "read_app_name",
+    "read_entrypoint_names",
+    "read_entrypoints",
+    "route_mismatch",
+    "served_inputs",
+    "verify",
+]
+
+# ---------------------------------------------------------------------------
+# Endpoint paths
+# ---------------------------------------------------------------------------
+
+#: Heracles mounts its service routes under this prefix, and ``atlan-frontend``
+#: builds both of these through ``getAPIPath(BASE_PATH='service', …)``. These are
+#: the frontend's paths, not ours: if it changes how it derives the setup route,
+#: this check goes stale. The mitigation is that it is in ONE place rather than
+#: in ~79 app repos.
+MARKETPLACE_APPS_PATH = "/api/service/marketplace/apps"
+CONFIGMAP_PATH = "/api/service/configmaps/{name}"
+
+_HTTP_TIMEOUT = 30
+_USER_AGENT = "atlan-application-sdk-setup-routes/1.0"
+
+#: Statuses that count as "this name is genuinely not served". The negative
+#: control accepts any of them rather than asserting which flavour of rejection
+#: Heracles picks — a 400 with ``code 1000`` is its reported shape for several
+#: faults, and pinning one would make the control brittle without making it
+#: stronger.
+_REJECTION_STATUSES = (400, 403, 404)
+
+#: How long to keep re-reading the catalog before concluding a card is absent.
+#:
+#: A bounded poll rather than a single read, because ``install()`` polling the
+#: *deployment* to SUCCEEDED is not evidence that the marketplace catalog and the
+#: app's configmap endpoint have caught up: the catalog is LM's snapshot and the
+#: configmaps are served by the pod, and nothing sequences those against the
+#: deployment verdict. The prototype this generalises never exercised the
+#: immediately-post-install path — every one of its runs read a tenant where the
+#: app had been installed earlier — so a single read here would be
+#: flaky-by-construction on exactly the path CI takes.
+DEFAULT_CATALOG_WAIT_SECONDS = 120
+_CATALOG_POLL_SECONDS = 10
+
+
+class SetupRouteError(RuntimeError):
+    """A setup route is broken, or the tenant could not be asked."""
+
+
+class RouteCheckSkipped(RuntimeError):
+    """There is no setup route to check, and that is not a failure.
+
+    Raised for an app with no marketplace card and for one that has not
+    generated a contract. Carries the reason so the caller can say why it
+    skipped instead of going quietly green.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Contract side — read from the committed artifacts, never hardcoded
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Entrypoint:
+    """One entry point, as the committed artifacts describe it."""
+
+    name: str
+    """Kebab-case wire name from ``atlan.yaml``. ``""`` for a flat app, whose
+    cards carry no ``entrypoint``."""
+
+    config_id: str
+    """``id`` from the generated workflow config — the name the form is served
+    under, and therefore the name the card must point at."""
+
+    declared: frozenset[str] = frozenset()
+    """Input names the committed contract declares for this entry point."""
+
+    source: Path | None = None
+    """The generated file that answered, for diagnostics."""
+
+
+def read_app_name(repo_root: Path) -> str:
+    """Return the app ``name`` from ``atlan.yaml``, as cards report it.
+
+    ``atlan.yaml``'s top-level ``name`` is the value the marketplace card's
+    ``name`` field carries, and it is the field the fleet is already forced to
+    commit — ``parse_atlan_yaml.py`` reads it on every release. Read here rather
+    than threaded in from a step output so the check has one source for it.
+    """
+    import yaml  # noqa: PLC0415 — deferred so an import of this module is cheap
+
+    path = repo_root / "atlan.yaml"
+    try:
+        parsed = yaml.safe_load(path.read_text()) or {}
+    except OSError as exc:
+        raise SetupRouteError(
+            f"cannot read {path}: {exc}. The route check runs in the app repo's "
+            "working directory and needs its committed atlan.yaml."
+        ) from exc
+    except yaml.YAMLError as exc:
+        raise SetupRouteError(f"{path} is invalid YAML: {exc}") from exc
+
+    name = str(parsed.get("name") or "").strip().lower()
+    if not name:
+        raise SetupRouteError(f'{path} has no top-level "name"')
+    return name
+
+
+def read_entrypoint_names(repo_root: Path) -> list[str]:
+    """Return the ``entrypoints[].name`` values that should have a setup page.
+
+    Empty is meaningful, not an error: a single-generated-contract app declares
+    no ``entrypoints`` block and is checked as one flat entry point keyed ``""``.
+
+    An entry point carrying ``marketplace_card: false`` is left out. That is the
+    behind-the-scenes pattern — an entry point the DAG invokes with no card for
+    a user to click — and it has no setup page to resolve, so asserting one
+    exists would be a false positive rather than a finding.
+
+    The **absence** of the key is not read as "no card", deliberately: live
+    connectors are cards today while emitting neither ``marketplace_card`` nor
+    ``package_id`` (the key only appears once ``packageId`` is set), so keying
+    on absence would skip the whole fleet and this check would assert nothing.
+    Only an explicit ``false`` opts out. FND-1659 is resolving what card
+    presence should key on; if it lands a clearer signal, this is the one place
+    that changes.
+    """
+    import yaml  # noqa: PLC0415 — see read_app_name
+
+    parsed = yaml.safe_load((repo_root / "atlan.yaml").read_text()) or {}
+    declared = parsed.get("entrypoints")
+    if not isinstance(declared, list):
+        return []
+    return [
+        str(entry["name"])
+        for entry in declared
+        if isinstance(entry, dict)
+        and entry.get("name")
+        and entry.get("marketplace_card", True) is not False
+    ]
+
+
+def _declares_any_entrypoint(repo_root: Path) -> bool:
+    """Whether ``atlan.yaml`` declares an ``entrypoints`` list with any entry.
+
+    Distinguishes "declares entrypoints, all of which opted out of a card" from
+    "declares no entrypoints at all" — a skip and a failure respectively, which
+    :func:`read_entrypoint_names` cannot tell apart on its own.
+    """
+    import yaml  # noqa: PLC0415 — see read_app_name
+
+    parsed = yaml.safe_load((repo_root / "atlan.yaml").read_text()) or {}
+    declared = parsed.get("entrypoints")
+    return isinstance(declared, list) and bool(declared)
+
+
+def declared_inputs(workflow_config: dict[str, Any]) -> frozenset[str]:
+    """Return the input names a generated workflow config declares.
+
+    ``config.properties`` is a flat dict keyed by the kebab-case input name.
+    Its siblings are deliberately not read: ``steps`` is the wizard
+    progression and ``anyOf`` the conditional-visibility rules, so neither is
+    the input set.
+    """
+    config = workflow_config.get("config")
+    if not isinstance(config, dict):
+        return frozenset()
+    properties = config.get("properties")
+    if not isinstance(properties, dict):
+        return frozenset()
+    return frozenset(str(key) for key in properties)
+
+
+def read_entrypoints(
+    repo_root: Path, generated_dir: str = "app/generated"
+) -> list[Entrypoint]:
+    """Read every entry point's committed workflow config.
+
+    The entry-point *names* come from ``atlan.yaml`` and the *files* are located
+    through :func:`application_sdk.app.generated_tree.form_configmap`, so this
+    agrees with the endpoint that serves them by construction rather than by a
+    second glob that could drift.
+
+    Raises:
+        RouteCheckSkipped: when the app has generated no contract — there is no
+            setup page for a tree that does not exist.
+        SetupRouteError: when a declared entry point has no generated config, or
+            its config carries no ``id``. Both mean the committed artifacts are
+            incoherent, which is a real failure rather than nothing to check.
+    """
+    generated = repo_root / generated_dir
+    layout = generated_layout(generated)
+    if layout == "unknown":
+        raise RouteCheckSkipped(
+            f"no generated contract under {generated} (no manifest.json at its "
+            "root or in any immediate subdirectory), so this app has no setup "
+            "form to serve and no route to check. Generate the contract if this "
+            "is unexpected."
+        )
+
+    names = read_entrypoint_names(repo_root) if layout == "multi" else [""]
+    if layout == "multi" and not names:
+        # Two different situations that must not share an outcome: an app whose
+        # entrypoints all declare `marketplace_card: false` has nothing to check
+        # (skip), while one declaring no entrypoints at all under a bundle
+        # layout is incoherent (fail). read_entrypoint_names returns an empty
+        # list for both.
+        if _declares_any_entrypoint(repo_root):
+            raise RouteCheckSkipped(
+                f"every entrypoint in {repo_root / 'atlan.yaml'} declares "
+                "marketplace_card: false, so none has a setup page for a user "
+                "to open and there is no route to check."
+            )
+        raise SetupRouteError(
+            f"{generated} has a bundle layout (per-entry-point subdirectories) "
+            "but atlan.yaml declares no entrypoints, so no entry point's card "
+            "can be located. One of the two is wrong."
+        )
+
+    found: list[Entrypoint] = []
+    for name in names:
+        path = form_configmap(generated, name, layout=layout)
+        if path is None:
+            raise SetupRouteError(
+                f"entrypoint {name!r} is declared in atlan.yaml but "
+                f"{generated / name if name else generated} holds no setup-form "
+                "configmap (only a manifest and/or credential templates). "
+                "Regenerate the contract."
+            )
+        try:
+            payload = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            raise SetupRouteError(f"cannot read {path}: {exc}") from exc
+        if not isinstance(payload, dict) or not payload.get("id"):
+            raise SetupRouteError(
+                f"{path} carries no top-level 'id', so there is no name for the "
+                "marketplace card to point at. Regenerate the contract."
+            )
+        found.append(
+            Entrypoint(
+                name=name,
+                config_id=str(payload["id"]),
+                declared=declared_inputs(payload),
+                source=path,
+            )
+        )
+    return found
+
+
+# ---------------------------------------------------------------------------
+# The pure checks — no network, so they are provable offline
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Card:
+    """One marketplace card, trimmed to the fields the check reads."""
+
+    id: str = ""
+    name: str = ""
+    entrypoint: str = ""
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> Card:
+        return cls(
+            id=str(payload.get("id") or ""),
+            name=str(payload.get("name") or ""),
+            entrypoint=str(payload.get("entrypoint") or ""),
+        )
+
+
+def route_mismatch(entrypoint: str, card: Card, config_id: str) -> str | None:
+    """Why this entry point's setup page will 404, or ``None`` if it resolves.
+
+    Pure, so the assertion it backs is provable without a tenant — see
+    ``tests/unit/testing/test_setup_routes.py``, which feeds it the card shape
+    the FND-1593 regression produced and asserts it reports the break naming
+    both sides.
+
+    Args:
+        entrypoint: The entry point's wire name, for the message.
+        card: The card the tenant serves, located by app name + entrypoint.
+        config_id: The ``id`` in this repo's committed workflow config.
+    """
+    if not card.id:
+        return (
+            f"Entrypoint {entrypoint or '<flat>'!r}: the marketplace card has no "
+            "id, so the marketplace cannot build a setup link for it at all."
+        )
+    if not config_id:
+        return (
+            f"Entrypoint {entrypoint or '<flat>'!r}: the generated workflow "
+            "config has no id. Regenerate the contract."
+        )
+    if card.id != config_id:
+        return (
+            f"Entrypoint {entrypoint or '<flat>'!r}: the marketplace card's id "
+            f"is {card.id!r}, but this repo generates its workflow config as "
+            f"{config_id!r}. The UI builds /workflows/setup/{card.id} from the "
+            f"card and the form is only served for {config_id!r}, so that page "
+            "404s for every user. A contract change that moves the card id — "
+            "setting `packageId` on the entrypoint is the known one (FND-1659) "
+            "— is the cause."
+        )
+    return None
+
+
+def input_shortfall(
+    entrypoint: str, declared: frozenset[str], served: frozenset[str]
+) -> str | None:
+    """Which declared inputs the tenant is not serving, or ``None``.
+
+    A **subset** check, not equality: the platform may decorate the schema with
+    fields the contract never named, and failing on those buys no safety. A
+    *missing* input is the signal — the deployed image predates the contract, or
+    a contract change never reached the tenant.
+    """
+    if not declared:
+        return (
+            f"Entrypoint {entrypoint or '<flat>'!r}: the committed workflow "
+            "config declares no inputs at all, so this check cannot tell a "
+            "served form from an empty one. Regenerate the contract."
+        )
+    missing = declared - served
+    if missing:
+        return (
+            f"Entrypoint {entrypoint or '<flat>'!r}: the tenant's form schema is "
+            f"missing {sorted(missing)}, which this repo's committed contract "
+            "declares. Most likely the tenant runs an older image than this "
+            "branch; it can also mean a contract change never reached the "
+            f"deployed app. Served: {sorted(served)}."
+        )
+    return None
+
+
+def locate_cards(
+    app_name: str, entrypoints: list[str], payloads: list[dict[str, Any]]
+) -> tuple[dict[str, Card], str | None]:
+    """Pick this app's cards out of the whole catalog, keyed by entry point.
+
+    Matched on app ``name`` **and** ``entrypoint``. Both are required: an
+    ``entrypoint`` alone is not app-scoped — every connector's crawler card
+    carries ``entrypoint: "crawler"``, so filtering on it alone matched a dozen
+    unrelated apps when the prototype tried it, and the count was plausible
+    enough to look like success.
+
+    Returns:
+        The cards found, and a reason string when one or more declared entry
+        points has no card (``None`` when every one resolved).
+    """
+    ours = [
+        card
+        for card in (Card.from_payload(p) for p in payloads)
+        if card.name == app_name
+    ]
+    by_entrypoint = {card.entrypoint: card for card in ours}
+
+    if not ours:
+        return {}, (
+            f"no marketplace card has name={app_name!r}. The tenant listed "
+            f"{len(payloads)} apps, so the catalog is readable — this app's "
+            "build is most likely not installed on this tenant."
+        )
+
+    missing = [name for name in entrypoints if name not in by_entrypoint]
+    if missing:
+        return by_entrypoint, (
+            f"{app_name!r} generates entrypoints {sorted(entrypoints)} but the "
+            f"tenant lists cards for {sorted(by_entrypoint)}. Missing: "
+            f"{sorted(missing)} — an entrypoint with no card has no setup page "
+            "at all. Either the installed build predates it, or the catalog "
+            "stopped expanding entrypoint cards."
+        )
+    return by_entrypoint, None
+
+
+def served_inputs(body: dict[str, Any]) -> frozenset[str]:
+    """Unwrap a ConfigMap response and return the input names it serves.
+
+    The endpoint answers with a K8s ConfigMap whose ``data.config`` is the form
+    schema as a JSON **string**, not a nested object — see
+    ``handler.service.get_configmap``, which builds it as
+    ``{"config": dumps(raw.get("config", raw))}``. The parsed value is therefore
+    the committed file's ``config`` VALUE: one nesting level shallower than the
+    committed file, which is the easiest thing to get wrong here.
+    """
+    data = body.get("data")
+    if not isinstance(data, dict):
+        raise SetupRouteError(
+            "configmap response carries no 'data' object; the endpoint's "
+            f"response shape has changed (keys: {sorted(body)})"
+        )
+    raw = data.get("config")
+    if not isinstance(raw, str):
+        raise SetupRouteError(
+            "configmap response has no string data.config; got "
+            f"{type(raw).__name__}. The endpoint's response shape has changed."
+        )
+    try:
+        schema = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SetupRouteError(f"data.config is not valid JSON: {exc}") from exc
+    properties = schema.get("properties") if isinstance(schema, dict) else None
+    if not isinstance(properties, dict):
+        return frozenset()
+    return frozenset(str(key) for key in properties)
+
+
+# ---------------------------------------------------------------------------
+# Tenant side
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TenantRoutes:
+    """Reads the two routes the setup page walks, with one bearer credential."""
+
+    base_url: str
+    bearer: str = field(repr=False)
+
+    def __post_init__(self) -> None:
+        candidate = self.base_url.strip().rstrip("/")
+        parsed = urllib.parse.urlparse(candidate)
+        if (
+            parsed.scheme != "https"
+            or not parsed.hostname
+            or parsed.username
+            or parsed.password
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise SetupRouteError(
+                f"invalid tenant base URL {self.base_url!r}: expected a bare "
+                "https://<host> with no userinfo, query, or fragment."
+            )
+        self.base_url = candidate
+
+    def get(self, path: str) -> tuple[int, object]:
+        """One GET. Returns ``(status, parsed_body)``; non-2xx is returned.
+
+        Redirects are NOT followed, deliberately: a 302 to a login page would
+        otherwise turn an auth failure into a 200 and mask everything
+        downstream.
+        """
+        request = urllib.request.Request(  # noqa: S310 — https base validated in __post_init__
+            f"{self.base_url}{path}", method="GET"
+        )
+        request.add_header("Authorization", f"Bearer {self.bearer}")
+        request.add_header("Accept", "application/json")
+        request.add_header("User-Agent", _USER_AGENT)
+        try:
+            with urllib.request.urlopen(  # noqa: S310 — see above
+                request, timeout=_HTTP_TIMEOUT
+            ) as response:
+                return response.status, _parse(response.read())
+        except urllib.error.HTTPError as exc:
+            return exc.code, _parse(exc.read())
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            raise SetupRouteError(
+                f"GET {path} could not reach {self.base_url}: {exc}"
+            ) from exc
+
+    def catalog(self) -> list[dict[str, Any]]:
+        """Every marketplace card the tenant lists."""
+        status, body = self.get(MARKETPLACE_APPS_PATH)
+        if status != 200 or not isinstance(body, dict):
+            raise SetupRouteError(
+                f"GET {MARKETPLACE_APPS_PATH} returned {status}; cannot resolve "
+                "marketplace cards. Check the token has marketplace read access."
+            )
+        apps = body.get("apps")
+        if not isinstance(apps, list):
+            raise SetupRouteError(
+                f"GET {MARKETPLACE_APPS_PATH} returned no 'apps' list "
+                f"(keys: {sorted(body)}); the response shape has changed."
+            )
+        # A truncated catalog reads as "this app is not installed" — a silent
+        # wrong answer, and the worst possible failure for a check whose value
+        # is that it does not false-positive. The endpoint reports `total`
+        # alongside the page, and no pagination parameter was needed at the
+        # ~140-app scale this was confirmed at; if a page limit is ever
+        # introduced, this turns a plausible-looking miss into a loud one
+        # rather than leaving the check quietly reading a prefix.
+        total = body.get("total")
+        if isinstance(total, int) and total > len(apps):
+            raise SetupRouteError(
+                f"GET {MARKETPLACE_APPS_PATH} reported total={total} but "
+                f"returned only {len(apps)} cards, so the catalog is paginated "
+                "and this read saw a prefix of it. An app missing from a "
+                "truncated page is indistinguishable from one that is not "
+                "installed, so this fails rather than guessing. The reader "
+                "needs a pagination parameter."
+            )
+        return [entry for entry in apps if isinstance(entry, dict)]
+
+    def configmap(self, name: str) -> tuple[int, dict[str, Any]]:
+        """Fetch one configmap by name, exactly as the setup page does."""
+        status, body = self.get(
+            CONFIGMAP_PATH.format(name=urllib.parse.quote(name, safe=""))
+        )
+        return status, body if isinstance(body, dict) else {}
+
+
+def _parse(raw: bytes) -> object:
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return raw.decode(errors="replace")
+
+
+def _await_cards(
+    routes: TenantRoutes,
+    app_name: str,
+    entrypoint_names: list[str],
+    wait_seconds: int,
+    on_progress: Callable[[str], None] | None = None,
+) -> dict[str, Card]:
+    """Poll the catalog until every entry point has a card, or give up.
+
+    See :data:`DEFAULT_CATALOG_WAIT_SECONDS` for why this polls rather than
+    reading once. The LAST reason is raised, not the first: an early read that
+    saw no card at all is less informative than a late one that saw all but one.
+    """
+    deadline = time.monotonic() + max(wait_seconds, 0)
+    reason = "the catalog was never read"
+    while True:
+        cards, reason_now = locate_cards(app_name, entrypoint_names, routes.catalog())
+        if reason_now is None:
+            return cards
+        reason = reason_now
+        if time.monotonic() >= deadline:
+            raise SetupRouteError(
+                f"{reason} Waited {wait_seconds}s for the marketplace catalog to "
+                "reconcile after the install."
+            )
+        if on_progress is not None:
+            on_progress(
+                f"catalog not ready ({reason_now}); "
+                f"retrying in {_CATALOG_POLL_SECONDS}s"
+            )
+        time.sleep(_CATALOG_POLL_SECONDS)
+
+
+def verify(
+    repo_root: Path,
+    routes: TenantRoutes,
+    *,
+    generated_dir: str = "app/generated",
+    wait_seconds: int = DEFAULT_CATALOG_WAIT_SECONDS,
+    on_progress: Callable[[str], None] | None = None,
+) -> list[str]:
+    """Check every entry point's setup route. Returns the lines to report.
+
+    Raises:
+        RouteCheckSkipped: when there is no setup route to check.
+        SetupRouteError: when a route is broken or the tenant cannot be asked.
+    """
+    app_name = read_app_name(repo_root)
+    entrypoints = read_entrypoints(repo_root, generated_dir)
+    cards = _await_cards(
+        routes, app_name, [e.name for e in entrypoints], wait_seconds, on_progress
+    )
+
+    # Negative control FIRST. Everything below asserts that a name the tenant
+    # knows answers 200; if the endpoint answered 200 for names it does not
+    # know, all of it would be vacuous — so prove the endpoint discriminates
+    # before trusting a single 200 from it.
+    bogus = f"{app_name}-nonexistent-setup-route-check"
+    status, _ = routes.configmap(bogus)
+    if status not in _REJECTION_STATUSES:
+        raise SetupRouteError(
+            f"GET {CONFIGMAP_PATH.format(name=bogus)} returned {status} for a "
+            "name that does not exist. Every assertion in this check relies on "
+            "an unknown config name being rejected, so none of them proves "
+            "anything until that holds."
+        )
+
+    report: list[str] = []
+    failures: list[str] = []
+    for entrypoint in entrypoints:
+        card = cards[entrypoint.name]
+        label = entrypoint.name or "<flat>"
+
+        mismatch = route_mismatch(entrypoint.name, card, entrypoint.config_id)
+        if mismatch is not None:
+            failures.append(mismatch)
+            continue
+
+        status, body = routes.configmap(card.id)
+        if status != 200:
+            failures.append(
+                f"Entrypoint {label!r}: GET "
+                f"{CONFIGMAP_PATH.format(name=card.id)} returned {status}. That "
+                f"is the request /workflows/setup/{card.id} makes to render its "
+                "form, so a non-200 here is a 404'd setup page for a user."
+            )
+            continue
+
+        served_name = (body.get("metadata") or {}).get("name")
+        if served_name != card.id:
+            failures.append(
+                f"Entrypoint {label!r}: asked the configmap endpoint for "
+                f"{card.id!r} and it served {served_name!r}. The setup page "
+                "would render another entry point's form."
+            )
+            continue
+
+        shortfall = input_shortfall(
+            entrypoint.name, entrypoint.declared, served_inputs(body)
+        )
+        if shortfall is not None:
+            failures.append(shortfall)
+            continue
+
+        report.append(
+            f"{label}: /workflows/setup/{card.id} resolves; "
+            f"{len(entrypoint.declared)} declared inputs all served"
+        )
+
+    if failures:
+        raise SetupRouteError("\n".join(failures))
+    return report

--- a/application_sdk/testing/setup_routes.py
+++ b/application_sdk/testing/setup_routes.py
@@ -75,7 +75,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -136,6 +136,37 @@ DEFAULT_CATALOG_WAIT_SECONDS = 120
 _CATALOG_POLL_SECONDS = 10
 
 
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Declines every redirect instead of following it.
+
+    Returning ``None`` from ``redirect_request`` tells urllib the response was
+    not handled, so the 3xx surfaces as an :class:`~urllib.error.HTTPError`
+    carrying its real status rather than being replaced by whatever the
+    redirect target returns.
+
+    This exists because the failure it prevents is invisible: a tenant that
+    bounces an unauthenticated request to a login page would otherwise hand
+    this check a 200, and a check built on "200 means the form is served"
+    cannot tell that from success.
+    """
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: object,
+        code: int,
+        msg: str,
+        headers: object,
+        newurl: str,
+    ) -> None:
+        return None
+
+
+#: Built once: an opener is stateless here and rebuilding it per request would
+#: re-parse the handler chain on every call.
+_OPENER = urllib.request.build_opener(_NoRedirect())
+
+
 class SetupRouteError(RuntimeError):
     """A setup route is broken, or the tenant could not be asked."""
 
@@ -156,15 +187,41 @@ class RouteCheckSkipped(RuntimeError):
 
 @dataclass(frozen=True)
 class Entrypoint:
-    """One entry point, as the committed artifacts describe it."""
+    """One entry point, as the committed artifacts describe it.
+
+    **Never carries an empty name.** An earlier revision keyed a flat app's
+    single contract under ``""``, which quietly became a magic value doing two
+    unrelated jobs — "this app declares no entrypoints" and "match a card whose
+    entrypoint field is blank" — and made a healthy single-card app report as
+    having no card at all. Every entry point here has a real, committed,
+    non-empty label, and every one is validated explicitly.
+    """
 
     name: str
-    """Kebab-case wire name from ``atlan.yaml``. ``""`` for a flat app, whose
-    cards carry no ``entrypoint``."""
+    """The label this entry point is checked and reported under; never empty.
+
+    For an app declaring ``entrypoints[]``, the kebab-case wire name from
+    ``atlan.yaml`` — which is also its directory in the generated tree and the
+    ``entrypoint`` its marketplace card carries.
+
+    For an app declaring none, the generated config's own ``id`` (``mysql``).
+    That is a committed fact rather than a placeholder, and it keeps the label
+    meaningful in a message without inventing a name the app never wrote down.
+    """
 
     config_id: str
     """``id`` from the generated workflow config — the name the form is served
     under, and therefore the name the card must point at."""
+
+    is_sole: bool = False
+    """``True`` when the app declares no ``entrypoints[]``, so this is its one
+    contract and its one card.
+
+    Load-bearing for card matching, and the reason no default has to be
+    calculated: with one card there is nothing to choose between, so the card's
+    own ``entrypoint`` field — whatever the catalog wrote there — takes no part
+    in the match. A bundle's cards are always matched by name.
+    """
 
     declared: frozenset[str] = frozenset()
     """Input names the committed contract declares for this entry point."""
@@ -226,10 +283,13 @@ def read_entrypoint_names(repo_root: Path) -> list[str]:
     if not isinstance(declared, list):
         return []
     return [
-        str(entry["name"])
+        str(entry["name"]).strip()
         for entry in declared
         if isinstance(entry, dict)
-        and entry.get("name")
+        # A blank or whitespace-only name is dropped rather than carried: it
+        # cannot name a directory, cannot match a card, and would reintroduce
+        # the empty-string key this module deliberately has no place for.
+        and str(entry.get("name") or "").strip()
         and entry.get("marketplace_card", True) is not False
     ]
 
@@ -292,7 +352,11 @@ def read_entrypoints(
             "is unexpected."
         )
 
-    names = read_entrypoint_names(repo_root) if layout == "multi" else [""]
+    sole = layout != "multi"
+    # One pass for a sole contract. `form_configmap` ignores the entrypoint
+    # for a non-`multi` layout, and the Entrypoint built below is labelled by
+    # its committed config id — so this value names nothing and is never a key.
+    names = ["<sole>"] if sole else read_entrypoint_names(repo_root)
     if layout == "multi" and not names:
         # Two different situations that must not share an outcome: an app whose
         # entrypoints all declare `marketplace_card: false` has nothing to check
@@ -330,10 +394,14 @@ def read_entrypoints(
                 f"{path} carries no top-level 'id', so there is no name for the "
                 "marketplace card to point at. Regenerate the contract."
             )
+        config_id = str(payload["id"])
         found.append(
             Entrypoint(
-                name=name,
-                config_id=str(payload["id"]),
+                # A sole contract is labelled by its own committed config id, so
+                # no entry point here ever carries an empty name.
+                name=config_id if sole else name,
+                config_id=config_id,
+                is_sole=sole,
                 declared=declared_inputs(payload),
                 source=path,
             )
@@ -378,17 +446,17 @@ def route_mismatch(entrypoint: str, card: Card, config_id: str) -> str | None:
     """
     if not card.id:
         return (
-            f"Entrypoint {entrypoint or '<flat>'!r}: the marketplace card has no "
+            f"Entrypoint {entrypoint!r}: the marketplace card has no "
             "id, so the marketplace cannot build a setup link for it at all."
         )
     if not config_id:
         return (
-            f"Entrypoint {entrypoint or '<flat>'!r}: the generated workflow "
+            f"Entrypoint {entrypoint!r}: the generated workflow "
             "config has no id. Regenerate the contract."
         )
     if card.id != config_id:
         return (
-            f"Entrypoint {entrypoint or '<flat>'!r}: the marketplace card's id "
+            f"Entrypoint {entrypoint!r}: the marketplace card's id "
             f"is {card.id!r}, but this repo generates its workflow config as "
             f"{config_id!r}. The UI builds /workflows/setup/{card.id} from the "
             f"card and the form is only served for {config_id!r}, so that page "
@@ -411,14 +479,14 @@ def input_shortfall(
     """
     if not declared:
         return (
-            f"Entrypoint {entrypoint or '<flat>'!r}: the committed workflow "
+            f"Entrypoint {entrypoint!r}: the committed workflow "
             "config declares no inputs at all, so this check cannot tell a "
             "served form from an empty one. Regenerate the contract."
         )
     missing = declared - served
     if missing:
         return (
-            f"Entrypoint {entrypoint or '<flat>'!r}: the tenant's form schema is "
+            f"Entrypoint {entrypoint!r}: the tenant's form schema is "
             f"missing {sorted(missing)}, which this repo's committed contract "
             "declares. Most likely the tenant runs an older image than this "
             "branch; it can also mean a contract change never reached the "
@@ -428,7 +496,9 @@ def input_shortfall(
 
 
 def locate_cards(
-    app_name: str, entrypoints: list[str], payloads: list[dict[str, Any]]
+    app_name: str,
+    entrypoints: Sequence[Entrypoint],
+    payloads: list[dict[str, Any]],
 ) -> tuple[dict[str, Card], str | None]:
     """Pick this app's cards out of the whole catalog, keyed by entry point.
 
@@ -438,17 +508,34 @@ def locate_cards(
     unrelated apps when the prototype tried it, and the count was plausible
     enough to look like success.
 
+    **A sole contract is matched by count, not by label.** An app declaring no
+    ``entrypoints[]`` has one form and one card, so there is nothing to choose
+    between and the card's ``entrypoint`` field takes no part in the match —
+    which is what lets a route/card-split app, whose single card is served
+    carrying one of its several route names, resolve correctly.
+
+    That is also why no default entry point is calculated anywhere in this
+    module. ``@entrypoint(default=True)`` is a runtime ``AppRegistry`` flag
+    absent from both ``atlan.yaml`` and ``manifest.json``, so any default
+    computed here would be a presumption — and every case that might have
+    needed one is answered by a fact instead: a bundle matches by name, and a
+    sole contract matches because it is the only one.
+
     Returns:
         The cards found, and a reason string when one or more declared entry
         points has no card (``None`` when every one resolved).
     """
+    # Case-folded on both sides. `read_app_name` lowercases atlan.yaml's `name`,
+    # but a card's `name` is whatever the catalog stores, and comparing the two
+    # verbatim reports a mixed-case card as "this app is not installed on this
+    # tenant" — a false negative wearing the most misleading message this check
+    # can emit. Stripped as well, for the same reason: neither side is a value
+    # we control the formatting of.
     ours = [
         card
         for card in (Card.from_payload(p) for p in payloads)
-        if card.name == app_name
+        if card.name.strip().lower() == app_name.strip().lower()
     ]
-    by_entrypoint = {card.entrypoint: card for card in ours}
-
     if not ours:
         return {}, (
             f"no marketplace card has name={app_name!r}. The tenant listed "
@@ -456,10 +543,51 @@ def locate_cards(
             "build is most likely not installed on this tenant."
         )
 
-    missing = [name for name in entrypoints if name not in by_entrypoint]
+    # A flat generated tree means ONE card, and its `entrypoint` is the tenant's
+    # business rather than ours: a route/card-split app has several
+    # `@entrypoint`s behind a single card, and that card is served carrying one
+    # of their names (`entrypoint: "crawler"`), not the empty string this check
+    # keys a flat tree under. Matching on the key would report a perfectly
+    # healthy single-card app as having no card at all.
+    #
+    # So for a flat tree the entrypoint is not part of the match — the app name
+    # already identified the card, and there is only one to identify.
+    if len(entrypoints) == 1 and entrypoints[0].is_sole:
+        sole = entrypoints[0]
+        if len(ours) > 1:
+            return {}, (
+                f"{app_name!r} declares no entrypoints and generates one setup "
+                f"form, but the tenant lists {len(ours)} cards for it "
+                f"(entrypoints: {sorted(card.entrypoint for card in ours)}). "
+                "Which card's id the setup route should match is ambiguous, so "
+                "this reports rather than guessing — most likely the generated "
+                "tree and the installed build disagree about the app's shape."
+            )
+        return {sole.name: ours[0]}, None
+
+    by_entrypoint = {card.entrypoint: card for card in ours if card.entrypoint}
+    names = [entrypoint.name for entrypoint in entrypoints]
+
+    unlabelled = [card for card in ours if not card.entrypoint]
+    if unlabelled:
+        # Reported, never attributed. This app declares its entrypoints by name,
+        # so a card carrying none cannot be assigned to one without a guess —
+        # and a guess here produces a spurious "the card points at the wrong
+        # form" that reads exactly like a real contract break.
+        return by_entrypoint, (
+            f"{app_name!r} declares entrypoints {sorted(names)}, but the tenant "
+            f"serves {len(unlabelled)} card(s) for it carrying no entrypoint "
+            f"(ids: {sorted(card.id for card in unlabelled)}). An unlabelled "
+            "card cannot be attributed to a named entrypoint, so this reports "
+            "it rather than presuming one. The usual cause is an installed "
+            "build that predates the entrypoint split, serving one card where "
+            "this branch generates several."
+        )
+
+    missing = [name for name in names if name not in by_entrypoint]
     if missing:
         return by_entrypoint, (
-            f"{app_name!r} generates entrypoints {sorted(entrypoints)} but the "
+            f"{app_name!r} generates entrypoints {sorted(names)} but the "
             f"tenant lists cards for {sorted(by_entrypoint)}. Missing: "
             f"{sorted(missing)} — an entrypoint with no card has no setup page "
             "at all. Either the installed build predates it, or the catalog "
@@ -532,9 +660,19 @@ class TenantRoutes:
     def get(self, path: str) -> tuple[int, object]:
         """One GET. Returns ``(status, parsed_body)``; non-2xx is returned.
 
-        Redirects are NOT followed, deliberately: a 302 to a login page would
-        otherwise turn an auth failure into a 200 and mask everything
-        downstream.
+        Redirects are declined rather than followed, via :class:`_NoRedirect`.
+        ``urlopen`` follows them by default, and that default is actively
+        dangerous here: a 302 to a login page would arrive as a **200 carrying
+        an HTML login form**, which turns an auth failure into a success. The
+        negative control would then see a "200" for a config name that cannot
+        exist and conclude the endpoint does not discriminate — except it never
+        gets that far, because a 200-shaped login page fails the JSON parse
+        first. Either way the failure is about the redirect and reads as
+        something else entirely.
+
+        A declined redirect surfaces as its real 3xx status, which no caller
+        treats as success and which the catalog read reports as a token
+        problem — the actual cause.
         """
         request = urllib.request.Request(  # noqa: S310 — https base validated in __post_init__
             f"{self.base_url}{path}", method="GET"
@@ -543,11 +681,14 @@ class TenantRoutes:
         request.add_header("Accept", "application/json")
         request.add_header("User-Agent", _USER_AGENT)
         try:
-            with urllib.request.urlopen(  # noqa: S310 — see above
+            with _OPENER.open(  # noqa: S310 — see above
                 request, timeout=_HTTP_TIMEOUT
             ) as response:
                 return response.status, _parse(response.read())
         except urllib.error.HTTPError as exc:
+            # A declined redirect lands here too, carrying its own 3xx status:
+            # `redirect_request` returning None makes urllib treat the response
+            # as unhandled, and the error processor raises it.
             return exc.code, _parse(exc.read())
         except (urllib.error.URLError, TimeoutError, OSError) as exc:
             raise SetupRouteError(
@@ -605,7 +746,7 @@ def _parse(raw: bytes) -> object:
 def _await_cards(
     routes: TenantRoutes,
     app_name: str,
-    entrypoint_names: list[str],
+    entrypoints: Sequence[Entrypoint],
     wait_seconds: int,
     on_progress: Callable[[str], None] | None = None,
 ) -> dict[str, Card]:
@@ -618,7 +759,7 @@ def _await_cards(
     deadline = time.monotonic() + max(wait_seconds, 0)
     reason = "the catalog was never read"
     while True:
-        cards, reason_now = locate_cards(app_name, entrypoint_names, routes.catalog())
+        cards, reason_now = locate_cards(app_name, entrypoints, routes.catalog())
         if reason_now is None:
             return cards
         reason = reason_now
@@ -651,9 +792,7 @@ def verify(
     """
     app_name = read_app_name(repo_root)
     entrypoints = read_entrypoints(repo_root, generated_dir)
-    cards = _await_cards(
-        routes, app_name, [e.name for e in entrypoints], wait_seconds, on_progress
-    )
+    cards = _await_cards(routes, app_name, entrypoints, wait_seconds, on_progress)
 
     # Negative control FIRST. Everything below asserts that a name the tenant
     # knows answers 200; if the endpoint answered 200 for names it does not
@@ -673,7 +812,7 @@ def verify(
     failures: list[str] = []
     for entrypoint in entrypoints:
         card = cards[entrypoint.name]
-        label = entrypoint.name or "<flat>"
+        label = entrypoint.name
 
         mismatch = route_mismatch(entrypoint.name, card, entrypoint.config_id)
         if mismatch is not None:

--- a/application_sdk/testing/setup_routes.py
+++ b/application_sdk/testing/setup_routes.py
@@ -78,7 +78,7 @@ import urllib.request
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 from application_sdk.app._generated_tree import form_configmap, generated_layout
 
@@ -87,6 +87,7 @@ __all__ = [
     "Card",
     "Entrypoint",
     "RouteCheckSkipped",
+    "RouteReader",
     "SetupRouteError",
     "TenantRoutes",
     "declared_inputs",
@@ -165,6 +166,30 @@ class _NoRedirect(urllib.request.HTTPRedirectHandler):
 #: Built once: an opener is stateless here and rebuilding it per request would
 #: re-parse the handler chain on every call.
 _OPENER = urllib.request.build_opener(_NoRedirect())
+
+
+class RouteReader(Protocol):
+    """The two reads :func:`verify` needs from a tenant.
+
+    Declared as a Protocol rather than typed against :class:`TenantRoutes`
+    because ``verify`` genuinely needs only these two methods — the transport,
+    the credential and the redirect policy are all `TenantRoutes`' business and
+    none of them reaches this far.
+
+    It is also what keeps the test suite free of suppressions. Annotating the
+    parameter with the concrete class meant every test passing a fake needed a
+    ``# type: ignore[arg-type]``, and fourteen identical suppressions are worse
+    than one honest signature: each one is a place where a genuine type error
+    would be silenced too.
+    """
+
+    def catalog(self) -> list[dict[str, Any]]:
+        """Every marketplace card the tenant lists."""
+        ...
+
+    def configmap(self, name: str) -> tuple[int, dict[str, Any]]:
+        """Fetch one configmap by name, as the setup page does."""
+        ...
 
 
 class SetupRouteError(RuntimeError):
@@ -744,7 +769,7 @@ def _parse(raw: bytes) -> object:
 
 
 def _await_cards(
-    routes: TenantRoutes,
+    routes: RouteReader,
     app_name: str,
     entrypoints: Sequence[Entrypoint],
     wait_seconds: int,
@@ -778,7 +803,7 @@ def _await_cards(
 
 def verify(
     repo_root: Path,
-    routes: TenantRoutes,
+    routes: RouteReader,
     *,
     generated_dir: str = "app/generated",
     wait_seconds: int = DEFAULT_CATALOG_WAIT_SECONDS,

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.32.1
-source-sha:    158e0a82071d1eb0a98c53abe7b9950ef4b6f434
-source-date:   2026-09-04T22:17:44+01:00
+source-sha:    6f91b14cea9a0be7db64fc4061b3e836fc0729b9
+source-date:   2026-09-05T00:27:17+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -3542,7 +3542,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `Entrypoint`
 
 - **Import:** `from application_sdk.testing.setup_routes import Entrypoint`
-- **Signature:** `class Entrypoint(name: str, config_id: str, declared: frozenset[str] = frozenset(), source: Path | None = None) -> None`
+- **Signature:** `class Entrypoint(name: str, ...)`
 - **Summary:** One entry point, as the committed artifacts describe it.
 - **Defined in:** `application_sdk/testing/setup_routes.py`
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 44 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 7 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 342 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 343 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -4014,6 +4014,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Import:** `from application_sdk.testing.setup_routes import RouteCheckSkipped`
 - **Signature:** `class RouteCheckSkipped`
 - **Summary:** There is no setup route to check, and that is not a failure.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
+
+#### `RouteReader`
+
+- **Import:** `from application_sdk.testing.setup_routes import RouteReader`
+- **Signature:** `class RouteReader`
+- **Summary:** The two reads :func:`verify` needs from a tenant.
 - **Defined in:** `application_sdk/testing/setup_routes.py`
 
 #### `RunLookup`

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.31.0
-source-sha:    f3045c7ac582ccbdd1064752739cacaca68eecd6
-source-date:   2026-09-02T13:38:19+00:00
+sdk-version:   3.32.1
+source-sha:    158e0a82071d1eb0a98c53abe7b9950ef4b6f434
+source-date:   2026-09-04T22:17:44+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 44 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 7 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 327 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 342 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -3385,6 +3385,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** The outbound call shapes a run makes, as profile keys.
 - **Defined in:** `application_sdk/testing/harness/budgets.py`
 
+#### `Card`
+
+- **Import:** `from application_sdk.testing.setup_routes import Card`
+- **Signature:** `class Card(id: str = '', name: str = '', entrypoint: str = '') -> None`
+- **Summary:** One marketplace card, trimmed to the fields the check reads.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
+
 #### `CategoryResult`
 
 - **Import:** `from application_sdk.testing.parity import CategoryResult`
@@ -3531,6 +3538,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `class DuplicateKeyPolicy`
 - **Summary:** What a non-unique join key on either side does to the comparison.
 - **Defined in:** `application_sdk/testing/golden.py`
+
+#### `Entrypoint`
+
+- **Import:** `from application_sdk.testing.setup_routes import Entrypoint`
+- **Signature:** `class Entrypoint(name: str, config_id: str, declared: frozenset[str] = frozenset(), source: Path | None = None) -> None`
+- **Summary:** One entry point, as the committed artifacts describe it.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
 
 #### `EvidenceBundle`
 
@@ -3995,6 +4009,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Identifies a custom-resource kind by its API coordinates.
 - **Defined in:** `application_sdk/testing/harness/cluster/_states.py`
 
+#### `RouteCheckSkipped`
+
+- **Import:** `from application_sdk.testing.setup_routes import RouteCheckSkipped`
+- **Signature:** `class RouteCheckSkipped`
+- **Summary:** There is no setup route to check, and that is not a failure.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
+
 #### `RunLookup`
 
 - **Import:** `from application_sdk.testing.e2e.client import RunLookup`
@@ -4046,6 +4067,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `class Settled(*, label: str, attempts: int, elapsed: timedelta, value: T)`
 - **Summary:** The probe reached the settled state inside its budget.
 - **Defined in:** `application_sdk/testing/harness/outcome.py`
+
+#### `SetupRouteError`
+
+- **Import:** `from application_sdk.testing.setup_routes import SetupRouteError`
+- **Signature:** `class SetupRouteError`
+- **Summary:** A setup route is broken, or the tenant could not be asked.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
 
 #### `SQLAppE2EFullTest`
 
@@ -4155,6 +4183,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `class TenantAuth(base_url: str, ...)`
 - **Summary:** How a run authenticates against the tenant under test.
 - **Defined in:** `application_sdk/testing/harness/identity.py`
+
+#### `TenantRoutes`
+
+- **Import:** `from application_sdk.testing.setup_routes import TenantRoutes`
+- **Signature:** `class TenantRoutes(base_url: str, bearer: str) -> None`
+- **Summary:** Reads the two routes the setup page walks, with one bearer credential.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
 
 #### `TypenameDiff`
 
@@ -4529,6 +4564,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Create a custom assertion from a user-provided function.
 - **Defined in:** `application_sdk/testing/integration/assertions.py`
 
+#### `declared_inputs`
+
+- **Import:** `from application_sdk.testing.setup_routes import declared_inputs`
+- **Signature:** `declared_inputs(workflow_config: dict[str, Any]) -> frozenset[str]`
+- **Summary:** Return the input names a generated workflow config declares.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
+
 #### `diff_golden`
 
 - **Import:** `from application_sdk.testing import diff_golden`
@@ -4848,6 +4890,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Wire mocked infrastructure for the session, after the source is up.
 - **Defined in:** `application_sdk/testing/integration/fixtures.py`
 
+#### `input_shortfall`
+
+- **Import:** `from application_sdk.testing.setup_routes import input_shortfall`
+- **Signature:** `input_shortfall(entrypoint: str, declared: frozenset[str], served: frozenset[str]) -> str | None`
+- **Summary:** Which declared inputs the tenant is not serving, or ``None``.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
+
 #### `integration_app_cls`
 
 - **Import:** `from application_sdk.testing.integration.fixtures import integration_app_cls`
@@ -5011,6 +5060,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Load expected metadata from a JSON file.
 - **Defined in:** `application_sdk/testing/integration/comparison.py`
 
+#### `locate_cards`
+
+- **Import:** `from application_sdk.testing.setup_routes import locate_cards`
+- **Signature:** `locate_cards(app_name: str, ...)`
+- **Summary:** Pick this app's cards out of the whole catalog, keyed by entry point.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
+
 #### `matches`
 
 - **Import:** `from application_sdk.testing.integration import matches`
@@ -5161,6 +5217,27 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Delete every asset under *connection_qualified_name*, then the connection.
 - **Defined in:** `application_sdk/testing/harness/teardown.py`
 
+#### `read_app_name`
+
+- **Import:** `from application_sdk.testing.setup_routes import read_app_name`
+- **Signature:** `read_app_name(repo_root: Path) -> str`
+- **Summary:** Return the app ``name`` from ``atlan.yaml``, as cards report it.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
+
+#### `read_entrypoint_names`
+
+- **Import:** `from application_sdk.testing.setup_routes import read_entrypoint_names`
+- **Signature:** `read_entrypoint_names(repo_root: Path) -> list[str]`
+- **Summary:** Return the ``entrypoints[].name`` values that should have a setup page.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
+
+#### `read_entrypoints`
+
+- **Import:** `from application_sdk.testing.setup_routes import read_entrypoints`
+- **Signature:** `read_entrypoints(repo_root: Path, generated_dir: str = 'app/generated') -> list[Entrypoint]`
+- **Summary:** Read every entry point's committed workflow config.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
+
 #### `read_records`
 
 - **Import:** `from application_sdk.testing.integration import read_records`
@@ -5212,6 +5289,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Stop a test that reset the logger's init state from leaking it forward.
 - **Defined in:** `application_sdk/testing/fixtures.py`
 
+#### `route_mismatch`
+
+- **Import:** `from application_sdk.testing.setup_routes import route_mismatch`
+- **Signature:** `route_mismatch(entrypoint: str, card: Card, config_id: str) -> str | None`
+- **Summary:** Why this entry point's setup page will 404, or ``None`` if it resolves.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
+
 #### `run_comparison`
 
 - **Import:** `from application_sdk.testing.parity import run_comparison`
@@ -5255,6 +5339,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `secrets_from_environment(environ: Mapping[str, str], *, also: Sequence[str] = ()) -> tuple[str, ...]`
 - **Summary:** Collect the literal values a run is holding, for :func:`redact`'s ``secrets``.
 - **Defined in:** `application_sdk/testing/harness/evidence.py`
+
+#### `served_inputs`
+
+- **Import:** `from application_sdk.testing.setup_routes import served_inputs`
+- **Signature:** `served_inputs(body: dict[str, Any]) -> frozenset[str]`
+- **Summary:** Unwrap a ConfigMap response and return the input names it serves.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
 
 #### `single_outcome`
 
@@ -5340,6 +5431,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Validate extracted output against pandera YAML schemas.
 - **Defined in:** `application_sdk/testing/integration/validation.py`
 
+#### `verify`
+
+- **Import:** `from application_sdk.testing.setup_routes import verify`
+- **Signature:** `verify(repo_root: Path, *, ...)`
+- **Summary:** Check every entry point's setup route. Returns the lines to report.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
+
 #### `wait_for_workflow`
 
 - **Import:** `from application_sdk.testing.e2e import wait_for_workflow`
@@ -5414,6 +5512,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `CountRead: TypeAlias`
 - **Summary:** _(no docstring)_
 - **Defined in:** `application_sdk/testing/harness/expectations.py`
+
+#### `DEFAULT_CATALOG_WAIT_SECONDS`
+
+- **Import:** `from application_sdk.testing.setup_routes import DEFAULT_CATALOG_WAIT_SECONDS`
+- **Signature:** `DEFAULT_CATALOG_WAIT_SECONDS`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/testing/setup_routes.py`
 
 #### `DEFAULT_TYPE_NAMES`
 

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -4,6 +4,7 @@
 - New code should target 85% coverage per `docs/standards/review-checklist.md` (the tooling threshold in `pyproject.toml` is 85% — CI fails below it).
 - Current tests live in `tests/unit/`; follow existing structure when adding new tests.
 - For how a *consumer app's* tests should be laid out, read `docs/agents/canonical-apps.md` and then the app itself — not an arbitrary `atlan-*-app`, which may be mid-migration or carry deprecated patterns.
+- When a fixture stands in for a **generated artifact** (`app/generated/**`, `atlan.yaml`, a served API envelope), build it from a real one and say in a comment which repo it was read from. A fixture with the shape inverted still passes — for a reason unrelated to its claim — and it flatters the code under test, which is APP-TESTS-001's self-certifying PR arriving through the fixture rather than the assertion. FND-1667 shipped one: a credential template written as `{"id": ...}` with no `config`, where the toolkit emits `config` and no `id`. Nothing caught it until someone ran the selector against a real tree.
 - For consumer apps built on this SDK, the conformance suite's T-series (`packages/conformance/conformance/docs/rules/tests.md`) enforces the agreed per-connector testing-tier architecture (unit + integration required, e2e recommended, UI optional except for top connectors) plus test-quality checks — assertion-free tests, uncollectable test files, disabled coverage gates, and more. Run it with `/remediate` or `uv run atlan-application-sdk-conformance detect --series T`.
 
 ## Asserting a Preflight Gate Verdict

--- a/docs/concepts/entry-points.md
+++ b/docs/concepts/entry-points.md
@@ -313,7 +313,7 @@ Without a query param, `GET /workflows/v1/manifest` serves the first candidate w
 ### One authority for the generated tree's shape
 
 Three facts about `app/generated/` are needed in more than one place, so they
-live in `application_sdk/app/generated_tree.py` and nowhere else:
+live in `application_sdk/app/_generated_tree.py` and nowhere else:
 
 | Function | Answers |
 | --- | --- |

--- a/docs/concepts/entry-points.md
+++ b/docs/concepts/entry-points.md
@@ -310,6 +310,49 @@ Without a query param, `GET /workflows/v1/manifest` serves the first candidate w
 
 > **Configmap discovery** also benefits from the subfolder layout: the handler uses `rglob("*.json")` so configmap files can live inside per-entry subfolders alongside the manifests.
 
+### One authority for the generated tree's shape
+
+Three facts about `app/generated/` are needed in more than one place, so they
+live in `application_sdk/app/generated_tree.py` and nowhere else:
+
+| Function | Answers |
+| --- | --- |
+| `generated_layout(dir)` | `multi` (per-entry-point subdirectories), `single` (flat), or `unknown` (nothing generated) |
+| `is_form_configmap(stem)` | Is this sibling `*.json` a setup form, or the DAG `manifest` / a `{atlan,csa}-connectors-*` credential template? |
+| `form_configmap(dir, ep)` | Which file is *this* entry point's setup form, given the layout |
+
+Everything that needs one of those reads it from there: the configmap
+endpoint's default-entrypoint fallback (`application_sdk.handler.service`), the
+artifact-schema registration guard (`_artifact_schema_guard`), and the
+tenant-side setup-route check (`application_sdk.testing.setup_routes`).
+
+The exclusion in `is_form_configmap` is load-bearing rather than cosmetic. For
+a flat app, `atlan-connectors-<source>.json` sorts alphabetically **before**
+`<source>.json`, so any file-discovery that globs `*.json` and takes the first
+match picks the credential template on every single-entry-point connector.
+
+Layout is read from the tree, never from `len(entry_points)`. A
+**route/card-split** app has several `@entrypoint`s behind one marketplace card
+and therefore one *flat* generated tree, so counting Python entry points calls
+it a bundle and sends every consumer looking under a subdirectory the toolkit
+will never write for it.
+
+### The setup page resolves on two independent lookups
+
+`/workflows/setup/<id>` in the UI spends its `id` segment twice: once to find
+the marketplace card (`app.id == id`) and once to fetch the form
+(`GET /api/service/configmaps/<id>`, which Heracles proxies to this SDK's
+`GET /workflows/v1/configmap/{id}`). The route therefore resolves **only when
+the card's `id` is a name the configmap endpoint also answers to**.
+
+Those two names come from different places, and a contract change can move one
+without the other — setting `Entrypoint.packageId` moves the card's identity
+onto the marketplace package while the form stays under the workflow config's
+`id`, which 404s the setup page with every generated artifact still
+self-consistent and every static gate still green. `application_sdk.testing.setup_routes`
+asserts that join against a live tenant; see
+`docs/standards/connector-ci-e2e.md` for where it runs in CI.
+
 ### Per-entry-point handler & core modules
 
 A multi-entry-point app can ship **per-entry-point** lifecycle code next to its hand-written package, discovered by convention:

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -1013,6 +1013,48 @@ The shared [`regenerate-contract`](../../.github/actions/regenerate-contract/act
 
 Regeneration is bound to the build, so it runs wherever the build runs: once per leg while each leg builds its own image, and once per run for a caller that builds ahead of the matrix and passes `prebuilt-image` (see [Building the image once](#building-the-image-once)). The binding is the invariant — the fresh `app/generated/` must exist in the workspace at the moment the image is built — not the per-leg cardinality.
 
+## Workflow-setup routes (FND-1667)
+
+A contract change can 404 a connector's setup page while **every** local and CI check stays green. That is what shipped in FND-1593: the generated artifacts were self-consistent, conformance was clean, the generated-artifact freshness gate passed, and both `/workflows/setup/*` pages returned 404 in the UI. Nothing was stale or hand-edited — the break lived only in the join between what the contract generates and what the tenant serves, and no gate looked there.
+
+`sdr-e2e`'s **Verify workflow-setup routes resolve** step closes that. It runs on the install path only (gated on `expected-app-version`, the same gate as the version verify), after the version check and before the suite.
+
+What it asserts, in the direction the UI walks it:
+
+1. locate this app's marketplace cards by app `name` **and** `entrypoint` — facts that are *not* the thing under test. `entrypoint` alone is not app-scoped: every connector's crawler card carries `entrypoint: "crawler"`.
+2. `card.id` equals the `id` in the committed `app/generated/<ep>/<config>.json`. This is the assertion that bites — a check asserting `GET configmaps/<known-good-name> == 200` would have passed straight through FND-1593, because that name never stopped working. What moved was the card pointing at it.
+3. `GET /api/service/configmaps/<card.id>` returns 200 and echoes back the name asked for.
+4. the served form declares every input the committed contract does — a **subset** check, so platform-added fields are not brittle while a stale image still fails.
+5. a negative control runs **first**: an unknown config name must really be rejected, or every 200 above is vacuous.
+
+### Skips, and what they mean
+
+| Situation | Outcome |
+|---|---|
+| No `manifest.json` anywhere under `app/generated/` (nothing generated) | **Skipped**, with a `::notice::` — no setup form exists to serve. Costs zero tenant calls. |
+| Caller did not install to the tenant (`expected-app-version` empty) | Step does not run — the tenant serves some other version, and the subset check would report a stale image as a contract break |
+| A declared entrypoint has no generated config, or a config has no `id` | **Fails** — the committed artifacts are incoherent, which is not "nothing to check" |
+
+Skip-not-fail on the first two is deliberate: without it this would be a fleet-wide false positive on its first run.
+
+### Timing
+
+The catalog read is a **bounded poll** (`--wait-seconds`, default 120s), not a single read. `install()` polling the *deployment* to `SUCCEEDED` is not evidence that LM's catalog snapshot and the pod's configmap endpoint have caught up — nothing sequences those against the deployment verdict — so a single read would be flaky-by-construction on exactly the path CI takes. Progress lines are flushed, so a patient step does not read as a hung one.
+
+### Where the logic lives, and why
+
+The check is `application_sdk/testing/setup_routes.py`; the CI shell around it is [`verify_setup_routes.py`](../../.github/actions/sdr-e2e/verify_setup_routes.py) in the composite. The split is not arbitrary:
+
+- The SDK is on **both** sides of the join being asserted. `/api/service/configmaps/<name>` is Heracles proxying to the app pod's own `GET /workflows/v1/configmap/{id}`, so the response envelope, the form-file selection rule and the generated-tree layout are read from `application_sdk/app/generated_tree.py` — the same authority the server reads. A second copy would let the server serve one file while the check compared against another, and that mismatch would read as a contract regression.
+- It therefore needs the SDK importable, which rules out `prepare-tenant`: that job runs a bare `python3` with no `uv sync`. By this point in `sdr-e2e` the app's environment is synced.
+- The `e2e` job that invokes this composite has `prepare-tenant` in its `needs:`, so every step here is strictly after the install.
+
+One insertion covers both e2e callers (`tests-reusable`'s `e2e` and `e2e-full-reusable`'s `e2e-full`), and no app repo carries any of it. `.github/scripts/tests/test_setup_routes_wiring.py` pins the placement, gate and injection discipline; `tests/unit/testing/test_setup_routes.py` proves the check bites, including a round-trip against the live configmap endpoint.
+
+### Known limitation
+
+The endpoint paths are `atlan-frontend`'s, not ours — `BASE_PATH = 'service'` plus `getAPIPath`, confirmed live. If the frontend changes how it derives the setup route, this check goes stale. The mitigation is that it is in one place rather than in every connector repo.
+
 ## Workspace-wipe defences (local-action mode)
 
 When the SDR composite is invoked via local path (`./.application-sdk/.github/actions/sdr-e2e`) during cross-repo dispatch, `setup-deps`' inner `actions/checkout` wipes the entire workspace — including `${{ github.action_path }}` itself. The composite:

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -1045,7 +1045,7 @@ The catalog read is a **bounded poll** (`--wait-seconds`, default 120s), not a s
 
 The check is `application_sdk/testing/setup_routes.py`; the CI shell around it is [`verify_setup_routes.py`](../../.github/actions/sdr-e2e/verify_setup_routes.py) in the composite. The split is not arbitrary:
 
-- The SDK is on **both** sides of the join being asserted. `/api/service/configmaps/<name>` is Heracles proxying to the app pod's own `GET /workflows/v1/configmap/{id}`, so the response envelope, the form-file selection rule and the generated-tree layout are read from `application_sdk/app/generated_tree.py` — the same authority the server reads. A second copy would let the server serve one file while the check compared against another, and that mismatch would read as a contract regression.
+- The SDK is on **both** sides of the join being asserted. `/api/service/configmaps/<name>` is Heracles proxying to the app pod's own `GET /workflows/v1/configmap/{id}`, so the response envelope, the form-file selection rule and the generated-tree layout are read from `application_sdk/app/_generated_tree.py` — the same authority the server reads. A second copy would let the server serve one file while the check compared against another, and that mismatch would read as a contract regression.
 - It therefore needs the SDK importable, which rules out `prepare-tenant`: that job runs a bare `python3` with no `uv sync`. By this point in `sdr-e2e` the app's environment is synced.
 - The `e2e` job that invokes this composite has `prepare-tenant` in its `needs:`, so every step here is strictly after the install.
 

--- a/tests/unit/testing/test_setup_routes.py
+++ b/tests/unit/testing/test_setup_routes.py
@@ -732,7 +732,7 @@ class TestVerify:
         _write_bundle(tmp_path)
         routes = _FakeRoutes([_both_cards()], _healthy_configmaps())
 
-        report = verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+        report = verify(tmp_path, routes, wait_seconds=0)
 
         assert len(report) == 2
         assert all("resolves" in line for line in report)
@@ -749,7 +749,7 @@ class TestVerify:
         _write_bundle(tmp_path)
         routes = _FakeRoutes([_both_cards()], _healthy_configmaps())
 
-        verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+        verify(tmp_path, routes, wait_seconds=0)
 
         assert routes.asked[0] == "clickhouse-nonexistent-setup-route-check"
 
@@ -759,7 +759,7 @@ class TestVerify:
         routes = _FakeRoutes([_both_cards()], _healthy_configmaps(), unknown_status=200)
 
         with pytest.raises(SetupRouteError, match="proves anything"):
-            verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+            verify(tmp_path, routes, wait_seconds=0)
 
     def test_reports_the_packageid_regression_against_a_tenant(
         self, tmp_path: Path
@@ -779,7 +779,7 @@ class TestVerify:
         routes = _FakeRoutes([catalog], _healthy_configmaps())
 
         with pytest.raises(SetupRouteError) as caught:
-            verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+            verify(tmp_path, routes, wait_seconds=0)
 
         message = str(caught.value)
         # Both entrypoints broke, so both must be reported — not just the first.
@@ -796,7 +796,7 @@ class TestVerify:
         routes = _FakeRoutes([_both_cards()], configmaps)
 
         with pytest.raises(SetupRouteError, match="404'd setup page"):
-            verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+            verify(tmp_path, routes, wait_seconds=0)
 
     def test_fails_when_the_endpoint_serves_a_different_name(
         self, tmp_path: Path
@@ -813,7 +813,7 @@ class TestVerify:
         routes = _FakeRoutes([_both_cards()], configmaps)
 
         with pytest.raises(SetupRouteError, match="served 'something-else'"):
-            verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+            verify(tmp_path, routes, wait_seconds=0)
 
     def test_polls_until_the_catalog_reconciles(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -839,7 +839,7 @@ class TestVerify:
 
         report = module.verify(
             tmp_path,
-            routes,  # type: ignore[arg-type]
+            routes,
             wait_seconds=60,
             on_progress=progress.append,
         )
@@ -867,7 +867,7 @@ class TestVerify:
         monkeypatch.setattr(module, "_CATALOG_POLL_SECONDS", 0)
 
         with pytest.raises(SetupRouteError) as caught:
-            module.verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+            module.verify(tmp_path, routes, wait_seconds=0)
 
         message = str(caught.value)
         assert "miner" in message
@@ -879,7 +879,7 @@ class TestVerify:
         routes = _FakeRoutes([[]], {})
 
         with pytest.raises(RouteCheckSkipped):
-            verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+            verify(tmp_path, routes, wait_seconds=0)
 
         # And it must skip BEFORE touching the tenant: an app with no setup page
         # should cost no tenant calls at all.
@@ -925,7 +925,7 @@ class TestCardlessEntrypoints:
         catalog = [_card_payload("clickhouse-crawler", entrypoint="crawler")]
         routes = _FakeRoutes([catalog], _healthy_configmaps())
 
-        report = verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+        report = verify(tmp_path, routes, wait_seconds=0)
 
         assert len(report) == 1
 
@@ -1003,7 +1003,9 @@ class TestCatalogTruncation:
 
             self.catalog_reads += 1
             body = {"total": self._total, "apps": self._catalogs[0]}
-            return TenantRoutes.catalog(_StubGet(body))  # type: ignore[arg-type]
+            # Calling the real guard as an unbound method with a stub self:
+            # `_StubGet` supplies only `get`, which is all `catalog` touches.
+            return TenantRoutes.catalog(_StubGet(body))  # type: ignore[arg-type] — stub supplies the only attribute `catalog` reads
 
     def test_a_short_page_fails_loudly(self, tmp_path: Path) -> None:
         _write_bundle(tmp_path)
@@ -1012,7 +1014,7 @@ class TestCatalogTruncation:
         )
 
         with pytest.raises(SetupRouteError, match="paginated"):
-            verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+            verify(tmp_path, routes, wait_seconds=0)
 
     def test_a_complete_page_is_accepted(self, tmp_path: Path) -> None:
         """`total` equal to the page length is the normal, unpaginated case."""
@@ -1020,7 +1022,7 @@ class TestCatalogTruncation:
         both = _both_cards()
         routes = self._TruncatingRoutes(both, total=len(both))
 
-        report = verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+        report = verify(tmp_path, routes, wait_seconds=0)
 
         assert len(report) == 2
 
@@ -1134,7 +1136,7 @@ class TestSoleContractCardMatching:
             {"mysql": (200, _configmap_response(schema, "mysql"))},
         )
 
-        report = verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+        report = verify(tmp_path, routes, wait_seconds=0)
 
         assert len(report) == 1
 
@@ -1235,7 +1237,9 @@ class TestRedirectsAreDeclined:
                 response = urllib.response.addinfourl(
                     _Body(b'{"ok": true}'), headers, req.full_url, first_status
                 )
-                response.msg = "Found"  # type: ignore[attr-defined]
+                # addinfourl has no declared `msg`, but HTTPErrorProcessor
+                # reads one off the response when it dispatches a non-2xx.
+                response.msg = "Found"  # type: ignore[attr-defined] — addinfourl has no declared `msg`; HTTPErrorProcessor reads it on a non-2xx
                 return response
 
         return _Fake

--- a/tests/unit/testing/test_setup_routes.py
+++ b/tests/unit/testing/test_setup_routes.py
@@ -1,0 +1,1010 @@
+"""Proves the workflow-setup route check actually bites.
+
+The check in :mod:`application_sdk.testing.setup_routes` only runs against a
+tenant with the app installed, so on its own there is no way to know its central
+assertion would fail on the regression it exists to catch. These tests pin that
+offline, on every PR.
+
+The fixtures below are real shapes, not invented ones:
+
+* the passing card is what ``GET /api/service/marketplace/apps`` returns for a
+  live connector today (``id: "clickhouse-crawler"``, ``name: "clickhouse"``,
+  ``entrypoint: "crawler"``)
+* the failing card carries ``id: "atlan-clickhouse"`` — the id the build with
+  ``packageId`` set produced, observed as a 404'ing
+  ``/workflows/setup/atlan-clickhouse`` in a tenant UI
+
+A regression test that does not fail without the fix is not a regression test,
+so :func:`test_bites_on_the_packageid_regression` and its miner twin are the
+load-bearing ones here: stubbing ``route_mismatch`` to return ``None`` must red
+this file.
+
+:class:`TestServedFormRoundTrip` is the other load-bearing part, and it tests
+something no amount of shape-fixture assertion can: that
+:func:`~application_sdk.testing.setup_routes.served_inputs` really inverts the
+envelope the SDK's own configmap endpoint builds. It drives the live FastAPI
+route rather than a hand-written dict, so the two sides of the join are pinned
+against each other in-repo — the committed generated file and the response a
+tenant proxies. The nesting differs by exactly one level between them
+(``handler.service`` serves ``raw.get("config", raw)``), which is the easiest
+thing in this whole check to get quietly wrong.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from application_sdk.testing.setup_routes import (
+    Card,
+    Entrypoint,
+    RouteCheckSkipped,
+    SetupRouteError,
+    declared_inputs,
+    input_shortfall,
+    locate_cards,
+    read_app_name,
+    read_entrypoint_names,
+    read_entrypoints,
+    route_mismatch,
+    served_inputs,
+    verify,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — the real shapes
+# ---------------------------------------------------------------------------
+
+
+def _card_payload(
+    card_id: str, *, entrypoint: str = "crawler", name: str = "clickhouse"
+) -> dict[str, Any]:
+    """A marketplace card as the catalog returns it, trimmed to the read fields.
+
+    The untrimmed card carries ~45 keys; these are the three the check reads
+    plus two that must be *ignored* (``package_id`` and ``installed``), so a
+    future reader can see they are deliberately not part of the decision.
+    """
+    return {
+        "id": card_id,
+        "name": name,
+        "displayName": "ClickHouse Assets",
+        "type": "connector",
+        "entrypoint": entrypoint,
+        "isNewApp": True,
+        "execution_mode": "native",
+        "installed": True,
+        "package_id": "",
+        "version": "v0.3.1",
+    }
+
+
+def _workflow_config(config_id: str = "clickhouse-crawler") -> dict[str, Any]:
+    """A generated workflow config, trimmed to the read fields.
+
+    ``config`` carries ``steps`` and ``anyOf`` alongside ``properties`` on a
+    real one; both are included here precisely so a test proves they are NOT
+    read as inputs.
+    """
+    return {
+        "id": config_id,
+        "name": "ClickHouse Assets",
+        "logo": "https://assets.example.invalid/logo.svg",
+        "config": {
+            "properties": {
+                "extraction-method": {"type": "conditional"},
+                "credential-guid": {"type": "string"},
+                "connection": {"type": "string"},
+            },
+            "steps": [{"id": "credentials"}],
+            "anyOf": [{"properties": {}}],
+        },
+    }
+
+
+def _configmap_response(
+    schema: dict[str, Any], name: str = "clickhouse-crawler"
+) -> dict[str, Any]:
+    """The ConfigMap a tenant serves: ``data.config`` is a JSON *string*."""
+    return {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {"name": name},
+        "data": {"config": json.dumps(schema)},
+    }
+
+
+# ---------------------------------------------------------------------------
+# route_mismatch — the load-bearing check
+# ---------------------------------------------------------------------------
+
+
+class TestRouteMismatch:
+    def test_passes_on_the_shipped_card_shape(self) -> None:
+        """The real card and the real generated config agree, so nothing fires."""
+        card = Card.from_payload(_card_payload("clickhouse-crawler"))
+        assert route_mismatch("crawler", card, "clickhouse-crawler") is None
+
+    def test_bites_on_the_packageid_regression(self) -> None:
+        """The FND-1593 shape must be reported, or the check is decoration.
+
+        ``packageId = "@atlan/clickhouse"`` moved the card id to
+        ``atlan-clickhouse`` while the workflow config stayed
+        ``clickhouse-crawler``, and both setup pages 404'd. This is that exact
+        divergence.
+        """
+        card = Card.from_payload(_card_payload("atlan-clickhouse"))
+
+        reason = route_mismatch("crawler", card, "clickhouse-crawler")
+
+        assert reason is not None, (
+            "route_mismatch accepted a card whose id does not match the "
+            "generated workflow config id — the shape that 404'd both setup "
+            "pages. The check built on it cannot catch that regression."
+        )
+        # Both sides, or whoever hits this in CI cannot act on it.
+        assert "atlan-clickhouse" in reason
+        assert "clickhouse-crawler" in reason
+        # And the route the user would actually land on.
+        assert "/workflows/setup/atlan-clickhouse" in reason
+
+    def test_bites_on_the_miner_regression(self) -> None:
+        """The second entrypoint regressed identically and must report identically."""
+        card = Card.from_payload(
+            _card_payload("atlan-clickhouse-miner", entrypoint="miner")
+        )
+
+        reason = route_mismatch("miner", card, "clickhouse-miner")
+
+        assert reason is not None
+        assert "atlan-clickhouse-miner" in reason
+        assert "clickhouse-miner" in reason
+
+    def test_names_the_cause_so_the_reader_can_act(self) -> None:
+        """The message must point at packageId, the known cause (FND-1659)."""
+        card = Card.from_payload(_card_payload("atlan-clickhouse"))
+
+        reason = route_mismatch("crawler", card, "clickhouse-crawler")
+
+        assert reason is not None
+        assert "packageId" in reason
+
+    def test_reports_a_card_with_no_id(self) -> None:
+        """No id at all means the marketplace cannot build a setup link."""
+        payload = _card_payload("clickhouse-crawler")
+        del payload["id"]
+
+        reason = route_mismatch(
+            "crawler", Card.from_payload(payload), "clickhouse-crawler"
+        )
+
+        assert reason is not None
+        assert "no id" in reason
+
+    def test_reports_an_ungenerated_workflow_config(self) -> None:
+        """An id-less config means the artifacts were never generated."""
+        card = Card.from_payload(_card_payload("clickhouse-crawler"))
+
+        reason = route_mismatch("crawler", card, "")
+
+        assert reason is not None
+        assert "Regenerate the contract" in reason
+
+    def test_a_flat_app_is_named_readably(self) -> None:
+        """An empty entrypoint name must not render as an empty quote in prose."""
+        card = Card.from_payload(_card_payload("atlan-mysql", entrypoint=""))
+
+        reason = route_mismatch("", card, "mysql")
+
+        assert reason is not None
+        assert "<flat>" in reason
+
+
+# ---------------------------------------------------------------------------
+# input_shortfall — the subset check
+# ---------------------------------------------------------------------------
+
+
+class TestInputShortfall:
+    def test_extra_served_fields_are_not_a_failure(self) -> None:
+        """A subset check: the platform may decorate the schema.
+
+        Failing on platform-added fields buys no safety and would red the fleet
+        the first time the platform grew one.
+        """
+        declared = frozenset({"credential-guid", "connection"})
+        served = declared | {"labFlag", "platform-injected"}
+
+        assert input_shortfall("crawler", declared, served) is None
+
+    def test_bites_on_a_missing_declared_input(self) -> None:
+        """A missing input is the signal — a stale image, or a change that never landed."""
+        declared = frozenset({"credential-guid", "connection", "include-filter"})
+        served = frozenset({"credential-guid", "connection"})
+
+        reason = input_shortfall("crawler", declared, served)
+
+        assert reason is not None
+        assert "include-filter" in reason
+        # The served set has to be in the message, or the reader cannot tell a
+        # stale image from a renamed field.
+        assert "credential-guid" in reason
+
+    def test_a_contract_declaring_nothing_is_reported(self) -> None:
+        """Zero declared inputs makes the check vacuous, so it must not pass."""
+        reason = input_shortfall("crawler", frozenset(), frozenset({"anything"}))
+
+        assert reason is not None
+        assert "declares no inputs" in reason
+
+
+# ---------------------------------------------------------------------------
+# locate_cards — the bug that makes a wrong answer look plausible
+# ---------------------------------------------------------------------------
+
+
+class TestLocateCards:
+    def test_entrypoint_alone_is_not_app_scoped(self) -> None:
+        """Every connector's crawler card carries ``entrypoint: "crawler"``.
+
+        Filtering on ``entrypoint`` alone matched a dozen unrelated apps when
+        the prototype tried it, and the count was plausible enough to look like
+        success. The match must AND with the app name.
+        """
+        # Ours FIRST, foreign cards after. Ordering is load-bearing: the cards
+        # are collapsed into a dict keyed by entrypoint, so last-wins. With ours
+        # last, a name-blind match would still happen to land on the right card
+        # and this test would pass while asserting nothing.
+        catalog = [_card_payload("clickhouse-crawler", name="clickhouse")]
+        catalog += [
+            _card_payload(f"{source}-crawler", name=source)
+            for source in (
+                "mssql",
+                "bigquery",
+                "snowflake",
+                "postgres",
+                "redshift",
+                "databricks",
+            )
+        ]
+
+        cards, reason = locate_cards("clickhouse", ["crawler"], catalog)
+
+        assert reason is None
+        assert set(cards) == {"crawler"}
+        assert cards["crawler"].id == "clickhouse-crawler"
+
+    def test_reports_an_app_absent_from_the_catalog(self) -> None:
+        catalog = [_card_payload("mssql-crawler", name="mssql")]
+
+        cards, reason = locate_cards("clickhouse", ["crawler"], catalog)
+
+        assert cards == {}
+        assert reason is not None
+        assert "not installed on this tenant" in reason
+        # The catalog size proves the read worked, which distinguishes "not
+        # installed" from "token cannot read the catalog".
+        assert "1 apps" in reason
+
+    def test_reports_an_entrypoint_with_no_card(self) -> None:
+        """An entrypoint with no card has no setup page at all."""
+        catalog = [_card_payload("clickhouse-crawler", name="clickhouse")]
+
+        cards, reason = locate_cards("clickhouse", ["crawler", "miner"], catalog)
+
+        assert set(cards) == {"crawler"}
+        assert reason is not None
+        assert "miner" in reason
+
+    def test_a_flat_app_card_keys_under_empty_string(self) -> None:
+        """A single-generated-contract app's card carries no ``entrypoint``."""
+        catalog = [_card_payload("mysql", name="mysql", entrypoint="")]
+
+        cards, reason = locate_cards("mysql", [""], catalog)
+
+        assert reason is None
+        assert cards[""].id == "mysql"
+
+
+# ---------------------------------------------------------------------------
+# served_inputs — the one-level nesting difference
+# ---------------------------------------------------------------------------
+
+
+class TestServedInputs:
+    def test_unwraps_the_json_string_config(self) -> None:
+        response = _configmap_response(
+            {"properties": {"credential-guid": {}, "connection": {}}}
+        )
+
+        assert served_inputs(response) == frozenset({"credential-guid", "connection"})
+
+    def test_rejects_a_non_string_config(self) -> None:
+        """A nested object instead of a string means the shape changed.
+
+        Silently coping would make the subset check read an empty served set
+        and report every declared input as missing.
+        """
+        response = _configmap_response({"properties": {}})
+        response["data"] = {"config": {"properties": {}}}
+
+        with pytest.raises(SetupRouteError, match="no string data.config"):
+            served_inputs(response)
+
+    def test_rejects_a_response_with_no_data(self) -> None:
+        with pytest.raises(SetupRouteError, match="no 'data' object"):
+            served_inputs({"metadata": {"name": "x"}})
+
+    def test_rejects_unparseable_config(self) -> None:
+        response = _configmap_response({"properties": {}})
+        response["data"] = {"config": "{not json"}
+
+        with pytest.raises(SetupRouteError, match="not valid JSON"):
+            served_inputs(response)
+
+    def test_a_schema_with_no_properties_serves_nothing(self) -> None:
+        """Empty, not an error — ``input_shortfall`` is what reports the gap."""
+        assert served_inputs(_configmap_response({"steps": []})) == frozenset()
+
+
+class TestDeclaredInputs:
+    def test_reads_only_config_properties(self) -> None:
+        """``steps`` and ``anyOf`` are the wizard and the visibility rules."""
+        assert declared_inputs(_workflow_config()) == frozenset(
+            {"extraction-method", "credential-guid", "connection"}
+        )
+
+    def test_a_config_less_payload_declares_nothing(self) -> None:
+        assert declared_inputs({"id": "x"}) == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# The artifact readers
+# ---------------------------------------------------------------------------
+
+
+def _write_bundle(root: Path) -> None:
+    """A two-entrypoint bundle, laid out exactly as the toolkit emits one."""
+    (root / "atlan.yaml").write_text(
+        "name: clickhouse\n"
+        "app_id: 019c72eb-f048-7a40-bb42-e5689dd8c150\n"
+        "entrypoints:\n"
+        "- name: crawler\n"
+        "  display_name: ClickHouse Assets\n"
+        "  type: connector\n"
+        "- name: miner\n"
+        "  display_name: ClickHouse Miner\n"
+        "  type: miner\n"
+    )
+    generated = root / "app" / "generated"
+    # The credential template the toolkit hoists to the bundle root. Its real
+    # shape carries a `config` and NO top-level `id` — verified against
+    # atlan-clickhouse-app and atlan-mysql-app.
+    (generated).mkdir(parents=True)
+    (generated / "atlan-connectors-clickhouse.json").write_text(
+        json.dumps({"connector": "clickhouse", "config": {"properties": {}}})
+    )
+    for entrypoint, config_id in (
+        ("crawler", "clickhouse-crawler"),
+        ("miner", "clickhouse-miner"),
+    ):
+        directory = generated / entrypoint
+        directory.mkdir()
+        (directory / "manifest.json").write_text("{}")
+        (directory / f"{config_id}.json").write_text(
+            json.dumps(_workflow_config(config_id))
+        )
+
+
+def _write_flat(root: Path) -> None:
+    """A single-generated-contract app: everything at the generated root."""
+    (root / "atlan.yaml").write_text(
+        "name: mysql\napp_id: 019c72eb-f048-7a40-bb42-e5689dd8c151\n"
+    )
+    generated = root / "app" / "generated"
+    generated.mkdir(parents=True)
+    (generated / "manifest.json").write_text("{}")
+    # Sorts BEFORE `mysql.json`, which is the whole point — see the test.
+    # Real shape: a `config`, no top-level `id`.
+    (generated / "atlan-connectors-mysql.json").write_text(
+        json.dumps({"connector": "mysql", "config": {"properties": {"host": {}}}})
+    )
+    (generated / "mysql.json").write_text(json.dumps(_workflow_config("mysql")))
+
+
+class TestArtifactReaders:
+    def test_reads_a_bundle(self, tmp_path: Path) -> None:
+        _write_bundle(tmp_path)
+
+        found = read_entrypoints(tmp_path)
+
+        assert [e.name for e in found] == ["crawler", "miner"]
+        assert [e.config_id for e in found] == [
+            "clickhouse-crawler",
+            "clickhouse-miner",
+        ]
+        assert found[0].declared == frozenset(
+            {"extraction-method", "credential-guid", "connection"}
+        )
+
+    def test_a_flat_app_does_not_pick_the_credential_template(
+        self, tmp_path: Path
+    ) -> None:
+        """Exclusion by stem, not by hoping the template lacks a key.
+
+        ``atlan-connectors-mysql.json`` sorts alphabetically BEFORE
+        ``mysql.json``, so file selection in a flat tree has to reject it
+        explicitly rather than relying on ordering.
+
+        Today's credential templates carry a ``config`` and no top-level
+        ``id``, so a selector keyed on "has both ``id`` and ``config``" also
+        skips them — but only incidentally. Nothing promises a template will
+        never gain an ``id``, and if one did, that selector would silently
+        start comparing a marketplace card against a credential id.
+
+        ``is_form_configmap`` rejects it by stem, which is the same rule the
+        configmap endpoint applies — so the server and this check cannot
+        disagree about which file is the form.
+        """
+        _write_flat(tmp_path)
+
+        found = read_entrypoints(tmp_path)
+
+        assert [e.name for e in found] == [""]
+        assert found[0].config_id == "mysql"
+
+    def test_skips_when_nothing_is_generated(self, tmp_path: Path) -> None:
+        """Skip, not fail: no generated tree means no setup page to check."""
+        (tmp_path / "atlan.yaml").write_text("name: nothing\n")
+        (tmp_path / "app" / "generated").mkdir(parents=True)
+
+        with pytest.raises(RouteCheckSkipped, match="no generated contract"):
+            read_entrypoints(tmp_path)
+
+    def test_skips_when_the_generated_dir_is_absent(self, tmp_path: Path) -> None:
+        (tmp_path / "atlan.yaml").write_text("name: nothing\n")
+
+        with pytest.raises(RouteCheckSkipped):
+            read_entrypoints(tmp_path)
+
+    def test_fails_when_a_declared_entrypoint_has_no_config(
+        self, tmp_path: Path
+    ) -> None:
+        """Incoherent committed artifacts are a real failure, not a skip."""
+        _write_bundle(tmp_path)
+        (tmp_path / "app" / "generated" / "miner" / "clickhouse-miner.json").unlink()
+
+        with pytest.raises(SetupRouteError, match="no setup-form configmap"):
+            read_entrypoints(tmp_path)
+
+    def test_fails_when_a_config_has_no_id(self, tmp_path: Path) -> None:
+        _write_bundle(tmp_path)
+        path = tmp_path / "app" / "generated" / "crawler" / "clickhouse-crawler.json"
+        path.write_text(json.dumps({"config": {"properties": {"a": {}}}}))
+
+        with pytest.raises(SetupRouteError, match="no top-level 'id'"):
+            read_entrypoints(tmp_path)
+
+    def test_fails_when_a_bundle_declares_no_entrypoints(self, tmp_path: Path) -> None:
+        """A nested tree with no atlan.yaml entrypoints has uncheckable cards."""
+        _write_bundle(tmp_path)
+        (tmp_path / "atlan.yaml").write_text("name: clickhouse\n")
+
+        with pytest.raises(SetupRouteError, match="declares no entrypoints"):
+            read_entrypoints(tmp_path)
+
+    def test_reads_the_app_name_lowercased(self, tmp_path: Path) -> None:
+        (tmp_path / "atlan.yaml").write_text("name: ClickHouse\n")
+
+        assert read_app_name(tmp_path) == "clickhouse"
+
+    def test_a_missing_atlan_yaml_is_a_clear_error(self, tmp_path: Path) -> None:
+        with pytest.raises(SetupRouteError, match="cannot read"):
+            read_app_name(tmp_path)
+
+    def test_a_nameless_atlan_yaml_is_rejected(self, tmp_path: Path) -> None:
+        (tmp_path / "atlan.yaml").write_text("app_id: x\n")
+
+        with pytest.raises(SetupRouteError, match='no top-level "name"'):
+            read_app_name(tmp_path)
+
+    def test_entrypoint_names_are_empty_for_a_flat_app(self, tmp_path: Path) -> None:
+        _write_flat(tmp_path)
+
+        assert read_entrypoint_names(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# The round trip — the two sides of the join, pinned against each other
+# ---------------------------------------------------------------------------
+
+
+class TestServedFormRoundTrip:
+    """Does ``served_inputs`` really invert what the SDK's endpoint serves?
+
+    Every other test here feeds hand-written shapes. These drive the live
+    ``GET /workflows/v1/configmap/{id}`` route — the endpoint a tenant's
+    ``/api/service/configmaps/<name>`` proxies to — so the committed file and
+    the served response are compared through the real code on both sides.
+
+    Heracles returns the ConfigMap at the top level while the SDK wraps it in
+    its standard ``{"data": ...}`` envelope, so these tests unwrap that one
+    layer to stand where the check stands. That unwrapping is Heracles', and
+    it is the one part of the path this repo cannot pin.
+    """
+
+    @staticmethod
+    def _serve(tmp_path: Path, config_id: str) -> dict[str, Any]:
+        from application_sdk.handler import service as svc_module
+        from tests.unit.handler.test_service import _make_client
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path / "app" / "generated"
+        try:
+            response = _make_client().get(f"/workflows/v1/configmap/{config_id}")
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+        assert response.status_code == 200, response.text
+        # Peel the SDK's response envelope, which is what Heracles does before
+        # handing the bare ConfigMap to the frontend.
+        return response.json()["data"]
+
+    def test_the_served_form_declares_everything_the_contract_does(
+        self, tmp_path: Path
+    ) -> None:
+        """The whole check, end to end, through the real endpoint.
+
+        If ``served_inputs`` read one nesting level too deep or too shallow,
+        this fails — which is exactly the mistake the differing depths invite.
+        """
+        _write_bundle(tmp_path)
+        committed = json.loads(
+            (
+                tmp_path / "app" / "generated" / "crawler" / "clickhouse-crawler.json"
+            ).read_text()
+        )
+
+        body = self._serve(tmp_path, "clickhouse-crawler")
+
+        assert body["metadata"]["name"] == "clickhouse-crawler"
+        assert (
+            input_shortfall("crawler", declared_inputs(committed), served_inputs(body))
+            is None
+        )
+
+    def test_a_form_missing_a_contract_input_is_caught(self, tmp_path: Path) -> None:
+        """A genuinely stale served schema must fail, not just a version gap.
+
+        The prototype's subset check passed against a tenant one patch version
+        behind — but only because that migration produced byte-identical
+        configs, so it never demonstrated it could catch a real shortfall. This
+        serves a form with an input deleted and proves it does.
+        """
+        _write_bundle(tmp_path)
+        path = tmp_path / "app" / "generated" / "crawler" / "clickhouse-crawler.json"
+        committed = json.loads(path.read_text())
+        declared = declared_inputs(committed)
+
+        # The deployed image serves a form that predates `include-filter` being
+        # renamed in — i.e. one input short of the committed contract.
+        stale = json.loads(path.read_text())
+        del stale["config"]["properties"]["connection"]
+        path.write_text(json.dumps(stale))
+
+        body = self._serve(tmp_path, "clickhouse-crawler")
+        reason = input_shortfall("crawler", declared, served_inputs(body))
+
+        assert reason is not None
+        assert "connection" in reason
+
+    def test_the_endpoint_rejects_a_name_it_does_not_know(self, tmp_path: Path) -> None:
+        """The negative control's premise, pinned against the real endpoint.
+
+        Every 200 the check trusts is worthless if the endpoint answers 200 for
+        unknown names. The live check asserts this against the tenant; this
+        asserts the SDK server it proxies to behaves that way at all.
+        """
+        from application_sdk.handler import service as svc_module
+        from tests.unit.handler.test_service import _make_client
+
+        _write_bundle(tmp_path)
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path / "app" / "generated"
+        try:
+            response = _make_client().get(
+                "/workflows/v1/configmap/clickhouse-nonexistent-setup-route-check"
+            )
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
+        assert response.status_code in (400, 403, 404)
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_entrypoint_defaults_are_inert() -> None:
+    """A bare Entrypoint declares nothing and names no source."""
+    entrypoint = Entrypoint(name="crawler", config_id="clickhouse-crawler")
+
+    assert entrypoint.declared == frozenset()
+    assert entrypoint.source is None
+
+
+# ---------------------------------------------------------------------------
+# verify() — the negative control and the bounded poll
+# ---------------------------------------------------------------------------
+
+
+class _FakeRoutes:
+    """Stands in for :class:`TenantRoutes` with scripted responses.
+
+    Not a mock: the tests below assert on *sequencing* — how many catalog reads
+    happened, and that the bogus-name probe happened before any real fetch — so
+    the fake records calls rather than only answering them.
+    """
+
+    def __init__(
+        self,
+        catalogs: list[list[dict[str, Any]]],
+        configmaps: dict[str, tuple[int, dict[str, Any]]],
+        *,
+        unknown_status: int = 404,
+    ) -> None:
+        self._catalogs = catalogs
+        self._configmaps = configmaps
+        self._unknown_status = unknown_status
+        self.catalog_reads = 0
+        self.asked: list[str] = []
+
+    def catalog(self) -> list[dict[str, Any]]:
+        index = min(self.catalog_reads, len(self._catalogs) - 1)
+        self.catalog_reads += 1
+        return self._catalogs[index]
+
+    def configmap(self, name: str) -> tuple[int, dict[str, Any]]:
+        self.asked.append(name)
+        if name in self._configmaps:
+            return self._configmaps[name]
+        return self._unknown_status, {}
+
+
+def _healthy_configmaps() -> dict[str, tuple[int, dict[str, Any]]]:
+    schema = {
+        "properties": {
+            "extraction-method": {},
+            "credential-guid": {},
+            "connection": {},
+            # A platform-added field the contract never named, so the subset
+            # check's tolerance is exercised on the happy path too.
+            "labFlag": {},
+        }
+    }
+    return {
+        "clickhouse-crawler": (200, _configmap_response(schema, "clickhouse-crawler")),
+        "clickhouse-miner": (200, _configmap_response(schema, "clickhouse-miner")),
+    }
+
+
+def _both_cards() -> list[dict[str, Any]]:
+    return [
+        _card_payload("clickhouse-crawler", entrypoint="crawler"),
+        _card_payload("clickhouse-miner", entrypoint="miner"),
+    ]
+
+
+class TestVerify:
+    def test_passes_end_to_end_on_a_healthy_tenant(self, tmp_path: Path) -> None:
+        _write_bundle(tmp_path)
+        routes = _FakeRoutes([_both_cards()], _healthy_configmaps())
+
+        report = verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+
+        assert len(report) == 2
+        assert all("resolves" in line for line in report)
+
+    def test_the_negative_control_runs_before_anything_is_trusted(
+        self, tmp_path: Path
+    ) -> None:
+        """The bogus probe must be the FIRST configmap asked for.
+
+        Every 200 the check trusts is worthless if the endpoint answers 200 for
+        unknown names, so the discrimination has to be proven before the first
+        real fetch — not after, where a vacuous pass has already been reported.
+        """
+        _write_bundle(tmp_path)
+        routes = _FakeRoutes([_both_cards()], _healthy_configmaps())
+
+        verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+
+        assert routes.asked[0] == "clickhouse-nonexistent-setup-route-check"
+
+    def test_fails_when_unknown_names_are_not_rejected(self, tmp_path: Path) -> None:
+        """A 200 for a name that cannot exist makes every assertion vacuous."""
+        _write_bundle(tmp_path)
+        routes = _FakeRoutes([_both_cards()], _healthy_configmaps(), unknown_status=200)
+
+        with pytest.raises(SetupRouteError, match="proves anything"):
+            verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+
+    def test_reports_the_packageid_regression_against_a_tenant(
+        self, tmp_path: Path
+    ) -> None:
+        """The whole point, exercised through verify() rather than the helper.
+
+        The card ids are the ones the FND-1593 build produced. Note the
+        configmaps for the CORRECT names still answer 200 — which is exactly why
+        a check asserting ``configmaps/clickhouse-crawler == 200`` would have
+        passed straight through this.
+        """
+        _write_bundle(tmp_path)
+        catalog = [
+            _card_payload("atlan-clickhouse", entrypoint="crawler"),
+            _card_payload("atlan-clickhouse-miner", entrypoint="miner"),
+        ]
+        routes = _FakeRoutes([catalog], _healthy_configmaps())
+
+        with pytest.raises(SetupRouteError) as caught:
+            verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+
+        message = str(caught.value)
+        # Both entrypoints broke, so both must be reported — not just the first.
+        assert "atlan-clickhouse" in message
+        assert "atlan-clickhouse-miner" in message
+        assert "clickhouse-crawler" in message
+        assert "clickhouse-miner" in message
+
+    def test_fails_when_the_card_id_resolves_to_a_404(self, tmp_path: Path) -> None:
+        """Card and config agree, but the tenant serves no form for the name."""
+        _write_bundle(tmp_path)
+        configmaps = _healthy_configmaps()
+        del configmaps["clickhouse-miner"]
+        routes = _FakeRoutes([_both_cards()], configmaps)
+
+        with pytest.raises(SetupRouteError, match="404'd setup page"):
+            verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+
+    def test_fails_when_the_endpoint_serves_a_different_name(
+        self, tmp_path: Path
+    ) -> None:
+        """Asked for one form, served another — the page renders the wrong one."""
+        _write_bundle(tmp_path)
+        configmaps = _healthy_configmaps()
+        configmaps["clickhouse-crawler"] = (
+            200,
+            _configmap_response(
+                {"properties": {"extraction-method": {}}}, "something-else"
+            ),
+        )
+        routes = _FakeRoutes([_both_cards()], configmaps)
+
+        with pytest.raises(SetupRouteError, match="served 'something-else'"):
+            verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+
+    def test_polls_until_the_catalog_reconciles(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A card absent on the first read but present later must pass.
+
+        ``install()`` polling the DEPLOYMENT to SUCCEEDED is not evidence that
+        LM's catalog snapshot has caught up, and the prototype this generalises
+        never exercised the immediately-post-install path — so a single read
+        would be flaky-by-construction on exactly the path CI takes.
+        """
+        from application_sdk.testing import setup_routes as module
+
+        _write_bundle(tmp_path)
+        both = _both_cards()
+        # First read: only the crawler card has appeared. Second: both.
+        routes = _FakeRoutes([both[:1], both], _healthy_configmaps())
+
+        # 0 so the test does not actually sleep. The interval is not what is
+        # under test — that a second read HAPPENS is.
+        monkeypatch.setattr(module, "_CATALOG_POLL_SECONDS", 0)
+        progress: list[str] = []
+
+        report = module.verify(
+            tmp_path,
+            routes,  # type: ignore[arg-type]
+            wait_seconds=60,
+            on_progress=progress.append,
+        )
+
+        assert len(report) == 2
+        assert routes.catalog_reads == 2
+        # The wait has to be visible in the log, or a patient step looks hung.
+        assert progress and "catalog not ready" in progress[0]
+
+    def test_gives_up_with_the_latest_reason(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A card that never appears fails, naming what was last seen.
+
+        The LAST reason, not the first: an early read that saw no card at all is
+        less informative than a late one that saw all but one.
+        """
+        from application_sdk.testing import setup_routes as module
+
+        _write_bundle(tmp_path)
+        routes = _FakeRoutes(
+            [[_card_payload("clickhouse-crawler", entrypoint="crawler")]],
+            _healthy_configmaps(),
+        )
+        monkeypatch.setattr(module, "_CATALOG_POLL_SECONDS", 0)
+
+        with pytest.raises(SetupRouteError) as caught:
+            module.verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+
+        message = str(caught.value)
+        assert "miner" in message
+        assert "Waited 0s" in message
+
+    def test_skips_an_app_with_no_generated_contract(self, tmp_path: Path) -> None:
+        """Skip-not-fail, or this is a fleet-wide false positive on day one."""
+        (tmp_path / "atlan.yaml").write_text("name: behind-the-scenes\n")
+        routes = _FakeRoutes([[]], {})
+
+        with pytest.raises(RouteCheckSkipped):
+            verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+
+        # And it must skip BEFORE touching the tenant: an app with no setup page
+        # should cost no tenant calls at all.
+        assert routes.catalog_reads == 0
+        assert routes.asked == []
+
+
+# ---------------------------------------------------------------------------
+# The two silent-wrong-answer shapes
+# ---------------------------------------------------------------------------
+
+
+class TestCardlessEntrypoints:
+    """`marketplace_card: false` is the behind-the-scenes pattern.
+
+    An entry point the DAG invokes with no card for a user to click has no setup
+    page, so asserting one exists is a false positive rather than a finding.
+    """
+
+    @staticmethod
+    def _bundle_with_cardless_miner(root: Path) -> None:
+        _write_bundle(root)
+        (root / "atlan.yaml").write_text(
+            "name: clickhouse\n"
+            "entrypoints:\n"
+            "- name: crawler\n"
+            "  type: connector\n"
+            "- name: miner\n"
+            "  type: miner\n"
+            "  marketplace_card: false\n"
+        )
+
+    def test_a_cardless_entrypoint_is_not_checked(self, tmp_path: Path) -> None:
+        self._bundle_with_cardless_miner(tmp_path)
+
+        found = read_entrypoints(tmp_path)
+
+        assert [e.name for e in found] == ["crawler"]
+
+    def test_a_cardless_entrypoint_does_not_fail_the_run(self, tmp_path: Path) -> None:
+        """The tenant lists no miner card, and that must be fine."""
+        self._bundle_with_cardless_miner(tmp_path)
+        catalog = [_card_payload("clickhouse-crawler", entrypoint="crawler")]
+        routes = _FakeRoutes([catalog], _healthy_configmaps())
+
+        report = verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+
+        assert len(report) == 1
+
+    def test_absent_means_a_card_is_expected(self, tmp_path: Path) -> None:
+        """Absence must NOT be read as "no card".
+
+        Live connectors are marketplace cards today while emitting neither
+        `marketplace_card` nor `package_id` — the key only appears once
+        `packageId` is set. Keying on absence would skip the entire fleet and
+        this check would assert nothing at all, which is strictly worse than
+        having no check.
+        """
+        _write_bundle(tmp_path)  # no marketplace_card key anywhere
+
+        assert read_entrypoint_names(tmp_path) == ["crawler", "miner"]
+
+    def test_true_is_also_checked(self, tmp_path: Path) -> None:
+        _write_bundle(tmp_path)
+        (tmp_path / "atlan.yaml").write_text(
+            "name: clickhouse\n"
+            "entrypoints:\n"
+            "- name: crawler\n"
+            "  marketplace_card: true\n"
+        )
+
+        assert read_entrypoint_names(tmp_path) == ["crawler"]
+
+    def test_all_cardless_is_a_skip_not_a_failure(self, tmp_path: Path) -> None:
+        _write_bundle(tmp_path)
+        (tmp_path / "atlan.yaml").write_text(
+            "name: behind-the-scenes\n"
+            "entrypoints:\n"
+            "- name: crawler\n"
+            "  marketplace_card: false\n"
+            "- name: miner\n"
+            "  marketplace_card: false\n"
+        )
+
+        with pytest.raises(RouteCheckSkipped, match="marketplace_card: false"):
+            read_entrypoints(tmp_path)
+
+    def test_a_bundle_declaring_no_entrypoints_still_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """Skip and fail must not be conflated.
+
+        `read_entrypoint_names` returns an empty list both for "all opted out"
+        and for "declares none", but only the first is a legitimate skip — the
+        second is a nested tree whose cards cannot be located, which is
+        incoherent committed state.
+        """
+        _write_bundle(tmp_path)
+        (tmp_path / "atlan.yaml").write_text("name: clickhouse\n")
+
+        with pytest.raises(SetupRouteError, match="declares no entrypoints"):
+            read_entrypoints(tmp_path)
+
+
+class TestCatalogTruncation:
+    """A truncated catalog read reports "not installed" — a silent wrong answer.
+
+    It is the worst failure available to a check whose entire value is that it
+    does not false-positive, so it must be loud instead.
+    """
+
+    class _TruncatingRoutes(_FakeRoutes):
+        def __init__(self, apps: list[dict[str, Any]], total: int) -> None:
+            super().__init__([apps], _healthy_configmaps())
+            self._total = total
+
+        # Re-implements the real `catalog()` guard path rather than the fake's
+        # shortcut, so the assertion is against the shipped code.
+        def catalog(self) -> list[dict[str, Any]]:
+            from application_sdk.testing.setup_routes import TenantRoutes
+
+            self.catalog_reads += 1
+            body = {"total": self._total, "apps": self._catalogs[0]}
+            return TenantRoutes.catalog(_StubGet(body))  # type: ignore[arg-type]
+
+    def test_a_short_page_fails_loudly(self, tmp_path: Path) -> None:
+        _write_bundle(tmp_path)
+        routes = self._TruncatingRoutes(
+            [_card_payload("clickhouse-crawler", entrypoint="crawler")], total=137
+        )
+
+        with pytest.raises(SetupRouteError, match="paginated"):
+            verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+
+    def test_a_complete_page_is_accepted(self, tmp_path: Path) -> None:
+        """`total` equal to the page length is the normal, unpaginated case."""
+        _write_bundle(tmp_path)
+        both = _both_cards()
+        routes = self._TruncatingRoutes(both, total=len(both))
+
+        report = verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+
+        assert len(report) == 2
+
+
+class _StubGet:
+    """Feeds one canned body to the real ``TenantRoutes.catalog`` guard.
+
+    Constructed rather than instantiating ``TenantRoutes`` so no URL validation
+    or network setup is involved; ``catalog()`` only calls ``self.get``.
+    """
+
+    def __init__(self, body: dict[str, Any]) -> None:
+        self._body = body
+
+    def get(self, path: str) -> tuple[int, object]:
+        return 200, self._body

--- a/tests/unit/testing/test_setup_routes.py
+++ b/tests/unit/testing/test_setup_routes.py
@@ -105,6 +105,20 @@ def _workflow_config(config_id: str = "clickhouse-crawler") -> dict[str, Any]:
     }
 
 
+def _eps(*names: str) -> list[Entrypoint]:
+    """Named entrypoints, as a bundle's `atlan.yaml` declares them."""
+    return [Entrypoint(name=name, config_id=f"clickhouse-{name}") for name in names]
+
+
+def _sole(config_id: str) -> list[Entrypoint]:
+    """The single entry point of an app declaring no `entrypoints[]`.
+
+    Labelled by its committed config id — never by an empty string, which is
+    the magic value this module deliberately has no place for.
+    """
+    return [Entrypoint(name=config_id, config_id=config_id, is_sole=True)]
+
+
 def _configmap_response(
     schema: dict[str, Any], name: str = "clickhouse-crawler"
 ) -> dict[str, Any]:
@@ -193,14 +207,20 @@ class TestRouteMismatch:
         assert reason is not None
         assert "Regenerate the contract" in reason
 
-    def test_a_flat_app_is_named_readably(self) -> None:
-        """An empty entrypoint name must not render as an empty quote in prose."""
+    def test_a_sole_entrypoint_is_named_by_its_config_id(self) -> None:
+        """Never an empty quote in prose, because the name is never empty.
+
+        An earlier revision rendered a flat app as `''` and papered over it with
+        a `<flat>` placeholder at every message site. The label is now a
+        committed fact, so there is nothing to paper over.
+        """
         card = Card.from_payload(_card_payload("atlan-mysql", entrypoint=""))
 
-        reason = route_mismatch("", card, "mysql")
+        reason = route_mismatch("mysql", card, "mysql")
 
         assert reason is not None
-        assert "<flat>" in reason
+        assert "'mysql'" in reason
+        assert "<flat>" not in reason
 
 
 # ---------------------------------------------------------------------------
@@ -271,7 +291,7 @@ class TestLocateCards:
             )
         ]
 
-        cards, reason = locate_cards("clickhouse", ["crawler"], catalog)
+        cards, reason = locate_cards("clickhouse", _eps("crawler"), catalog)
 
         assert reason is None
         assert set(cards) == {"crawler"}
@@ -280,7 +300,7 @@ class TestLocateCards:
     def test_reports_an_app_absent_from_the_catalog(self) -> None:
         catalog = [_card_payload("mssql-crawler", name="mssql")]
 
-        cards, reason = locate_cards("clickhouse", ["crawler"], catalog)
+        cards, reason = locate_cards("clickhouse", _eps("crawler"), catalog)
 
         assert cards == {}
         assert reason is not None
@@ -293,20 +313,24 @@ class TestLocateCards:
         """An entrypoint with no card has no setup page at all."""
         catalog = [_card_payload("clickhouse-crawler", name="clickhouse")]
 
-        cards, reason = locate_cards("clickhouse", ["crawler", "miner"], catalog)
+        cards, reason = locate_cards("clickhouse", _eps("crawler", "miner"), catalog)
 
         assert set(cards) == {"crawler"}
         assert reason is not None
         assert "miner" in reason
 
-    def test_a_flat_app_card_keys_under_empty_string(self) -> None:
-        """A single-generated-contract app's card carries no ``entrypoint``."""
+    def test_a_sole_contract_card_keys_under_its_config_id(self) -> None:
+        """No empty-string key anywhere, and the card matches by count.
+
+        The card's own `entrypoint` takes no part in the match — there is one
+        card and one form, so there is nothing to choose between.
+        """
         catalog = [_card_payload("mysql", name="mysql", entrypoint="")]
 
-        cards, reason = locate_cards("mysql", [""], catalog)
+        cards, reason = locate_cards("mysql", _sole("mysql"), catalog)
 
         assert reason is None
-        assert cards[""].id == "mysql"
+        assert cards["mysql"].id == "mysql"
 
 
 # ---------------------------------------------------------------------------
@@ -453,8 +477,9 @@ class TestArtifactReaders:
 
         found = read_entrypoints(tmp_path)
 
-        assert [e.name for e in found] == [""]
+        assert [e.name for e in found] == ["mysql"]
         assert found[0].config_id == "mysql"
+        assert found[0].is_sole is True
 
     def test_skips_when_nothing_is_generated(self, tmp_path: Path) -> None:
         """Skip, not fail: no generated tree means no setup page to check."""
@@ -1008,3 +1033,262 @@ class _StubGet:
 
     def get(self, path: str) -> tuple[int, object]:
         return 200, self._body
+
+
+# ---------------------------------------------------------------------------
+# Review findings — three shapes that each reported a healthy app as broken
+# ---------------------------------------------------------------------------
+
+
+class TestCardNameCasing:
+    """`read_app_name` lowercases atlan.yaml; a card's name is the catalog's.
+
+    Comparing them verbatim reports a mixed-case card as "not installed on this
+    tenant" — a false negative wearing the most misleading message this check
+    can emit, since it points the reader at the deploy rather than at the match.
+    """
+
+    def test_a_mixed_case_card_still_matches(self) -> None:
+        catalog = [_card_payload("clickhouse-crawler", name="ClickHouse")]
+
+        cards, reason = locate_cards("clickhouse", _eps("crawler"), catalog)
+
+        assert reason is None
+        assert cards["crawler"].id == "clickhouse-crawler"
+
+    def test_a_padded_card_name_still_matches(self) -> None:
+        """Neither side is a value whose formatting we control."""
+        catalog = [_card_payload("clickhouse-crawler", name="  clickhouse  ")]
+
+        cards, reason = locate_cards("clickhouse", _eps("crawler"), catalog)
+
+        assert reason is None
+        assert cards["crawler"].id == "clickhouse-crawler"
+
+    def test_a_genuinely_different_app_still_does_not_match(self) -> None:
+        """Case-folding must not widen the match to a different app."""
+        catalog = [_card_payload("clickhouse-crawler", name="clickhouse-legacy")]
+
+        cards, reason = locate_cards("clickhouse", _eps("crawler"), catalog)
+
+        assert cards == {}
+        assert reason is not None
+
+
+class TestSoleContractCardMatching:
+    """An app's single card, whatever `entrypoint` the catalog gave it.
+
+    A route/card-split app (BLDX-1342) has several `@entrypoint`s behind ONE
+    card and therefore one flat generated tree. That card is served carrying a
+    real entrypoint name — and an earlier revision keyed such an app under `""`
+    and matched on that key, so a perfectly healthy single-card app reported as
+    having no card at all.
+
+    Two things fix it, and neither is a guess. Entrypoints never carry an empty
+    name: a sole contract is labelled by its committed config id. And a sole
+    contract's card is matched by COUNT — one form, one card, nothing to choose
+    between — so the card's own `entrypoint` takes no part in the match.
+
+    That is also why no default entrypoint is calculated: every case that might
+    have needed one is answered by a fact instead. `@entrypoint(default=True)`
+    is a runtime `AppRegistry` flag absent from both `atlan.yaml` and
+    `manifest.json`, so a default computed here could only ever be a
+    presumption.
+    """
+
+    def test_a_sole_card_with_a_named_entrypoint_matches(self, tmp_path: Path) -> None:
+        catalog = [_card_payload("mysql", name="mysql", entrypoint="crawler")]
+
+        cards, reason = locate_cards("mysql", _sole("mysql"), catalog)
+
+        assert reason is None
+        assert cards["mysql"].id == "mysql"
+
+    def test_a_sole_card_with_no_entrypoint_still_matches(self) -> None:
+        """The case that already worked must keep working."""
+        catalog = [_card_payload("mysql", name="mysql", entrypoint="")]
+
+        cards, reason = locate_cards("mysql", _sole("mysql"), catalog)
+
+        assert reason is None
+        assert cards["mysql"].id == "mysql"
+
+    def test_a_sole_contract_verifies_end_to_end_against_a_named_card(
+        self, tmp_path: Path
+    ) -> None:
+        """The whole check, on the shape that used to report "no card"."""
+        _write_flat(tmp_path)
+        schema = {
+            "properties": {
+                "extraction-method": {},
+                "credential-guid": {},
+                "connection": {},
+            }
+        }
+        routes = _FakeRoutes(
+            [[_card_payload("mysql", name="mysql", entrypoint="crawler")]],
+            {"mysql": (200, _configmap_response(schema, "mysql"))},
+        )
+
+        report = verify(tmp_path, routes, wait_seconds=0)  # type: ignore[arg-type]
+
+        assert len(report) == 1
+
+    def test_two_cards_for_a_sole_contract_is_reported_not_guessed(self) -> None:
+        """One form, two cards: the two disagree about the app's shape.
+
+        Picking either would be a coin toss that reports as a pass or as a
+        contract break depending on which way it landed, so this names the
+        disagreement instead.
+        """
+        catalog = [
+            _card_payload("mysql", name="mysql", entrypoint="crawler"),
+            _card_payload("mysql-miner", name="mysql", entrypoint="miner"),
+        ]
+
+        cards, reason = locate_cards("mysql", _sole("mysql"), catalog)
+
+        assert cards == {}
+        assert reason is not None
+        assert "ambiguous" in reason
+        assert "crawler" in reason and "miner" in reason
+
+    def test_a_bundle_still_matches_on_entrypoint(self) -> None:
+        """The count-match is scoped to a sole contract only.
+
+        A bundle must keep matching card to entrypoint by name, or one entry
+        point's form could be checked against another's card.
+        """
+        catalog = [
+            _card_payload("clickhouse-crawler", entrypoint="crawler"),
+            _card_payload("clickhouse-miner", entrypoint="miner"),
+        ]
+
+        cards, reason = locate_cards("clickhouse", _eps("crawler", "miner"), catalog)
+
+        assert reason is None
+        assert cards["crawler"].id == "clickhouse-crawler"
+        assert cards["miner"].id == "clickhouse-miner"
+
+
+class TestRedirectsAreDeclined:
+    """`urlopen` follows redirects by default, and that default is dangerous.
+
+    A tenant that bounces an unauthenticated request to a login page would hand
+    this check a 200 carrying HTML. A check built on "200 means the form is
+    served" cannot tell that from success, and the negative control — the one
+    assertion that certifies all the others — is exactly what it disarms.
+    """
+
+    @staticmethod
+    def _serve(handler_status: int, location: str = "https://login.invalid/sso"):
+        """Run a one-request HTTP server returning *handler_status*."""
+        import http.server
+        import threading
+
+        class _Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler's name
+                self.send_response(handler_status)
+                if 300 <= handler_status < 400:
+                    self.send_header("Location", location)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"ok": true}')
+
+            def log_message(self, *args: object) -> None:
+                pass
+
+        server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        return server
+
+    def test_a_302_stays_a_302(self) -> None:
+        """The finding, pinned: following it would report 200 for a login page."""
+        from application_sdk.testing.setup_routes import TenantRoutes
+
+        server = self._serve(302)
+        try:
+            routes = TenantRoutes.__new__(TenantRoutes)
+            routes.base_url = f"http://127.0.0.1:{server.server_port}"
+            routes.bearer = "unused"
+
+            status, _ = routes.get("/anything")
+        finally:
+            server.shutdown()
+
+        assert status == 302, (
+            "the redirect was followed; a 302 to a login page would arrive as a "
+            "200 and the negative control would certify nothing"
+        )
+
+    def test_a_200_is_still_a_200(self) -> None:
+        """Declining redirects must not disturb the ordinary path."""
+        from application_sdk.testing.setup_routes import TenantRoutes
+
+        server = self._serve(200)
+        try:
+            routes = TenantRoutes.__new__(TenantRoutes)
+            routes.base_url = f"http://127.0.0.1:{server.server_port}"
+            routes.bearer = "unused"
+
+            status, body = routes.get("/anything")
+        finally:
+            server.shutdown()
+
+        assert status == 200
+        assert body == {"ok": True}
+
+    def test_a_redirect_is_not_a_valid_rejection(self) -> None:
+        """The negative control must not accept a 3xx as "correctly rejected".
+
+        A tenant redirecting every request would otherwise look like a tenant
+        that discriminates unknown names, which is the vacuous state the
+        control exists to detect.
+        """
+        from application_sdk.testing.setup_routes import _REJECTION_STATUSES
+
+        for redirect in (301, 302, 303, 307, 308):
+            assert redirect not in _REJECTION_STATUSES
+
+
+class TestUnlabelledBundleCard:
+    """A bundle's card carrying no entrypoint is reported, never attributed.
+
+    This is the case a calculated default was considered for and rejected. An
+    unlabelled card cannot be assigned to a named entrypoint without presuming
+    one, and presuming wrong produces "the card points at the wrong form" —
+    which reads exactly like a real contract break, sending the reader after a
+    regression that does not exist.
+
+    Reporting it is also the more useful answer: the usual cause is an installed
+    build that predates the entrypoint split, serving one card where this branch
+    generates several. That is a genuine finding, and naming it beats silently
+    checking one arbitrary entrypoint against it.
+    """
+
+    def test_an_unlabelled_card_is_reported(self) -> None:
+        catalog = [_card_payload("clickhouse", name="clickhouse", entrypoint="")]
+
+        cards, reason = locate_cards("clickhouse", _eps("crawler", "miner"), catalog)
+
+        assert reason is not None
+        assert "cannot be attributed" in reason
+        assert "predates the entrypoint split" in reason
+        # It must not have been silently assigned to either entrypoint.
+        assert cards == {}
+
+    def test_no_default_is_calculated_anywhere(self) -> None:
+        """No alphabetical-first fallback survived the redesign.
+
+        A default computed from committed artifacts is wrong for any app that
+        marks a non-alphabetical `@entrypoint(default=True)` — invisible from
+        `atlan.yaml` and `manifest.json` alike — so the module must contain no
+        such computation to drift back into use.
+        """
+        import application_sdk.testing.setup_routes as module
+
+        source = Path(module.__file__).read_text(encoding="utf-8")
+
+        assert "calculated_default" not in source
+        assert "sorted(names)[0]" not in source

--- a/tests/unit/testing/test_setup_routes.py
+++ b/tests/unit/testing/test_setup_routes.py
@@ -32,7 +32,11 @@ thing in this whole check to get quietly wrong.
 
 from __future__ import annotations
 
+import email.message
+import io
 import json
+import urllib.request
+import urllib.response
 from pathlib import Path
 from typing import Any
 
@@ -1178,66 +1182,124 @@ class TestRedirectsAreDeclined:
     this check a 200 carrying HTML. A check built on "200 means the form is
     served" cannot tell that from success, and the negative control — the one
     assertion that certifies all the others — is exactly what it disarms.
+
+    These drive urllib's REAL redirect dispatch over a fake transport rather
+    than over a socket. `OpenerDirector` routes a 3xx through
+    `HTTPErrorProcessor` to the redirect handler exactly as it would on the
+    wire, so swapping only the transport leaves the behaviour under test
+    untouched — and the unit tier bans sockets (`--disable-socket` on
+    Linux/macOS; the guard is skipped on Windows only because
+    ProactorEventLoop needs AF_INET internally, which is why a socket-based
+    version of this passed there and failed everywhere else).
+
+    `test_the_default_handler_would_have_followed_it` is the control that makes
+    the rest mean something: it shows the redirect really was there to be
+    followed, so a passing "stays a 302" cannot be a fake transport that simply
+    never redirected.
     """
 
-    @staticmethod
-    def _serve(handler_status: int, location: str = "https://login.invalid/sso"):
-        """Run a one-request HTTP server returning *handler_status*."""
-        import http.server
-        import threading
+    _LOGIN = "http://127.0.0.1:1/sso"
 
-        class _Handler(http.server.BaseHTTPRequestHandler):
-            def do_GET(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler's name
-                self.send_response(handler_status)
-                if 300 <= handler_status < 400:
-                    self.send_header("Location", location)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(b'{"ok": true}')
+    @classmethod
+    def _transport(cls, first_status: int) -> type[urllib.request.HTTPHandler]:
+        """A transport returning *first_status*, then a 200 at the login URL.
 
-            def log_message(self, *args: object) -> None:
-                pass
+        Both hops are answered locally, so following the redirect is fully
+        observable without a network.
+        """
+        login = cls._LOGIN
 
-        server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
-        thread.start()
-        return server
+        class _Body(io.BytesIO):
+            """A response body carrying `msg`.
 
-    def test_a_302_stays_a_302(self) -> None:
+            `HTTPRedirectHandler.http_error_302` reads `fp.msg` when it builds
+            the follow-up request, and a bare `BytesIO` cannot carry attributes
+            — so without this the control below fails inside urllib rather than
+            demonstrating the redirect it exists to demonstrate.
+            """
+
+            msg = "Found"
+
+        class _Fake(urllib.request.HTTPHandler):
+            def http_open(self, req: urllib.request.Request) -> object:
+                if req.full_url == login:
+                    headers = email.message.Message()
+                    headers["Content-Type"] = "text/html"
+                    return urllib.response.addinfourl(
+                        _Body(b"<html>sign in</html>"), headers, req.full_url, 200
+                    )
+                headers = email.message.Message()
+                headers["Content-Type"] = "application/json"
+                if 300 <= first_status < 400:
+                    headers["Location"] = login
+                response = urllib.response.addinfourl(
+                    _Body(b'{"ok": true}'), headers, req.full_url, first_status
+                )
+                response.msg = "Found"  # type: ignore[attr-defined]
+                return response
+
+        return _Fake
+
+    def _get(
+        self, monkeypatch: pytest.MonkeyPatch, opener: object
+    ) -> tuple[int, object]:
+        from application_sdk.testing import setup_routes as module
+
+        monkeypatch.setattr(module, "_OPENER", opener)
+        routes = module.TenantRoutes.__new__(module.TenantRoutes)
+        routes.base_url = "http://127.0.0.1:1"
+        routes.bearer = "unused"
+        return routes.get("/anything")
+
+    def test_a_302_stays_a_302(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The finding, pinned: following it would report 200 for a login page."""
-        from application_sdk.testing.setup_routes import TenantRoutes
+        from application_sdk.testing.setup_routes import _NoRedirect
 
-        server = self._serve(302)
-        try:
-            routes = TenantRoutes.__new__(TenantRoutes)
-            routes.base_url = f"http://127.0.0.1:{server.server_port}"
-            routes.bearer = "unused"
+        opener = urllib.request.build_opener(self._transport(302), _NoRedirect)
 
-            status, _ = routes.get("/anything")
-        finally:
-            server.shutdown()
+        status, _ = self._get(monkeypatch, opener)
 
         assert status == 302, (
             "the redirect was followed; a 302 to a login page would arrive as a "
             "200 and the negative control would certify nothing"
         )
 
-    def test_a_200_is_still_a_200(self) -> None:
+    def test_the_default_handler_would_have_followed_it(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The control: without the override, the login page arrives as a 200.
+
+        This is what makes the test above meaningful rather than vacuous — the
+        redirect was genuinely there to be followed, and declining it is what
+        changes the outcome.
+        """
+        opener = urllib.request.build_opener(self._transport(302))
+
+        status, body = self._get(monkeypatch, opener)
+
+        assert status == 200
+        assert "sign in" in str(body)
+
+    def test_a_200_is_still_a_200(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Declining redirects must not disturb the ordinary path."""
-        from application_sdk.testing.setup_routes import TenantRoutes
+        from application_sdk.testing.setup_routes import _NoRedirect
 
-        server = self._serve(200)
-        try:
-            routes = TenantRoutes.__new__(TenantRoutes)
-            routes.base_url = f"http://127.0.0.1:{server.server_port}"
-            routes.bearer = "unused"
+        opener = urllib.request.build_opener(self._transport(200), _NoRedirect)
 
-            status, body = routes.get("/anything")
-        finally:
-            server.shutdown()
+        status, body = self._get(monkeypatch, opener)
 
         assert status == 200
         assert body == {"ok": True}
+
+    def test_the_shipped_opener_carries_the_handler(self) -> None:
+        """The tests above build their own opener; this pins the real one.
+
+        Without it they would prove `_NoRedirect` works while `TenantRoutes`
+        quietly used a default opener.
+        """
+        from application_sdk.testing.setup_routes import _OPENER, _NoRedirect
+
+        assert any(isinstance(h, _NoRedirect) for h in _OPENER.handlers)
 
     def test_a_redirect_is_not_a_valid_rejection(self) -> None:
         """The negative control must not accept a 3xx as "correctly rejected".


### PR DESCRIPTION
Closes FND-1667.

## The gap

A contract change can 404 a connector's setup page while **every local and CI check stays green**. FND-1593 shipped exactly that:

|  | URL | Result |
| -- | -- | -- |
| before | `/workflows/setup/<connector>-crawler` | works |
| after `packageId` | `/workflows/setup/atlan-<connector>` | **404** |

The generated artifacts were all self-consistent, conformance was clean (K001/K002 cleared), and the generated-artifact freshness gate passed. Nothing was stale or hand-edited. The break lived only in the **join between what the contract generates and what the tenant serves**, and no gate looked there. A human opened the UI and found it.

That is a gap, not a one-off: any contract change that moves a marketplace card's identity breaks the setup page while leaving every mechanical check satisfied.

## What this adds

A fleet-wide check for that join, with **no changes in any app repo**. It asserts, in the direction the UI walks it:

1. **Locate the app's cards** by app `name` **and** `entrypoint` — facts that are not the thing under test. `entrypoint` alone is not app-scoped: every connector's crawler card carries `entrypoint: "crawler"`, so filtering on it alone matches a dozen unrelated apps with a plausible-looking count.
2. **`card.id` equals the `id`** in the committed generated workflow config. This is the assertion that bites — a check asserting `GET configmaps/<known-good-name> == 200` **would have passed straight through the regression**, because that name never stopped working. What moved was the card pointing at it.
3. **`GET /api/service/configmaps/<card.id>`** answers 200 and echoes back the name asked for.
4. **The served form declares every input the committed contract does** — a *subset* check, so platform-added fields are not brittle while a stale image still fails.
5. **A negative control runs first**: an unknown config name must really be rejected, or every 200 above is vacuous.

## Design decisions worth reviewing

### One authority for the generated tree, because the SDK is on both sides

`/api/service/configmaps/<name>` is Heracles proxying to the app pod's **own** `GET /workflows/v1/configmap/{id}` in `handler/service.py`. So rather than re-deriving how to read `app/generated/**`, three facts move into `application_sdk/app/generated_tree.py` and both pre-existing call sites now read from there:

| Function | Was in | Answers |
| --- | --- | --- |
| `generated_layout()` | `_artifact_schema_guard` | `multi` / `single` / `unknown` |
| `is_form_configmap()` | `handler/service` | form, vs `manifest` / `{atlan,csa}-connectors-*` template |
| `form_configmap()` | new | which file is *this* entry point's form |

A second copy would let the server serve one file while the check compared against another — and that mismatch would read as a contract regression rather than as two divergent copies of one rule. The consolidation already pays: deleting the credential-template exclusion reds one new test **and three pre-existing `test_service.py` tests**.

### The step is in `sdr-e2e`, not `prepare-tenant`

The ticket proposed `prepare-tenant`. That job has two `uses:` steps, both `actions/checkout` — no `setup-uv`, no `uv sync` — so the SDK is not importable there. Adding a sync would be worse than moving the step: `.github/scripts` is sparse-checked-out at `job.workflow_sha`, always the SDK commit under test, whereas a sync installs whatever version the **app** pinned. An SDK PR changing the check would then silently exercise the app's pin, and a fix would reach the fleet only as apps bumped.

`sdr-e2e` satisfies all three constraints at once: the SDK is synced, the tenant creds are exported, and the calling `e2e` job carries `prepare-tenant` in its `needs:` — so the step is strictly post-install. **One insertion covers both e2e callers** (`tests-reusable`'s `e2e` and `e2e-full-reusable`'s `e2e-full`).

Gated on `expected-app-version`, the same gate as the version verify, which is precisely "this run installed the app under test". Without that gate the subset check would report a stale tenant image as a contract break. Placed after the version verify and before the suite: a version mismatch has to be the error the reader sees first, and an app whose setup page will not load is not usefully installed.

The ticket's `verify-routes` subcommand on `e2e_tenant_app.py` was **dropped** — that script is deliberately stdlib-only ("these run in CI jobs that have not yet installed the SDK") and is the driver `prepare-tenant` invokes, so an SDK-importing subcommand would put a one-job-only import into a module another job uses.

### Version skew, and the second commit

Both callers reference the action as `@main`, so this reaches every repo's next e2e run at once — while the SDK it imports is the connector's own pinned version. Without a guard that is `ModuleNotFoundError` and a red e2e leg in **every connector pinned below the release carrying the check**, with nothing wrong in any app.

The second commit adds an **import probe** (not a version comparison — no floor constant to keep in step with a release number) that skips with a `::notice::` when the module is absent. The window closes on its own as apps bump. Three subprocess tests drive the real shell against a synthesised older SDK, because the property is "survives an old pin" and only running it proves that.

### Bounded poll, not a single read

`install()` polling the *deployment* to SUCCEEDED is not evidence that LM's catalog snapshot and the pod's configmap endpoint have caught up — nothing sequences those against the deployment verdict, and the prototype this generalises never exercised the immediately-post-install path. The poll prints a flushed line per retry, so **the first real run reads out the actual latency** rather than leaving the window an assumption.

### Skip, don't fail

| Situation | Outcome |
| --- | --- |
| No generated contract | Skipped, `::notice::`, zero tenant calls |
| Entry point declares `marketplace_card: false` | Not checked (behind-the-scenes pattern) |
| App's pinned SDK predates the check | Skipped, `::notice::` saying no app-side action is needed |
| Caller did not install (`expected-app-version` empty) | Step does not run |
| Declared entry point has no generated config, or no `id` | **Fails** — incoherent committed state |

Absence of `marketplace_card` is deliberately **not** read as "no card": live connectors are cards today while emitting neither that key nor `package_id`, so keying on absence would silently skip the fleet and assert nothing.

## Two silent-wrong-answer shapes closed beyond the ticket

1. **Catalog truncation** — a truncated page makes an installed app look absent, reported as "not installed on this tenant". That is the worst available failure for a check whose value is not false-positiving. Now compares `total` against the page length and names pagination as the cause.
2. **Negative-control ordering** — the bogus-name probe runs *before* any 200 is trusted. Last would mean a vacuous pass has already been reported.

## Testing

53 unit tests, 18 wiring guards, **2853 passing** across the affected suites. Full `.github/scripts/tests/` run: exit 0.

Mutation-checked; eight mutants, all caught:

| Mutant | Tests reded |
| --- | --- |
| `route_mismatch` → always `None` | 7 |
| `served_inputs` reads one nesting level too deep | 5 |
| `locate_cards` drops app-name scoping | 2 |
| `is_form_configmap` drops the credential exclusion | 4 (1 new + **3 pre-existing**) |
| catalog truncation guard removed | 1 |
| `marketplace_card` absence read as "no card" | 16 |
| skew guard removed (the pre-fix state) | 3 |
| skew probe always reports "absent" | 1 |

That last one is the most dangerous mutant in the set: it greens every leg forever and looks identical to a pass.

A round-trip test (`TestServedFormRoundTrip`) drives the live FastAPI configmap route rather than a hand-written envelope, so both sides of the join are pinned in-repo — including a case that serves a form with an input deleted, since the prototype's subset check had never been shown to catch a genuine shortfall.

### Two corrections to my own work, both of the silently-passing kind

- A mutation exposed that one new test was **vacuous**: our card happened to be last in the fixture catalog and the entrypoint-keyed dict is last-wins, so it passed even with the app-name scoping removed. Fixture reordered.
- A credential-template fixture had the shape **inverted** (`id` and no `config`; the toolkit emits `config` and no `id`). It passed for a reason unrelated to its claim, its docstring named a mechanism that does not hold, and it flattered the code under test. Both fixtures now carry the real shape, verified against `atlan-clickhouse-app` and `atlan-mysql-app`.

The second generalises, so `docs/agents/testing.md` gains a note: build generated-artifact fixtures from a real artifact and cite the source repo. It is APP-TESTS-001's self-certifying PR arriving through the *fixture* rather than the assertion, which is the harder direction to notice.

## Docs

- `docs/concepts/entry-points.md` — the one-authority table, why the credential-template exclusion is load-bearing, why layout is read from the tree rather than `len(entry_points)` (route/card-split apps), and the two-lookup setup route.
- `docs/standards/connector-ci-e2e.md` — a "Workflow-setup routes" section: what it asserts, the skip/fail table, the bounded poll, why the logic is split, and the known limitation.
- `docs/agents/testing.md` — the fixture-fidelity note above.

## Known limitation

The endpoint paths are `atlan-frontend`'s, not ours (`BASE_PATH = 'service'` + `getAPIPath`, confirmed live). If the frontend changes how it derives the setup route, this check goes stale — the mitigation is that it is in one place rather than in ~79 app repos. Note the ticket's risk bullet is half wrong as written: the *path* is the frontend's, the *envelope* is ours.

## Follow-up, deliberately not in this PR

The two prototype files in `atlan-clickhouse-app` (`tests/e2e/test_workflow_setup_routes.py`, `tests/unit/test_setup_route_check.py`) stay until the release carrying this check is available; that repo's PR #146 is held open on purpose and merges after. Sequencing agreed with the author of the prototype.

Post-install catalog latency is still an open measurement, not a resolved question — the poll is the right shape regardless, and the first CI run's log will supply the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBcfABsscvG9MaNFSe4MWT
