### PR TITLE
fix(handler): stop serving artifact_schemas.json as the setup form (FND-1682)

### DIFF
--- a/application_sdk/app/_artifact_schema_guard.py
+++ b/application_sdk/app/_artifact_schema_guard.py
@@ -53,7 +53,11 @@ from typing import TYPE_CHECKING, Annotated, Any, get_args, get_origin
 
 import orjson
 
-from application_sdk.app._generated_tree import GeneratedLayout, generated_layout
+from application_sdk.app._generated_tree import (
+    ARTIFACT_SCHEMAS_STEM,
+    GeneratedLayout,
+    generated_layout,
+)
 from application_sdk.constants import CONTRACT_GENERATED_DIR
 from application_sdk.contracts.types import FileReference
 from application_sdk.observability.logger_adaptor import get_logger
@@ -77,7 +81,10 @@ _logger = get_logger(__name__)
 #: reader never has to go looking for the deadline.
 ARTIFACT_SCHEMA_REMOVAL_VERSION = "4.0"
 
-_ARTIFACT_SCHEMAS_FILENAME = "artifact_schemas.json"
+#: Derived from the stem :mod:`application_sdk.app._generated_tree` owns, so
+#: the file this guard reads and the file form discovery must *skip* can never
+#: be two different names (FND-1682).
+_ARTIFACT_SCHEMAS_FILENAME = f"{ARTIFACT_SCHEMAS_STEM}.json"
 
 
 @dataclass(frozen=True)

--- a/application_sdk/app/_generated_tree.py
+++ b/application_sdk/app/_generated_tree.py
@@ -40,16 +40,37 @@ from pathlib import Path
 from typing import Literal
 
 __all__ = [
+    "ARTIFACT_SCHEMAS_STEM",
     "CREDENTIAL_TEMPLATE_PREFIXES",
     "GeneratedLayout",
     "MANIFEST_STEM",
+    "NON_FORM_STEMS",
     "form_configmap",
     "generated_layout",
     "is_form_configmap",
+    "pick_form_configmap",
 ]
 
 #: Stem of the DAG manifest that sits alongside the generated setup forms.
 MANIFEST_STEM = "manifest"
+
+#: Stem of the artifact-schema declarations the toolkit emits for an app with an
+#: ``artifactSchemas`` block (conformance K016). Read by
+#: :mod:`application_sdk.validation.sources` and
+#: :mod:`application_sdk.app._artifact_schema_guard`; named here because it is
+#: also a *non-form* sibling and form discovery must skip it.
+ARTIFACT_SCHEMAS_STEM = "artifact_schemas"
+
+#: Whole stems — as opposed to the family prefixes below — that are never a
+#: setup form.
+#:
+#: ``artifact_schemas`` earns its place the hard way (FND-1682): it sorts before
+#: every real form stem, so once an app declared ``artifactSchemas`` the
+#: alphabetical fallback in ``handler.service.get_configmap`` served the schema
+#: document as the form. It has no ``config`` key and no ``properties``, so the
+#: setup wizard rendered blank behind an HTTP 200 — nothing in the logs, the
+#: network tab or pod stderr.
+NON_FORM_STEMS = frozenset({MANIFEST_STEM, ARTIFACT_SCHEMAS_STEM})
 
 #: Non-form JSON siblings that live in the generated dir next to the setup-form
 #: configmaps. Credential templates are emitted per object-store family
@@ -73,12 +94,55 @@ GeneratedLayout = Literal["multi", "single", "unknown"]
 def is_form_configmap(stem: str) -> bool:
     """Whether a generated JSON stem is a setup-form configmap.
 
-    True when *stem* is neither the DAG ``manifest`` nor a credential template.
+    True when *stem* is neither one of the well-known non-form documents
+    (:data:`NON_FORM_STEMS`) nor a credential template.
+
+    **An exclusion list is the backstop, not the primary answer.** It can only
+    ever name the siblings the toolkit emits *today*, so a caller that has an
+    entry-point name to go on should ask :func:`pick_form_configmap`, which
+    matches the form by name first and falls back to this filter. FND-1682 is
+    what the filter alone costs: a new sibling that sorted first was served as
+    the form, and every adopting app lost its setup UI at the next release.
 
     Args:
         stem: A generated file's name without its ``.json`` suffix.
     """
-    return stem != MANIFEST_STEM and not stem.startswith(CREDENTIAL_TEMPLATE_PREFIXES)
+    return stem not in NON_FORM_STEMS and not stem.startswith(
+        CREDENTIAL_TEMPLATE_PREFIXES
+    )
+
+
+def pick_form_configmap(directory: Path, entrypoint: str) -> Path | None:
+    """Return *directory*'s setup form for *entrypoint*, or ``None``.
+
+    Two steps, in this order:
+
+    1. ``<directory>/<entrypoint>.json`` when it exists. The toolkit names an
+       entry point's form after the entry point, so this is an identification
+       rather than a guess.
+    2. Otherwise the first stem :func:`is_form_configmap` accepts, in sorted
+       order for determinism.
+
+    Step 2 alone is what broke in FND-1682, and step 1 is why the same class of
+    break does not return with the *next* sibling the toolkit learns to emit.
+    Step 2 remains because the form is not always named after the entry point —
+    a connector's ``crawler`` entry point emits ``snowflake-crawler.json`` — so
+    dropping it would 404 the apps the fallback exists for.
+
+    Args:
+        directory: A directory in the generated tree. Missing or not a
+            directory yields ``None``.
+        entrypoint: The entry point's kebab-case wire name.
+    """
+    if not directory.is_dir():
+        return None
+    named = directory / f"{entrypoint}.json"
+    if is_form_configmap(entrypoint) and named.is_file():
+        return named
+    for candidate in sorted(directory.glob("*.json")):
+        if is_form_configmap(candidate.stem):
+            return candidate
+    return None
 
 
 def generated_layout(generated: Path) -> GeneratedLayout:
@@ -137,12 +201,13 @@ def form_configmap(
         The nested directory, then the flat one — best effort, since a repo
         that has not generated has nothing to be right about.
 
-    Within the chosen directory the first stem that :func:`is_form_configmap`
-    accepts wins, in sorted order for determinism. That exclusion is what keeps
-    a flat app's ``atlan-connectors-<source>.json`` from being mistaken for its
-    form: sorted alphabetically the credential template comes *first*, so a
-    glob without the exclusion picks the wrong file on every single-entrypoint
-    connector.
+    Within the chosen directory :func:`pick_form_configmap` decides, so a form
+    named after the entry point is identified by name and anything else falls
+    back to the sorted :func:`is_form_configmap` scan. That exclusion is what
+    keeps a flat app's ``atlan-connectors-<source>.json`` from being mistaken
+    for its form: sorted alphabetically the credential template comes *first*,
+    so a glob without the exclusion picks the wrong file on every
+    single-entrypoint connector.
 
     Args:
         generated: The generated directory, usually ``app/generated``.
@@ -163,9 +228,7 @@ def form_configmap(
         search = (generated / entrypoint, generated)
 
     for directory in search:
-        if not directory.is_dir():
-            continue
-        for candidate in sorted(directory.glob("*.json")):
-            if is_form_configmap(candidate.stem):
-                return candidate
+        found = pick_form_configmap(directory, entrypoint)
+        if found is not None:
+            return found
     return None

--- a/application_sdk/app/_generated_tree.py
+++ b/application_sdk/app/_generated_tree.py
@@ -36,6 +36,7 @@ re-exported from ``application_sdk.app``.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Literal
 
@@ -45,9 +46,12 @@ __all__ = [
     "GeneratedLayout",
     "MANIFEST_STEM",
     "NON_FORM_STEMS",
+    "choose_form_configmap",
+    "eligible_form_configmaps",
     "form_configmap",
     "generated_layout",
     "is_form_configmap",
+    "names_entrypoint",
     "pick_form_configmap",
 ]
 
@@ -97,12 +101,12 @@ def is_form_configmap(stem: str) -> bool:
     True when *stem* is neither one of the well-known non-form documents
     (:data:`NON_FORM_STEMS`) nor a credential template.
 
-    **An exclusion list is the backstop, not the primary answer.** It can only
-    ever name the siblings the toolkit emits *today*, so a caller that has an
-    entry-point name to go on should ask :func:`pick_form_configmap`, which
-    matches the form by name first and falls back to this filter. FND-1682 is
-    what the filter alone costs: a new sibling that sorted first was served as
-    the form, and every adopting app lost its setup UI at the next release.
+    **This list can only ever name the siblings the toolkit emits today.**
+    FND-1682 is what a stale one costs: ``artifact_schemas.json`` was not on it,
+    sorted before every real form stem, and so was served as the form by every
+    app that adopted conformance K016. A caller with an entry-point name to go
+    on should ask :func:`pick_form_configmap`, which prefers a form that
+    :func:`names_entrypoint` over anything this filter merely fails to reject.
 
     Args:
         stem: A generated file's name without its ``.json`` suffix.
@@ -112,37 +116,97 @@ def is_form_configmap(stem: str) -> bool:
     )
 
 
+def names_entrypoint(stem: str, entrypoint: str) -> bool:
+    """Whether a form's *stem* identifies itself as *entrypoint*'s.
+
+    Two spellings are in the field, and both are identifications rather than
+    guesses:
+
+    * ``<entrypoint>`` — a flat app whose form is named for its entry point
+      (``bridge.json`` for ``bridge``).
+    * ``<source>-<entrypoint>`` — the connector convention, where the entry
+      point is the *role* and the file carries the source (``crawler`` →
+      ``snowflake-crawler.json``, ``miner`` → ``postgres-miner.json``).
+
+    The suffix spelling is not a nicety: across the connector fleet the exact
+    spelling matches almost nothing, because the entry points are called
+    ``crawler`` and ``miner`` while the files are named for the source. Matching
+    only the exact form leaves every connector on the last-resort scan.
+
+    Args:
+        stem: A generated file's name without its ``.json`` suffix.
+        entrypoint: The entry point's kebab-case wire name.
+    """
+    return stem == entrypoint or stem.endswith(f"-{entrypoint}")
+
+
+def eligible_form_configmaps(directory: Path) -> list[Path]:
+    """Every ``*.json`` in *directory* that could be a setup form, sorted.
+
+    The non-form siblings (:func:`is_form_configmap`) are already gone. What
+    remains is what any pick has to choose between, and a caller that wants to
+    *report* on the choice — the configmap endpoint warns when it had to fall
+    back to alphabetical order among several — needs the list, not just the
+    winner.
+
+    Args:
+        directory: A directory in the generated tree. Missing or not a
+            directory yields ``[]``.
+    """
+    if not directory.is_dir():
+        return []
+    return [
+        candidate
+        for candidate in sorted(directory.glob("*.json"))
+        if is_form_configmap(candidate.stem)
+    ]
+
+
+def choose_form_configmap(candidates: Sequence[Path], entrypoint: str) -> Path | None:
+    """Pick *entrypoint*'s form out of *candidates*, or ``None`` if empty.
+
+    Three steps, in this order:
+
+    1. The candidate whose stem :func:`names_entrypoint` — an identification.
+    2. The only candidate, when there is exactly one. Nothing else it could be.
+    3. Otherwise the alphabetically first, which **is** a guess.
+
+    **Step 3 stays, deliberately.** It is the compatibility path for every app
+    that has not adopted a name the SDK can recognise, and dropping it (or
+    turning ambiguity into a 404) would break apps that work today in order to
+    protect against a sibling the toolkit does not yet emit. FND-1682 was not
+    caused by the guess being *reachable*; it was caused by
+    ``artifact_schemas.json`` being eligible at all, which
+    :data:`NON_FORM_STEMS` now fixes. Steps 1 and 2 shrink how often step 3 has
+    to run — across the connector fleet they answer every generated directory —
+    but the endpoint that calls this logs a warning when step 3 does run with
+    more than one candidate, so a future sibling shows up in the logs instead of
+    only in a blank wizard.
+
+    Args:
+        candidates: Eligible forms, from :func:`eligible_form_configmaps`.
+        entrypoint: The entry point's kebab-case wire name.
+    """
+    if not candidates:
+        return None
+    named = [c for c in candidates if names_entrypoint(c.stem, entrypoint)]
+    if len(named) == 1:
+        return named[0]
+    return candidates[0]
+
+
 def pick_form_configmap(directory: Path, entrypoint: str) -> Path | None:
     """Return *directory*'s setup form for *entrypoint*, or ``None``.
 
-    Two steps, in this order:
-
-    1. ``<directory>/<entrypoint>.json`` when it exists. The toolkit names an
-       entry point's form after the entry point, so this is an identification
-       rather than a guess.
-    2. Otherwise the first stem :func:`is_form_configmap` accepts, in sorted
-       order for determinism.
-
-    Step 2 alone is what broke in FND-1682, and step 1 is why the same class of
-    break does not return with the *next* sibling the toolkit learns to emit.
-    Step 2 remains because the form is not always named after the entry point —
-    a connector's ``crawler`` entry point emits ``snowflake-crawler.json`` — so
-    dropping it would 404 the apps the fallback exists for.
+    :func:`eligible_form_configmaps` then :func:`choose_form_configmap` — the
+    convenience spelling for callers that do not need the candidate list.
 
     Args:
         directory: A directory in the generated tree. Missing or not a
             directory yields ``None``.
         entrypoint: The entry point's kebab-case wire name.
     """
-    if not directory.is_dir():
-        return None
-    named = directory / f"{entrypoint}.json"
-    if is_form_configmap(entrypoint) and named.is_file():
-        return named
-    for candidate in sorted(directory.glob("*.json")):
-        if is_form_configmap(candidate.stem):
-            return candidate
-    return None
+    return choose_form_configmap(eligible_form_configmaps(directory), entrypoint)
 
 
 def generated_layout(generated: Path) -> GeneratedLayout:

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -56,7 +56,11 @@ from pydantic import ValidationError
 from temporalio.client import WorkflowFailureError
 
 from application_sdk._runtime.offload import run_in_thread
-from application_sdk.app._generated_tree import pick_form_configmap
+from application_sdk.app._generated_tree import (
+    choose_form_configmap,
+    eligible_form_configmaps,
+    names_entrypoint,
+)
 from application_sdk.app.entrypoint import canonical_workflow_type
 from application_sdk.common.dispatch import resolve_dispatch_workflow_id
 from application_sdk.common.task_queue import (
@@ -1940,24 +1944,50 @@ def _register_workflow_routes(
                 # single-entrypoint app 404'd on an app-id request even though its
                 # form file was present — a blank setup wizard in the UI.
                 #
-                # Within each directory `pick_form_configmap` decides: the form
-                # named after the entrypoint (`<ep.name>.json`) when it exists,
-                # otherwise the first stem that survives the non-form exclusion
-                # (`manifest.json`, `artifact_schemas.json`, and the
-                # `{atlan,csa}-connectors-*` credential templates), sorted for
-                # determinism. Name-first matters: the exclusion list can only
-                # name the siblings the toolkit emits today, and FND-1682 is
-                # what the sorted scan alone cost — `artifact_schemas.json`
-                # sorts before every real form stem, so every app that adopted
-                # K016 served the schema document as its form and rendered a
-                # blank setup wizard behind an HTTP 200.
+                # Within each directory `choose_form_configmap` decides: a form
+                # that names the entrypoint (`<ep.name>.json`, or the connector
+                # convention `<source>-<ep.name>.json`), else the only file that
+                # survives the non-form exclusion (`manifest.json`,
+                # `artifact_schemas.json`, the `{atlan,csa}-connectors-*`
+                # credential templates), else the alphabetically first.
+                #
+                # That last step is a guess, and it stays: it is the
+                # compatibility path for apps whose form name the SDK cannot
+                # recognise, and 404ing them to avoid a hypothetical would break
+                # working apps. FND-1682 was not the guess being reachable — it
+                # was `artifact_schemas.json` being eligible at all, which
+                # NON_FORM_STEMS now fixes. What the guess still owes an
+                # operator is *visibility*: it produced an HTTP 200 carrying a
+                # document with no `properties`, so a blank setup wizard looked
+                # identical to a working app from the logs, the network tab and
+                # pod stderr alike. Hence the warning below — the next
+                # unrecognised sibling shows up in the logs on the first
+                # request, before anyone opens the wizard.
                 for search_dir in (
                     CONTRACT_GENERATED_DIR / ep.name,
                     CONTRACT_GENERATED_DIR,
                 ):
-                    target = pick_form_configmap(search_dir, ep.name)
-                    if target is not None:
-                        break
+                    candidates = eligible_form_configmaps(search_dir)
+                    target = choose_form_configmap(candidates, ep.name)
+                    if target is None:
+                        continue
+                    if len(candidates) > 1 and not names_entrypoint(
+                        target.stem, ep.name
+                    ):
+                        # conformance: ignore[L009] logs caller-invisible context (the rejected candidates) that no HTTP response carries.
+                        logger.warning(
+                            "ConfigMap form chosen alphabetically for entrypoint "
+                            "%s: %d generated files are eligible and none is "
+                            "named for it, so %s.json was served as the setup "
+                            "form (candidates=%s). If that is the wrong file, "
+                            "name the form <entrypoint>.json or "
+                            "<source>-<entrypoint>.json in the app's contract.",
+                            ep.name,
+                            len(candidates),
+                            target.stem,
+                            [c.stem for c in candidates],
+                        )
+                    break
 
         if target is not None:
             with open(target, encoding="utf-8") as f:

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -56,7 +56,7 @@ from pydantic import ValidationError
 from temporalio.client import WorkflowFailureError
 
 from application_sdk._runtime.offload import run_in_thread
-from application_sdk.app._generated_tree import is_form_configmap
+from application_sdk.app._generated_tree import pick_form_configmap
 from application_sdk.app.entrypoint import canonical_workflow_type
 from application_sdk.common.dispatch import resolve_dispatch_workflow_id
 from application_sdk.common.task_queue import (
@@ -1940,21 +1940,22 @@ def _register_workflow_routes(
                 # single-entrypoint app 404'd on an app-id request even though its
                 # form file was present — a blank setup wizard in the UI.
                 #
-                # Pick the form file by excluding the well-known non-form
-                # siblings (`manifest.json` and the `{atlan,csa}-connectors-*`
-                # credential templates) via `is_form_configmap`. Sorted for
-                # determinism.
+                # Within each directory `pick_form_configmap` decides: the form
+                # named after the entrypoint (`<ep.name>.json`) when it exists,
+                # otherwise the first stem that survives the non-form exclusion
+                # (`manifest.json`, `artifact_schemas.json`, and the
+                # `{atlan,csa}-connectors-*` credential templates), sorted for
+                # determinism. Name-first matters: the exclusion list can only
+                # name the siblings the toolkit emits today, and FND-1682 is
+                # what the sorted scan alone cost — `artifact_schemas.json`
+                # sorts before every real form stem, so every app that adopted
+                # K016 served the schema document as its form and rendered a
+                # blank setup wizard behind an HTTP 200.
                 for search_dir in (
                     CONTRACT_GENERATED_DIR / ep.name,
                     CONTRACT_GENERATED_DIR,
                 ):
-                    if not search_dir.is_dir():
-                        continue
-                    for json_file in sorted(search_dir.glob("*.json")):
-                        if not is_form_configmap(json_file.stem):
-                            continue
-                        target = json_file
-                        break
+                    target = pick_form_configmap(search_dir, ep.name)
                     if target is not None:
                         break
 

--- a/docs/concepts/entry-points.md
+++ b/docs/concepts/entry-points.md
@@ -318,7 +318,8 @@ live in `application_sdk/app/_generated_tree.py` and nowhere else:
 | Function | Answers |
 | --- | --- |
 | `generated_layout(dir)` | `multi` (per-entry-point subdirectories), `single` (flat), or `unknown` (nothing generated) |
-| `is_form_configmap(stem)` | Is this sibling `*.json` a setup form, or the DAG `manifest` / a `{atlan,csa}-connectors-*` credential template? |
+| `is_form_configmap(stem)` | Is this sibling `*.json` a setup form, or one of the non-form documents — the DAG `manifest`, `artifact_schemas`, a `{atlan,csa}-connectors-*` credential template? |
+| `pick_form_configmap(dir, ep)` | Which file in *this* directory is the form: `<ep>.json` by name, else the first stem `is_form_configmap` accepts |
 | `form_configmap(dir, ep)` | Which file is *this* entry point's setup form, given the layout |
 
 Everything that needs one of those reads it from there: the configmap
@@ -330,6 +331,19 @@ The exclusion in `is_form_configmap` is load-bearing rather than cosmetic. For
 a flat app, `atlan-connectors-<source>.json` sorts alphabetically **before**
 `<source>.json`, so any file-discovery that globs `*.json` and takes the first
 match picks the credential template on every single-entry-point connector.
+
+But an exclusion list can only ever name the siblings the toolkit emits
+*today*, which is why `pick_form_configmap` identifies the form **by name
+first** and treats the sorted scan as the fallback. FND-1682 is what the scan
+alone cost: adopting conformance K016 makes the toolkit emit
+`artifact_schemas.json`, which is neither the manifest nor a credential
+template and sorts before every real form stem. Every adopting app served the
+schema document as its form — no `config` key, no `properties`, so the setup
+wizard rendered blank behind an HTTP 200 with nothing in the logs, the network
+tab, or pod stderr. The name-first step is what stops the *next* new sibling
+from repeating it; the exclusion stays because a form is not always named after
+its entry point (a connector's `crawler` entry point emits
+`<source>-crawler.json`).
 
 Layout is read from the tree, never from `len(entry_points)`. A
 **route/card-split** app has several `@entrypoint`s behind one marketplace card

--- a/docs/concepts/entry-points.md
+++ b/docs/concepts/entry-points.md
@@ -319,7 +319,7 @@ live in `application_sdk/app/_generated_tree.py` and nowhere else:
 | --- | --- |
 | `generated_layout(dir)` | `multi` (per-entry-point subdirectories), `single` (flat), or `unknown` (nothing generated) |
 | `is_form_configmap(stem)` | Is this sibling `*.json` a setup form, or one of the non-form documents — the DAG `manifest`, `artifact_schemas`, a `{atlan,csa}-connectors-*` credential template? |
-| `pick_form_configmap(dir, ep)` | Which file in *this* directory is the form: `<ep>.json` by name, else the first stem `is_form_configmap` accepts |
+| `pick_form_configmap(dir, ep)` | Which file in *this* directory is the form: one that names the entry point, else the only eligible one, else the alphabetically first |
 | `form_configmap(dir, ep)` | Which file is *this* entry point's setup form, given the layout |
 
 Everything that needs one of those reads it from there: the configmap
@@ -333,17 +333,36 @@ a flat app, `atlan-connectors-<source>.json` sorts alphabetically **before**
 match picks the credential template on every single-entry-point connector.
 
 But an exclusion list can only ever name the siblings the toolkit emits
-*today*, which is why `pick_form_configmap` identifies the form **by name
-first** and treats the sorted scan as the fallback. FND-1682 is what the scan
-alone cost: adopting conformance K016 makes the toolkit emit
-`artifact_schemas.json`, which is neither the manifest nor a credential
-template and sorts before every real form stem. Every adopting app served the
-schema document as its form — no `config` key, no `properties`, so the setup
-wizard rendered blank behind an HTTP 200 with nothing in the logs, the network
-tab, or pod stderr. The name-first step is what stops the *next* new sibling
-from repeating it; the exclusion stays because a form is not always named after
-its entry point (a connector's `crawler` entry point emits
-`<source>-crawler.json`).
+*today*. FND-1682 is what a stale one cost: adopting conformance K016 makes the
+toolkit emit `artifact_schemas.json`, which is neither the manifest nor a
+credential template and sorts before every real form stem. Every adopting app
+served the schema document as its form — no `config` key, no `properties`, so
+the setup wizard rendered blank behind an HTTP 200 with nothing in the logs,
+the network tab, or pod stderr.
+
+So `pick_form_configmap` reaches for an *identification* before a guess, in
+three steps:
+
+1. **A form that names the entry point** — `<entry-point>.json`, or the
+   connector convention `<source>-<entry-point>.json` (`crawler` →
+   `snowflake-crawler.json`). The suffix spelling carries the connector fleet:
+   its entry points are named for the role (`crawler`, `miner`) while its files
+   are named for the source, so exact matching alone would fire almost nowhere.
+2. **The only eligible file**, when exactly one survives the exclusion. There
+   is nothing else it could be. This is what answers a route/card-split app,
+   whose form is named for the app (`metabase.json`) and relates to its entry
+   points by no rule at all.
+3. **The alphabetically first**, otherwise.
+
+**Step 3 is a guess, and it stays.** It is the compatibility path for apps
+whose form name the SDK cannot recognise, and turning it into a 404 would break
+apps that work today to defend against a sibling the toolkit does not yet emit
+— a census of the fleet's committed `app/generated` trees found no directory
+with two eligible files. What the guess owed an operator was visibility, not
+removal: the configmap endpoint now logs a WARNING naming the file it served
+and the candidates it rejected whenever step 3 decides, so the next
+unrecognised sibling appears in the logs on the first request rather than only
+as a blank wizard.
 
 Layout is read from the tree, never from `len(entry_points)`. A
 **route/card-split** app has several `@entrypoint`s behind one marketplace card

--- a/tests/unit/app/test_generated_tree.py
+++ b/tests/unit/app/test_generated_tree.py
@@ -23,6 +23,7 @@ from application_sdk.app._generated_tree import (
     form_configmap,
     generated_layout,
     is_form_configmap,
+    names_entrypoint,
     pick_form_configmap,
 )
 
@@ -103,16 +104,17 @@ class TestPickFormConfigMap:
         _write(tmp_path, "aaa-unknown-sibling.json", "manifest.json", "metabase.json")
         assert pick_form_configmap(tmp_path, "metabase") == tmp_path / "metabase.json"
 
-    def test_falls_back_to_scan_when_form_is_not_named_for_the_entrypoint(
-        self, tmp_path: Path
-    ) -> None:
-        """A connector's ``crawler`` entry point emits ``<source>-crawler.json``.
+    def test_connector_suffix_names_the_entrypoint(self, tmp_path: Path) -> None:
+        """``crawler`` is identified by ``snowflake-crawler.json``.
 
-        The named file does not exist, so the filtered scan answers — dropping
-        it would 404 exactly the apps the fallback exists for.
+        The connector convention makes the entry point the *role* and the file
+        carry the source, so exact-name matching alone would leave the entire
+        connector fleet on the last-resort guess. Here the unrecognised sibling
+        sorts first and must still lose.
         """
         _write(
             tmp_path,
+            "aaa-unknown-sibling.json",
             "atlan-connectors-snowflake.json",
             "manifest.json",
             "snowflake-crawler.json",
@@ -120,6 +122,48 @@ class TestPickFormConfigMap:
         assert (
             pick_form_configmap(tmp_path, "crawler")
             == tmp_path / "snowflake-crawler.json"
+        )
+
+    def test_sole_candidate_wins_without_naming_the_entrypoint(
+        self, tmp_path: Path
+    ) -> None:
+        """One eligible file is an identification: nothing else it could be.
+
+        A route/card-split app is this shape — ``metabase.json`` serves an
+        ``extract_metadata`` entry point, and no naming rule relates the two.
+        """
+        _write(
+            tmp_path,
+            "artifact_schemas.json",
+            "atlan-connectors-metabase.json",
+            "manifest.json",
+            "metabase.json",
+        )
+        assert (
+            pick_form_configmap(tmp_path, "extract-metadata")
+            == tmp_path / "metabase.json"
+        )
+
+    def test_alphabetical_guess_survives_as_the_compatibility_path(
+        self, tmp_path: Path
+    ) -> None:
+        """Several candidates, none named for the entry point → first by name.
+
+        This step *is* a guess, and it is kept on purpose: it is what serves an
+        app whose form name the SDK cannot recognise. Turning this case into a
+        ``None`` (a 404) would break apps that work today to defend against a
+        sibling the toolkit does not yet emit — a census of the fleet's
+        committed ``app/generated`` trees found no directory with two eligible
+        files, so the trade buys nothing and costs the un-adopted.
+
+        FND-1682 was never the guess being *reachable*; it was
+        ``artifact_schemas.json`` being eligible at all. The endpoint logs a
+        warning when it lands here, which is the part that was missing.
+        """
+        _write(tmp_path, "aaa-unknown-sibling.json", "manifest.json", "metabase.json")
+        assert (
+            pick_form_configmap(tmp_path, "extract-metadata")
+            == tmp_path / "aaa-unknown-sibling.json"
         )
 
     def test_returns_none_when_every_sibling_is_excluded(self, tmp_path: Path) -> None:
@@ -137,13 +181,43 @@ class TestPickFormConfigMap:
     def test_entrypoint_named_after_a_non_form_sibling_falls_back(
         self, tmp_path: Path
     ) -> None:
-        """The name-first step never re-admits an excluded file.
+        """The naming step never re-admits an excluded file.
 
         An entry point called ``manifest`` would otherwise name its way past the
-        exclusion and serve the DAG as the form.
+        exclusion and serve the DAG as the form. It cannot: the name match runs
+        over the *eligible* candidates, never over the directory.
         """
         _write(tmp_path, "manifest.json", "metabase.json")
         assert pick_form_configmap(tmp_path, "manifest") == tmp_path / "metabase.json"
+
+
+class TestNamesEntrypoint:
+    """Which stems count as identifying an entry point."""
+
+    @pytest.mark.parametrize(
+        ("stem", "entrypoint"),
+        [
+            ("bridge", "bridge"),
+            ("snowflake-crawler", "crawler"),
+            ("postgres-miner", "miner"),
+        ],
+    )
+    def test_recognised_spellings(self, stem: str, entrypoint: str) -> None:
+        assert names_entrypoint(stem, entrypoint) is True
+
+    @pytest.mark.parametrize(
+        ("stem", "entrypoint"),
+        [
+            # Substring, not a suffix on a hyphen boundary: a form for some
+            # other role must not answer for this one.
+            ("crawler-legacy", "crawler"),
+            # The hyphen is required — "recrawler" is a different word.
+            ("recrawler", "crawler"),
+            ("metabase", "extract-metadata"),
+        ],
+    )
+    def test_unrecognised_spellings(self, stem: str, entrypoint: str) -> None:
+        assert names_entrypoint(stem, entrypoint) is False
 
 
 class TestFormConfigMapWithArtifactSchemas:

--- a/tests/unit/app/test_generated_tree.py
+++ b/tests/unit/app/test_generated_tree.py
@@ -1,0 +1,165 @@
+"""FND-1682: which sibling of the generated tree is the setup form.
+
+The generated dir holds an entry point's form next to files that are *not*
+forms — the DAG ``manifest``, the per-object-store-family credential templates,
+and (since conformance K016) ``artifact_schemas``. Picking the wrong one is
+silent by construction: the configmap endpoint returns HTTP 200 carrying a
+document with no ``properties``, and the setup wizard renders blank with nothing
+in the logs, the network tab or pod stderr.
+
+These tests pin both halves of the answer — the exclusion vocabulary, and the
+name-first pick that keeps the *next* new sibling from repeating FND-1682.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from application_sdk.app._generated_tree import (
+    ARTIFACT_SCHEMAS_STEM,
+    form_configmap,
+    generated_layout,
+    is_form_configmap,
+    pick_form_configmap,
+)
+
+
+def _write(directory: Path, *names: str) -> None:
+    """Create *names* under *directory* with throwaway JSON content."""
+    directory.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        (directory / name).write_text(json.dumps({"stem": Path(name).stem}))
+
+
+class TestIsFormConfigMap:
+    """The exclusion vocabulary — the fallback half of form discovery."""
+
+    @pytest.mark.parametrize(
+        "stem",
+        [
+            "manifest",
+            "artifact_schemas",
+            "atlan-connectors-snowflake",
+            "csa-connectors-objectstore",
+        ],
+    )
+    def test_non_form_siblings_rejected(self, stem: str) -> None:
+        assert is_form_configmap(stem) is False
+
+    @pytest.mark.parametrize("stem", ["metabase", "snowflake-crawler", "openapi"])
+    def test_form_stems_accepted(self, stem: str) -> None:
+        assert is_form_configmap(stem) is True
+
+    def test_artifact_schemas_sorts_before_a_real_form(self) -> None:
+        """The property that made FND-1682 silent rather than loud.
+
+        ``artifact_schemas`` sorts before every plausible form stem, so a sorted
+        scan without the exclusion picks it *first* on any app that adopted
+        K016 — not on some unlucky subset.
+        """
+        assert ARTIFACT_SCHEMAS_STEM < "metabase"
+        assert ARTIFACT_SCHEMAS_STEM < "atlan-connectors-metabase"
+
+    def test_stem_agrees_with_the_validation_loader(self) -> None:
+        """The guard, the loader and form discovery name one file.
+
+        ``application_sdk.validation.sources`` reads the same file this module
+        tells form discovery to skip. They are spelled in two modules because
+        ``_generated_tree`` stays import-light, so the join is pinned here
+        instead: a rename that updated only one side would put the SDK back to
+        serving a schema document as a setup form.
+        """
+        from application_sdk.validation.sources import ARTIFACT_SCHEMAS_FILENAME
+
+        assert ARTIFACT_SCHEMAS_FILENAME == f"{ARTIFACT_SCHEMAS_STEM}.json"
+
+
+class TestPickFormConfigMap:
+    """Name-first, then the filtered sorted scan."""
+
+    def test_skips_artifact_schemas_and_serves_the_form(self, tmp_path: Path) -> None:
+        """The FND-1682 tree: K016 adopted, form stem sorting after it."""
+        _write(
+            tmp_path,
+            "artifact_schemas.json",
+            "atlan-connectors-metabase.json",
+            "manifest.json",
+            "metabase.json",
+        )
+        assert pick_form_configmap(tmp_path, "metabase") == tmp_path / "metabase.json"
+
+    def test_entrypoint_named_form_wins_over_an_alphabetical_sibling(
+        self, tmp_path: Path
+    ) -> None:
+        """A new non-form sibling cannot displace the form it is named for.
+
+        ``aaa-unknown-sibling`` stands in for whatever the toolkit emits next:
+        it is on no exclusion list, and it sorts first. Name-first is what makes
+        that harmless rather than a re-run of FND-1682.
+        """
+        _write(tmp_path, "aaa-unknown-sibling.json", "manifest.json", "metabase.json")
+        assert pick_form_configmap(tmp_path, "metabase") == tmp_path / "metabase.json"
+
+    def test_falls_back_to_scan_when_form_is_not_named_for_the_entrypoint(
+        self, tmp_path: Path
+    ) -> None:
+        """A connector's ``crawler`` entry point emits ``<source>-crawler.json``.
+
+        The named file does not exist, so the filtered scan answers — dropping
+        it would 404 exactly the apps the fallback exists for.
+        """
+        _write(
+            tmp_path,
+            "atlan-connectors-snowflake.json",
+            "manifest.json",
+            "snowflake-crawler.json",
+        )
+        assert (
+            pick_form_configmap(tmp_path, "crawler")
+            == tmp_path / "snowflake-crawler.json"
+        )
+
+    def test_returns_none_when_every_sibling_is_excluded(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "artifact_schemas.json",
+            "atlan-connectors-snowflake.json",
+            "manifest.json",
+        )
+        assert pick_form_configmap(tmp_path, "crawler") is None
+
+    def test_returns_none_for_a_missing_directory(self, tmp_path: Path) -> None:
+        assert pick_form_configmap(tmp_path / "nope", "crawler") is None
+
+    def test_entrypoint_named_after_a_non_form_sibling_falls_back(
+        self, tmp_path: Path
+    ) -> None:
+        """The name-first step never re-admits an excluded file.
+
+        An entry point called ``manifest`` would otherwise name its way past the
+        exclusion and serve the DAG as the form.
+        """
+        _write(tmp_path, "manifest.json", "metabase.json")
+        assert pick_form_configmap(tmp_path, "manifest") == tmp_path / "metabase.json"
+
+
+class TestFormConfigMapWithArtifactSchemas:
+    """The layout-aware wrapper inherits both fixes."""
+
+    def test_flat_app_serves_its_form_not_the_schemas(self, tmp_path: Path) -> None:
+        _write(tmp_path, "artifact_schemas.json", "manifest.json", "metabase.json")
+        assert generated_layout(tmp_path) == "single"
+        assert form_configmap(tmp_path, "metabase") == tmp_path / "metabase.json"
+
+    def test_bundle_serves_the_entrypoint_form_not_the_schemas(
+        self, tmp_path: Path
+    ) -> None:
+        nested = tmp_path / "crawler"
+        _write(
+            nested, "artifact_schemas.json", "manifest.json", "snowflake-crawler.json"
+        )
+        assert generated_layout(tmp_path) == "multi"
+        assert form_configmap(tmp_path, "crawler") == nested / "snowflake-crawler.json"

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -2348,6 +2348,102 @@ class TestConfigMapEndpoints:
         finally:
             svc_module.CONTRACT_GENERATED_DIR = original
 
+    def test_configmap_default_fallback_skips_artifact_schemas(
+        self, tmp_path: Path
+    ) -> None:
+        """App-id request must not serve ``artifact_schemas.json`` as the form.
+
+        Regression, FND-1682. Once an app declares an ``artifactSchemas`` block
+        (conformance K016) the toolkit emits ``artifact_schemas.json`` beside
+        the form. It is neither the manifest nor a credential template, and it
+        sorts before every plausible form stem, so the fallback's sorted scan
+        picked it and the handler returned ``raw.get("config", raw)`` — the
+        whole schema document, which carries no ``properties``. HTTP 200, blank
+        setup wizard, nothing in the logs or the network tab. Latent for every
+        app adopting K016; ``atlan-metabase-app`` was the first confirmed one
+        (FND-1681).
+        """
+        from application_sdk.app.base import App
+        from application_sdk.app.entrypoint import entrypoint
+        from application_sdk.handler import service as svc_module
+
+        class _OneEpApp(App):
+            @entrypoint
+            async def crawler(self, input: _RoutingInput) -> _RoutingOutput:
+                return _RoutingOutput()
+
+        # Flat single-entrypoint layout, in the order `sorted()` sees it:
+        # artifact_schemas < atlan-connectors-* < manifest < the form.
+        (tmp_path / "artifact_schemas.json").write_text(
+            json.dumps({"version": "1.0", "artifacts": {}})
+        )
+        (tmp_path / "atlan-connectors-metabase.json").write_text(
+            json.dumps({"config": {"key": "credential-schema"}})
+        )
+        (tmp_path / "manifest.json").write_text(json.dumps({"dag": {}}))
+        (tmp_path / "metabase.json").write_text(
+            json.dumps({"config": {"key": "form-config"}})
+        )
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            svc = create_app_handler_service(
+                _TestHandler(), app_name="metabase", app_class=_OneEpApp
+            )
+            client = TestClient(svc, raise_server_exceptions=False)
+            response = client.get("/workflows/v1/configmap/atlan-metabase")
+            assert response.status_code == 200
+            parsed_config = json.loads(response.json()["data"]["data"]["config"])
+            assert parsed_config["key"] == "form-config"
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
+    def test_configmap_default_fallback_prefers_entrypoint_named_form(
+        self, tmp_path: Path
+    ) -> None:
+        """An unrecognised sibling that sorts first does not become the form.
+
+        The exclusion list can only name the siblings the toolkit emits today,
+        so the fallback identifies the form by name first —
+        ``<ep.name>.json`` — and only then falls back to the sorted scan.
+        ``aaa-unknown-sibling.json`` stands in for whatever the toolkit emits
+        next: on no exclusion list, sorting first. Without the name-first step
+        this is FND-1682 again with a different filename.
+        """
+        from application_sdk.app.base import App
+        from application_sdk.app.entrypoint import entrypoint
+        from application_sdk.handler import service as svc_module
+
+        class _OneEpApp(App):
+            @entrypoint
+            async def crawler(self, input: _RoutingInput) -> _RoutingOutput:
+                return _RoutingOutput()
+
+        crawler_dir = tmp_path / "crawler"
+        crawler_dir.mkdir()
+        (crawler_dir / "aaa-unknown-sibling.json").write_text(
+            json.dumps({"config": {"key": "not-a-form"}})
+        )
+        (crawler_dir / "manifest.json").write_text(json.dumps({"dag": {}}))
+        (crawler_dir / "crawler.json").write_text(
+            json.dumps({"config": {"key": "form-config"}})
+        )
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            svc = create_app_handler_service(
+                _TestHandler(), app_name="metabase", app_class=_OneEpApp
+            )
+            client = TestClient(svc, raise_server_exceptions=False)
+            response = client.get("/workflows/v1/configmap/atlan-metabase")
+            assert response.status_code == 200
+            parsed_config = json.loads(response.json()["data"]["data"]["config"])
+            assert parsed_config["key"] == "form-config"
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
     def test_configmap_default_fallback_prefers_nested_over_flat_form(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -2405,11 +2405,12 @@ class TestConfigMapEndpoints:
         """An unrecognised sibling that sorts first does not become the form.
 
         The exclusion list can only name the siblings the toolkit emits today,
-        so the fallback identifies the form by name first —
-        ``<ep.name>.json`` — and only then falls back to the sorted scan.
-        ``aaa-unknown-sibling.json`` stands in for whatever the toolkit emits
-        next: on no exclusion list, sorting first. Without the name-first step
-        this is FND-1682 again with a different filename.
+        so the fallback identifies the form by name first — ``<ep.name>.json``,
+        or the connector convention ``<source>-<ep.name>.json`` — and only then
+        falls back to the sorted scan. ``aaa-unknown-sibling.json`` stands in
+        for whatever the toolkit emits next: on no exclusion list, sorting
+        first. Without the naming step this is FND-1682 again with a different
+        filename.
         """
         from application_sdk.app.base import App
         from application_sdk.app.entrypoint import entrypoint
@@ -2441,6 +2442,110 @@ class TestConfigMapEndpoints:
             assert response.status_code == 200
             parsed_config = json.loads(response.json()["data"]["data"]["config"])
             assert parsed_config["key"] == "form-config"
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
+    def test_configmap_default_fallback_matches_connector_suffix_form(
+        self, tmp_path: Path
+    ) -> None:
+        """``crawler`` resolves ``snowflake-crawler.json`` over a first-sorting sibling.
+
+        The connector convention names the entry point for the *role* and the
+        file for the source, so exact-name matching alone never fires across the
+        connector fleet — every one of them would ride the alphabetical guess.
+        """
+        from application_sdk.app.base import App
+        from application_sdk.app.entrypoint import entrypoint
+        from application_sdk.handler import service as svc_module
+
+        class _OneEpApp(App):
+            @entrypoint
+            async def crawler(self, input: _RoutingInput) -> _RoutingOutput:
+                return _RoutingOutput()
+
+        crawler_dir = tmp_path / "crawler"
+        crawler_dir.mkdir()
+        (crawler_dir / "aaa-unknown-sibling.json").write_text(
+            json.dumps({"config": {"key": "not-a-form"}})
+        )
+        (crawler_dir / "manifest.json").write_text(json.dumps({"dag": {}}))
+        (crawler_dir / "snowflake-crawler.json").write_text(
+            json.dumps({"config": {"key": "form-config"}})
+        )
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            svc = create_app_handler_service(
+                _TestHandler(), app_name="snowflake", app_class=_OneEpApp
+            )
+            client = TestClient(svc, raise_server_exceptions=False)
+            response = client.get("/workflows/v1/configmap/atlan-snowflake")
+            assert response.status_code == 200
+            parsed_config = json.loads(response.json()["data"]["data"]["config"])
+            assert parsed_config["key"] == "form-config"
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
+    def test_configmap_alphabetical_last_resort_serves_and_warns(
+        self, tmp_path: Path
+    ) -> None:
+        """Several candidates, none named for the entrypoint → serve + WARN.
+
+        The alphabetical pick is the compatibility path for apps whose form name
+        the SDK cannot recognise, so it still answers rather than 404ing. What
+        it owes an operator is visibility: FND-1682 was invisible precisely
+        because the wrong file came back as an HTTP 200. The warning names the
+        file served and the candidates rejected, so the next unrecognised
+        sibling shows up on the first request instead of in a blank wizard.
+        """
+        from application_sdk.app.base import App
+        from application_sdk.app.entrypoint import entrypoint
+        from application_sdk.handler import service as svc_module
+
+        class _SplitApp(App):
+            @entrypoint
+            async def extract_metadata(self, input: _RoutingInput) -> _RoutingOutput:
+                return _RoutingOutput()
+
+        # Route/card-split shape: the form is named for the app, not the entry
+        # point, so nothing here identifies itself and both files are eligible.
+        (tmp_path / "aaa-unknown-sibling.json").write_text(
+            json.dumps({"config": {"key": "guessed"}})
+        )
+        (tmp_path / "manifest.json").write_text(json.dumps({"dag": {}}))
+        (tmp_path / "metabase.json").write_text(
+            json.dumps({"config": {"key": "the-real-form"}})
+        )
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            svc = create_app_handler_service(
+                _TestHandler(), app_name="metabase", app_class=_SplitApp
+            )
+            client = TestClient(svc, raise_server_exceptions=False)
+            with patch("application_sdk.handler.service.logger") as mock_logger:
+                response = client.get("/workflows/v1/configmap/atlan-metabase")
+            assert response.status_code == 200
+            # Still served — the guess is the compatibility path, not an error.
+            parsed_config = json.loads(response.json()["data"]["data"]["config"])
+            assert parsed_config["key"] == "guessed"
+
+            warned = [
+                call
+                for call in mock_logger.warning.call_args_list
+                if "chosen alphabetically" in call.args[0]
+            ]
+            assert len(warned) == 1
+            # The rejected candidates are the diagnostic: they are what tells an
+            # operator which file they meant to serve.
+            assert warned[0].args[1:] == (
+                "extract-metadata",
+                2,
+                "aaa-unknown-sibling",
+                ["aaa-unknown-sibling", "metabase"],
+            )
         finally:
             svc_module.CONTRACT_GENERATED_DIR = original
 


### PR DESCRIPTION
Fixes FND-1682. Blocks FND-1681.

## The bug

`GET /workflows/v1/configmap/{id}` serves the wrong file for any app that declares an `artifactSchemas` block, and the failure is silent on every surface.

The marketplace UI builds the configmap URL from the **app id** (`atlan-metabase`), not the generated form stem (`metabase`), so the handler's exact-stem match misses and the request falls through to the default-entrypoint fallback. That fallback picked the alphabetically first `*.json` that survived `is_form_configmap` — and once conformance K016 is adopted the toolkit emits `artifact_schemas.json`, which is neither the DAG `manifest` nor a `{atlan,csa}-connectors-*` credential template, and sorts before every real form stem:

| sorted `app/generated/*.json` | `is_form_configmap` | outcome |
| -- | -- | -- |
| `artifact_schemas.json` | ✅ | **← served as the form** |
| `atlan-connectors-<app>.json` | ❌ excluded | |
| `manifest.json` | ❌ excluded | |
| `<app>.json` (the real form) | ✅ | never reached |

The handler returns `raw.get("config", raw)`. `artifact_schemas.json` has no `config` key, so the whole schema document came back as the form config. It carries no `properties`, so the setup wizard rendered blank — behind an HTTP 200, with nothing in the logs, the network tab or pod stderr.

Latent for every app adopting K016 whose form stem sorts after `artifact_schemas`, which is in practice all of them: each adopting connector silently loses its setup UI at its next release.

## The fix

Both remedies from the ticket, because either alone leaves the class of break open. Both land in `application_sdk/app/_generated_tree.py`, which already owns the "which sibling JSON is a form" fact for the endpoint *and* for the FND-1667 tenant-side route check.

**1. Exclusion.** `artifact_schemas` joins `manifest` in a new `NON_FORM_STEMS`, rejected by `is_form_configmap`. The literal is named once as `ARTIFACT_SCHEMAS_STEM`, and `_artifact_schema_guard` now derives its `_ARTIFACT_SCHEMAS_FILENAME` from it rather than re-spelling it.

**2. Stop depending on alphabetical order.** New `pick_form_configmap(directory, entrypoint)`: `<entrypoint>.json` by name when it exists, otherwise the filtered sorted scan. An exclusion list can only ever name the siblings the toolkit emits *today* — the name-first step is what stops the next new sibling repeating this with a different filename.

The sorted scan stays as step 2 on purpose: a form is not always named after its entry point (a connector's `crawler` entry point emits `<source>-crawler.json`), so dropping it would 404 exactly the apps the fallback exists for. `handler.service.get_configmap` and `form_configmap` both go through the new helper, so the server and the route check cannot disagree about which file is the form.

## Judgment call worth a reviewer's eye

`application_sdk/validation/sources.py` keeps its own `ARTIFACT_SCHEMAS_FILENAME` rather than importing the new stem. Importing `application_sdk.app._generated_tree` from `validation` executes `application_sdk/app/__init__.py` — temporalio and the whole app surface — for a string, and `_generated_tree` is deliberately import-light because a CI-time check reads it. The join is pinned by a test instead (`test_stem_agrees_with_the_validation_loader`), so a rename that updates only one side fails loudly.

## Tests

- `tests/unit/app/test_generated_tree.py` (new, 16 cases): the exclusion vocabulary, the name-first pick, the fallback scan, an unrecognised sibling standing in for whatever the toolkit emits next, an entry point named `manifest` that must not name its way past the exclusion, and the constant join above.
- `tests/unit/handler/test_service.py` (+2): reproduce the reported tree — `artifact_schemas.json` + `atlan-connectors-metabase.json` + `manifest.json` + `metabase.json`, requested as `atlan-metabase` — and assert the form is served; plus the name-first preference at the endpoint.

Full unit suite green (9877 passed, 9 skipped). Pre-commit clean. Conformance `--scope sdk` reports no new findings in the touched files.

## Docs

`docs/concepts/entry-points.md`: the one-authority table gains `pick_form_configmap`, and the "the exclusion is load-bearing" paragraph now explains why an exclusion list alone is not enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014t79wifGShjphmGyHfuFKR
