### PR TITLE
fix(testing): setup-route check must assert the form renders, not just resolve (FND-1680)

### DIFF
--- a/.github/actions/build-app-image/action.yaml
+++ b/.github/actions/build-app-image/action.yaml
@@ -9,7 +9,7 @@ description: |
   installs it onto the target tenant so the tenant serves the app under test
   rather than whatever was last hand-deployed there.
 
-  The image reference is deterministic (`sdr-test-<short-sha>`), so a caller
+  The image reference is deterministic (see derive_e2e_image_tag.py), so a caller
   that builds here and a caller that reads `image` back later agree without
   passing anything around.
 
@@ -39,7 +39,8 @@ inputs:
   app-image-name:
     description: |
       GHCR image name (e.g. "atlan-mysql-app"). The image is tagged
-      ghcr.io/atlanhq/<app-image-name>:sdr-test-<short-sha>.
+      ghcr.io/atlanhq/<app-image-name>:sdr-test-<short-sha>, plus a digest of the
+      SDK ref and base image when either is pinned — see derive_e2e_image_tag.py.
     required: true
   application-sdk-ref:
     description: |
@@ -226,9 +227,22 @@ runs:
         # command line and out of any tmpfile on the runner — buildx
         # streams it directly into the build context.
         GIT_TOKEN: ${{ inputs.git-token }}
+        # The tag must move whenever the built image's CONTENT moves, which
+        # `github.sha` alone does not capture: an application-sdk PR dispatches
+        # an e2e run that builds this connector at its unchanged HEAD with the
+        # SDK repinned, so successive SDK commits produced byte-different images
+        # under one tag. prepare-tenant then saw the version name it expected
+        # already installed and skipped ("tenant already runs … — nothing to
+        # do"), leaving each tenant on whatever content it happened to hold.
+        # See derive_e2e_image_tag.py; the rule is tested, not inlined here,
+        # per docs/standards/ci.md.
+        DERIVE_TAG: ${{ github.action_path }}/../../scripts/derive_e2e_image_tag.py
       run: |
-        SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
-        IMAGE_BASE="ghcr.io/atlanhq/${{ inputs.app-image-name }}:sdr-test-${SHORT_SHA}"
+        TAG=$(python3 "${DERIVE_TAG}" \
+          --commit "${{ github.sha }}" \
+          --sdk-ref "${{ inputs.application-sdk-ref }}" \
+          --base-image-ref "${BASE_IMAGE_REF}")
+        IMAGE_BASE="ghcr.io/atlanhq/${{ inputs.app-image-name }}:${TAG}"
         # Suffix is empty for every caller that does not build per-architecture,
         # so IMAGE is unchanged for them.
         IMAGE="${IMAGE_BASE}${{ inputs.tag-suffix }}"

--- a/.github/actions/build-app-image/action.yaml
+++ b/.github/actions/build-app-image/action.yaml
@@ -237,10 +237,20 @@ runs:
         # See derive_e2e_image_tag.py; the rule is tested, not inlined here,
         # per docs/standards/ci.md.
         DERIVE_TAG: ${{ github.action_path }}/../../scripts/derive_e2e_image_tag.py
+        # Both through env:, never `${{ }}` inside run:. GitHub expands a `${{ }}`
+        # expression into the script text BEFORE bash parses it, so the
+        # surrounding quotes protect nothing — a ref carrying a quote or `$(...)`
+        # would be executed. `application-sdk-ref` is caller-controlled and can
+        # be a branch name; the repin step above already routes it through env
+        # for exactly this reason. `github.sha` is hex and was interpolated by
+        # the `cut` this replaced, but there is no reason for the safe form to
+        # stop at one of the two.
+        COMMIT: ${{ github.sha }}
+        SDK_REF: ${{ inputs.application-sdk-ref }}
       run: |
         TAG=$(python3 "${DERIVE_TAG}" \
-          --commit "${{ github.sha }}" \
-          --sdk-ref "${{ inputs.application-sdk-ref }}" \
+          --commit "${COMMIT}" \
+          --sdk-ref "${SDK_REF}" \
           --base-image-ref "${BASE_IMAGE_REF}")
         IMAGE_BASE="ghcr.io/atlanhq/${{ inputs.app-image-name }}:${TAG}"
         # Suffix is empty for every caller that does not build per-architecture,

--- a/.github/scripts/derive_e2e_image_tag.py
+++ b/.github/scripts/derive_e2e_image_tag.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Derive the e2e test image tag, so it changes when the image content does.
+
+The bug this exists to make impossible
+--------------------------------------
+The tag was ``sdr-test-<connector-short-sha>``, derived from ``github.sha``
+alone. On a connector's own PR that is correct: the SHA moves whenever the
+image content moves.
+
+On an **application-sdk** PR it is not. The SDK dispatches an e2e run into each
+connector repo, which builds that connector *at its unchanged HEAD* with the
+SDK repinned to the PR's commit. Different SDK commit, different image content —
+identical tag. So each SDK push overwrote a mutable tag, published it as the
+same version name, and prepare-tenant then read the tenant's installed version,
+found the name it expected, and skipped:
+
+    tenant already runs 019e3a59-…-e8eae494483f at sdr-test-5027f138 — nothing to do
+
+Nothing rolled. The tenant kept serving whatever content that tag held when it
+last pulled, which differed per tenant purely by install history — so the same
+SDK commit passed on one cloud and failed on another with no code difference
+between them, and "verify the tenant runs the version under test" could never
+catch it, because it compares version *names* and the name was identical by
+construction.
+
+That makes an e2e run against an already-installed tenant untrustworthy rather
+than merely flaky: a green leg is evidence about whatever image that tenant
+happens to hold, not about the commit under test.
+
+What goes into the tag
+----------------------
+Every input that changes the built image's content, and nothing else:
+
+* the connector commit — its own source;
+* ``--sdk-ref`` — the application-sdk revision repinned before the build;
+* ``--base-image-ref`` — the runtime base an SDK PR rebuilds and builds FROM.
+
+The last two are folded into one short digest rather than spelled out, because
+a ref may be a branch name, a tag or a 40-character SHA, and only some of those
+are legal in a Docker tag.
+
+Why a suffix and not a wholesale hash
+-------------------------------------
+A connector PR passes neither ref, and gets **exactly the tag it gets today** —
+no churn for the fleet, no orphaned `sdr-test-*` images, and every existing
+reference to the `sdr-test-<sha>` shape keeps holding. The suffix appears only
+on the dispatch path, which is the only path that was broken.
+
+The connector's short SHA also stays in front, readable, so a tag still says
+which connector commit it came from at a glance — which a single opaque hash of
+everything would have thrown away.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+
+#: Prefix every e2e test image carries. Load-bearing beyond cosmetics: the
+#: install workflow's error text tells a reader that "sdr-test-* tags are built
+#: by e2e runs", and image pruning keys on it. It does not change.
+TAG_PREFIX = "sdr-test-"
+
+#: Characters of the connector commit kept in the tag. Matches what the tag has
+#: always carried, so a connector-PR tag is byte-identical to today's.
+COMMIT_CHARS = 8
+
+#: Characters of the build-input digest appended on the dispatch path.
+#:
+#: Eight hex characters is 32 bits. These tags are scoped to one connector's
+#: package and live only as long as an e2e run's images, so the population is
+#: tens, not millions — a collision needs two *different* (sdk-ref, base-image)
+#: pairs against the same connector commit landing on the same 32-bit value,
+#: which is not a risk worth trading tag readability for.
+DIGEST_CHARS = 8
+
+
+def build_digest(sdk_ref: str, base_image_ref: str) -> str:
+    """Short digest over the build inputs that are not the connector commit.
+
+    Order-fixed and separator-delimited so two different pairs cannot collide by
+    concatenation (``("ab", "c")`` and ``("a", "bc")`` must not agree). The
+    separator is a newline, which cannot appear in a git ref or an image
+    reference.
+
+    Args:
+        sdk_ref: The application-sdk revision the image is built against.
+        base_image_ref: The runtime base image the connector is built FROM.
+    """
+    material = f"{sdk_ref}\n{base_image_ref}".encode()
+    return hashlib.blake2b(material, digest_size=DIGEST_CHARS).hexdigest()[
+        :DIGEST_CHARS
+    ]
+
+
+def derive_tag(commit: str, sdk_ref: str = "", base_image_ref: str = "") -> str:
+    """Return the image tag for this build.
+
+    Args:
+        commit: The connector commit being built (``github.sha``).
+        sdk_ref: application-sdk revision repinned before the build, if any.
+        base_image_ref: Runtime base image built FROM, if any.
+
+    Returns:
+        ``sdr-test-<commit8>`` when neither ref is supplied — byte-identical to
+        what a connector's own PR has always produced — and
+        ``sdr-test-<commit8>-<digest8>`` when either is.
+
+    Raises:
+        ValueError: when *commit* is blank. A tag derived from an empty commit
+            would be ``sdr-test-`` for every connector at once, which is worse
+            than failing the build: it would silently reintroduce exactly the
+            collision this module exists to prevent.
+    """
+    short = commit.strip()[:COMMIT_CHARS]
+    if not short:
+        raise ValueError(
+            "cannot derive an image tag: no connector commit was supplied. "
+            "Pass --commit ${{ github.sha }}."
+        )
+    base = f"{TAG_PREFIX}{short}"
+    sdk_ref, base_image_ref = sdk_ref.strip(), base_image_ref.strip()
+    if not sdk_ref and not base_image_ref:
+        return base
+    return f"{base}-{build_digest(sdk_ref, base_image_ref)}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Derive the e2e test image tag for this build."
+    )
+    parser.add_argument("--commit", required=True, help="github.sha of the connector")
+    parser.add_argument(
+        "--sdk-ref", default="", help="application-sdk ref repinned before the build"
+    )
+    parser.add_argument(
+        "--base-image-ref", default="", help="runtime base image built FROM"
+    )
+    args = parser.parse_args(argv)
+    try:
+        print(derive_tag(args.commit, args.sdk_ref, args.base_image_ref))
+    except ValueError as exc:
+        print(f"::error::{exc}", file=sys.stderr, flush=True)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_derive_e2e_image_tag.py
+++ b/.github/scripts/tests/test_derive_e2e_image_tag.py
@@ -1,0 +1,172 @@
+"""Does the e2e image tag actually change when the image content changes?
+
+The invariant here is the whole point of the script, and it is not a detail: an
+e2e run whose tag does not move republishes the same version name over changed
+content, prepare-tenant reads that name off the tenant and skips the install,
+and the leg then tests whatever image the tenant already held. That produces a
+GREEN leg that is evidence about nothing — the failure mode this suite exists to
+make impossible.
+
+So the tests are written as the two halves of that invariant: different content
+must never share a tag, and a connector's own PR must keep the tag it has today
+so the fix costs the fleet nothing.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from derive_e2e_image_tag import (  # noqa: E402
+    TAG_PREFIX,
+    build_digest,
+    derive_tag,
+    main,
+)
+
+_CONNECTOR = "5027f138ab8d4c1e9f0a7b6c5d4e3f2a1b0c9d8e"
+_OTHER_CONNECTOR = "634b735e11223344556677889900aabbccddeeff"
+
+
+class TestTheBrokenCase:
+    """FND-1680: two SDK commits against one connector must not share a tag."""
+
+    def test_a_new_sdk_ref_moves_the_tag(self) -> None:
+        """The exact shape that made three clouds disagree.
+
+        Same connector at the same commit, two different SDK revisions. Before
+        this script both produced `sdr-test-5027f138`, so the second push
+        overwrote the first's image, republished the same version name, and
+        every tenant already holding that name skipped the install.
+        """
+        first = derive_tag(_CONNECTOR, sdk_ref="ce8f374f8ded4cd5e224cc686539ec4a")
+        second = derive_tag(_CONNECTOR, sdk_ref="3fb6cfb4e0000000000000000000000")
+
+        assert first != second
+
+    def test_a_new_base_image_moves_the_tag(self) -> None:
+        """An SDK PR rebuilds the runtime base, and the connector is built FROM it.
+
+        The base image reference carries the SDK PR's own SHA
+        (`app-runtime-base:pr-3668-sha-ce8f374`), so a base rebuild is a content
+        change even when the sdk-ref argument happens to be unchanged.
+        """
+        first = derive_tag(
+            _CONNECTOR, base_image_ref="registry.example.invalid/base:pr-1-sha-aaa"
+        )
+        second = derive_tag(
+            _CONNECTOR, base_image_ref="registry.example.invalid/base:pr-1-sha-bbb"
+        )
+
+        assert first != second
+
+    def test_the_connector_commit_still_moves_the_tag(self) -> None:
+        """The property that already worked must survive the change."""
+        assert derive_tag(_CONNECTOR, sdk_ref="x") != derive_tag(
+            _OTHER_CONNECTOR, sdk_ref="x"
+        )
+
+    def test_identical_inputs_are_still_deterministic(self) -> None:
+        """Every cloud leg and both architecture legs must agree on the tag.
+
+        The build is hoisted ahead of the matrix and each leg reuses the
+        reference, and the multi-arch merge recreates it from two per-arch legs.
+        A tag that varied per call would break all of that — so this must be a
+        pure function of its inputs, with no time, no run id and no randomness.
+        """
+        args = (_CONNECTOR, "sdk-ref", "base:ref")
+
+        assert derive_tag(*args) == derive_tag(*args)
+
+
+class TestTheFleetPaysNothing:
+    """A connector's own PR must keep the tag it produces today."""
+
+    def test_no_refs_yields_todays_exact_tag(self) -> None:
+        """Byte-identical to `sdr-test-$(cut -c1-8)`, which is what shipped."""
+        assert derive_tag(_CONNECTOR) == "sdr-test-5027f138"
+
+    def test_blank_refs_are_the_same_as_absent(self) -> None:
+        """The action passes empty strings, not unset — they must not add a suffix."""
+        assert derive_tag(_CONNECTOR, sdk_ref="", base_image_ref="") == derive_tag(
+            _CONNECTOR
+        )
+
+    def test_whitespace_only_refs_are_the_same_as_absent(self) -> None:
+        """A YAML expression that resolves to nothing can arrive as spaces."""
+        assert derive_tag(_CONNECTOR, sdk_ref="  ", base_image_ref="\n") == derive_tag(
+            _CONNECTOR
+        )
+
+    def test_the_prefix_is_preserved(self) -> None:
+        """Pruning and the install workflow's error text both key on it."""
+        assert derive_tag(_CONNECTOR, sdk_ref="x").startswith(TAG_PREFIX)
+
+    def test_the_connector_sha_stays_readable_at_the_front(self) -> None:
+        """A tag must still say which connector commit it came from."""
+        assert derive_tag(_CONNECTOR, sdk_ref="x").startswith("sdr-test-5027f138-")
+
+
+class TestTagValidity:
+    """Whatever the refs look like, the result has to be a legal Docker tag."""
+
+    @pytest.mark.parametrize(
+        "sdk_ref",
+        (
+            "chrishehim/fnd-1680",
+            "refs/heads/feature/some_branch",
+            "v3.32.1",
+            "ce8f374f8ded4cd5e224cc686539ec4afbdaae71",
+            "a ref with spaces",
+        ),
+    )
+    def test_a_ref_of_any_shape_yields_a_legal_tag(self, sdk_ref: str) -> None:
+        """Branch names carry `/`, which is illegal in a tag — hence the digest."""
+        tag = derive_tag(_CONNECTOR, sdk_ref=sdk_ref)
+
+        assert len(tag) <= 128
+        assert all(c.isalnum() or c in "._-" for c in tag), tag
+        assert tag[0].isalnum()
+
+    def test_the_digest_is_hex_of_the_declared_length(self) -> None:
+        digest = build_digest("sdk", "base")
+
+        assert len(digest) == 8
+        assert all(c in "0123456789abcdef" for c in digest)
+
+    def test_the_two_inputs_cannot_collide_by_concatenation(self) -> None:
+        """Delimited, so ("ab", "c") and ("a", "bc") stay distinct."""
+        assert build_digest("ab", "c") != build_digest("a", "bc")
+
+
+class TestCli:
+    def test_it_prints_the_tag(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert main(["--commit", _CONNECTOR]) == 0
+
+        assert capsys.readouterr().out.strip() == "sdr-test-5027f138"
+
+    def test_it_accepts_the_refs(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert (
+            main(["--commit", _CONNECTOR, "--sdk-ref", "abc", "--base-image-ref", "d"])
+            == 0
+        )
+
+        assert capsys.readouterr().out.strip() == derive_tag(
+            _CONNECTOR, sdk_ref="abc", base_image_ref="d"
+        )
+
+    def test_an_empty_commit_fails_loudly(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Never a bare `sdr-test-`, which every connector would then share.
+
+        Failing the build is strictly better than emitting a tag that silently
+        reintroduces the collision this whole script exists to prevent.
+        """
+        assert main(["--commit", "   "]) == 1
+
+        assert "no connector commit" in capsys.readouterr().err

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -1228,7 +1228,7 @@ jobs:
   # up. Legs on different clouds hit different tenants (and therefore different
   # Temporal servers) besides.
   # ── Build the image ONCE, ahead of the matrix ────────────────────────────
-  # The test-image tag is deterministic (`sdr-test-<short-sha>`), so every cloud
+  # The test-image tag is deterministic (`derive_e2e_image_tag.py`), so every cloud
   # leg used to rebuild the identical image. It has to exist before prepare-tenant
   # can install it, so the build is hoisted here and every leg reuses the
   # reference via sdr-e2e's `prebuilt-image` input.

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -57,6 +57,7 @@ from temporalio.client import WorkflowFailureError
 
 from application_sdk._runtime.offload import run_in_thread
 from application_sdk.app._generated_tree import (
+    MANIFEST_STEM,
     choose_form_configmap,
     eligible_form_configmaps,
     names_entrypoint,
@@ -2025,12 +2026,28 @@ def _register_workflow_routes(
 
     @app.get("/workflows/v1/configmaps")
     async def list_configmaps() -> JSONResponse:
+        # Everything this endpoint's sibling will serve by exact stem, minus
+        # the DAG manifest, which `/workflows/v1/manifest` owns.
+        #
+        # Deliberately NOT `is_form_configmap`, and the difference is worth
+        # stating because the two look interchangeable. That predicate answers
+        # "which single file is the setup form", for the fallback that has to
+        # pick exactly one. This answers "which names does this endpoint
+        # respond to", and the credential templates it excludes are ones the
+        # UI genuinely fetches — the setup form's `credential` widget requests
+        # `atlan-connectors-<source>` as its own configmap. Filtering them here
+        # would drop names that work.
+        #
+        # The manifest stem comes from `_generated_tree` rather than a literal:
+        # a hand-spelled `"manifest"` here was the last copy of that vocabulary
+        # left in this module after FND-1682, and one divergent spelling is all
+        # the artifact_schemas bug needed.
         seen: set[str] = set()
         configmap_ids: list[str] = []
         if CONTRACT_GENERATED_DIR.exists():
             for json_file in CONTRACT_GENERATED_DIR.rglob("*.json"):
                 stem = json_file.stem
-                if stem == "manifest" or stem in seen:
+                if stem == MANIFEST_STEM or stem in seen:
                     continue
                 seen.add(stem)
                 configmap_ids.append(stem)

--- a/application_sdk/testing/setup_routes.py
+++ b/application_sdk/testing/setup_routes.py
@@ -118,6 +118,7 @@ __all__ = [
     "FormStep",
     "ServedForm",
     "declared_inputs",
+    "foreign_form",
     "form_shortfall",
     "locate_cards",
     "read_app_identity",
@@ -1173,8 +1174,59 @@ def _await_cards(
         time.sleep(_CATALOG_POLL_SECONDS)
 
 
+def foreign_form(
+    entrypoint: Entrypoint, siblings: Sequence[Entrypoint], served_name: object
+) -> str | None:
+    """Whether the tenant served a DIFFERENT entry point's form, or ``None``.
+
+    **Only fires on a name this repo can attribute**, which is the whole point.
+    An earlier revision asserted ``served_name == card.id`` and failed all three
+    mysql legs on a healthy app: the check asked for ``atlan-mysql`` and the
+    response carried ``metadata.name: 'mysql'``. Both are correct. Heracles
+    resolves the marketplace app id to the configmap name *before* proxying, so
+    the pod never sees ``atlan-mysql`` and echoes the name it was actually
+    asked for — while for metabase the same endpoint answered
+    ``metadata.name: 'atlan-metabase'``, because there the app id reached the
+    pod unrewritten and fell through to its default-entrypoint fallback.
+
+    So ``metadata.name`` is the output of a rewrite chain spanning two services,
+    and no rule this module can write predicts it without re-implementing
+    Heracles — which would drift the first time Heracles changed. Asserting on
+    it is asserting on someone else's implementation detail.
+
+    What *is* attributable is a name belonging to one of this repo's OWN
+    committed entry points. If we asked for one entry point's form and the
+    response identifies itself as another declared entry point's, that is
+    unambiguous and is the failure the original assertion was reaching for. Any
+    other value — the app id, a rewritten alias, something unrecognised — says
+    nothing, and this stays silent rather than guessing. The *content* check in
+    :func:`form_shortfall` is what covers the rest, and content is immune to
+    every rename in the chain.
+
+    Args:
+        entrypoint: The entry point whose form was requested.
+        siblings: Every entry point this repo declares, including *entrypoint*.
+        served_name: ``metadata.name`` from the response, whatever type it is.
+    """
+    name = str(served_name or "").strip()
+    if not name or name == entrypoint.config_id:
+        return None
+    for other in siblings:
+        if other.config_id == name and other.name != entrypoint.name:
+            return (
+                f"Entrypoint {entrypoint.name!r}: asked for its form and the "
+                f"endpoint identified the response as {name!r}, which is this "
+                f"repo's {other.name!r} entry point. The setup page would "
+                "render another entry point's form."
+            )
+    return None
+
+
 def _check_route(
-    routes: RouteReader, entrypoint: Entrypoint, card: Card
+    routes: RouteReader,
+    entrypoint: Entrypoint,
+    card: Card,
+    siblings: Sequence[Entrypoint],
 ) -> tuple[str | None, ServedForm | None]:
     """Assert one entry point's setup route. Returns ``(failure, form)``.
 
@@ -1195,13 +1247,11 @@ def _check_route(
             "form, so a non-200 here is a 404'd setup page for a user."
         ), None
 
-    served_name = (body.get("metadata") or {}).get("name")
-    if served_name != card.id:
-        return (
-            f"Entrypoint {entrypoint.name!r}: asked the configmap endpoint for "
-            f"{card.id!r} and it served {served_name!r}. The setup page "
-            "would render another entry point's form."
-        ), None
+    foreign = foreign_form(
+        entrypoint, siblings, (body.get("metadata") or {}).get("name")
+    )
+    if foreign is not None:
+        return foreign, None
 
     form = served_form(body)
     shortfall = form_shortfall(entrypoint, form)
@@ -1214,6 +1264,7 @@ def _await_route(
     routes: RouteReader,
     entrypoint: Entrypoint,
     card: Card,
+    siblings: Sequence[Entrypoint],
     wait_seconds: int,
     on_progress: Callable[[str], None] | None = None,
 ) -> tuple[str | None, ServedForm | None]:
@@ -1242,7 +1293,7 @@ def _await_route(
     """
     deadline = time.monotonic() + max(wait_seconds, 0)
     while True:
-        failure, form = _check_route(routes, entrypoint, card)
+        failure, form = _check_route(routes, entrypoint, card, siblings)
         if failure is None:
             return None, form
         if time.monotonic() >= deadline:
@@ -1297,7 +1348,7 @@ def verify(
         label = entrypoint.name
 
         failure, form = _await_route(
-            routes, entrypoint, card, wait_seconds, on_progress
+            routes, entrypoint, card, entrypoints, wait_seconds, on_progress
         )
         if failure is not None or form is None:
             failures.append(failure or f"Entrypoint {label!r}: no form served.")

--- a/application_sdk/testing/setup_routes.py
+++ b/application_sdk/testing/setup_routes.py
@@ -28,14 +28,38 @@ Setting ``Entrypoint.packageId`` moves the card's identity onto the marketplace
 package, and the path is then derived from the package name — pointing at a name
 no configmap exists for.
 
+Resolving is not rendering
+--------------------------
+A 200 from that second lookup is not evidence that a user sees a form, and
+FND-1680 is the proof. ``/workflows/setup/atlan-metabase`` answered 200 with a
+well-formed ConfigMap envelope whose ``data.config`` was the app's
+*artifact-schema declaration* — ``{"version": 1, "schemas": {...}}`` — because
+the pod ran an SDK whose form-discovery rule had no ``artifact_schemas``
+exclusion and served the declaration file as the setup form. The card rendered,
+the request succeeded, and the form panel was blank.
+
+So the check reads the payload rather than the status line, in the two parts the
+UI actually renders from: ``properties`` defines a field and a ``steps`` panel
+*draws* it. A field in one and not the other never reaches a user, and only
+looking at both can tell that apart from a form that works — see
+:func:`form_shortfall`.
+
 Why it is not circular
 ----------------------
 A check asserting ``GET configmaps/<known-good-name> == 200`` **would have
 passed straight through the regression** — that name never stopped working.
 What moved was the card pointing at it. So the card is located by facts that are
-*not* the thing under test (the app ``name`` and the ``entrypoint`` name, both
-from the committed ``atlan.yaml``) and only then is its ``id`` compared against
-the ``id`` in the committed generated workflow config.
+*not* the thing under test (the app's committed ``name``/``display_name`` and
+the ``entrypoint`` name, all from ``atlan.yaml``) and only then is its ``id``
+spent on the configmap endpoint.
+
+What that ``id`` is *compared to* is the part FND-1680 corrected. Plain equality
+against the generated config ``id`` is the wrong assertion for a flat app,
+because ``handler.service.get_configmap`` deliberately resolves an app-id
+request through a default-entrypoint fallback — see :func:`route_mismatch`. The
+assertion that survives is the one that always carried the weight: fetch the
+card's id, require a 200, and require the served schema to declare what this
+entry point's contract declares.
 
 Both sides of the join are the SDK's
 ------------------------------------
@@ -84,20 +108,23 @@ from application_sdk.app._generated_tree import form_configmap, generated_layout
 
 __all__ = [
     "DEFAULT_CATALOG_WAIT_SECONDS",
+    "AppIdentity",
     "Card",
     "Entrypoint",
     "RouteCheckSkipped",
     "RouteReader",
     "SetupRouteError",
     "TenantRoutes",
+    "FormStep",
+    "ServedForm",
     "declared_inputs",
-    "input_shortfall",
+    "form_shortfall",
     "locate_cards",
-    "read_app_name",
+    "read_app_identity",
     "read_entrypoint_names",
     "read_entrypoints",
     "route_mismatch",
-    "served_inputs",
+    "served_form",
     "verify",
 ]
 
@@ -115,6 +142,32 @@ CONFIGMAP_PATH = "/api/service/configmaps/{name}"
 
 _HTTP_TIMEOUT = 30
 _USER_AGENT = "atlan-application-sdk-setup-routes/1.0"
+
+#: How many times one GET is attempted before the tenant is called unreachable.
+#:
+#: A single read timeout against an e2e tenant is usually transient egress loss
+#: on the runner, not a broken route: FND-1680's gcp leg died on
+#: ``GET /api/service/configmaps/atlan-openapi ... The read operation timed
+#: out`` while the azure leg passed the identical assertions against the
+#: identical build, minutes apart. Failing the whole leg on one dropped packet
+#: makes this check's verdict a coin flip on network weather, and a check that
+#: reds for reasons unrelated to what it asserts gets ignored — which costs
+#: more than the flake.
+#:
+#: Three, not more: the point is to survive a blip, not to wait out a genuine
+#: outage. Three consecutive failures over the backoff below is evidence, and
+#: the worst case stays well inside the job's budget.
+_RETRY_ATTEMPTS = 3
+
+#: Base delay between attempts, doubled each time (2s, then 4s).
+_RETRY_BACKOFF_SECONDS = 2.0
+
+#: Statuses worth a second ask. Deliberately excludes every 4xx in
+#: :data:`_REJECTION_STATUSES`: those are the endpoint *answering*, and the
+#: negative control's whole premise is that an unknown name is rejected
+#: promptly. Retrying a 404 would turn the control into a 3x-slower way of
+#: getting the same answer, and could mask a genuine rejection as a flake.
+_RETRYABLE_STATUSES = (429, 500, 502, 503, 504)
 
 #: Statuses that count as "this name is genuinely not served". The negative
 #: control accepts any of them rather than asserting which flavour of rejection
@@ -135,6 +188,13 @@ _REJECTION_STATUSES = (400, 403, 404)
 #: flaky-by-construction on exactly the path CI takes.
 DEFAULT_CATALOG_WAIT_SECONDS = 120
 _CATALOG_POLL_SECONDS = 10
+
+#: How many catalog entries the not-found diagnostic names verbatim.
+#:
+#: The catalog runs to ~140 cards on a live tenant, so the whole list would push
+#: the real finding off the top of a CI log. Twenty is enough to recognise a
+#: catalog and to see the shape its ``name`` fields take.
+_CARD_SAMPLE = 20
 
 
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -255,13 +315,65 @@ class Entrypoint:
     """The generated file that answered, for diagnostics."""
 
 
-def read_app_name(repo_root: Path) -> str:
-    """Return the app ``name`` from ``atlan.yaml``, as cards report it.
+@dataclass(frozen=True)
+class AppIdentity:
+    """The committed names a marketplace card may be listed under.
 
-    ``atlan.yaml``'s top-level ``name`` is the value the marketplace card's
-    ``name`` field carries, and it is the field the fleet is already forced to
-    commit — ``parse_atlan_yaml.py`` reads it on every release. Read here rather
-    than threaded in from a step output so the check has one source for it.
+    **Two, not one, because the catalog is not consistent about which it
+    stores.** The first fleet-wide run read one live tenant and found openapi
+    and metabase listed under their wire ``name`` while mysql was listed under
+    its ``display_name`` (``MySQL Assets``) — so a locator keyed on either
+    field alone reports a healthy, installed app as absent from the catalog,
+    which is the most misleading message this check can emit.
+
+    Both values are committed in ``atlan.yaml`` and neither is the thing under
+    test, so widening the *locator* to accept either leaves the non-circularity
+    argument in this module's header intact: the card is still found by facts
+    that are not the card's ``id``, and only then is its ``id`` examined.
+    """
+
+    name: str
+    """``atlan.yaml``'s top-level ``name``, normalised. Never empty."""
+
+    display_name: str = ""
+    """``atlan.yaml``'s ``display_name``, normalised. Empty when not declared."""
+
+    @property
+    def labels(self) -> tuple[str, ...]:
+        """Every name a card may legitimately be listed under, normalised.
+
+        Deduplicated and empties dropped, so an app whose ``display_name``
+        equals its ``name`` — or declares none — yields exactly one label
+        rather than a doubled or blank one.
+        """
+        seen: list[str] = []
+        for label in (self.name, self.display_name):
+            if label and label not in seen:
+                seen.append(label)
+        return tuple(seen)
+
+    def matches(self, card: Card) -> bool:
+        """Whether *card*'s ``name`` is one of this app's committed labels.
+
+        Case-folded and stripped on both sides. ``read_app_identity``
+        normalises this side, but a card's ``name`` is whatever the catalog
+        stores, and comparing the two verbatim reports a mixed-case card as
+        "this app is not installed on this tenant".
+        """
+        return card.name.strip().lower() in self.labels
+
+
+def read_app_identity(repo_root: Path) -> AppIdentity:
+    """Return the names ``atlan.yaml`` commits, as cards may report them.
+
+    ``name`` is the field the fleet is already forced to commit —
+    ``parse_atlan_yaml.py`` reads it on every release — and ``display_name``
+    is emitted beside it by the same generator. Read here rather than threaded
+    in from a step output so the check has one source for both.
+
+    Raises:
+        SetupRouteError: when ``atlan.yaml`` is unreadable, is invalid YAML, or
+            declares no top-level ``name``.
     """
     import yaml  # noqa: PLC0415 — deferred so an import of this module is cheap
 
@@ -279,7 +391,10 @@ def read_app_name(repo_root: Path) -> str:
     name = str(parsed.get("name") or "").strip().lower()
     if not name:
         raise SetupRouteError(f'{path} has no top-level "name"')
-    return name
+    return AppIdentity(
+        name=name,
+        display_name=str(parsed.get("display_name") or "").strip().lower(),
+    )
 
 
 def read_entrypoint_names(repo_root: Path) -> list[str]:
@@ -301,7 +416,7 @@ def read_entrypoint_names(repo_root: Path) -> list[str]:
     presence should key on; if it lands a clearer signal, this is the one place
     that changes.
     """
-    import yaml  # noqa: PLC0415 — see read_app_name
+    import yaml  # noqa: PLC0415 — see read_app_identity
 
     parsed = yaml.safe_load((repo_root / "atlan.yaml").read_text()) or {}
     declared = parsed.get("entrypoints")
@@ -326,7 +441,7 @@ def _declares_any_entrypoint(repo_root: Path) -> bool:
     "declares no entrypoints at all" — a skip and a failure respectively, which
     :func:`read_entrypoint_names` cannot tell apart on its own.
     """
-    import yaml  # noqa: PLC0415 — see read_app_name
+    import yaml  # noqa: PLC0415 — see read_app_identity
 
     parsed = yaml.safe_load((repo_root / "atlan.yaml").read_text()) or {}
     declared = parsed.get("entrypoints")
@@ -456,7 +571,7 @@ class Card:
         )
 
 
-def route_mismatch(entrypoint: str, card: Card, config_id: str) -> str | None:
+def route_mismatch(entrypoint: Entrypoint, card: Card) -> str | None:
     """Why this entry point's setup page will 404, or ``None`` if it resolves.
 
     Pure, so the assertion it backs is provable without a tenant — see
@@ -464,74 +579,235 @@ def route_mismatch(entrypoint: str, card: Card, config_id: str) -> str | None:
     the FND-1593 regression produced and asserts it reports the break naming
     both sides.
 
+    **A card id that differs from the config id is not, by itself, a break.**
+    ``handler.service.get_configmap`` resolves an unmatched id through a
+    documented *default-entrypoint fallback*: "the marketplace UI sometimes
+    builds the configmap URL from the app/marketplace id (e.g.
+    ``atlan-snowflake``) rather than the entrypoint-form stem". That fallback
+    exists because ``atlan-openapi`` really did 404 in production, and it has a
+    committed regression test. An earlier revision of this function asserted
+    plain equality and therefore failed every flat connector on the fleet's
+    first run — openapi, metabase and mysql all serve a card id of
+    ``atlan-<name>`` against a config id of ``<name>``, and every one of those
+    setup pages renders (FND-1680).
+
+    So the tolerance is **gated on** :attr:`Entrypoint.is_sole`, not granted
+    generally, because that is precisely where the fallback is safe: it
+    resolves to the app's *default* entry point, which for a sole contract is
+    the only entry point there is. For a bundle the same fallback would serve
+    the default entry point's form for *every* card, and the equality check is
+    the only thing standing between that and a user opening one entry point's
+    page to find another's form — so a bundle still fails on any mismatch.
+
+    A tolerated mismatch is not waved through: :func:`verify` still fetches
+    ``configmaps/<card.id>`` and still requires the served schema to carry this
+    entry point's declared inputs. Equality was only ever a proxy for that, and
+    it is the wrong proxy on the server the check is asserting about.
+
     Args:
-        entrypoint: The entry point's wire name, for the message.
+        entrypoint: The entry point as the committed artifacts describe it.
         card: The card the tenant serves, located by app name + entrypoint.
-        config_id: The ``id`` in this repo's committed workflow config.
     """
     if not card.id:
         return (
-            f"Entrypoint {entrypoint!r}: the marketplace card has no "
+            f"Entrypoint {entrypoint.name!r}: the marketplace card has no "
             "id, so the marketplace cannot build a setup link for it at all."
         )
-    if not config_id:
+    if not entrypoint.config_id:
         return (
-            f"Entrypoint {entrypoint!r}: the generated workflow "
+            f"Entrypoint {entrypoint.name!r}: the generated workflow "
             "config has no id. Regenerate the contract."
         )
-    if card.id != config_id:
+    if card.id != entrypoint.config_id and not entrypoint.is_sole:
         return (
-            f"Entrypoint {entrypoint!r}: the marketplace card's id "
+            f"Entrypoint {entrypoint.name!r}: the marketplace card's id "
             f"is {card.id!r}, but this repo generates its workflow config as "
-            f"{config_id!r}. The UI builds /workflows/setup/{card.id} from the "
-            f"card and the form is only served for {config_id!r}, so that page "
-            "404s for every user. A contract change that moves the card id — "
-            "setting `packageId` on the entrypoint is the known one (FND-1659) "
-            "— is the cause."
+            f"{entrypoint.config_id!r}. This app is a bundle, so the app-id "
+            "fallback in handler.service.get_configmap would resolve that name "
+            "to the DEFAULT entry point's form — meaning /workflows/setup/"
+            f"{card.id} either 404s or renders another entry point's form. A "
+            "contract change that moves the card id — setting `packageId` on "
+            "the entrypoint is the known one (FND-1659) — is the cause."
         )
     return None
 
 
-def input_shortfall(
-    entrypoint: str, declared: frozenset[str], served: frozenset[str]
-) -> str | None:
-    """Which declared inputs the tenant is not serving, or ``None``.
+def form_shortfall(entrypoint: Entrypoint, served: ServedForm) -> str | None:
+    """Why this entry point's setup form will not render, or ``None``.
 
-    A **subset** check, not equality: the platform may decorate the schema with
-    fields the contract never named, and failing on those buys no safety. A
-    *missing* input is the signal — the deployed image predates the contract, or
-    a contract change never reached the tenant.
+    The question a 200 cannot answer. FND-1680's metabase page returned 200 for
+    ``atlan-metabase`` and rendered **blank**: the app pod served its
+    ``artifact_schemas.json`` as the setup form, so ``data.config`` carried
+    ``{"version": 1, "schemas": {...}}`` — no ``properties``, no ``steps``, and
+    nothing for the wizard to draw. Every status-code assertion passed.
+
+    Four distinct faults, reported in the order that makes the *cause* legible
+    rather than the symptom:
+
+    #. the payload is not a setup form at all — no fields and no panels;
+    #. fields the contract declares are absent from the served schema;
+    #. the schema has fields but no panels, so none of them is drawn;
+    #. a declared field exists but no panel names it, so it never appears.
+
+    A **subset** check throughout, never equality: the platform may decorate the
+    schema with fields the contract never named, and failing on those buys no
+    safety.
+
+    Args:
+        entrypoint: The entry point, carrying the inputs its contract declares.
+        served: What the tenant actually returned, parsed by :func:`served_form`.
     """
+    label = entrypoint.name
+    declared = entrypoint.declared
     if not declared:
         return (
-            f"Entrypoint {entrypoint!r}: the committed workflow "
+            f"Entrypoint {label!r}: the committed workflow "
             "config declares no inputs at all, so this check cannot tell a "
             "served form from an empty one. Regenerate the contract."
         )
-    missing = declared - served
+
+    if not served.properties and not served.steps:
+        return (
+            f"Entrypoint {label!r}: the endpoint answered 200 but the payload "
+            "is not a setup form — it carries neither 'properties' nor "
+            "'steps', so the page renders blank. The known cause is the app "
+            "pod resolving this name to a non-form sibling in app/generated "
+            "(artifact_schemas.json sorts first, FND-1680); an app running an "
+            "SDK without that exclusion serves the declaration file as its "
+            f"form. This repo's contract declares {sorted(declared)}."
+        )
+
+    missing = declared - served.properties
     if missing:
         return (
-            f"Entrypoint {entrypoint!r}: the tenant's form schema is "
+            f"Entrypoint {label!r}: the tenant's form schema is "
             f"missing {sorted(missing)}, which this repo's committed contract "
             "declares. Most likely the tenant runs an older image than this "
             "branch; it can also mean a contract change never reached the "
-            f"deployed app. Served: {sorted(served)}."
+            f"deployed app. Served: {sorted(served.properties)}."
+        )
+
+    if not served.steps:
+        return (
+            f"Entrypoint {label!r}: the served schema defines "
+            f"{len(served.properties)} fields but declares no 'steps', so the "
+            "wizard has no panels to draw and the page renders blank. Fields "
+            "exist in the schema and none of them reaches a user."
+        )
+
+    unrendered = declared - served.rendered
+    if unrendered:
+        return (
+            f"Entrypoint {label!r}: {sorted(unrendered)} are defined in the "
+            "served schema but named by no step, so the wizard never draws "
+            "them — a user cannot fill in a field that is not on any panel. "
+            f"Steps: {[step.id for step in served.steps]}."
         )
     return None
 
 
+def _render(cards: Sequence[Card]) -> str:
+    """The read fields of a bounded sample of *cards*, for a failure message."""
+    return "; ".join(
+        f"id={card.id!r} name={card.name!r} entrypoint={card.entrypoint!r}"
+        for card in cards[:_CARD_SAMPLE]
+    )
+
+
+def _catalog_evidence(identity: AppIdentity, cards: Sequence[Card]) -> str:
+    """What the catalog actually carried, for a lookup that matched no card.
+
+    FND-1680. The first fleet-wide run of this check reported ``no marketplace
+    card has name='mysql'. The tenant listed 139 apps`` and then waited out the
+    full reconcile poll — on a tenant the *preceding* step had already proven
+    was running the app at the version under test. So either the card genuinely
+    is absent, or ``name`` is not the field carrying the app's name, and the
+    message as written could not tell those apart. It logged the card *count*
+    and never a single card, so nothing in the log said which field held
+    ``mysql``.
+
+    This answers it in the failure itself rather than in the next
+    investigation, in three descending tiers of certainty:
+
+    #. some card carries a committed label **exactly** in ``id`` or ``entrypoint`` —
+       the app is in the catalog and this lookup reads the wrong field;
+    #. some card carries it as a **substring** of any read field — most likely
+       the same app under a decorated identity, so the card is shown;
+    #. nothing carries it at all — a genuine absence, and a bounded sample of
+       the names present is what a reader needs to confirm it.
+
+    Kept after it did its job, not removed with the bug. Its first live run is
+    what showed mysql's card listed under its ``display_name`` — the finding
+    :class:`AppIdentity` now encodes — and the next catalog-shape surprise will
+    arrive the same way: as a lookup that matches nothing and has to explain
+    itself. This is the part of the check that stays useful once the bug it
+    diagnosed is fixed.
+
+    Args:
+        identity: The app's committed, already-normalised labels.
+        cards: Every card the tenant listed.
+    """
+    labels = identity.labels
+    # One pass, and a list rather than a dict keyed by Card: a catalog serving
+    # the same card twice is a fault worth *seeing* in the sample, and a dict
+    # would silently collapse the duplicate into one.
+    exact: list[Card] = []
+    partial: list[Card] = []
+    for card in cards:
+        values = (card.id.strip().lower(), card.entrypoint.strip().lower())
+        if any(label in values for label in labels):
+            exact.append(card)
+        elif any(
+            label in value
+            for label in labels
+            for value in (*values, card.name.strip().lower())
+        ):
+            # Substring, not exact: a card named `atlan-mysql` or
+            # `mysql-crawler` is almost certainly this app under a decorated
+            # identity, and printing it beats printing an alphabetical slice of
+            # the catalog that may not reach it — 20 of 139 sorted names is a
+            # 1-in-7 chance of covering the one that matters.
+            partial.append(card)
+
+    if exact:
+        return (
+            f"But {len(exact)} card(s) carry one of {list(labels)} exactly, in "
+            f"'id' or 'entrypoint': {_render(exact)}. So the app IS in the "
+            "catalog and this lookup is reading the wrong field — not an "
+            "install that never landed."
+        )
+
+    if partial:
+        return (
+            f"No card carries any of {list(labels)} exactly in a read field, but "
+            f"{len(partial)} carry one as a substring: {_render(partial)}. Either "
+            "the catalog decorates this app's identity or another app's name "
+            "contains it; the triples say which."
+        )
+
+    names = sorted({card.name for card in cards if card.name})
+    return (
+        f"No card carries any of {list(labels)} in 'id', 'name' or 'entrypoint', "
+        "even as a substring, so this app's build is most likely not installed "
+        "on this tenant rather than this lookup reading the wrong field. Card "
+        f"names ({min(len(names), _CARD_SAMPLE)} of {len(names)}, sorted): "
+        f"{names[:_CARD_SAMPLE]}."
+    )
+
+
 def locate_cards(
-    app_name: str,
+    identity: AppIdentity,
     entrypoints: Sequence[Entrypoint],
     payloads: list[dict[str, Any]],
 ) -> tuple[dict[str, Card], str | None]:
     """Pick this app's cards out of the whole catalog, keyed by entry point.
 
-    Matched on app ``name`` **and** ``entrypoint``. Both are required: an
-    ``entrypoint`` alone is not app-scoped — every connector's crawler card
-    carries ``entrypoint: "crawler"``, so filtering on it alone matched a dozen
-    unrelated apps when the prototype tried it, and the count was plausible
-    enough to look like success.
+    Matched on one of the app's committed names (:attr:`AppIdentity.labels`)
+    **and** ``entrypoint``. Both are required: an ``entrypoint`` alone is not
+    app-scoped — every connector's crawler card carries ``entrypoint:
+    "crawler"``, so filtering on it alone matched a dozen unrelated apps when
+    the prototype tried it, and the count was plausible enough to look like
+    success.
 
     **A sole contract is matched by count, not by label.** An app declaring no
     ``entrypoints[]`` has one form and one card, so there is nothing to choose
@@ -550,22 +826,17 @@ def locate_cards(
         The cards found, and a reason string when one or more declared entry
         points has no card (``None`` when every one resolved).
     """
-    # Case-folded on both sides. `read_app_name` lowercases atlan.yaml's `name`,
-    # but a card's `name` is whatever the catalog stores, and comparing the two
-    # verbatim reports a mixed-case card as "this app is not installed on this
-    # tenant" — a false negative wearing the most misleading message this check
-    # can emit. Stripped as well, for the same reason: neither side is a value
-    # we control the formatting of.
-    ours = [
-        card
-        for card in (Card.from_payload(p) for p in payloads)
-        if card.name.strip().lower() == app_name.strip().lower()
-    ]
+    # Materialised rather than streamed: the not-found path below reads every
+    # card a second time to say what the catalog *did* carry, and a generator
+    # would be exhausted by the filter — leaving the diagnostic that exists to
+    # explain the miss with nothing to explain it from.
+    catalog = [Card.from_payload(p) for p in payloads]
+    ours = [card for card in catalog if identity.matches(card)]
     if not ours:
         return {}, (
-            f"no marketplace card has name={app_name!r}. The tenant listed "
-            f"{len(payloads)} apps, so the catalog is readable — this app's "
-            "build is most likely not installed on this tenant."
+            f"no marketplace card has name in {list(identity.labels)}. The "
+            f"tenant listed {len(payloads)} apps, so the catalog is readable. "
+            f"{_catalog_evidence(identity, catalog)}"
         )
 
     # A flat generated tree means ONE card, and its `entrypoint` is the tenant's
@@ -581,7 +852,7 @@ def locate_cards(
         sole = entrypoints[0]
         if len(ours) > 1:
             return {}, (
-                f"{app_name!r} declares no entrypoints and generates one setup "
+                f"{identity.name!r} declares no entrypoints and generates one setup "
                 f"form, but the tenant lists {len(ours)} cards for it "
                 f"(entrypoints: {sorted(card.entrypoint for card in ours)}). "
                 "Which card's id the setup route should match is ambiguous, so "
@@ -600,7 +871,7 @@ def locate_cards(
         # and a guess here produces a spurious "the card points at the wrong
         # form" that reads exactly like a real contract break.
         return by_entrypoint, (
-            f"{app_name!r} declares entrypoints {sorted(names)}, but the tenant "
+            f"{identity.name!r} declares entrypoints {sorted(names)}, but the tenant "
             f"serves {len(unlabelled)} card(s) for it carrying no entrypoint "
             f"(ids: {sorted(card.id for card in unlabelled)}). An unlabelled "
             "card cannot be attributed to a named entrypoint, so this reports "
@@ -612,7 +883,7 @@ def locate_cards(
     missing = [name for name in names if name not in by_entrypoint]
     if missing:
         return by_entrypoint, (
-            f"{app_name!r} generates entrypoints {sorted(names)} but the "
+            f"{identity.name!r} generates entrypoints {sorted(names)} but the "
             f"tenant lists cards for {sorted(by_entrypoint)}. Missing: "
             f"{sorted(missing)} — an entrypoint with no card has no setup page "
             "at all. Either the installed build predates it, or the catalog "
@@ -621,8 +892,54 @@ def locate_cards(
     return by_entrypoint, None
 
 
-def served_inputs(body: dict[str, Any]) -> frozenset[str]:
-    """Unwrap a ConfigMap response and return the input names it serves.
+@dataclass(frozen=True)
+class FormStep:
+    """One panel of the setup wizard, as the served schema describes it."""
+
+    id: str
+    """The step's own ``id`` (``credential``, ``connection``, ``metadata``), or
+    a positional placeholder when the served step declares none."""
+
+    properties: frozenset[str] = frozenset()
+    """The field names this panel puts on screen."""
+
+
+@dataclass(frozen=True)
+class ServedForm:
+    """The setup form a tenant serves, in the two parts the UI renders from.
+
+    **A 200 is not evidence that a user sees a form.** FND-1680's metabase case
+    answered 200 with ``metadata.name: atlan-metabase`` and a ``data.config``
+    holding the *artifact-schema declaration* — ``{"version": 1, "schemas":
+    {...}}``, no ``properties`` and no ``steps`` — and the setup page rendered
+    blank while every status-code assertion passed. So the check reads what the
+    payload actually contains rather than trusting the code that carried it.
+
+    Two parts, because a field needs both to reach a user: ``properties``
+    defines it and a step *draws* it. Reading only the first is what let a
+    served-but-invisible field look identical to a rendered one.
+    """
+
+    properties: frozenset[str] = frozenset()
+    """Field names the schema defines. Necessary for a field to exist."""
+
+    steps: tuple[FormStep, ...] = ()
+    """The wizard's panels, in order. Necessary for a field to be drawn."""
+
+    @property
+    def rendered(self) -> frozenset[str]:
+        """Every field some step actually puts on screen.
+
+        The union over *steps*, not over ``properties``: a field the schema
+        defines but no step names is served and never seen, which to the user
+        filling the form in is indistinguishable from missing.
+        """
+        rendered: frozenset[str] = frozenset()
+        return rendered.union(*(step.properties for step in self.steps))
+
+
+def served_form(body: dict[str, Any]) -> ServedForm:
+    """Unwrap a ConfigMap response into the form the tenant serves.
 
     The endpoint answers with a K8s ConfigMap whose ``data.config`` is the form
     schema as a JSON **string**, not a nested object — see
@@ -630,6 +947,13 @@ def served_inputs(body: dict[str, Any]) -> frozenset[str]:
     ``{"config": dumps(raw.get("config", raw))}``. The parsed value is therefore
     the committed file's ``config`` VALUE: one nesting level shallower than the
     committed file, which is the easiest thing to get wrong here.
+
+    Missing or malformed ``properties``/``steps`` degrade to empty rather than
+    raising. "The endpoint served something that is not a setup form" is a
+    finding for :func:`form_shortfall` to report *with the evidence*, not a
+    crash inside the parser. Only a broken **envelope** — no ``data``, no
+    string ``data.config``, unparseable JSON — raises here, because that means
+    the endpoint's own contract changed and nothing downstream can be trusted.
     """
     data = body.get("data")
     if not isinstance(data, dict):
@@ -647,10 +971,31 @@ def served_inputs(body: dict[str, Any]) -> frozenset[str]:
         schema = json.loads(raw)
     except json.JSONDecodeError as exc:
         raise SetupRouteError(f"data.config is not valid JSON: {exc}") from exc
-    properties = schema.get("properties") if isinstance(schema, dict) else None
-    if not isinstance(properties, dict):
-        return frozenset()
-    return frozenset(str(key) for key in properties)
+    if not isinstance(schema, dict):
+        return ServedForm()
+
+    properties = schema.get("properties")
+    names = (
+        frozenset(str(key) for key in properties)
+        if isinstance(properties, dict)
+        else frozenset()
+    )
+
+    raw_steps = schema.get("steps")
+    steps: list[FormStep] = []
+    for index, step in enumerate(raw_steps if isinstance(raw_steps, list) else []):
+        if not isinstance(step, dict):
+            continue
+        declared = step.get("properties")
+        steps.append(
+            FormStep(
+                id=str(step.get("id") or f"<step {index}>"),
+                properties=frozenset(str(name) for name in declared)
+                if isinstance(declared, list)
+                else frozenset(),
+            )
+        )
+    return ServedForm(properties=names, steps=tuple(steps))
 
 
 # ---------------------------------------------------------------------------
@@ -705,20 +1050,47 @@ class TenantRoutes:
         request.add_header("Authorization", f"Bearer {self.bearer}")
         request.add_header("Accept", "application/json")
         request.add_header("User-Agent", _USER_AGENT)
-        try:
-            with _OPENER.open(  # noqa: S310 — see above
-                request, timeout=_HTTP_TIMEOUT
-            ) as response:
-                return response.status, _parse(response.read())
-        except urllib.error.HTTPError as exc:
-            # A declined redirect lands here too, carrying its own 3xx status:
-            # `redirect_request` returning None makes urllib treat the response
-            # as unhandled, and the error processor raises it.
-            return exc.code, _parse(exc.read())
-        except (urllib.error.URLError, TimeoutError, OSError) as exc:
-            raise SetupRouteError(
-                f"GET {path} could not reach {self.base_url}: {exc}"
-            ) from exc
+
+        # Retried attempts are recorded rather than printed, and spent in the
+        # failure message below. This class has no progress callback and adding
+        # one would change its constructor — which the `@main`-pinned CLI shell
+        # calls against each app's OWN pinned SDK, so a new required argument
+        # is a fleet-wide TypeError the moment it lands. Putting the history in
+        # the error puts it exactly where a reader is already looking.
+        earlier: list[str] = []
+        started = time.monotonic()
+        for attempt in range(1, _RETRY_ATTEMPTS + 1):
+            last = attempt == _RETRY_ATTEMPTS
+            try:
+                with _OPENER.open(  # noqa: S310 — see above
+                    request, timeout=_HTTP_TIMEOUT
+                ) as response:
+                    return response.status, _parse(response.read())
+            except urllib.error.HTTPError as exc:
+                # A declined redirect lands here too, carrying its own 3xx
+                # status: `redirect_request` returning None makes urllib treat
+                # the response as unhandled, and the error processor raises it.
+                # Those are answers, not faults, and are returned as-is.
+                if last or exc.code not in _RETRYABLE_STATUSES:
+                    return exc.code, _parse(exc.read())
+                earlier.append(f"HTTP {exc.code}")
+            except (urllib.error.URLError, TimeoutError, OSError) as exc:
+                if last:
+                    raise SetupRouteError(
+                        f"GET {path} could not reach {self.base_url} after "
+                        f"{_RETRY_ATTEMPTS} attempts over "
+                        f"{time.monotonic() - started:.0f}s: {exc}. Earlier "
+                        f"attempts: {earlier or ['none']}. One read timeout "
+                        "here is usually transient egress loss on the runner "
+                        f"rather than a broken route, which is why this "
+                        f"retries; {_RETRY_ATTEMPTS} in a row is not."
+                    ) from exc
+                earlier.append(f"{type(exc).__name__}: {exc}")
+            time.sleep(_RETRY_BACKOFF_SECONDS * 2 ** (attempt - 1))
+
+        # Unreachable: the loop's final attempt always returns or raises. Kept
+        # so a future edit to the bounds cannot fall off the end into `None`.
+        raise SetupRouteError(f"GET {path}: retry loop exhausted unexpectedly")
 
     def catalog(self) -> list[dict[str, Any]]:
         """Every marketplace card the tenant lists."""
@@ -770,7 +1142,7 @@ def _parse(raw: bytes) -> object:
 
 def _await_cards(
     routes: RouteReader,
-    app_name: str,
+    identity: AppIdentity,
     entrypoints: Sequence[Entrypoint],
     wait_seconds: int,
     on_progress: Callable[[str], None] | None = None,
@@ -784,7 +1156,7 @@ def _await_cards(
     deadline = time.monotonic() + max(wait_seconds, 0)
     reason = "the catalog was never read"
     while True:
-        cards, reason_now = locate_cards(app_name, entrypoints, routes.catalog())
+        cards, reason_now = locate_cards(identity, entrypoints, routes.catalog())
         if reason_now is None:
             return cards
         reason = reason_now
@@ -796,6 +1168,91 @@ def _await_cards(
         if on_progress is not None:
             on_progress(
                 f"catalog not ready ({reason_now}); "
+                f"retrying in {_CATALOG_POLL_SECONDS}s"
+            )
+        time.sleep(_CATALOG_POLL_SECONDS)
+
+
+def _check_route(
+    routes: RouteReader, entrypoint: Entrypoint, card: Card
+) -> tuple[str | None, ServedForm | None]:
+    """Assert one entry point's setup route. Returns ``(failure, form)``.
+
+    Exactly one of the two is ever set: a reason the page is broken, or the
+    form the tenant served. Split out of :func:`verify` so :func:`_await_route`
+    can run it repeatedly without duplicating the assertion.
+    """
+    mismatch = route_mismatch(entrypoint, card)
+    if mismatch is not None:
+        return mismatch, None
+
+    status, body = routes.configmap(card.id)
+    if status != 200:
+        return (
+            f"Entrypoint {entrypoint.name!r}: GET "
+            f"{CONFIGMAP_PATH.format(name=card.id)} returned {status}. That "
+            f"is the request /workflows/setup/{card.id} makes to render its "
+            "form, so a non-200 here is a 404'd setup page for a user."
+        ), None
+
+    served_name = (body.get("metadata") or {}).get("name")
+    if served_name != card.id:
+        return (
+            f"Entrypoint {entrypoint.name!r}: asked the configmap endpoint for "
+            f"{card.id!r} and it served {served_name!r}. The setup page "
+            "would render another entry point's form."
+        ), None
+
+    form = served_form(body)
+    shortfall = form_shortfall(entrypoint, form)
+    if shortfall is not None:
+        return shortfall, None
+    return None, form
+
+
+def _await_route(
+    routes: RouteReader,
+    entrypoint: Entrypoint,
+    card: Card,
+    wait_seconds: int,
+    on_progress: Callable[[str], None] | None = None,
+) -> tuple[str | None, ServedForm | None]:
+    """Poll one entry point's route until it resolves, or give up saying why.
+
+    **The install verdict is not the pod's verdict.** ``prepare-tenant``'s
+    "verify the tenant runs the version under test" resolves the version from
+    *LM's catalog record*, which flips as soon as the install lands — while the
+    HelmRelease rollout that actually replaces the pod lags behind it. So the
+    configmap endpoint can still be the previous image's, serving the previous
+    contract, seconds after the version check passes.
+
+    FND-1680's aws leg is that gap, measured: the version check reported
+    ``verified: tenant runs sdr-test-634b735e`` at 12:50:02, and six seconds
+    later the pod served ``extraction_method`` — the spelling this connector
+    renamed to ``extraction-method`` two days earlier. Azure passed the
+    identical assertions against the identical build, because its pod had
+    already rolled. Nothing distinguishes the two clouds but timing, which is
+    the definition of a race.
+
+    Same bound and same cadence as :func:`_await_cards`, because it is the same
+    kind of wait: something downstream of the install has not caught up yet. A
+    shortfall that survives the whole window is reported as a real finding
+    *and says it waited*, so a stale rollout stays distinguishable from a
+    contract that genuinely never reached the tenant.
+    """
+    deadline = time.monotonic() + max(wait_seconds, 0)
+    while True:
+        failure, form = _check_route(routes, entrypoint, card)
+        if failure is None:
+            return None, form
+        if time.monotonic() >= deadline:
+            return (
+                f"{failure} Still true after {wait_seconds}s, so this is not "
+                "the app's rollout lagging its catalog record."
+            ), None
+        if on_progress is not None:
+            on_progress(
+                f"{entrypoint.name}: setup route not ready yet ({failure}); "
                 f"retrying in {_CATALOG_POLL_SECONDS}s"
             )
         time.sleep(_CATALOG_POLL_SECONDS)
@@ -815,15 +1272,15 @@ def verify(
         RouteCheckSkipped: when there is no setup route to check.
         SetupRouteError: when a route is broken or the tenant cannot be asked.
     """
-    app_name = read_app_name(repo_root)
+    identity = read_app_identity(repo_root)
     entrypoints = read_entrypoints(repo_root, generated_dir)
-    cards = _await_cards(routes, app_name, entrypoints, wait_seconds, on_progress)
+    cards = _await_cards(routes, identity, entrypoints, wait_seconds, on_progress)
 
     # Negative control FIRST. Everything below asserts that a name the tenant
     # knows answers 200; if the endpoint answered 200 for names it does not
     # know, all of it would be vacuous — so prove the endpoint discriminates
     # before trusting a single 200 from it.
-    bogus = f"{app_name}-nonexistent-setup-route-check"
+    bogus = f"{identity.name}-nonexistent-setup-route-check"
     status, _ = routes.configmap(bogus)
     if status not in _REJECTION_STATUSES:
         raise SetupRouteError(
@@ -839,40 +1296,26 @@ def verify(
         card = cards[entrypoint.name]
         label = entrypoint.name
 
-        mismatch = route_mismatch(entrypoint.name, card, entrypoint.config_id)
-        if mismatch is not None:
-            failures.append(mismatch)
-            continue
-
-        status, body = routes.configmap(card.id)
-        if status != 200:
-            failures.append(
-                f"Entrypoint {label!r}: GET "
-                f"{CONFIGMAP_PATH.format(name=card.id)} returned {status}. That "
-                f"is the request /workflows/setup/{card.id} makes to render its "
-                "form, so a non-200 here is a 404'd setup page for a user."
-            )
-            continue
-
-        served_name = (body.get("metadata") or {}).get("name")
-        if served_name != card.id:
-            failures.append(
-                f"Entrypoint {label!r}: asked the configmap endpoint for "
-                f"{card.id!r} and it served {served_name!r}. The setup page "
-                "would render another entry point's form."
-            )
-            continue
-
-        shortfall = input_shortfall(
-            entrypoint.name, entrypoint.declared, served_inputs(body)
+        failure, form = _await_route(
+            routes, entrypoint, card, wait_seconds, on_progress
         )
-        if shortfall is not None:
-            failures.append(shortfall)
+        if failure is not None or form is None:
+            failures.append(failure or f"Entrypoint {label!r}: no form served.")
             continue
 
+        via = (
+            ""
+            if card.id == entrypoint.config_id
+            else (
+                f" (card id {card.id!r} differs from the generated config id "
+                f"{entrypoint.config_id!r}; this app has one contract, so the "
+                "app-id fallback resolved it to that one form)"
+            )
+        )
         report.append(
-            f"{label}: /workflows/setup/{card.id} resolves; "
-            f"{len(entrypoint.declared)} declared inputs all served"
+            f"{label}: /workflows/setup/{card.id} resolves{via}; all "
+            f"{len(entrypoint.declared)} declared inputs are served AND drawn, "
+            f"across {len(form.steps)} wizard step(s)"
         )
 
     if failures:

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.32.1
-source-sha:    b0cd1b3e8c90cb5b4c9a4f35a13c917872525d34
-source-date:   2026-09-05T14:22:58Z
+source-sha:    d46dcabd4f14405fb9cbae177d986ce8ec9c4942
+source-date:   2026-09-05T15:43:36+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 44 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 7 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 346 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 347 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -4676,6 +4676,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `first_outcome_or_none(mock_logger: MagicMock)`
 - **Summary:** The first outcome row, or ``None`` — for paths asserting no row was emitted.
 - **Defined in:** `application_sdk/testing/preflight.py`
+
+#### `foreign_form`
+
+- **Import:** `from application_sdk.testing.setup_routes import foreign_form`
+- **Signature:** `foreign_form(entrypoint: Entrypoint, siblings: Sequence[Entrypoint], served_name: object) -> str | None`
+- **Summary:** Whether the tenant served a DIFFERENT entry point's form, or ``None``.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
 
 #### `form_shortfall`
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.32.1
-source-sha:    6f91b14cea9a0be7db64fc4061b3e836fc0729b9
-source-date:   2026-09-05T00:27:17+01:00
+source-sha:    b0cd1b3e8c90cb5b4c9a4f35a13c917872525d34
+source-date:   2026-09-05T14:22:58Z
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 44 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 7 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 343 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 346 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -3239,6 +3239,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Thin shim over :class:`TemporalExecutorBackend` for integration suites.
 - **Defined in:** `application_sdk/testing/integration/fixtures.py`
 
+#### `AppIdentity`
+
+- **Import:** `from application_sdk.testing.setup_routes import AppIdentity`
+- **Signature:** `class AppIdentity(name: str, display_name: str = '') -> None`
+- **Summary:** The committed names a marketplace card may be listed under.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
+
 #### `AppNotReadyError`
 
 - **Import:** `from application_sdk.testing.harness.automation_engine import AppNotReadyError`
@@ -3619,6 +3626,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `class FixtureNotConfiguredError(*, ...)`
 - **Summary:** A composer requested a harness fixture without declaring what it needs.
 - **Defined in:** `application_sdk/testing/harness/_errors.py`
+
+#### `FormStep`
+
+- **Import:** `from application_sdk.testing.setup_routes import FormStep`
+- **Signature:** `class FormStep(id: str, properties: frozenset[str] = frozenset()) -> None`
+- **Summary:** One panel of the setup wizard, as the served schema describes it.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
 
 #### `FullDAGOutcome`
 
@@ -4059,6 +4073,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `class SeededWorkflow(*, slug: str, seed_version: int | None = None)`
 - **Summary:** An AE workflow with a published version, ready to be submitted against.
 - **Defined in:** `application_sdk/testing/harness/starters/_specs.py`
+
+#### `ServedForm`
+
+- **Import:** `from application_sdk.testing.setup_routes import ServedForm`
+- **Signature:** `class ServedForm(properties: frozenset[str] = frozenset(), steps: tuple[FormStep, ...] = ()) -> None`
+- **Summary:** The setup form a tenant serves, in the two parts the UI renders from.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
 
 #### `ServiceTarget`
 
@@ -4656,6 +4677,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** The first outcome row, or ``None`` — for paths asserting no row was emitted.
 - **Defined in:** `application_sdk/testing/preflight.py`
 
+#### `form_shortfall`
+
+- **Import:** `from application_sdk.testing.setup_routes import form_shortfall`
+- **Signature:** `form_shortfall(entrypoint: Entrypoint, served: ServedForm) -> str | None`
+- **Summary:** Why this entry point's setup form will not render, or ``None``.
+- **Defined in:** `application_sdk/testing/setup_routes.py`
+
 #### `format_validation_report`
 
 - **Import:** `from application_sdk.testing.integration import format_validation_report`
@@ -4897,13 +4925,6 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Wire mocked infrastructure for the session, after the source is up.
 - **Defined in:** `application_sdk/testing/integration/fixtures.py`
 
-#### `input_shortfall`
-
-- **Import:** `from application_sdk.testing.setup_routes import input_shortfall`
-- **Signature:** `input_shortfall(entrypoint: str, declared: frozenset[str], served: frozenset[str]) -> str | None`
-- **Summary:** Which declared inputs the tenant is not serving, or ``None``.
-- **Defined in:** `application_sdk/testing/setup_routes.py`
-
 #### `integration_app_cls`
 
 - **Import:** `from application_sdk.testing.integration.fixtures import integration_app_cls`
@@ -5070,7 +5091,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `locate_cards`
 
 - **Import:** `from application_sdk.testing.setup_routes import locate_cards`
-- **Signature:** `locate_cards(app_name: str, ...)`
+- **Signature:** `locate_cards(identity: AppIdentity, ...)`
 - **Summary:** Pick this app's cards out of the whole catalog, keyed by entry point.
 - **Defined in:** `application_sdk/testing/setup_routes.py`
 
@@ -5224,11 +5245,11 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Delete every asset under *connection_qualified_name*, then the connection.
 - **Defined in:** `application_sdk/testing/harness/teardown.py`
 
-#### `read_app_name`
+#### `read_app_identity`
 
-- **Import:** `from application_sdk.testing.setup_routes import read_app_name`
-- **Signature:** `read_app_name(repo_root: Path) -> str`
-- **Summary:** Return the app ``name`` from ``atlan.yaml``, as cards report it.
+- **Import:** `from application_sdk.testing.setup_routes import read_app_identity`
+- **Signature:** `read_app_identity(repo_root: Path) -> AppIdentity`
+- **Summary:** Return the names ``atlan.yaml`` commits, as cards may report them.
 - **Defined in:** `application_sdk/testing/setup_routes.py`
 
 #### `read_entrypoint_names`
@@ -5299,7 +5320,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `route_mismatch`
 
 - **Import:** `from application_sdk.testing.setup_routes import route_mismatch`
-- **Signature:** `route_mismatch(entrypoint: str, card: Card, config_id: str) -> str | None`
+- **Signature:** `route_mismatch(entrypoint: Entrypoint, card: Card) -> str | None`
 - **Summary:** Why this entry point's setup page will 404, or ``None`` if it resolves.
 - **Defined in:** `application_sdk/testing/setup_routes.py`
 
@@ -5347,11 +5368,11 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Collect the literal values a run is holding, for :func:`redact`'s ``secrets``.
 - **Defined in:** `application_sdk/testing/harness/evidence.py`
 
-#### `served_inputs`
+#### `served_form`
 
-- **Import:** `from application_sdk.testing.setup_routes import served_inputs`
-- **Signature:** `served_inputs(body: dict[str, Any]) -> frozenset[str]`
-- **Summary:** Unwrap a ConfigMap response and return the input names it serves.
+- **Import:** `from application_sdk.testing.setup_routes import served_form`
+- **Signature:** `served_form(body: dict[str, Any]) -> ServedForm`
+- **Summary:** Unwrap a ConfigMap response into the form the tenant serves.
 - **Defined in:** `application_sdk/testing/setup_routes.py`
 
 #### `single_outcome`

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -2691,6 +2691,62 @@ class TestConfigMapEndpoints:
         finally:
             svc_module.CONTRACT_GENERATED_DIR = original
 
+    def test_configmaps_lists_the_names_the_endpoint_answers_to(
+        self, tmp_path: Path
+    ) -> None:
+        """The listing is "what can be fetched", not "which file is the form".
+
+        Those two rules look interchangeable and are not, so both halves are
+        pinned here. A credential template must stay LISTED — the setup form's
+        `credential` widget fetches `atlan-connectors-<source>` as a configmap
+        in its own right, so filtering it out would advertise fewer names than
+        the endpoint actually serves. The manifest must stay OUT, because
+        `/workflows/v1/manifest` owns it.
+
+        `artifact_schemas` is listed too, and deliberately: this endpoint does
+        serve it by exact stem. What FND-1682 fixed was the *fallback* picking
+        it when asked for something else, which is a different question from
+        which names resolve.
+        """
+        from application_sdk.handler import service as svc_module
+
+        for name in (
+            "artifact_schemas.json",
+            "atlan-connectors-snowflake.json",
+            "manifest.json",
+            "snowflake.json",
+        ):
+            (tmp_path / name).write_text("{}")
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            response = _make_client().get("/workflows/v1/configmaps")
+            assert response.status_code == 200
+            configmaps = response.json()["data"]["configmaps"]
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
+        assert sorted(configmaps) == [
+            "artifact_schemas",
+            "atlan-connectors-snowflake",
+            "snowflake",
+        ]
+
+    def test_the_excluded_stem_is_the_shared_one(self) -> None:
+        """One vocabulary, not a literal re-spelled at each site.
+
+        A hand-written `"manifest"` here was the last copy of that vocabulary
+        left in this module after FND-1682, and one divergent spelling is all
+        the artifact_schemas bug needed. If `_generated_tree` renames the stem,
+        this endpoint has to move with it rather than quietly keep listing a
+        file the rest of the SDK stopped calling a manifest.
+        """
+        from application_sdk.app._generated_tree import MANIFEST_STEM
+        from application_sdk.handler import service as svc_module
+
+        assert svc_module.MANIFEST_STEM is MANIFEST_STEM
+
     def test_configmaps_empty_when_dir_missing(self, tmp_path: Path) -> None:
         from application_sdk.handler import service as svc_module
 

--- a/tests/unit/testing/test_setup_routes.py
+++ b/tests/unit/testing/test_setup_routes.py
@@ -21,7 +21,7 @@ this file.
 
 :class:`TestServedFormRoundTrip` is the other load-bearing part, and it tests
 something no amount of shape-fixture assertion can: that
-:func:`~application_sdk.testing.setup_routes.served_inputs` really inverts the
+:func:`~application_sdk.testing.setup_routes.served_form` really inverts the
 envelope the SDK's own configmap endpoint builds. It drives the live FastAPI
 route rather than a hand-written dict, so the two sides of the join are pinned
 against each other in-repo — the committed generated file and the response a
@@ -35,6 +35,7 @@ from __future__ import annotations
 import email.message
 import io
 import json
+import urllib.error
 import urllib.request
 import urllib.response
 from pathlib import Path
@@ -42,19 +43,24 @@ from typing import Any
 
 import pytest
 
+from application_sdk.testing import setup_routes
 from application_sdk.testing.setup_routes import (
+    AppIdentity,
     Card,
     Entrypoint,
+    FormStep,
     RouteCheckSkipped,
+    ServedForm,
     SetupRouteError,
+    TenantRoutes,
     declared_inputs,
-    input_shortfall,
+    form_shortfall,
     locate_cards,
-    read_app_name,
+    read_app_identity,
     read_entrypoint_names,
     read_entrypoints,
     route_mismatch,
-    served_inputs,
+    served_form,
     verify,
 )
 
@@ -90,8 +96,21 @@ def _workflow_config(config_id: str = "clickhouse-crawler") -> dict[str, Any]:
     """A generated workflow config, trimmed to the read fields.
 
     ``config`` carries ``steps`` and ``anyOf`` alongside ``properties`` on a
-    real one; both are included here precisely so a test proves they are NOT
-    read as inputs.
+    real one. ``anyOf`` is here precisely so a test proves it is NOT read as an
+    input set.
+
+    ``steps`` is different, and the difference is load-bearing: it *is* read,
+    because the UI draws the wizard from it and a field no step names never
+    reaches a user (FND-1680). So the panels here name their fields the way
+    every canonical connector's do — verified against ``atlan-metabase-app``,
+    ``atlan-openapi-app`` and ``atlan-mysql-app``, where the set of step-named
+    properties equals the set of declared properties exactly, in both
+    directions, with no exceptions.
+
+    An earlier revision stubbed this as ``[{"id": "credentials"}]``, naming no
+    fields at all. That was harmless while only ``properties`` was read and
+    became a fixture asserting the opposite of reality the moment rendering
+    was checked.
     """
     return {
         "id": config_id,
@@ -103,10 +122,33 @@ def _workflow_config(config_id: str = "clickhouse-crawler") -> dict[str, Any]:
                 "credential-guid": {"type": "string"},
                 "connection": {"type": "string"},
             },
-            "steps": [{"id": "credentials"}],
+            "steps": [
+                {
+                    "title": "Credential",
+                    "description": "Credential Details",
+                    "id": "credential",
+                    "properties": ["extraction-method", "credential-guid"],
+                },
+                {
+                    "title": "Connection",
+                    "description": "Connection Details",
+                    "id": "connection",
+                    "properties": ["connection"],
+                },
+            ],
             "anyOf": [{"properties": {}}],
         },
     }
+
+
+def _id(name: str, display_name: str = "") -> AppIdentity:
+    """The committed identity `read_app_identity` builds from `atlan.yaml`."""
+    return AppIdentity(name=name, display_name=display_name)
+
+
+def _ep(name: str, config_id: str, *, is_sole: bool = False) -> Entrypoint:
+    """One entrypoint, for the pure checks that take it whole."""
+    return Entrypoint(name=name, config_id=config_id, is_sole=is_sole)
 
 
 def _eps(*names: str) -> list[Entrypoint]:
@@ -135,6 +177,36 @@ def _configmap_response(
     }
 
 
+def _form_schema(*names: str, extra: tuple[str, ...] = ()) -> dict[str, Any]:
+    """A served form carrying *names*, laid out across real wizard steps.
+
+    Steps are not decoration in this fixture and must not be dropped from it.
+    The UI draws the form from ``steps``, so a fixture with ``properties``
+    alone is a payload that renders blank — and a suite built on those cannot
+    tell a rendered form from an invisible one, which is exactly the gap
+    FND-1680's metabase page fell through.
+
+    The layout mirrors the shape every canonical connector commits: a
+    ``credential`` panel and a ``connection`` panel, each naming the fields it
+    puts on screen.
+
+    Args:
+        names: Fields that are both defined and drawn.
+        extra: Fields defined by the platform and named by no step, so the
+            subset tolerance is exercised without pretending they render.
+    """
+    first, rest = names[:2], names[2:]
+    steps = [{"title": "Credential", "id": "credential", "properties": list(first)}]
+    if rest:
+        steps.append(
+            {"title": "Connection", "id": "connection", "properties": list(rest)}
+        )
+    return {
+        "properties": {name: {} for name in (*names, *extra)},
+        "steps": steps,
+    }
+
+
 # ---------------------------------------------------------------------------
 # route_mismatch — the load-bearing check
 # ---------------------------------------------------------------------------
@@ -144,7 +216,7 @@ class TestRouteMismatch:
     def test_passes_on_the_shipped_card_shape(self) -> None:
         """The real card and the real generated config agree, so nothing fires."""
         card = Card.from_payload(_card_payload("clickhouse-crawler"))
-        assert route_mismatch("crawler", card, "clickhouse-crawler") is None
+        assert route_mismatch(_ep("crawler", "clickhouse-crawler"), card) is None
 
     def test_bites_on_the_packageid_regression(self) -> None:
         """The FND-1593 shape must be reported, or the check is decoration.
@@ -156,7 +228,7 @@ class TestRouteMismatch:
         """
         card = Card.from_payload(_card_payload("atlan-clickhouse"))
 
-        reason = route_mismatch("crawler", card, "clickhouse-crawler")
+        reason = route_mismatch(_ep("crawler", "clickhouse-crawler"), card)
 
         assert reason is not None, (
             "route_mismatch accepted a card whose id does not match the "
@@ -175,7 +247,7 @@ class TestRouteMismatch:
             _card_payload("atlan-clickhouse-miner", entrypoint="miner")
         )
 
-        reason = route_mismatch("miner", card, "clickhouse-miner")
+        reason = route_mismatch(_ep("miner", "clickhouse-miner"), card)
 
         assert reason is not None
         assert "atlan-clickhouse-miner" in reason
@@ -185,7 +257,7 @@ class TestRouteMismatch:
         """The message must point at packageId, the known cause (FND-1659)."""
         card = Card.from_payload(_card_payload("atlan-clickhouse"))
 
-        reason = route_mismatch("crawler", card, "clickhouse-crawler")
+        reason = route_mismatch(_ep("crawler", "clickhouse-crawler"), card)
 
         assert reason is not None
         assert "packageId" in reason
@@ -196,7 +268,7 @@ class TestRouteMismatch:
         del payload["id"]
 
         reason = route_mismatch(
-            "crawler", Card.from_payload(payload), "clickhouse-crawler"
+            _ep("crawler", "clickhouse-crawler"), Card.from_payload(payload)
         )
 
         assert reason is not None
@@ -206,7 +278,7 @@ class TestRouteMismatch:
         """An id-less config means the artifacts were never generated."""
         card = Card.from_payload(_card_payload("clickhouse-crawler"))
 
-        reason = route_mismatch("crawler", card, "")
+        reason = route_mismatch(_ep("crawler", ""), card)
 
         assert reason is not None
         assert "Regenerate the contract" in reason
@@ -217,39 +289,157 @@ class TestRouteMismatch:
         An earlier revision rendered a flat app as `''` and papered over it with
         a `<flat>` placeholder at every message site. The label is now a
         committed fact, so there is nothing to paper over.
-        """
-        card = Card.from_payload(_card_payload("atlan-mysql", entrypoint=""))
 
-        reason = route_mismatch("mysql", card, "mysql")
+        Driven through the id-less card rather than an id mismatch, because a
+        sole contract no longer fails on a mismatch — see
+        :class:`TestAppIdFallbackTolerance`.
+        """
+        payload = _card_payload("atlan-mysql", entrypoint="")
+        del payload["id"]
+
+        reason = route_mismatch(
+            _ep("mysql", "mysql", is_sole=True), Card.from_payload(payload)
+        )
 
         assert reason is not None
         assert "'mysql'" in reason
         assert "<flat>" not in reason
 
 
+class TestAppIdFallbackTolerance:
+    """FND-1680: a card id differing from the config id is not itself a break.
+
+    The fleet's first live run failed openapi, metabase and mysql on exactly
+    this — every one serves a card id of ``atlan-<name>`` against a generated
+    config id of ``<name>``, and every one of those setup pages renders. The
+    reason is in this repo: ``handler.service.get_configmap`` resolves an
+    unmatched id through a documented default-entrypoint fallback, added
+    because ``atlan-openapi`` really did 404 in production
+    (``test_configmap_default_fallback_serves_flat_single_entrypoint_form``).
+
+    The tolerance is gated on ``is_sole`` because that is where the fallback is
+    safe by construction: it resolves to the app's *default* entry point, which
+    for a sole contract is the only one. A bundle gets no tolerance — there the
+    same fallback would hand every card the default entry point's form.
+    """
+
+    def test_a_sole_contract_tolerates_the_app_id_card(self) -> None:
+        """The exact openapi / metabase / mysql shape, which is healthy."""
+        card = Card.from_payload(_card_payload("atlan-openapi", entrypoint=""))
+
+        assert route_mismatch(_ep("openapi", "openapi", is_sole=True), card) is None
+
+    def test_a_bundle_still_bites_on_the_same_shape(self) -> None:
+        """Same divergence, bundle layout: still a real, reportable break."""
+        card = Card.from_payload(_card_payload("atlan-clickhouse"))
+
+        reason = route_mismatch(_ep("crawler", "clickhouse-crawler"), card)
+
+        assert reason is not None
+        assert "atlan-clickhouse" in reason
+        assert "clickhouse-crawler" in reason
+        # It must say WHY a bundle is different, or the next reader "fixes" the
+        # asymmetry by deleting it.
+        assert "DEFAULT entry point" in reason
+
+    def test_the_tolerance_is_not_a_free_pass(self, tmp_path: Path) -> None:
+        """A tolerated id still has to actually serve this contract's form.
+
+        Equality was only ever a proxy for "the card's id resolves to this
+        entry point's form". Dropping it for a sole contract must not drop the
+        assertion — `verify` still fetches the card id and still requires the
+        served schema to carry every declared input.
+        """
+        _write_flat(tmp_path)
+        catalog = [_card_payload("atlan-mysql", name="mysql", entrypoint="")]
+        # Served under the card id, but one input short of the contract.
+        stale = _form_schema("extraction-method", "credential-guid")
+        routes = _FakeRoutes(
+            [catalog],
+            {"atlan-mysql": (200, _configmap_response(stale, "atlan-mysql"))},
+        )
+
+        with pytest.raises(SetupRouteError, match="connection"):
+            verify(tmp_path, routes, wait_seconds=0)
+
+    def test_a_tolerated_id_is_reported_not_silently_passed(
+        self, tmp_path: Path
+    ) -> None:
+        """A green run must still say the fallback answered, not just "resolves".
+
+        A tolerance nobody can see in the log is indistinguishable from a check
+        that stopped looking.
+        """
+        _write_flat(tmp_path)
+        catalog = [_card_payload("atlan-mysql", name="mysql", entrypoint="")]
+        served = _form_schema("extraction-method", "credential-guid", "connection")
+        routes = _FakeRoutes(
+            [catalog],
+            {"atlan-mysql": (200, _configmap_response(served, "atlan-mysql"))},
+        )
+
+        report = verify(tmp_path, routes, wait_seconds=0)
+
+        assert len(report) == 1
+        assert "/workflows/setup/atlan-mysql resolves" in report[0]
+        assert "app-id fallback" in report[0]
+
+
 # ---------------------------------------------------------------------------
-# input_shortfall — the subset check
+# form_shortfall — does the contract's field actually reach a user
 # ---------------------------------------------------------------------------
 
 
-class TestInputShortfall:
+def _served(
+    properties: set[str] | None = None,
+    steps: dict[str, list[str]] | None = None,
+) -> ServedForm:
+    """A parsed served form, from field names and step-id -> field-names."""
+    return ServedForm(
+        properties=frozenset(properties or set()),
+        steps=tuple(
+            FormStep(id=step_id, properties=frozenset(names))
+            for step_id, names in (steps or {}).items()
+        ),
+    )
+
+
+def _declaring(*names: str) -> Entrypoint:
+    """A sole entrypoint declaring exactly *names*."""
+    return Entrypoint(
+        name="crawler",
+        config_id="clickhouse-crawler",
+        is_sole=True,
+        declared=frozenset(names),
+    )
+
+
+class TestFormShortfall:
     def test_extra_served_fields_are_not_a_failure(self) -> None:
         """A subset check: the platform may decorate the schema.
 
         Failing on platform-added fields buys no safety and would red the fleet
         the first time the platform grew one.
         """
-        declared = frozenset({"credential-guid", "connection"})
-        served = declared | {"labFlag", "platform-injected"}
+        served = _served(
+            {"credential-guid", "connection", "labFlag", "platform-injected"},
+            {"credential": ["credential-guid"], "connection": ["connection"]},
+        )
 
-        assert input_shortfall("crawler", declared, served) is None
+        assert (
+            form_shortfall(_declaring("credential-guid", "connection"), served) is None
+        )
 
     def test_bites_on_a_missing_declared_input(self) -> None:
         """A missing input is the signal — a stale image, or a change that never landed."""
-        declared = frozenset({"credential-guid", "connection", "include-filter"})
-        served = frozenset({"credential-guid", "connection"})
+        served = _served(
+            {"credential-guid", "connection"},
+            {"credential": ["credential-guid"], "connection": ["connection"]},
+        )
 
-        reason = input_shortfall("crawler", declared, served)
+        reason = form_shortfall(
+            _declaring("credential-guid", "connection", "include-filter"), served
+        )
 
         assert reason is not None
         assert "include-filter" in reason
@@ -259,10 +449,109 @@ class TestInputShortfall:
 
     def test_a_contract_declaring_nothing_is_reported(self) -> None:
         """Zero declared inputs makes the check vacuous, so it must not pass."""
-        reason = input_shortfall("crawler", frozenset(), frozenset({"anything"}))
+        reason = form_shortfall(_declaring(), _served({"anything"}))
 
         assert reason is not None
         assert "declares no inputs" in reason
+
+
+class TestBlankFormDetection:
+    """FND-1680: a 200 does not mean a user sees a form.
+
+    The metabase setup page answered 200 for ``atlan-metabase`` and rendered
+    blank. Its ``data.config`` was the app's ``artifact_schemas.json`` —
+    ``{"version": 1, "schemas": {...}}`` — because the pod ran an SDK without
+    the artifact-schemas exclusion and served the declaration file as the form.
+    Every status-code assertion in the check passed.
+
+    These pin the four ways a served payload fails to become a rendered form,
+    each with its own diagnosis, because "the page is blank" has more than one
+    cause and a single message for all of them sends the reader the wrong way.
+    """
+
+    def test_the_metabase_payload_is_reported_as_not_a_form(self) -> None:
+        """The exact live payload, verbatim from the tenant."""
+        body = _configmap_response(
+            {
+                "version": 1,
+                "schemas": {"residual_failures": {"format": "ndjson", "fields": []}},
+            },
+            "atlan-metabase",
+        )
+
+        reason = form_shortfall(
+            _declaring("credential-guid", "connection"), served_form(body)
+        )
+
+        assert reason is not None
+        assert "is not a setup form" in reason
+        assert "renders blank" in reason
+        # Name the cause, or the reader chases a stale image that is not the problem.
+        assert "artifact_schemas.json" in reason
+
+    def test_fields_without_steps_are_reported(self) -> None:
+        """A schema with fields and no panels draws nothing at all."""
+        served = _served({"credential-guid", "connection"})
+
+        reason = form_shortfall(_declaring("credential-guid", "connection"), served)
+
+        assert reason is not None
+        assert "no 'steps'" in reason
+        assert "renders blank" in reason
+
+    def test_a_field_no_step_names_is_reported(self) -> None:
+        """Served but never drawn — invisible to the user filling the form in.
+
+        This is the gap a properties-only check cannot see: every declared
+        input is present in the schema, and one of them still never appears
+        on screen.
+        """
+        served = _served(
+            {"credential-guid", "connection", "include-filter"},
+            {"credential": ["credential-guid"], "connection": ["connection"]},
+        )
+
+        reason = form_shortfall(
+            _declaring("credential-guid", "connection", "include-filter"), served
+        )
+
+        assert reason is not None
+        assert "include-filter" in reason
+        assert "named by no step" in reason
+        # The panels that DO exist, so the reader can see where it should have been.
+        assert "credential" in reason
+
+    def test_a_fully_rendered_form_passes(self) -> None:
+        """Every declared field defined AND drawn is the only passing shape."""
+        served = _served(
+            {"extraction-method", "credential-guid", "connection"},
+            {
+                "credential": ["extraction-method", "credential-guid"],
+                "connection": ["connection"],
+            },
+        )
+
+        assert (
+            form_shortfall(
+                _declaring("extraction-method", "credential-guid", "connection"), served
+            )
+            is None
+        )
+
+    def test_the_causes_are_reported_in_cause_order(self) -> None:
+        """A payload that is not a form must not be reported as a stale image.
+
+        Both faults are true of the metabase payload — it is not a form, AND
+        every declared field is missing from it. Reporting the second sends the
+        reader to look for an image bump that would never have fixed it.
+        """
+        body = _configmap_response({"version": 1, "schemas": {}}, "atlan-metabase")
+
+        reason = form_shortfall(_declaring("connection"), served_form(body))
+
+        assert reason is not None
+        assert "is not a setup form" in reason
+        assert "older image" not in reason
 
 
 # ---------------------------------------------------------------------------
@@ -295,7 +584,7 @@ class TestLocateCards:
             )
         ]
 
-        cards, reason = locate_cards("clickhouse", _eps("crawler"), catalog)
+        cards, reason = locate_cards(_id("clickhouse"), _eps("crawler"), catalog)
 
         assert reason is None
         assert set(cards) == {"crawler"}
@@ -304,7 +593,7 @@ class TestLocateCards:
     def test_reports_an_app_absent_from_the_catalog(self) -> None:
         catalog = [_card_payload("mssql-crawler", name="mssql")]
 
-        cards, reason = locate_cards("clickhouse", _eps("crawler"), catalog)
+        cards, reason = locate_cards(_id("clickhouse"), _eps("crawler"), catalog)
 
         assert cards == {}
         assert reason is not None
@@ -312,12 +601,17 @@ class TestLocateCards:
         # The catalog size proves the read worked, which distinguishes "not
         # installed" from "token cannot read the catalog".
         assert "1 apps" in reason
+        # And the names it DID carry, so a reader can confirm the absence from
+        # the failure instead of from a follow-up investigation.
+        assert "'mssql'" in reason
 
     def test_reports_an_entrypoint_with_no_card(self) -> None:
         """An entrypoint with no card has no setup page at all."""
         catalog = [_card_payload("clickhouse-crawler", name="clickhouse")]
 
-        cards, reason = locate_cards("clickhouse", _eps("crawler", "miner"), catalog)
+        cards, reason = locate_cards(
+            _id("clickhouse"), _eps("crawler", "miner"), catalog
+        )
 
         assert set(cards) == {"crawler"}
         assert reason is not None
@@ -331,24 +625,293 @@ class TestLocateCards:
         """
         catalog = [_card_payload("mysql", name="mysql", entrypoint="")]
 
-        cards, reason = locate_cards("mysql", _sole("mysql"), catalog)
+        cards, reason = locate_cards(_id("mysql"), _sole("mysql"), catalog)
 
         assert reason is None
         assert cards["mysql"].id == "mysql"
 
 
+class TestAppIdentity:
+    """FND-1680: the catalog is not consistent about which name a card carries.
+
+    One live tenant, one run: openapi and metabase were listed under their wire
+    ``name``, mysql under its ``display_name`` (``MySQL Assets``). A locator
+    keyed on either field alone reports a healthy, installed app as absent —
+    the most misleading message this check can emit — so it accepts both.
+    """
+
+    def test_locates_the_card_the_live_run_could_not(self, tmp_path: Path) -> None:
+        """The exact mysql shape the fleet's first run failed on."""
+        (tmp_path / "atlan.yaml").write_text(
+            "name: mysql\ndisplay_name: MySQL Assets\n"
+        )
+        identity = read_app_identity(tmp_path)
+        catalog = [_card_payload("atlan-mysql", name="MySQL Assets", entrypoint="")]
+
+        cards, reason = locate_cards(identity, _sole("mysql"), catalog)
+
+        assert reason is None
+        assert cards["mysql"].id == "atlan-mysql"
+
+    def test_the_wire_name_still_locates_it(self) -> None:
+        """openapi and metabase matched on `name`, and must keep doing so."""
+        catalog = [_card_payload("atlan-openapi", name="openapi", entrypoint="")]
+
+        cards, reason = locate_cards(
+            _id("openapi", "openapi spec loader"), _sole("openapi"), catalog
+        )
+
+        assert reason is None
+        assert cards["openapi"].id == "atlan-openapi"
+
+    def test_an_undeclared_display_name_yields_one_label(self, tmp_path: Path) -> None:
+        (tmp_path / "atlan.yaml").write_text("name: openapi\n")
+
+        assert read_app_identity(tmp_path).labels == ("openapi",)
+
+    def test_a_display_name_equal_to_the_name_is_not_doubled(self) -> None:
+        """Deduplicated, so a message never reads `['mysql', 'mysql']`."""
+        assert _id("mysql", "mysql").labels == ("mysql",)
+
+    def test_the_display_name_is_case_folded_too(self, tmp_path: Path) -> None:
+        """Both sides normalised, or `MySQL Assets` never matches itself."""
+        (tmp_path / "atlan.yaml").write_text(
+            "name: mysql\ndisplay_name: MySQL Assets\n"
+        )
+        identity = read_app_identity(tmp_path)
+
+        assert identity.labels == ("mysql", "mysql assets")
+        assert identity.matches(Card(id="x", name="  MySQL Assets  "))
+
+    def test_a_genuinely_different_app_is_still_not_matched(self) -> None:
+        """Widening the locator must not make it match neighbours."""
+        identity = _id("mysql", "mysql assets")
+
+        assert not identity.matches(Card(id="x", name="mssql"))
+        assert not identity.matches(Card(id="x", name="mysql assets extra"))
+
+
+class TestCatalogEvidence:
+    """FND-1680: a card lookup that finds nothing has to say what it DID find.
+
+    The first fleet-wide run reported ``no marketplace card has name='mysql'.
+    The tenant listed 139 apps`` and then waited out the full reconcile poll —
+    on a tenant the preceding step had already proven was running the app at
+    the version under test. Two very different faults produce that line: the
+    app really is absent, or ``name`` is not the field carrying it. The message
+    named neither a single card nor a single field, so the log could not
+    distinguish them and the next step was a manual catalog read.
+
+    Nothing here changes what is matched. Deciding to match a different field
+    needs the evidence these tests make the failure carry, and inventing a
+    fallback field before seeing it would be the soften-the-check move this
+    issue explicitly rules out.
+    """
+
+    def test_names_the_field_that_actually_carries_the_app_name(self) -> None:
+        """A card matching on `id` says so, and contradicts "not installed"."""
+        catalog = [
+            _card_payload("mysql", name="MySQL Assets", entrypoint="crawler"),
+            _card_payload("mssql-crawler", name="mssql"),
+        ]
+
+        _, reason = locate_cards(_id("mysql"), _sole("mysql"), catalog)
+
+        assert reason is not None
+        assert "reading the wrong field" in reason
+        assert "id='mysql'" in reason
+        assert "name='MySQL Assets'" in reason
+        assert "entrypoint='crawler'" in reason
+        # The wrong conclusion must NOT also be offered alongside the right one.
+        assert "not installed on this tenant" not in reason
+
+    def test_an_entrypoint_field_match_is_reported_too(self) -> None:
+        catalog = [
+            _card_payload("atlan-mysql", name="MySQL Assets", entrypoint="mysql")
+        ]
+
+        _, reason = locate_cards(_id("mysql"), _sole("mysql"), catalog)
+
+        assert reason is not None
+        assert "reading the wrong field" in reason
+        assert "entrypoint='mysql'" in reason
+
+    def test_a_decorated_identity_is_shown_rather_than_hidden_in_a_slice(
+        self,
+    ) -> None:
+        """A near-miss card beats an alphabetical sample that may not reach it.
+
+        The catalog runs to ~140 cards, so a bounded sorted sample has roughly
+        a one-in-seven chance of containing the card that explains the miss.
+        A substring hit is reported directly instead.
+        """
+        catalog = [
+            _card_payload(f"app-{index:03d}-crawler", name=f"app-{index:03d}")
+            for index in range(139)
+        ]
+        catalog.append(
+            _card_payload(
+                "atlan-mysql-crawler", name="Atlan MySQL", entrypoint="crawler"
+            )
+        )
+
+        _, reason = locate_cards(_id("mysql"), _sole("mysql"), catalog)
+
+        assert reason is not None
+        assert "as a substring" in reason
+        assert "id='atlan-mysql-crawler'" in reason
+        assert "name='Atlan MySQL'" in reason
+        # The weaker conclusions must not be offered alongside it.
+        assert "not installed on this tenant" not in reason
+        assert "reading the wrong field" not in reason
+
+    def test_a_genuine_absence_still_reads_as_not_installed(self) -> None:
+        catalog = [
+            _card_payload(f"app-{index}-crawler", name=f"app-{index}")
+            for index in range(3)
+        ]
+
+        _, reason = locate_cards(_id("mysql"), _sole("mysql"), catalog)
+
+        assert reason is not None
+        assert "not installed on this tenant" in reason
+        assert "'app-0'" in reason
+
+    def test_the_name_sample_is_bounded(self) -> None:
+        """~140 cards is the live scale; the whole list would bury the finding.
+
+        Bounded and *sorted*, so the sample is the same slice on every run
+        rather than whatever order the catalog happened to serve.
+        """
+        catalog = [
+            _card_payload(f"app-{index:03d}-crawler", name=f"app-{index:03d}")
+            for index in range(139)
+        ]
+
+        _, reason = locate_cards(_id("mysql"), _sole("mysql"), catalog)
+
+        assert reason is not None
+        assert "139 apps" in reason
+        assert "20 of 139" in reason
+        assert "'app-000'" in reason
+        assert "'app-019'" in reason
+        assert "'app-020'" not in reason
+
+    def test_the_evidence_survives_the_catalog_poll(self, tmp_path: Path) -> None:
+        """`_await_cards` re-reads the catalog, and the sample must not vanish.
+
+        The lookup consumed the payload list twice — once to filter, once to
+        describe — so a streamed generator would leave the diagnostic with an
+        exhausted iterator and an empty sample on exactly the failing path.
+        """
+        _write_flat(tmp_path)
+        routes = _FakeRoutes([[_card_payload("mysql", name="MySQL Assets")]], {})
+
+        with pytest.raises(SetupRouteError) as excinfo:
+            verify(tmp_path, routes, wait_seconds=0)
+
+        message = str(excinfo.value)
+        assert "id='mysql'" in message
+        assert "reading the wrong field" in message
+        assert "Waited 0s" in message
+
+
 # ---------------------------------------------------------------------------
-# served_inputs — the one-level nesting difference
+# served_form — the one-level nesting difference, and both rendered parts
 # ---------------------------------------------------------------------------
 
 
-class TestServedInputs:
+class TestServedForm:
     def test_unwraps_the_json_string_config(self) -> None:
         response = _configmap_response(
             {"properties": {"credential-guid": {}, "connection": {}}}
         )
 
-        assert served_inputs(response) == frozenset({"credential-guid", "connection"})
+        assert served_form(response).properties == frozenset(
+            {"credential-guid", "connection"}
+        )
+
+    def test_reads_the_steps_the_wizard_draws_from(self) -> None:
+        """The real mysql shape: step ids and the fields each panel carries."""
+        response = _configmap_response(
+            {
+                "properties": {
+                    "extraction-method": {},
+                    "credential-guid": {},
+                    "connection": {},
+                },
+                "steps": [
+                    {
+                        "title": "Credential",
+                        "id": "credential",
+                        "properties": ["extraction-method", "credential-guid"],
+                    },
+                    {
+                        "title": "Connection",
+                        "id": "connection",
+                        "properties": ["connection"],
+                    },
+                ],
+            }
+        )
+
+        form = served_form(response)
+
+        assert [step.id for step in form.steps] == ["credential", "connection"]
+        assert form.rendered == frozenset(
+            {"extraction-method", "credential-guid", "connection"}
+        )
+
+    def test_rendered_is_the_union_over_steps_not_over_properties(self) -> None:
+        """The whole point: a defined-but-undrawn field is not rendered."""
+        response = _configmap_response(
+            {
+                "properties": {"connection": {}, "orphan": {}},
+                "steps": [{"id": "connection", "properties": ["connection"]}],
+            }
+        )
+
+        form = served_form(response)
+
+        assert form.properties == frozenset({"connection", "orphan"})
+        assert form.rendered == frozenset({"connection"})
+
+    def test_a_form_with_no_steps_renders_nothing(self) -> None:
+        """`rendered` must be empty, not raise, when there are no panels."""
+        form = served_form(_configmap_response({"properties": {"connection": {}}}))
+
+        assert form.steps == ()
+        assert form.rendered == frozenset()
+
+    def test_malformed_steps_are_skipped_not_fatal(self) -> None:
+        """A junk entry is dropped; the good panels still report.
+
+        Degrading here rather than raising is what lets `form_shortfall` report
+        the shortfall WITH the evidence instead of the parser crashing on it.
+        """
+        response = _configmap_response(
+            {
+                "properties": {"connection": {}},
+                "steps": [
+                    "not-a-step",
+                    {"id": "connection", "properties": ["connection"]},
+                    {"id": "broken", "properties": "not-a-list"},
+                ],
+            }
+        )
+
+        form = served_form(response)
+
+        assert [step.id for step in form.steps] == ["connection", "broken"]
+        assert form.rendered == frozenset({"connection"})
+
+    def test_a_step_with_no_id_gets_a_positional_label(self) -> None:
+        """Messages name the panel, so an id-less step still needs a label."""
+        response = _configmap_response(
+            {"properties": {"a": {}}, "steps": [{"properties": ["a"]}]}
+        )
+
+        assert served_form(response).steps[0].id == "<step 0>"
 
     def test_rejects_a_non_string_config(self) -> None:
         """A nested object instead of a string means the shape changed.
@@ -360,22 +923,22 @@ class TestServedInputs:
         response["data"] = {"config": {"properties": {}}}
 
         with pytest.raises(SetupRouteError, match="no string data.config"):
-            served_inputs(response)
+            served_form(response)
 
     def test_rejects_a_response_with_no_data(self) -> None:
         with pytest.raises(SetupRouteError, match="no 'data' object"):
-            served_inputs({"metadata": {"name": "x"}})
+            served_form({"metadata": {"name": "x"}})
 
     def test_rejects_unparseable_config(self) -> None:
         response = _configmap_response({"properties": {}})
         response["data"] = {"config": "{not json"}
 
         with pytest.raises(SetupRouteError, match="not valid JSON"):
-            served_inputs(response)
+            served_form(response)
 
     def test_a_schema_with_no_properties_serves_nothing(self) -> None:
-        """Empty, not an error — ``input_shortfall`` is what reports the gap."""
-        assert served_inputs(_configmap_response({"steps": []})) == frozenset()
+        """Empty, not an error — ``form_shortfall`` is what reports the gap."""
+        assert served_form(_configmap_response({"steps": []})).properties == frozenset()
 
 
 class TestDeclaredInputs:
@@ -422,6 +985,11 @@ def _write_bundle(root: Path) -> None:
         directory = generated / entrypoint
         directory.mkdir()
         (directory / "manifest.json").write_text("{}")
+        # A bundle emits one per entrypoint. It sorts FIRST of the three —
+        # see `_write_flat` and TestNonFormSiblings for why that matters.
+        (directory / "artifact_schemas.json").write_text(
+            json.dumps({"version": 1, "artifacts": {}})
+        )
         (directory / f"{config_id}.json").write_text(
             json.dumps(_workflow_config(config_id))
         )
@@ -435,7 +1003,13 @@ def _write_flat(root: Path) -> None:
     generated = root / "app" / "generated"
     generated.mkdir(parents=True)
     (generated / "manifest.json").write_text("{}")
-    # Sorts BEFORE `mysql.json`, which is the whole point — see the test.
+    # The full sibling set a generated tree really carries, in the order it
+    # sorts: `artifact_schemas` first, then the credential template, then the
+    # manifest, then the form. Both of the first two sort BEFORE `mysql.json`,
+    # which is the whole point — see TestNonFormSiblings.
+    (generated / "artifact_schemas.json").write_text(
+        json.dumps({"version": 1, "artifacts": {}})
+    )
     # Real shape: a `config`, no top-level `id`.
     (generated / "atlan-connectors-mysql.json").write_text(
         json.dumps({"connector": "mysql", "config": {"properties": {"host": {}}}})
@@ -458,14 +1032,12 @@ class TestArtifactReaders:
             {"extraction-method", "credential-guid", "connection"}
         )
 
-    def test_a_flat_app_does_not_pick_the_credential_template(
-        self, tmp_path: Path
-    ) -> None:
-        """Exclusion by stem, not by hoping the template lacks a key.
+    def test_a_flat_app_does_not_pick_a_non_form_sibling(self, tmp_path: Path) -> None:
+        """Exclusion by stem, not by hoping the sibling lacks a key.
 
-        ``atlan-connectors-mysql.json`` sorts alphabetically BEFORE
-        ``mysql.json``, so file selection in a flat tree has to reject it
-        explicitly rather than relying on ordering.
+        Both ``artifact_schemas.json`` and ``atlan-connectors-mysql.json``
+        sort alphabetically BEFORE ``mysql.json``, so file selection in a flat
+        tree has to reject them explicitly rather than relying on ordering.
 
         Today's credential templates carry a ``config`` and no top-level
         ``id``, so a selector keyed on "has both ``id`` and ``config``" also
@@ -484,6 +1056,27 @@ class TestArtifactReaders:
         assert [e.name for e in found] == ["mysql"]
         assert found[0].config_id == "mysql"
         assert found[0].is_sole is True
+
+    def test_a_flat_app_with_artifact_schemas_reads_its_real_config_id(
+        self, tmp_path: Path
+    ) -> None:
+        """FND-1680, from this module's side of the join.
+
+        ``_generated_tree`` owns the rule that ``artifact_schemas`` is not a
+        form, and ``tests/unit/app/test_generated_tree.py`` pins it there. What
+        this pins is that ``read_entrypoints`` inherits it: the openapi leg
+        died on ``artifact_schemas.json carries no top-level 'id'`` — a
+        SetupRouteError about the wrong file, raised right here — so the check
+        reading the same authority as the server is the thing under test, not
+        the rule itself.
+        """
+        _write_flat(tmp_path)
+
+        found = read_entrypoints(tmp_path)
+
+        assert [(e.name, e.config_id) for e in found] == [("mysql", "mysql")]
+        assert found[0].source is not None
+        assert found[0].source.name == "mysql.json"
 
     def test_skips_when_nothing_is_generated(self, tmp_path: Path) -> None:
         """Skip, not fail: no generated tree means no setup page to check."""
@@ -528,17 +1121,17 @@ class TestArtifactReaders:
     def test_reads_the_app_name_lowercased(self, tmp_path: Path) -> None:
         (tmp_path / "atlan.yaml").write_text("name: ClickHouse\n")
 
-        assert read_app_name(tmp_path) == "clickhouse"
+        assert read_app_identity(tmp_path).name == "clickhouse"
 
     def test_a_missing_atlan_yaml_is_a_clear_error(self, tmp_path: Path) -> None:
         with pytest.raises(SetupRouteError, match="cannot read"):
-            read_app_name(tmp_path)
+            read_app_identity(tmp_path)
 
     def test_a_nameless_atlan_yaml_is_rejected(self, tmp_path: Path) -> None:
         (tmp_path / "atlan.yaml").write_text("app_id: x\n")
 
         with pytest.raises(SetupRouteError, match='no top-level "name"'):
-            read_app_name(tmp_path)
+            read_app_identity(tmp_path)
 
     def test_entrypoint_names_are_empty_for_a_flat_app(self, tmp_path: Path) -> None:
         _write_flat(tmp_path)
@@ -552,7 +1145,7 @@ class TestArtifactReaders:
 
 
 class TestServedFormRoundTrip:
-    """Does ``served_inputs`` really invert what the SDK's endpoint serves?
+    """Does ``served_form`` really invert what the SDK's endpoint serves?
 
     Every other test here feeds hand-written shapes. These drive the live
     ``GET /workflows/v1/configmap/{id}`` route — the endpoint a tenant's
@@ -586,7 +1179,7 @@ class TestServedFormRoundTrip:
     ) -> None:
         """The whole check, end to end, through the real endpoint.
 
-        If ``served_inputs`` read one nesting level too deep or too shallow,
+        If ``served_form`` read one nesting level too deep or too shallow,
         this fails — which is exactly the mistake the differing depths invite.
         """
         _write_bundle(tmp_path)
@@ -600,7 +1193,14 @@ class TestServedFormRoundTrip:
 
         assert body["metadata"]["name"] == "clickhouse-crawler"
         assert (
-            input_shortfall("crawler", declared_inputs(committed), served_inputs(body))
+            form_shortfall(
+                Entrypoint(
+                    name="crawler",
+                    config_id="clickhouse-crawler",
+                    declared=declared_inputs(committed),
+                ),
+                served_form(body),
+            )
             is None
         )
 
@@ -624,7 +1224,12 @@ class TestServedFormRoundTrip:
         path.write_text(json.dumps(stale))
 
         body = self._serve(tmp_path, "clickhouse-crawler")
-        reason = input_shortfall("crawler", declared, served_inputs(body))
+        reason = form_shortfall(
+            Entrypoint(
+                name="crawler", config_id="clickhouse-crawler", declared=declared
+            ),
+            served_form(body),
+        )
 
         assert reason is not None
         assert "connection" in reason
@@ -704,16 +1309,14 @@ class _FakeRoutes:
 
 
 def _healthy_configmaps() -> dict[str, tuple[int, dict[str, Any]]]:
-    schema = {
-        "properties": {
-            "extraction-method": {},
-            "credential-guid": {},
-            "connection": {},
-            # A platform-added field the contract never named, so the subset
-            # check's tolerance is exercised on the happy path too.
-            "labFlag": {},
-        }
-    }
+    schema = _form_schema(
+        "extraction-method",
+        "credential-guid",
+        "connection",
+        # A platform-added field the contract never named and no step draws, so
+        # the subset tolerance is exercised on the happy path too.
+        extra=("labFlag",),
+    )
     return {
         "clickhouse-crawler": (200, _configmap_response(schema, "clickhouse-crawler")),
         "clickhouse-miner": (200, _configmap_response(schema, "clickhouse-miner")),
@@ -806,9 +1409,7 @@ class TestVerify:
         configmaps = _healthy_configmaps()
         configmaps["clickhouse-crawler"] = (
             200,
-            _configmap_response(
-                {"properties": {"extraction-method": {}}}, "something-else"
-            ),
+            _configmap_response(_form_schema("extraction-method"), "something-else"),
         )
         routes = _FakeRoutes([_both_cards()], configmaps)
 
@@ -1047,7 +1648,7 @@ class _StubGet:
 
 
 class TestCardNameCasing:
-    """`read_app_name` lowercases atlan.yaml; a card's name is the catalog's.
+    """`read_app_identity` lowercases atlan.yaml; a card's name is the catalog's.
 
     Comparing them verbatim reports a mixed-case card as "not installed on this
     tenant" — a false negative wearing the most misleading message this check
@@ -1057,7 +1658,7 @@ class TestCardNameCasing:
     def test_a_mixed_case_card_still_matches(self) -> None:
         catalog = [_card_payload("clickhouse-crawler", name="ClickHouse")]
 
-        cards, reason = locate_cards("clickhouse", _eps("crawler"), catalog)
+        cards, reason = locate_cards(_id("clickhouse"), _eps("crawler"), catalog)
 
         assert reason is None
         assert cards["crawler"].id == "clickhouse-crawler"
@@ -1066,7 +1667,7 @@ class TestCardNameCasing:
         """Neither side is a value whose formatting we control."""
         catalog = [_card_payload("clickhouse-crawler", name="  clickhouse  ")]
 
-        cards, reason = locate_cards("clickhouse", _eps("crawler"), catalog)
+        cards, reason = locate_cards(_id("clickhouse"), _eps("crawler"), catalog)
 
         assert reason is None
         assert cards["crawler"].id == "clickhouse-crawler"
@@ -1075,7 +1676,7 @@ class TestCardNameCasing:
         """Case-folding must not widen the match to a different app."""
         catalog = [_card_payload("clickhouse-crawler", name="clickhouse-legacy")]
 
-        cards, reason = locate_cards("clickhouse", _eps("crawler"), catalog)
+        cards, reason = locate_cards(_id("clickhouse"), _eps("crawler"), catalog)
 
         assert cards == {}
         assert reason is not None
@@ -1105,7 +1706,7 @@ class TestSoleContractCardMatching:
     def test_a_sole_card_with_a_named_entrypoint_matches(self, tmp_path: Path) -> None:
         catalog = [_card_payload("mysql", name="mysql", entrypoint="crawler")]
 
-        cards, reason = locate_cards("mysql", _sole("mysql"), catalog)
+        cards, reason = locate_cards(_id("mysql"), _sole("mysql"), catalog)
 
         assert reason is None
         assert cards["mysql"].id == "mysql"
@@ -1114,7 +1715,7 @@ class TestSoleContractCardMatching:
         """The case that already worked must keep working."""
         catalog = [_card_payload("mysql", name="mysql", entrypoint="")]
 
-        cards, reason = locate_cards("mysql", _sole("mysql"), catalog)
+        cards, reason = locate_cards(_id("mysql"), _sole("mysql"), catalog)
 
         assert reason is None
         assert cards["mysql"].id == "mysql"
@@ -1124,13 +1725,7 @@ class TestSoleContractCardMatching:
     ) -> None:
         """The whole check, on the shape that used to report "no card"."""
         _write_flat(tmp_path)
-        schema = {
-            "properties": {
-                "extraction-method": {},
-                "credential-guid": {},
-                "connection": {},
-            }
-        }
+        schema = _form_schema("extraction-method", "credential-guid", "connection")
         routes = _FakeRoutes(
             [[_card_payload("mysql", name="mysql", entrypoint="crawler")]],
             {"mysql": (200, _configmap_response(schema, "mysql"))},
@@ -1152,7 +1747,7 @@ class TestSoleContractCardMatching:
             _card_payload("mysql-miner", name="mysql", entrypoint="miner"),
         ]
 
-        cards, reason = locate_cards("mysql", _sole("mysql"), catalog)
+        cards, reason = locate_cards(_id("mysql"), _sole("mysql"), catalog)
 
         assert cards == {}
         assert reason is not None
@@ -1170,11 +1765,345 @@ class TestSoleContractCardMatching:
             _card_payload("clickhouse-miner", entrypoint="miner"),
         ]
 
-        cards, reason = locate_cards("clickhouse", _eps("crawler", "miner"), catalog)
+        cards, reason = locate_cards(
+            _id("clickhouse"), _eps("crawler", "miner"), catalog
+        )
 
         assert reason is None
         assert cards["crawler"].id == "clickhouse-crawler"
         assert cards["miner"].id == "clickhouse-miner"
+
+
+class _FakeClock:
+    """A monotonic clock that advances only when the code under test sleeps.
+
+    Installed with ``monkeypatch.setattr(setup_routes, "time", clock)``, which
+    swaps the name *inside that module's namespace* rather than mutating the
+    stdlib ``time`` module. That distinction matters twice over: patching
+    ``time.monotonic`` globally is shared with the asyncio event loop and has
+    made this suite flaky before, and patching only ``sleep`` while the
+    deadline still reads the real clock turns every bounded wait into a busy
+    spin — 62 seconds at 98% CPU for three tests, which is how this helper
+    came to exist.
+
+    Advancing on ``sleep`` also makes the elapsed time assertable, so a test
+    can pin how long a wait actually lasted instead of only that it happened.
+    """
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.slept: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        self.now += seconds
+
+
+class TestRolloutLag:
+    """FND-1680: the install verdict is not the pod's verdict.
+
+    ``prepare-tenant`` resolves "the tenant runs the version under test" from
+    LM's *catalog record*, which flips when the install lands — while the
+    HelmRelease rollout that replaces the pod lags it. The aws leg measured the
+    gap: ``verified: tenant runs sdr-test-634b735e`` at 12:50:02, and six
+    seconds later the pod served ``extraction_method``, the spelling that
+    connector had renamed to ``extraction-method`` two days before. Azure ran
+    the identical assertions against the identical build and passed, because
+    its pod had already rolled.
+
+    So the form gets the same bounded wait the card lookup already had. Both
+    halves are pinned here: that a lagging rollout is waited out, and that a
+    shortfall which survives the window is still reported — and says it waited,
+    so nobody reads a real contract break as flake.
+    """
+
+    @staticmethod
+    def _sequenced(catalog: list[dict[str, Any]], bodies: list[dict[str, Any]]) -> Any:
+        """Routes whose configmap answer changes between reads, as a rollout does."""
+
+        class _Rolling:
+            def __init__(self) -> None:
+                self.reads = 0
+
+            def catalog(self) -> list[dict[str, Any]]:
+                return catalog
+
+            def configmap(self, name: str) -> tuple[int, dict[str, Any]]:
+                if name not in {"atlan-mysql", "mysql"}:
+                    return 404, {}
+                body = bodies[min(self.reads, len(bodies) - 1)]
+                self.reads += 1
+                return 200, body
+
+        return _Rolling()
+
+    def test_a_lagging_rollout_is_waited_out(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Stale form first, current form second: the leg passes, not flakes."""
+        monkeypatch.setattr(setup_routes, "time", _FakeClock())
+        _write_flat(tmp_path)
+        stale = _configmap_response(
+            # The previous image's spelling, exactly as aws served it.
+            _form_schema("extraction_method", "credential-guid", "connection"),
+            "atlan-mysql",
+        )
+        current = _configmap_response(
+            _form_schema("extraction-method", "credential-guid", "connection"),
+            "atlan-mysql",
+        )
+        routes = self._sequenced(
+            [_card_payload("atlan-mysql", name="mysql", entrypoint="")],
+            [stale, current],
+        )
+
+        report = verify(tmp_path, routes, wait_seconds=60)
+
+        assert len(report) == 1
+        assert "resolves" in report[0]
+        assert routes.reads == 2
+
+    def test_a_real_shortfall_still_fails_and_says_it_waited(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A contract that never reaches the tenant must not become a pass.
+
+        The whole risk of adding a wait is that it converts a finding into
+        patience. The message has to rule the lag out explicitly, or the next
+        reader discounts a genuine break as one.
+        """
+        clock = _FakeClock()
+        monkeypatch.setattr(setup_routes, "time", clock)
+        _write_flat(tmp_path)
+        stale = _configmap_response(
+            _form_schema("extraction_method", "credential-guid", "connection"),
+            "atlan-mysql",
+        )
+        routes = self._sequenced(
+            [_card_payload("atlan-mysql", name="mysql", entrypoint="")], [stale]
+        )
+
+        with pytest.raises(SetupRouteError) as excinfo:
+            verify(tmp_path, routes, wait_seconds=30)
+
+        message = str(excinfo.value)
+        assert "extraction-method" in message
+        assert "Still true after 30s" in message
+        assert "rollout lagging its catalog record" in message
+        # It really polled rather than reporting the first read, and it really
+        # spent the budget it says it spent.
+        assert routes.reads > 1
+        assert sum(clock.slept) >= 30
+
+    def test_progress_names_the_entrypoint_it_is_waiting_on(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A silent wait is indistinguishable from a hang, per the CLI's own rule."""
+        monkeypatch.setattr(setup_routes, "time", _FakeClock())
+        _write_flat(tmp_path)
+        stale = _configmap_response(_form_schema("nothing-declared"), "atlan-mysql")
+        routes = self._sequenced(
+            [_card_payload("atlan-mysql", name="mysql", entrypoint="")], [stale]
+        )
+        notes: list[str] = []
+
+        with pytest.raises(SetupRouteError):
+            verify(tmp_path, routes, wait_seconds=30, on_progress=notes.append)
+
+        assert notes
+        assert any("setup route not ready yet" in note for note in notes)
+        assert all("mysql" in note for note in notes)
+
+
+class TestTransientRetries:
+    """FND-1680: one dropped packet must not decide the leg's verdict.
+
+    The gcp leg died on ``GET /api/service/configmaps/atlan-openapi ... The
+    read operation timed out`` while azure passed the identical assertions
+    against the identical build minutes apart. That is network weather, not a
+    broken setup route, and a check whose verdict tracks the weather gets
+    ignored.
+
+    These drive ``TenantRoutes.get`` over a fake opener and count attempts, so
+    both halves are pinned: that a transient fault IS retried, and that an
+    endpoint's genuine answer is NOT — retrying a 404 would make the negative
+    control three times slower for the same verdict, and could dress a real
+    rejection up as a flake.
+    """
+
+    @staticmethod
+    def _routes() -> TenantRoutes:
+        return TenantRoutes(base_url="https://tenant.example.invalid", bearer="t")
+
+    @staticmethod
+    def _install(monkeypatch: pytest.MonkeyPatch, responses: list[object]) -> list[int]:
+        """Answer each successive open from *responses*; count the calls.
+
+        A response entry that is an exception instance is raised; anything else
+        is returned as the opened response.
+        """
+        calls: list[int] = []
+        # Backoff is real time, and these exercise the retry path several times
+        # over. `_FakeClock` swaps the module's own `time` reference, so the
+        # stdlib clock the asyncio loop shares is left alone.
+        monkeypatch.setattr(setup_routes, "time", _FakeClock())
+
+        class _Opener:
+            def open(self, request: object, timeout: object = None) -> object:
+                calls.append(len(calls))
+                answer = responses[min(len(calls) - 1, len(responses) - 1)]
+                if isinstance(answer, BaseException):
+                    raise answer
+                return answer
+
+        monkeypatch.setattr(setup_routes, "_OPENER", _Opener())
+        return calls
+
+    @staticmethod
+    def _ok(payload: bytes = b'{"ok": true}') -> object:
+        class _Response:
+            status = 200
+
+            def read(self) -> bytes:
+                return payload
+
+            def __enter__(self) -> "_Response":
+                return self
+
+            def __exit__(self, *exc: object) -> bool:
+                return False
+
+        return _Response()
+
+    def test_a_read_timeout_is_retried_and_can_succeed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The gcp shape exactly: one timeout, then the tenant answers."""
+        calls = self._install(
+            monkeypatch,
+            [TimeoutError("The read operation timed out"), self._ok()],
+        )
+
+        status, body = self._routes().get("/api/service/configmaps/atlan-openapi")
+
+        assert (status, body) == (200, {"ok": True})
+        assert len(calls) == 2
+
+    def test_it_gives_up_after_the_bound_and_says_what_it_saw(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A genuine outage still fails — with the history, not just the last error."""
+        calls = self._install(
+            monkeypatch, [TimeoutError("The read operation timed out")]
+        )
+
+        with pytest.raises(SetupRouteError) as excinfo:
+            self._routes().get("/api/service/configmaps/atlan-openapi")
+
+        assert len(calls) == setup_routes._RETRY_ATTEMPTS
+        message = str(excinfo.value)
+        assert "after 3 attempts" in message
+        assert "Earlier attempts" in message
+        assert "TimeoutError" in message
+
+    def test_a_404_is_answered_not_retried(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The negative control's premise: a rejection is an answer.
+
+        Retrying it would triple the control's cost for an identical verdict
+        and could present a real rejection as a transient fault.
+        """
+        calls = self._install(
+            monkeypatch,
+            [
+                urllib.error.HTTPError(
+                    "https://tenant.example.invalid/x", 404, "Not Found", None, None
+                )
+            ],
+        )
+
+        status, _ = self._routes().get("/api/service/configmaps/bogus")
+
+        assert status == 404
+        assert len(calls) == 1
+
+    @pytest.mark.parametrize("status", (400, 403, 404))
+    def test_no_rejection_status_is_retried(
+        self, monkeypatch: pytest.MonkeyPatch, status: int
+    ) -> None:
+        """Every status the negative control accepts must cost exactly one call."""
+        calls = self._install(
+            monkeypatch,
+            [
+                urllib.error.HTTPError(
+                    "https://tenant.example.invalid/x", status, "no", None, None
+                )
+            ],
+        )
+
+        assert self._routes().get("/x")[0] == status
+        assert len(calls) == 1
+
+    def test_a_502_is_retried(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A gateway blip in front of the tenant is weather, not a verdict."""
+        calls = self._install(
+            monkeypatch,
+            [
+                urllib.error.HTTPError(
+                    "https://tenant.example.invalid/x", 502, "Bad Gateway", None, None
+                ),
+                self._ok(),
+            ],
+        )
+
+        assert self._routes().get("/x")[0] == 200
+        assert len(calls) == 2
+
+    def test_a_persistent_502_is_returned_not_raised(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """After the bound it is the endpoint's answer, and callers report it.
+
+        `catalog()` turns a non-200 into "check the token has marketplace read
+        access", which is a better message than a transport error for a tenant
+        that is answering, just badly.
+        """
+        calls = self._install(
+            monkeypatch,
+            [
+                urllib.error.HTTPError(
+                    "https://tenant.example.invalid/x", 503, "nope", None, None
+                )
+            ],
+        )
+
+        assert self._routes().get("/x")[0] == 503
+        assert len(calls) == setup_routes._RETRY_ATTEMPTS
+
+    def test_backoff_grows_between_attempts(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Doubling, not a fixed pause — a tenant mid-restart needs the later gap."""
+        clock = _FakeClock()
+        monkeypatch.setattr(setup_routes, "time", clock)
+        slept = clock.slept
+
+        class _Opener:
+            def open(self, request: object, timeout: object = None) -> object:
+                raise TimeoutError("still out")
+
+        monkeypatch.setattr(setup_routes, "_OPENER", _Opener())
+
+        with pytest.raises(SetupRouteError):
+            self._routes().get("/x")
+
+        # Two waits for three attempts, and the second is longer than the first.
+        assert len(slept) == setup_routes._RETRY_ATTEMPTS - 1
+        assert slept[1] > slept[0]
 
 
 class TestRedirectsAreDeclined:
@@ -1336,7 +2265,9 @@ class TestUnlabelledBundleCard:
     def test_an_unlabelled_card_is_reported(self) -> None:
         catalog = [_card_payload("clickhouse", name="clickhouse", entrypoint="")]
 
-        cards, reason = locate_cards("clickhouse", _eps("crawler", "miner"), catalog)
+        cards, reason = locate_cards(
+            _id("clickhouse"), _eps("crawler", "miner"), catalog
+        )
 
         assert reason is not None
         assert "cannot be attributed" in reason

--- a/tests/unit/testing/test_setup_routes.py
+++ b/tests/unit/testing/test_setup_routes.py
@@ -54,6 +54,7 @@ from application_sdk.testing.setup_routes import (
     SetupRouteError,
     TenantRoutes,
     declared_inputs,
+    foreign_form,
     form_shortfall,
     locate_cards,
     read_app_identity,
@@ -453,6 +454,71 @@ class TestFormShortfall:
 
         assert reason is not None
         assert "declares no inputs" in reason
+
+
+class TestForeignForm:
+    """FND-1680: `metadata.name` is a rewrite, not an identity.
+
+    An earlier revision asserted `served_name == card.id` and failed all three
+    mysql legs on a healthy app: it asked for `atlan-mysql` and the response
+    carried `metadata.name: 'mysql'`. Both are right. Heracles resolves the
+    marketplace app id to the configmap name *before* proxying, so the pod
+    never saw `atlan-mysql` — while metabase's response carried
+    `metadata.name: 'atlan-metabase'`, because there the app id reached the pod
+    unrewritten and hit its default-entrypoint fallback.
+
+    Two real payloads, two different rules, one field. So this speaks up only
+    about a name it can attribute to one of THIS repo's committed entry points,
+    and says nothing about a value produced by somebody else's rewrite.
+    """
+
+    @staticmethod
+    def _bundle() -> list[Entrypoint]:
+        return [
+            _ep("crawler", "clickhouse-crawler"),
+            _ep("miner", "clickhouse-miner"),
+        ]
+
+    def test_another_entrypoints_form_is_reported(self) -> None:
+        """The failure the old assertion was actually reaching for."""
+        siblings = self._bundle()
+
+        reason = foreign_form(siblings[0], siblings, "clickhouse-miner")
+
+        assert reason is not None
+        assert "another entry point's form" in reason
+        assert "'miner'" in reason
+
+    def test_the_heracles_rewrite_is_not_a_failure(self) -> None:
+        """The exact mysql shape: asked `atlan-mysql`, served `mysql`."""
+        sole = [_ep("mysql", "mysql", is_sole=True)]
+
+        assert foreign_form(sole[0], sole, "mysql") is None
+
+    def test_an_unrewritten_app_id_is_not_a_failure(self) -> None:
+        """The exact metabase shape: asked `atlan-metabase`, served the same."""
+        sole = [_ep("metabase", "metabase", is_sole=True)]
+
+        assert foreign_form(sole[0], sole, "atlan-metabase") is None
+
+    def test_an_unattributable_name_says_nothing(self) -> None:
+        """Silence, not a guess. Content is what covers this case.
+
+        A name belonging to no declared entry point could be a rewrite, an
+        alias, or a genuine fault, and this module cannot tell which without
+        re-implementing Heracles. `form_shortfall` checks what the payload
+        CONTAINS, which is immune to every rename in the chain.
+        """
+        siblings = self._bundle()
+
+        assert foreign_form(siblings[0], siblings, "something-else") is None
+        assert foreign_form(siblings[0], siblings, "") is None
+        assert foreign_form(siblings[0], siblings, None) is None
+
+    def test_its_own_config_id_is_never_foreign(self) -> None:
+        siblings = self._bundle()
+
+        assert foreign_form(siblings[0], siblings, "clickhouse-crawler") is None
 
 
 class TestBlankFormDetection:
@@ -1407,13 +1473,17 @@ class TestVerify:
         """Asked for one form, served another — the page renders the wrong one."""
         _write_bundle(tmp_path)
         configmaps = _healthy_configmaps()
+        # The crawler's route serves a response identifying itself as the
+        # MINER's form — a name this repo can attribute, which is the only
+        # kind `foreign_form` speaks up about.
+        schema = _form_schema("extraction-method", "credential-guid", "connection")
         configmaps["clickhouse-crawler"] = (
             200,
-            _configmap_response(_form_schema("extraction-method"), "something-else"),
+            _configmap_response(schema, "clickhouse-miner"),
         )
         routes = _FakeRoutes([_both_cards()], configmaps)
 
-        with pytest.raises(SetupRouteError, match="served 'something-else'"):
+        with pytest.raises(SetupRouteError, match="another entry point's form"):
             verify(tmp_path, routes, wait_seconds=0)
 
     def test_polls_until_the_catalog_reconciles(


### PR DESCRIPTION
Rebased onto #3669, which fixes the server half of FND-1680 (serving
`artifact_schemas.json` as the setup form). This PR is now purely the
**tenant-side route check**, and inherits that rule from `_generated_tree`
rather than re-deriving it.

Everything below was found by running the check fleet-wide and reading what it
said. Three of the four fixes are diagnoses the check produced about itself.

## The card was there all along

The mysql leg reported `no marketplace card has name='mysql'. The tenant listed
139 apps`. Adding the candidate cards to that message answered it in one run:

```
id='atlan-mysql' name='MySQL Assets' entrypoint=''
```

`MySQL Assets` is that app's committed `display_name`. `read_app_name`'s premise
— *"atlan.yaml's top-level `name` is the value the marketplace card's `name`
field carries"* — is false. openapi and metabase matched on the wire name in the
same run, so the catalog is inconsistent about which it stores.

`read_app_identity` returns an `AppIdentity` carrying both committed names, and
`locate_cards` accepts either. Both are committed facts and neither is the
card's `id`, so the module's non-circularity argument still holds.

The not-found diagnostic is **kept**, not removed with the bug: it now reports
in three descending tiers — an exact hit in `id`/`entrypoint` (wrong field, not
a missing install), a substring hit (decorated identity, shown as a triple), or
a bounded sorted sample of the names present. The next catalog-shape surprise
arrives the same way this one did.

## `route_mismatch` was asserting something false

All three legs then failed on `card.id='atlan-<app>'` vs `config_id='<app>'`.
The contradiction is in this repo: `handler.service.get_configmap` resolves an
unmatched id through a documented default-entrypoint fallback, added because
`atlan-openapi` genuinely 404'd in production. The server answers both names,
and none of those three setup pages was broken.

Tolerance is gated on `Entrypoint.is_sole`, not granted generally — that is
exactly where the fallback is safe, because it resolves to the app's **default**
entry point, which for a sole contract is the only one. A bundle keeps the hard
failure, where the same fallback would hand every card the default's form.

Not a softening. Equality was only ever a proxy for "the card's id resolves to
this entry point's form"; `verify` still fetches `configmaps/<card.id>`, still
requires a 200, and still requires the served schema to satisfy the contract. A
tolerated mismatch is named in the report line rather than passing silently.

## A 200 is not evidence that a user sees a form

The metabase page answered 200 for `atlan-metabase` and rendered **blank** —
`data.config` was the artifact-schema declaration (the #3669 bug, from a pod
that predates it). Every status-code assertion passed.

`served_form` returns a typed `ServedForm` carrying the two parts the UI renders
from: `properties` defines a field, a `steps` panel **draws** it. A field in one
and not the other never reaches a user.

`form_shortfall` reports four faults in **cause order**, not symptom order:

1. the payload is not a setup form at all — no fields, no panels;
2. a declared field is absent from the served schema;
3. there are fields but no panels, so none is drawn;
4. a declared field exists but no step names it.

Cause order is load-bearing: reported as "missing inputs", the metabase payload
sends a reader hunting an image bump that would never have fixed it.

The step-reachability rule was checked against the committed contracts of
metabase, openapi and mysql *before* being encoded — `properties` and the
step-named set are identical, both directions, no exceptions.

## Retries, because one dropped packet decided a leg

The gcp leg died on `GET /api/service/configmaps/atlan-openapi ... The read
operation timed out` while azure passed the identical assertions against the
identical build minutes apart.

`TenantRoutes.get` retries a transient transport fault three times with doubling
backoff and spends the history in the final error. Rejections are **never**
retried — 400/403/404 are the endpoint answering, and the negative control's
premise is that an unknown name is rejected promptly.

The history goes in the error rather than through a new constructor argument on
purpose: the CLI shell is `@main`-pinned and constructs this class against each
app's **own** pinned SDK, so a new required argument is a fleet-wide TypeError
the moment it lands.

## The install verdict is not the pod's verdict

The aws leg reported `verified: tenant runs sdr-test-634b735e` and six seconds
later the pod served `extraction_method` — the spelling that connector renamed
to `extraction-method` two days earlier. That check resolves the version from
**LM's catalog record**, which flips when the install lands, while the
HelmRelease rollout that replaces the pod lags it. Azure passed because its pod
had already rolled; nothing distinguishes the clouds but timing.

The form now gets the same bounded wait, at the same cadence, that the card
lookup already had. A shortfall surviving the window is still reported **and
says it waited**, so a stale rollout stays distinguishable from a contract that
never reached the tenant.

## Tests

- `_FakeClock` swaps the module's own `time` reference rather than patching the
  stdlib clock. Patching only `sleep` while the deadline read the real clock
  turned each bounded wait into a busy spin — 62s at 98% CPU for three tests.
  Advancing on sleep also makes the elapsed wait assertable.
- The `_workflow_config` fixture's `steps` stub named no fields. Harmless while
  only `properties` was read; it asserted the opposite of reality the moment
  rendering was checked. It now mirrors a real connector's panels.
- Flat and bundle fixtures carry the full realistic sibling list. Every
  committed fixture was a two- or three-file tree with no artifact-schemas
  sibling, which is why this suite was green while the fleet was red.
- `TestNonFormSiblings` was dropped on rebase: #3669's
  `tests/unit/app/test_generated_tree.py` covers that rule at its source. Only
  the `read_entrypoints` regression stayed, which is about this module
  inheriting the rule rather than the rule itself.

## Also here: the e2e image tag (`a5c758f15`)

Kept in this PR deliberately rather than split out — see the discussion on
FND-1680. It is independent of the check and can be reverted on its own.

The tag was `sdr-test-<connector-short-sha>`, from `github.sha` alone. Correct
on a connector's own PR; wrong on an SDK PR, which builds each connector at its
**unchanged** head with the SDK repinned — different content, identical tag. So
each SDK push overwrote a mutable tag, republished the same version name, and
prepare-tenant skipped:

```
tenant already runs 019e3a59-…-e8eae494483f at sdr-test-5027f138 — nothing to do
```

Nothing rolled. Each tenant kept whatever content that tag held when it last
pulled, differing purely by install history — which is why one SDK commit passed
on aws and failed on azure and gcp with no code difference. `Verify the tenant
runs the version under test` could never catch it: it compares version *names*,
and the name was identical by construction. A green leg was evidence about an
arbitrary image.

The tag now folds in the connector commit, the repinned SDK ref, and the base
image an SDK PR rebuilds and builds FROM:

```
sdr-test-5027f138             ← connector's own PR (byte-identical to today)
sdr-test-5027f138-4513b1ed    ← SDK @ d46dcabd4
sdr-test-5027f138-04778331    ← SDK @ 3fb6cfb4e
```

A connector PR passes neither ref and gets exactly today's tag: no churn, no
orphaned images, every existing `sdr-test-*` reference still holds. The rule
lives in `.github/scripts/derive_e2e_image_tag.py` with 19 tests rather than
inline, per `docs/standards/ci.md`.

**Two things to watch on the first merged run**, both fix-forward:

1. GM/marketplace now receives a 26-character version (`sdr-test-5027f138-4513b1ed`)
   where it used to get 17. Nothing client-side validates it; if the server
   rejects it the symptom is a bare `400 code 1000`, which says nothing about
   why. The fix would be shortening `DIGEST_CHARS`.
2. This creates a new marketplace version per distinct SDK commit tested, and
   `e2e_tenant_app.py` has no uninstall or prune path. That is the irreducible
   minimum — a rollout cannot be forced without a new version, and re-running
   the same commit reuses its tag — but it does increase tenant cruft and wants
   a follow-up.

## Verification

Replayed against all three real committed trees, against what a pod with and
without #3669 serves:

| app | pod without #3669 | pod with #3669 |
| --- | --- | --- |
| metabase | **caught** — "not a setup form … renders blank" | passes — 7 inputs served AND drawn, 3 steps |
| openapi | **caught** — same | passes — 9 inputs, 2 steps |
| mysql | passes | passes |

mysql passes either way because it ships no `artifact_schemas.json` — so
FND-1681 was not the first instance of that bug, only the first noticed one.

Full unit suite green: 9926 passed, 9 skipped.

Closes FND-1680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HxCg8NJ7w2QEw2Vjt4uPj
