### PR TITLE
fix(testing): e2e version verify must stop reading its own input (FND-1684)

### DIFF
--- a/.github/actions/build-app-image/action.yaml
+++ b/.github/actions/build-app-image/action.yaml
@@ -205,6 +205,31 @@ runs:
         application-sdk-ref: ${{ inputs.application-sdk-ref }}
         check-drift: "false"
 
+    # Make the image able to say which build it is (FND-1684).
+    #
+    # `verify` in e2e_tenant_app.py used to read the marketplace install record —
+    # the same record `install` writes and then skips on — so a tenant whose pods
+    # had not moved in weeks passed the check that exists to catch exactly that.
+    # The only fully-truthful answer comes from the pod, and the identity CI
+    # compares against (the image tag) is minted after every committed artifact
+    # exists, so it has to enter at build time.
+    #
+    # A --build-arg alone is not enough: BuildKit ignores a build-arg the
+    # Dockerfile does not ARG, and an ARG is not inherited across FROM, so
+    # declaring it in the SDK base image would do nothing for the connector built
+    # on top of it. This appends the two lines that promote it to an image ENV,
+    # to the runner's ephemeral checkout only — nothing is written back to the
+    # connector repo, and a connector that adopts the lines itself is left alone.
+    #
+    # BEFORE the buildx build, and after the contract regeneration so it cannot
+    # disturb it. The logic is in a tested script rather than inlined shell, per
+    # docs/standards/ci.md.
+    - name: Stamp the build identity into the Dockerfile
+      shell: bash
+      env:
+        STAMP: ${{ github.action_path }}/../../scripts/stamp_build_identity.py
+      run: python3 "${STAMP}"
+
     # Buildx is required for the GHA cache backend below.
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
@@ -262,6 +287,14 @@ runs:
         # ONLY when non-empty — passing `BASE_IMAGE=` empty would clobber the
         # Dockerfile's default FROM and break the non-e2e / merge-queue path.
         BUILD_ARGS=()
+        # The build identity the pod will report (FND-1684). TAG, not IMAGE:
+        # `tag-suffix` is per-ARCHITECTURE, and the tenant pulls the merged
+        # manifest, so a suffixed value would make each arch report a different
+        # identity and neither would match what `verify --expected` compares
+        # against — which is this un-suffixed tag, via merge-e2e-image's
+        # `version` output. The Dockerfile stamp above is what turns this
+        # build-arg into an image ENV.
+        BUILD_ARGS+=(--build-arg "ATLAN_BUILD_ID=${TAG}")
         if [ -n "${BASE_IMAGE_REF}" ]; then
           echo "Building connector on dispatched base image: ${BASE_IMAGE_REF}"
           BUILD_ARGS+=(--build-arg "BASE_IMAGE=${BASE_IMAGE_REF}")

--- a/.github/scripts/e2e_tenant_api.py
+++ b/.github/scripts/e2e_tenant_api.py
@@ -77,6 +77,13 @@ RELEASE_SCAN_PATH = (
     f"{_SERVICE_PREFIX}/marketplace/apps/{{app_id}}/releases/{{release_id}}"
 )
 
+#: Heracles' configmap proxy: it forwards to the app pod's own
+#: ``GET /workflows/v1/configmap/{id}``, so a 200 here is an answer from the
+#: RUNNING POD rather than from a marketplace record. That is what makes it the
+#: route the build-identity check reads (FND-1684) — and it is already proxied,
+#: so reading it needs no new Heracles rule.
+CONFIGMAP_PATH = f"{_SERVICE_PREFIX}/configmaps/{{name}}"
+
 #: AE submit / create. `submit=false` creates the workflow without executing it,
 #: which still drives Heracles' server-side manifest fetch from the deployed pod.
 PACKAGE_WORKFLOWS_PATH = f"{_SERVICE_PREFIX}/package-workflows"

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -120,6 +120,7 @@ from e2e_tenant_api import (
     APP_EVENTS_PATH,
     APP_FAILURE_PATH,
     APP_INFO_PATH,
+    CONFIGMAP_PATH,
     DEPLOYMENT_PATH,
     INSTALL_PATH,
     PUBLISH_PATH,
@@ -441,6 +442,28 @@ _DESCRIBE_POD_MAX_LINES = 120
 _DESCRIBE_MAX_PODS = 6
 
 
+#: The configmap id the app pod answers with its build identity (FND-1684).
+#:
+#: Must match ``application_sdk.app.build_identity.BUILD_IDENTITY_CONFIGMAP_ID``.
+#: Spelled here as a literal rather than imported, because this script must stay
+#: stdlib-only: ``install`` runs on the runner's system Python, where the SDK is
+#: not importable at all. ``test_build_identity_ids_agree`` asserts the two
+#: spellings match, so a rename cannot silently degrade this check to "the pod
+#: reports nothing".
+BUILD_IDENTITY_CONFIGMAP_ID = "atlan-build-identity"
+
+#: Where the SDK's build-identity module lives, for the diagnostic probe in
+#: :func:`_local_sdk_serves_build_identity`. A dotted path rather than an import:
+#: see that function for why it must not import anything.
+_BUILD_IDENTITY_MODULE = "application_sdk.app.build_identity"
+
+#: Keys carrying a deployment id in an ``/apps/{id}/info`` payload. LM does not
+#: document the shape, so this reads whichever of them is present rather than
+#: asserting one — an absent id degrades to "the deployment layer could not be
+#: consulted", which is a stated outcome here, not a failure.
+_DEPLOYMENT_ID_KEYS = ("deployment_id", "deploymentId")
+
+
 class TenantAppError(RuntimeError):
     """The install or verification failed."""
 
@@ -466,6 +489,47 @@ class DeploymentFailed(TenantAppError):
     """
 
 
+#: The layers an installed version can be established at, weakest first. Named
+#: rather than boolean because "verified" was the word that hid FND-1684: the
+#: step said "verified: tenant runs X" while having read only LM's install
+#: record — the same record the install had just written and then skipped on.
+#:
+#: ``install-record``
+#:     LM says the tenant's install record names this version. Says nothing
+#:     about any pod: the record is written at install time and never revisited.
+#: ``deployment``
+#:     LM additionally reports ``deployment_status: SUCCEEDED`` for the
+#:     deployment. Stronger, but LM reporting SUCCEEDED while nothing moves is a
+#:     known shape (uninstall reports success and deletes nothing, DISTR-921),
+#:     so this can lie in the same direction as the record.
+#: ``pod``
+#:     The app pod itself reported the build identity stamped into the image
+#:     under test. The only layer a tenant whose pods did not move cannot fake.
+LAYER_INSTALL_RECORD = "install-record"
+LAYER_DEPLOYMENT = "deployment"
+LAYER_POD = "pod"
+
+
+@dataclass(frozen=True)
+class PodIdentity:
+    """What the app pod said when asked which build it is.
+
+    Three outcomes, and they must not be collapsed:
+
+    * ``reachable=False`` — the route did not answer (an SDK predating it, or
+      Heracles/the pod not serving). Nothing was established either way.
+    * ``reachable=True, build_id=""`` — the pod answered, and the image it runs
+      carries no build identity. Also establishes nothing about the version, but
+      it does establish that the route works, which is a different next step.
+    * ``reachable=True, build_id="…"`` — the answer this whole change exists for.
+    """
+
+    reachable: bool
+    build_id: str = ""
+    app_name: str = ""
+    detail: str = ""
+
+
 @dataclass(frozen=True)
 class InstallOutcome:
     """What an install actually did, for the step log and $GITHUB_OUTPUT."""
@@ -477,6 +541,12 @@ class InstallOutcome:
     installed_version: str = ""
     release_status: str = ""
     skipped: bool = False
+    #: LM's terminal verdict for the deployment, when one could be read.
+    deployment_status: str = ""
+    #: What the pod reported, when it reported anything.
+    pod_build_id: str = ""
+    #: The strongest layer this outcome was established at. See LAYER_*.
+    verified_layer: str = LAYER_INSTALL_RECORD
 
     def as_outputs(self) -> dict[str, str]:
         return {
@@ -487,6 +557,9 @@ class InstallOutcome:
             "installed_version": self.installed_version,
             "release_status": self.release_status,
             "skipped": "true" if self.skipped else "false",
+            "deployment_status": self.deployment_status,
+            "pod_build_id": self.pod_build_id,
+            "verified_layer": self.verified_layer,
         }
 
 
@@ -598,6 +671,19 @@ def _installed_version(client: TenantClient, app_id: str) -> str:
     treat those the same way: install. Distinguishing them would require LM to
     commit to a shape it has not.
     """
+    return _read_install_record(client, app_id)[0]
+
+
+def _read_install_record(
+    client: TenantClient, app_id: str
+) -> tuple[str, dict[str, object]]:
+    """One ``/info`` read, returning ``(installed version, raw payload)``.
+
+    Both halves come from one request because a caller that needs the payload as
+    well as the version — ``verify``, which then looks up the deployment id in it
+    — would otherwise fetch the same document twice and could see two different
+    snapshots of a tenant another run is mutating.
+    """
     response = client.get(APP_INFO_PATH.format(app_id=path_segment(app_id)))
     if not response.ok:
         # Not fatal: a 404 is the "never installed on this tenant" case, which
@@ -606,7 +692,7 @@ def _installed_version(client: TenantClient, app_id: str) -> str:
             f"::notice::app info returned HTTP {response.status} for {app_id} — "
             "treating as not installed"
         )
-        return ""
+        return "", {}
     data = response.data()
     version = _extract_version(data) or resolve_version_via_catalog(data)
     if not version:
@@ -621,13 +707,188 @@ def _installed_version(client: TenantClient, app_id: str) -> str:
             _INFO_DIAGNOSTIC_MAX_LINES,
             "head",
         )
-    return version
+    return version, data
 
 
 def _app_info(client: TenantClient, app_id: str) -> dict[str, object]:
     """Return the app's info payload, or ``{}`` when it cannot be read."""
     response = client.get(APP_INFO_PATH.format(app_id=path_segment(app_id)))
     return response.data() if response.ok else {}
+
+
+# ---------------------------------------------------------------------------
+# What the pod itself says (FND-1684)
+# ---------------------------------------------------------------------------
+
+
+def parse_pod_identity(payload: dict[str, object]) -> PodIdentity:
+    """Read a build identity out of a configmap envelope.
+
+    The handler serves the same shape as any other configmap — ``data.config``
+    is a JSON string — with the parsed keys repeated beside it. Both are read,
+    ``data`` first, so neither a client that only forwards ``config`` nor one
+    that flattens it can make a reachable pod look unreachable.
+    """
+    data = payload.get("data")
+    fields: dict[str, object] = dict(data) if isinstance(data, dict) else {}
+
+    raw_config = fields.get("config")
+    if isinstance(raw_config, str) and raw_config.strip():
+        try:
+            decoded = json.loads(raw_config)
+        except json.JSONDecodeError:
+            decoded = None
+        if isinstance(decoded, dict):
+            # The flattened keys win when both are present: they are what this
+            # handler writes directly, and `config` is a re-encoding of them.
+            fields = {**decoded, **fields}
+
+    return PodIdentity(
+        reachable=True,
+        build_id=str(fields.get("build_id") or "").strip(),
+        app_name=str(fields.get("app_name") or "").strip(),
+    )
+
+
+def read_pod_build_identity(client: TenantClient) -> PodIdentity:
+    """Ask the running pod which build it is.
+
+    ``/api/service/configmaps/<name>`` is Heracles proxying to the app pod's own
+    ``GET /workflows/v1/configmap/{id}``, so unlike every other read in this file
+    a 200 here comes from the POD rather than from a marketplace record. That is
+    the whole point: the install record and the deployment record are both
+    written by the install and never revisited, so a check that reads them can
+    pass on a tenant whose pods have not moved in weeks.
+
+    Never raises. Every failure mode collapses to ``reachable=False`` carrying
+    the reason, because the caller's decision is the same for all of them — fall
+    back to the record layers and say so — and because a transport error here
+    must not turn a leg red for a diagnostic the leg can do without.
+    """
+    path = CONFIGMAP_PATH.format(name=path_segment(BUILD_IDENTITY_CONFIGMAP_ID))
+    try:
+        response = client.get(path)
+    except TenantApiError as exc:
+        return PodIdentity(reachable=False, detail=str(exc))
+    if not response.ok:
+        return PodIdentity(
+            reachable=False,
+            detail=f"HTTP {response.status} from {path}",
+        )
+    try:
+        payload = response.data()
+    except TenantApiError as exc:
+        return PodIdentity(reachable=False, detail=str(exc))
+    return parse_pod_identity(payload)
+
+
+def _local_sdk_serves_build_identity() -> bool:
+    """True when the SDK synced on THIS runner carries the build-identity route.
+
+    Diagnostic only — it never decides pass or fail. What it buys is the
+    difference between two unreadable-pod messages that need opposite next
+    steps: an SDK too old to serve the route, versus a pod that is not running
+    the build under test at all.
+
+    It is not proof, and the message says so. The e2e action can pin the
+    *harness* SDK independently of the connector's runtime pin
+    (``harness-sdk-ref``), so a runner carrying the module does not by itself
+    establish that the image under test carries it too.
+
+    ``find_spec`` rather than an import: this module must stay importable on the
+    runner's bare system Python, where ``install`` runs and no SDK exists.
+    ``ModuleNotFoundError`` is what a missing PARENT package raises.
+    """
+    try:
+        import importlib.util  # noqa: PLC0415 — lazy: diagnostic-only, and this module must import on a bare interpreter
+
+        return importlib.util.find_spec(_BUILD_IDENTITY_MODULE) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def _unreadable_pod_hint(identity: PodIdentity) -> str:
+    """Explain an unreadable pod identity, and say what it does NOT establish."""
+    if identity.reachable:
+        return (
+            "The pod answered but reports no build identity, so the image it "
+            "runs was built without the ATLAN_BUILD_ID stamp "
+            "(.github/actions/build-app-image in application-sdk adds it). That "
+            "is consistent with a correctly reconciled tenant AND with a stale "
+            "one; it distinguishes neither."
+        )
+    carried = (
+        " The SDK synced on this runner DOES carry the route, which makes "
+        "'the pod is not running the build under test' the likelier of the two "
+        "— though not proof, since the harness SDK can be pinned ahead of the "
+        "connector's runtime pin (harness-sdk-ref)."
+        if _local_sdk_serves_build_identity()
+        else " The SDK synced on this runner does not carry the route either, "
+        "so this is most likely a pin that predates it and closes on its own "
+        "when the connector bumps."
+    )
+    return (
+        f"The pod did not answer the build-identity route ({identity.detail}), "
+        "so either the deployed image runs an SDK predating it, or the pod is "
+        f"not the one this run deployed.{carried}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# What LM's deployment record says
+# ---------------------------------------------------------------------------
+
+
+def deployment_id_from_info(payload: dict[str, object], _depth: int = 0) -> str:
+    """Find a deployment id in an ``/apps/{id}/info`` payload, or "".
+
+    Same depth-bounded walk as :func:`_extract_version`, and for the same reason:
+    LM nests the install state under ``installed`` and wraps payloads in ``data``
+    inconsistently, and an unbounded walk over a self-referential payload would
+    crash the step rather than degrade.
+
+    "" is a normal outcome, not an error. LM does not commit to exposing a
+    deployment id here, so the deployment layer is consulted when it can be and
+    reported as unavailable when it cannot.
+    """
+    if _depth >= _WALK_MAX_DEPTH:
+        return ""
+    for key in _DEPLOYMENT_ID_KEYS:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    for nest in _VERSION_NESTS:
+        inner = payload.get(nest)
+        if isinstance(inner, dict):
+            found = deployment_id_from_info(inner, _depth + 1)
+            if found:
+                return found
+    return ""
+
+
+def read_deployment_status(client: TenantClient, deployment_id: str) -> str:
+    """Return LM's terminal verdict for one deployment, or "" when unreadable.
+
+    A single read, not a poll: every caller here is asking about a deployment
+    that already reached a terminal state, so there is nothing to wait for.
+    :func:`_poll_deployment` remains the one that waits.
+    """
+    if not deployment_id:
+        return ""
+    try:
+        response = client.get(
+            DEPLOYMENT_PATH.format(deployment_id=path_segment(deployment_id))
+        )
+    except TenantApiError as exc:
+        print(f"::warning::deployment status read failed for {deployment_id}: {exc}")
+        return ""
+    if not response.ok:
+        print(
+            f"::warning::deployment status read returned HTTP {response.status} "
+            f"for {deployment_id}"
+        )
+        return ""
+    return str(response.data().get("deployment_status") or "")
 
 
 def _registered_source_repo(info: dict[str, object], _depth: int = 0) -> str:
@@ -1987,6 +2248,83 @@ def _tolerate_pod_churn(
     return reason
 
 
+def _converged_outcome(
+    read_client: TenantClient,
+    app_id: str,
+    version: str,
+    info: dict[str, object],
+    current: str,
+) -> InstallOutcome:
+    """The no-op path: LM's install record already names the version under test.
+
+    This is the path FND-1684 was about. Returning here on the record alone made
+    the version check read its own input — ``verify`` read the same record
+    ``install`` had just skipped on — so once the record existed for a connector
+    SHA, every later run on that SHA skipped the install AND passed the verify,
+    whatever the cluster was actually running. Two openapi runs 24 minutes apart
+    did exactly that, and neither run's image ever reached the tenant.
+
+    It still skips. Re-publishing and re-installing would land in LM's "App
+    already installed" branch, which starts no deployment, so forcing it through
+    would establish nothing new at real cost. What changes is that the skip is
+    now **corroborated where it can be**, and the outcome says which layer did
+    it, so a skip resting on the record alone is reported as exactly that rather
+    than as a verification.
+    """
+    pod = read_pod_build_identity(read_client)
+    if pod.reachable and pod.build_id and pod.build_id != version:
+        raise TenantAppError(
+            f"LM's install record says {app_id} is at {version}, but the running "
+            f"pod reports build {pod.build_id}. The record is written at install "
+            "time and never revisited, so it can name a version the cluster "
+            "never reconciled to; the pod cannot. Failing here rather than "
+            "letting the legs test a version this tenant does not serve."
+        )
+
+    deployment_id = deployment_id_from_info(info)
+    status = read_deployment_status(read_client, deployment_id)
+
+    if pod.reachable and pod.build_id == version:
+        layer = LAYER_POD
+        print(
+            f"tenant already runs {app_id} at {version} — nothing to do "
+            "(confirmed by the pod's own build identity)"
+        )
+    elif status == _SUCCEEDED:
+        layer = LAYER_DEPLOYMENT
+        print(
+            f"tenant already runs {app_id} at {version} — nothing to do "
+            f"(LM's deployment {deployment_id} reports {status}; the pod could "
+            "not be asked)"
+        )
+        print(f"::warning::{_unreadable_pod_hint(pod)}")
+    else:
+        layer = LAYER_INSTALL_RECORD
+        deployment_note = (
+            f" LM's deployment {deployment_id} reports {status or '<unreadable>'}."
+            if deployment_id
+            else " No deployment id is exposed in the app info payload, so the "
+            "deployment layer could not be consulted either."
+        )
+        print(
+            f"::warning::skipping the install for {app_id} at {version} on the "
+            "strength of LM's install record ALONE. Neither the pod nor a "
+            "SUCCEEDED deployment record corroborates it, so this run has NOT "
+            "established that the tenant serves the version under test. "
+            f"{_unreadable_pod_hint(pod)}{deployment_note}"
+        )
+
+    return InstallOutcome(
+        version=version,
+        installed_version=current,
+        skipped=True,
+        deployment_id=deployment_id,
+        deployment_status=status,
+        pod_build_id=pod.build_id,
+        verified_layer=layer,
+    )
+
+
 def install(args: argparse.Namespace) -> InstallOutcome:
     """Register + install + wait, converging by version."""
     # app_id is a free-text workflow input that lands in request paths; the
@@ -2009,10 +2347,7 @@ def install(args: argparse.Namespace) -> InstallOutcome:
     # instead of taking the no-op path.
     current = _extract_version(info) or resolve_version_via_catalog(info)
     if current and current == args.version:
-        print(f"tenant already runs {app_id} at {args.version} — nothing to do")
-        return InstallOutcome(
-            version=args.version, installed_version=current, skipped=True
-        )
+        return _converged_outcome(read_client, app_id, args.version, info, current)
     if current:
         print(f"tenant runs {current}; installing {args.version}")
     else:
@@ -2097,11 +2432,18 @@ def install(args: argparse.Namespace) -> InstallOutcome:
     # authority anyway.
     foreign: list[str] = []
     churn = ""
+    #: LM's own terminal verdict, recorded rather than inferred: the two
+    #: tolerance paths below carry on past a FAILED one, and reporting that as
+    #: SUCCEEDED in the outcome would put back exactly the kind of
+    #: pass-shaped-record FND-1684 is about.
+    deploy_verdict = ""
     if deployment_id:
         print(f"install accepted, deployment_id={deployment_id}")
         try:
             _poll_deployment(read_client, deployment_id, args.timeout_seconds)
+            deploy_verdict = _SUCCEEDED
         except DeploymentFailed as exc:
+            deploy_verdict = _FAILED
             diagnostics = _dump_failure(read_client, app_id)
             foreign = foreign_failure(diagnostics, args.image)
             if foreign:
@@ -2195,6 +2537,32 @@ def install(args: argparse.Namespace) -> InstallOutcome:
             f"{', '.join(foreign)}, not this install. Those pods should still be "
             "cleaned up — they will fail this check on every future install."
         )
+
+    # Ask the pod itself (FND-1684). This is the last thing the install does and
+    # the strongest thing it can establish: everything above it — LM's install
+    # record, LM's deployment verdict — is written by the install and never
+    # revisited, and LM reporting SUCCEEDED while nothing moves is a known shape
+    # (DISTR-921). A disagreement here is fatal, because the whole purpose of
+    # this job is to leave the tenant serving the version under test.
+    pod = read_pod_build_identity(read_client)
+    if pod.reachable and pod.build_id and pod.build_id != args.version:
+        raise TenantAppError(
+            f"the tenant's install record and deployment both report "
+            f"{args.version}, but the running pod reports build {pod.build_id}. "
+            "The deployment did not reconcile onto the pod serving traffic, so "
+            "the legs would test whatever that pod runs. Nothing above this "
+            "could have caught it: both records are written by the install and "
+            "never revisited."
+        )
+    if pod.reachable and pod.build_id == args.version:
+        pod_layer = LAYER_POD
+        print(f"pod reports build {pod.build_id} — it is running this image")
+    else:
+        pod_layer = (
+            LAYER_DEPLOYMENT if deploy_verdict == _SUCCEEDED else LAYER_INSTALL_RECORD
+        )
+        print(f"::warning::{_unreadable_pod_hint(pod)}")
+
     return InstallOutcome(
         version=args.version,
         version_id=version_id,
@@ -2202,41 +2570,115 @@ def install(args: argparse.Namespace) -> InstallOutcome:
         deployment_id=deployment_id,
         installed_version=installed,
         release_status=status,
+        deployment_status=deploy_verdict,
+        pod_build_id=pod.build_id,
+        verified_layer=pod_layer,
     )
 
 
 def verify(args: argparse.Namespace) -> str:
-    """Assert the tenant runs ``--expected``. Returns the installed version."""
+    """Assert the tenant runs ``--expected``. Returns the installed version.
+
+    Reads three layers, strongest first, and says which one decided (FND-1684).
+    It used to read exactly one — LM's install record — which is the record
+    ``install`` writes and then skips on, so the check was reading its own
+    input: a tenant whose pods had not moved in weeks passed it, minutes before
+    a pod-derived check failed on the same tenant.
+
+    ``pod``
+        ``/api/service/configmaps/atlan-build-identity``, which Heracles proxies
+        to the app pod's own handler. The image under test is stamped with its
+        tag at build time, so a matching answer here is proof the pod serving
+        traffic IS the build under test. **Decides on its own, both ways.**
+    ``deployment``
+        LM's ``deployment_status``. Consulted only when the pod could not
+        answer, and never on its own evidence: LM reporting SUCCEEDED while
+        nothing moves is a known shape (DISTR-921).
+    ``install-record``
+        The version LM says is installed. The weakest layer and the one that was
+        being reported as a verification; it is still checked, because a
+        disagreement here is real, but a pass at this layer alone now says so.
+    """
     # See install(): resolve from atlan.yaml first, then validate the result.
     app_id = validate_app_id(resolve_app_id(args.app_id))
     base_url = validate_tenant_base_url(args.base_url)
     _, read_client = _clients(base_url)
-    installed = _installed_version(read_client, app_id)
-    if installed != args.expected:
-        # Two different situations, and the message has to distinguish them or
-        # the reader chases the wrong one. An empty read means the tenant could
-        # not tell us what it runs — which is NOT the same as running the wrong
-        # thing, and LM reports it for a perfectly reconciled install whenever
-        # Atlas has no `atlanAppCurrentVersion` attribute (see
-        # _PLACEHOLDER_VERSIONS). The shape dump above says which.
-        cause = (
-            "the tenant did not report a version at all — see the info dump "
-            "above. LM falls back to a placeholder when Atlas carries no "
-            "`atlanAppCurrentVersion` attribute, so this can happen after a "
-            "deployment that reconciled fine; it means the version is "
-            "unverifiable here, not that the wrong one is installed."
-            if not installed
-            else "A concurrent e2e run against this tenant, or a manual deploy, "
-            "is the usual cause."
+
+    pod = read_pod_build_identity(read_client)
+    if pod.reachable and pod.build_id:
+        if pod.build_id != args.expected:
+            raise TenantAppError(
+                f"the app pod on this tenant reports build {pod.build_id}, but "
+                f"this leg tests {args.expected}. Read from the pod itself "
+                f"(/api/service/configmaps/{BUILD_IDENTITY_CONFIGMAP_ID}), not "
+                "from a marketplace record, so this is what the cluster is "
+                "actually serving: the deployment did not reach the pod, or a "
+                "concurrent run replaced it. Heracles fetches the DAG from the "
+                "deployed pod at AE submit, so continuing would test that build "
+                "rather than this one."
+            )
+        print(
+            f"verified at the POD layer: the app pod reports build "
+            f"{pod.build_id}, which is the version under test"
         )
-        raise TenantAppError(
-            f"tenant is running {installed or '<nothing / unreported>'} for app "
-            f"{app_id}, but this leg tests {args.expected}. Heracles fetches "
-            "the DAG from the deployed pod at AE submit, so continuing would "
-            f"test a different version than the one under test. {cause}"
+        return pod.build_id
+
+    # The pod could not answer. Everything below reads marketplace records,
+    # which are written by the install and never revisited — so a pass here is
+    # weaker than it looks, and the log has to say so rather than printing the
+    # bare "verified" that hid this for as long as it did.
+    print(f"::warning::{_unreadable_pod_hint(pod)}")
+
+    installed, info = _read_install_record(read_client, app_id)
+    if installed and installed == args.expected:
+        deployment_id = deployment_id_from_info(info)
+        status = read_deployment_status(read_client, deployment_id)
+        if deployment_id and status and status != _SUCCEEDED:
+            raise TenantAppError(
+                f"LM's install record names {installed}, but its deployment "
+                f"{deployment_id} reports {status} rather than {_SUCCEEDED}. The "
+                "install record is written before the deployment reconciles, so "
+                "it can name a version the cluster never reached."
+            )
+        layer = LAYER_DEPLOYMENT if status == _SUCCEEDED else LAYER_INSTALL_RECORD
+        checked = (
+            f"LM's install record AND deployment {deployment_id} ({status})"
+            if layer == LAYER_DEPLOYMENT
+            else "LM's install record ALONE"
         )
-    print(f"verified: tenant runs {installed}")
-    return installed
+        print(
+            f"verified at the {layer.upper()} layer: {checked} name "
+            f"{installed}. The pod itself was NOT asked, so this does not "
+            "establish that the cluster reconciled onto it — see the warning "
+            "above."
+        )
+        return installed
+
+    # Reached only when the install record disagrees: the matching case returned
+    # above, at whichever layer established it.
+    #
+    # Two different situations, and the message has to distinguish them or the
+    # reader chases the wrong one. An empty read means the tenant could not tell
+    # us what it runs — which is NOT the same as running the wrong thing, and LM
+    # reports it for a perfectly reconciled install whenever Atlas has no
+    # `atlanAppCurrentVersion` attribute (see _PLACEHOLDER_VERSIONS). The shape
+    # dump above says which.
+    cause = (
+        "the tenant did not report a version at all — see the info dump "
+        "above. LM falls back to a placeholder when Atlas carries no "
+        "`atlanAppCurrentVersion` attribute, so this can happen after a "
+        "deployment that reconciled fine; it means the version is "
+        "unverifiable here, not that the wrong one is installed."
+        if not installed
+        else "A concurrent e2e run against this tenant, or a manual deploy, "
+        "is the usual cause."
+    )
+    raise TenantAppError(
+        f"tenant is running {installed or '<nothing / unreported>'} for app "
+        f"{app_id}, but this leg tests {args.expected}. Heracles fetches "
+        "the DAG from the deployed pod at AE submit, so continuing would "
+        f"test a different version than the one under test. {cause}"
+    )
 
 
 def _write_outputs(outputs: dict[str, str]) -> None:

--- a/.github/scripts/stamp_build_identity.py
+++ b/.github/scripts/stamp_build_identity.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Make a connector Dockerfile carry the build identity CI is about to give it.
+
+FND-1684. The e2e version check used to read its own input: ``install`` skipped
+when the marketplace install record already named the expected version, and
+``verify`` then read the same record. A tenant whose pods had not moved in weeks
+passed the check that exists to catch exactly that.
+
+The only fully-truthful answer is one the **pod itself** emits, and nothing
+committed to an app repo can carry it: the identity CI compares against is the
+image tag (``sdr-test-<commit8>[-<digest8>]``, see ``derive_e2e_image_tag.py``),
+minted *after* every committed artifact exists. So it has to enter at image build
+time, as a ``--build-arg``.
+
+Why this rewrites the Dockerfile
+--------------------------------
+A ``--build-arg`` is not an image ``ENV``. BuildKit ignores a build-arg the
+Dockerfile does not ``ARG``, and an ``ARG`` is not inherited across ``FROM`` — so
+declaring it in the SDK's base image does nothing for a connector built on top of
+it. Promoting the value to an ``ENV`` the running container can read takes two
+lines in the connector's *own* Dockerfile.
+
+Adding those two lines to every connector repo would mean a PR per repo, each one
+landing at its own pace, with the check silently degraded everywhere it had not
+landed yet. Appending them here — to the runner's ephemeral checkout, at the
+moment of build, from the action every connector already calls at ``@main`` —
+makes the stamp arrive on the same day for the whole fleet with no per-app
+change. Nothing is written back to any repo.
+
+Where the lines land
+--------------------
+Appended at the end of the file, which is the final stage of a multi-stage build
+and therefore the stage that becomes the image. (``build-app-image`` never passes
+``--target``, so "last stage" and "the image" are the same thing here. The check
+below refuses a Dockerfile using ``--target``-only conventions it cannot reason
+about — see :func:`_final_stage_is_last`.)
+
+Appending also keeps the layer cache intact: every earlier layer is unchanged, so
+a stamp that differs per commit invalidates only the trailing ``ENV`` layer.
+
+Idempotent: a Dockerfile that already declares the ARG (because a connector added
+it by hand, or because this ran twice) is left alone.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+#: The build-arg / env-var name. Must match
+#: ``application_sdk.app.build_identity.BUILD_ID_ENV``; the SDK side is the
+#: reader and this is the writer, and a divergent spelling here degrades the
+#: check to "the pod reports no build identity" rather than failing loudly — so
+#: the wiring test asserts the two agree.
+BUILD_ID_ARG = "ATLAN_BUILD_ID"
+
+_MARKER = "# --- build identity (application-sdk build-app-image, FND-1684) ---"
+
+STANZA = f"""
+{_MARKER}
+# Appended by CI, never committed. Promotes the --build-arg to an image ENV so
+# the running pod can report which build it is. Empty for any build that does not
+# pass it, which every reader treats as "this image carries no build identity".
+ARG {BUILD_ID_ARG}=""
+ENV {BUILD_ID_ARG}=${BUILD_ID_ARG}
+"""
+
+#: A ``FROM`` line, for the multi-stage sanity check below. Deliberately loose:
+#: it only has to count stages and spot ``AS <name>``, not parse a Dockerfile.
+_FROM_RE = re.compile(r"^\s*FROM\s+\S+(?:\s+AS\s+(?P<name>\S+))?\s*$", re.IGNORECASE)
+
+#: An existing declaration of the arg, in any of the spellings a hand-written
+#: Dockerfile might use (``ARG ATLAN_BUILD_ID``, with or without a default).
+_ALREADY_RE = re.compile(rf"^\s*ARG\s+{BUILD_ID_ARG}\b", re.MULTILINE)
+
+
+class StampError(RuntimeError):
+    """The Dockerfile could not be stamped."""
+
+
+def _final_stage_is_last(text: str) -> bool:
+    """True when appending to the end of *text* lands in the image's final stage.
+
+    Which is the case for every shape ``build-app-image`` builds: it runs
+    ``docker buildx build .`` with no ``--target``, and BuildKit then builds the
+    LAST stage in the file. A single-stage Dockerfile trivially qualifies; so
+    does a multi-stage one, because the last ``FROM`` is still the target.
+
+    The one shape this cannot serve is a Dockerfile whose last stage is not the
+    one meant to ship — which only arises with ``--target``. Rather than guess,
+    this returns True whenever there is at least one ``FROM`` and lets the caller
+    refuse an empty file. Kept as a named function so the reasoning has somewhere
+    to live and the test has something to pin.
+    """
+    return any(_FROM_RE.match(line) for line in text.splitlines())
+
+
+def stamp(text: str) -> str:
+    """Return *text* with the build-identity stanza appended.
+
+    Returns it unchanged when the arg is already declared, so a connector that
+    adopts the two lines itself does not end up with them twice — and so running
+    this twice on one checkout is a no-op rather than a growing file.
+    """
+    if _ALREADY_RE.search(text):
+        return text
+    if not _final_stage_is_last(text):
+        raise StampError(
+            "the Dockerfile has no FROM instruction, so there is no stage to "
+            "stamp the build identity into. Refusing to append: an image built "
+            "from this would report no build identity, and the e2e version "
+            "check would silently fall back to reading the marketplace install "
+            "record — the circular check FND-1684 removed."
+        )
+    return text.rstrip("\n") + "\n" + STANZA
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dockerfile",
+        default="Dockerfile",
+        help="Path to the connector Dockerfile in the runner's checkout.",
+    )
+    args = parser.parse_args(argv)
+
+    path = Path(args.dockerfile)
+    if not path.is_file():
+        # Not this script's failure to report: the build step that follows dies
+        # on the same missing file with a clearer message. Say what was skipped
+        # so the absent stamp is not later read as a stale pod.
+        print(
+            f"::warning::{path} not found; the image will carry no build "
+            "identity and the e2e version check will fall back to the "
+            "marketplace install record (see FND-1684)."
+        )
+        return 0
+
+    original = path.read_text(encoding="utf-8")
+    try:
+        stamped = stamp(original)
+    except StampError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    if stamped == original:
+        print(f"{path} already declares {BUILD_ID_ARG}; leaving it unchanged")
+        return 0
+
+    path.write_text(stamped, encoding="utf-8")
+    print(f"stamped {BUILD_ID_ARG} into {path} (runner checkout only, not committed)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import builtins
+import json
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -20,6 +21,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import e2e_tenant_app as app  # noqa: E402
+import stamp_build_identity  # noqa: E402
 from e2e_tenant_api import Response, TenantApiError, TenantClient  # noqa: E402
 
 _TENANT = "https://example-tenant.atlan.test"
@@ -112,8 +114,44 @@ def _creds(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(app, "mint_oauth_token", lambda *_a, **_k: "stub.jwt.token")
 
 
+def _pod_identity(build_id: str, app_name: str = "openapi") -> Response:
+    """The envelope the app pod's configmap handler serves (FND-1684)."""
+    payload = {"build_id": build_id, "app_name": app_name}
+    return _ok(
+        {
+            "data": {
+                "kind": "ConfigMap",
+                "apiVersion": "v1",
+                "metadata": {"name": app.BUILD_IDENTITY_CONFIGMAP_ID},
+                "data": {"config": json.dumps(payload), **payload},
+            }
+        }
+    )
+
+
+#: The pod-unreachable answer every test gets unless it says otherwise.
+#:
+#: 404 rather than a match, deliberately: it is what a tenant running an SDK
+#: that predates the build-identity route returns, which is the whole fleet on
+#: the day this lands. Defaulting to it keeps each test below exercising the
+#: layer it was written for, and makes a test that wants the pod layer say so.
+_POD_UNREACHABLE = StubRoute(
+    "GET",
+    f"/configmaps/{app.BUILD_IDENTITY_CONFIGMAP_ID}",
+    Response(status=404, body={"detail": "not found"}),
+)
+
+
 def _wire(monkeypatch: pytest.MonkeyPatch, transport: StubTransport) -> StubTransport:
     monkeypatch.setattr(TenantClient, "request", transport.request)
+    # Appended, not prepended: a test that scripts its own build-identity route
+    # (sticky or one-shot) still wins, because StubTransport consumes `routes`
+    # before consulting `sticky` and scans `sticky` in order.
+    if not any(
+        _POD_UNREACHABLE.path_fragment in route.path_fragment
+        for route in (*transport.routes, *transport.sticky)
+    ):
+        transport.sticky.append(_POD_UNREACHABLE)
     return transport
 
 
@@ -508,7 +546,11 @@ class _PublishTimesOutThen:
 
 
 def test_publish_retries_a_transport_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
-    transport = _PublishTimesOutThen(inner=_publish_after(), failures=2)
+    # `_wire` on the INNER transport, for its default build-identity route only;
+    # the outer patch below is what TenantClient actually calls.
+    transport = _PublishTimesOutThen(
+        inner=_wire(monkeypatch, _publish_after()), failures=2
+    )
     monkeypatch.setattr(TenantClient, "request", transport.request)
     outcome = app.install(_install_args(publish_retry_seconds=240))
     assert outcome.deployment_id == "d1"
@@ -666,6 +708,305 @@ def test_verify_fails_when_nothing_is_installed(
     )
     with pytest.raises(app.TenantAppError, match="nothing"):
         app.verify(_verify_args(_VERSION))
+
+
+# ── The check must not read its own input (FND-1684) ─────────────────────────
+#
+# `install` skips when LM's install record already names the expected version,
+# and `verify` used to read the SAME record. Since the expected version is stable
+# per connector SHA, once that record existed every later run on that SHA skipped
+# the install AND passed the verify — permanently, whatever the cluster ran. Two
+# openapi runs 24 minutes apart did exactly that and neither image reached the
+# tenant.
+#
+# The tests below pin the three things that had to become true: the pod is asked
+# first and decides both ways, a skipped install is not reported as a verified
+# one, and the log names the layer that actually established the version.
+
+
+def test_verify_fails_when_the_pod_reports_a_different_build(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The install record can agree while the pod disagrees. The pod wins.
+
+    This is the FND-1683 tenant: LM's record named the version under test, and
+    the pods had not moved in 44 days. Under the old check that was a pass.
+    """
+    transport = _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[],
+            sticky=[
+                StubRoute(
+                    "GET",
+                    f"/configmaps/{app.BUILD_IDENTITY_CONFIGMAP_ID}",
+                    _pod_identity("sdr-test-44daysago"),
+                ),
+                # Agrees with `--expected`, which is precisely the trap.
+                StubRoute("GET", "/info", _ok({"version": _VERSION})),
+            ],
+        ),
+    )
+    with pytest.raises(app.TenantAppError) as excinfo:
+        app.verify(_verify_args(_VERSION))
+    message = str(excinfo.value)
+    assert "sdr-test-44daysago" in message and _VERSION in message
+    assert app.BUILD_IDENTITY_CONFIGMAP_ID in message, (
+        "the message has to say which layer answered, or the next reader goes "
+        "back to the marketplace record that agreed"
+    )
+    assert transport.paths("GET")[0].endswith(app.BUILD_IDENTITY_CONFIGMAP_ID), (
+        "the pod is asked FIRST: a record read that happens to agree must not be "
+        "able to short-circuit the one layer it cannot fake"
+    )
+
+
+def test_verify_passes_on_the_pod_layer_without_reading_the_record(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[],
+            sticky=[
+                StubRoute(
+                    "GET",
+                    f"/configmaps/{app.BUILD_IDENTITY_CONFIGMAP_ID}",
+                    _pod_identity(_VERSION),
+                )
+            ],
+        ),
+    )
+    assert app.verify(_verify_args(_VERSION)) == _VERSION
+    assert not [p for p in transport.paths("GET") if p.endswith("/info")], (
+        "a pod that reports the build under test settles it; reading the "
+        "install record as well could only weaken the answer"
+    )
+
+
+def test_verify_says_which_layer_decided(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A pass on the record alone must not print the word the pod earns.
+
+    The step used to print `verified: tenant runs X` after reading an install
+    record. That sentence is what let the defect survive review twice.
+    """
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[], sticky=[StubRoute("GET", "/info", _ok({"version": _VERSION}))]
+        ),
+    )
+    assert app.verify(_verify_args(_VERSION)) == _VERSION
+    out = capsys.readouterr().out
+    assert app.LAYER_INSTALL_RECORD.upper() in out
+    assert "The pod itself was NOT asked" in out
+
+
+def test_verify_fails_when_the_deployment_never_reconciled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LM writes the install record before the deployment reconciles.
+
+    So a record naming the right version, beside a deployment that FAILED, is
+    not a pass — and the deployment record is a layer `verify` did not consult
+    at all before this.
+    """
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[],
+            sticky=[
+                StubRoute(
+                    "GET",
+                    "/info",
+                    _ok({"installed": {"version": _VERSION, "deployment_id": "d9"}}),
+                ),
+                StubRoute(
+                    "GET",
+                    "/deployments/d9",
+                    _ok({"deployment_status": "FAILED"}),
+                ),
+            ],
+        ),
+    )
+    with pytest.raises(app.TenantAppError) as excinfo:
+        app.verify(_verify_args(_VERSION))
+    assert "FAILED" in str(excinfo.value) and "d9" in str(excinfo.value)
+
+
+def test_a_skipped_install_reports_the_layer_it_rested_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The converge path is where the circularity started."""
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[], sticky=[StubRoute("GET", "/info", _ok({"version": _VERSION}))]
+        ),
+    )
+    outcome = app.install(_install_args())
+    assert outcome.skipped is True
+    assert outcome.verified_layer == app.LAYER_INSTALL_RECORD, (
+        "no pod answer and no deployment record means nothing corroborated the "
+        "install record, and the outcome has to say so"
+    )
+    assert outcome.as_outputs()["verified_layer"] == app.LAYER_INSTALL_RECORD
+
+
+def test_a_skipped_install_is_corroborated_by_the_pod(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[],
+            sticky=[
+                StubRoute("GET", "/info", _ok({"version": _VERSION})),
+                StubRoute(
+                    "GET",
+                    f"/configmaps/{app.BUILD_IDENTITY_CONFIGMAP_ID}",
+                    _pod_identity(_VERSION),
+                ),
+            ],
+        ),
+    )
+    outcome = app.install(_install_args())
+    assert outcome.skipped is True
+    assert outcome.verified_layer == app.LAYER_POD
+    assert outcome.pod_build_id == _VERSION
+
+
+def test_a_skip_is_refused_when_the_pod_contradicts_the_record(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[],
+            sticky=[
+                StubRoute("GET", "/info", _ok({"version": _VERSION})),
+                StubRoute(
+                    "GET",
+                    f"/configmaps/{app.BUILD_IDENTITY_CONFIGMAP_ID}",
+                    _pod_identity("sdr-test-stale111"),
+                ),
+            ],
+        ),
+    )
+    with pytest.raises(app.TenantAppError, match="sdr-test-stale111"):
+        app.install(_install_args())
+
+
+def test_install_fails_when_the_pod_never_took_the_new_build(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both records can report success while the pod serving traffic does not.
+
+    LM reporting SUCCEEDED without anything moving is a known shape (DISTR-921),
+    so the deployment verdict cannot be the last word either.
+    """
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(status=404, body={})),
+                StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+                StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+                StubRoute(
+                    "GET", "/deployments/d1", _ok({"deployment_status": "SUCCEEDED"})
+                ),
+                StubRoute("GET", "/info", _ok({"version": _VERSION})),
+            ],
+            sticky=[
+                StubRoute("GET", "/releases/", Response(status=404, body={})),
+                StubRoute(
+                    "GET",
+                    f"/configmaps/{app.BUILD_IDENTITY_CONFIGMAP_ID}",
+                    _pod_identity("sdr-test-previous"),
+                ),
+            ],
+        ),
+    )
+    with pytest.raises(app.TenantAppError) as excinfo:
+        app.install(_install_args())
+    assert "sdr-test-previous" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param({"deployment_id": "d1"}, id="top-level"),
+        pytest.param({"installed": {"deployment_id": "d1"}}, id="installed-nest"),
+        pytest.param({"data": {"deploymentId": "d1"}}, id="camel-in-data"),
+    ],
+)
+def test_deployment_id_is_found_wherever_lm_puts_it(payload: dict[str, object]) -> None:
+    """LM does not commit to a shape, so the walk reads whichever key is there."""
+    assert app.deployment_id_from_info(payload) == "d1"
+
+
+def test_no_deployment_id_is_a_stated_outcome_not_a_crash() -> None:
+    assert app.deployment_id_from_info({"installed": {"version": _VERSION}}) == ""
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        pytest.param(
+            {"data": {"data": {"build_id": "t1", "app_name": "openapi"}}},
+            "t1",
+            id="flattened-keys",
+        ),
+        pytest.param(
+            {"data": {"data": {"config": '{"build_id": "t2"}'}}},
+            "t2",
+            id="config-string-only",
+        ),
+        pytest.param(
+            {"data": {"data": {"config": "not json"}}}, "", id="unparseable-config"
+        ),
+        pytest.param({"data": {"data": {}}}, "", id="unstamped-image"),
+    ],
+)
+def test_pod_identity_is_read_from_either_half_of_the_envelope(
+    body: dict[str, object], expected: str
+) -> None:
+    """`data.config` is a JSON string and the keys are repeated beside it.
+
+    Both are read so neither a client that forwards only `config` nor one that
+    flattens it can make a reachable pod look unreachable — which would silently
+    demote the check to the record layer it exists to stop trusting.
+    """
+    identity = app.parse_pod_identity(body["data"])  # type: ignore[arg-type]
+    assert identity.reachable is True
+    assert identity.build_id == expected
+
+
+def test_an_unreachable_pod_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A transport fault here must not red a leg for a diagnostic it can skip."""
+
+    def _boom(*_a: object, **_k: object) -> Response:
+        raise TenantApiError("connection refused")
+
+    monkeypatch.setattr(TenantClient, "request", _boom)
+    identity = app.read_pod_build_identity(TenantClient(base_url=_TENANT, bearer="t"))
+    assert identity.reachable is False
+    assert "connection refused" in identity.detail
+
+
+def test_build_identity_ids_agree() -> None:
+    """One spelling on both sides of the wire, or the check silently degrades.
+
+    A rename on either side would not fail: the pod would 404 and `verify` would
+    fall back to the marketplace records with a warning. That is the failure mode
+    this whole change removes, so it gets a test rather than a comment.
+    """
+    root = Path(__file__).resolve().parents[3]
+    sdk = (root / "application_sdk" / "app" / "build_identity.py").read_text()
+    assert f'BUILD_IDENTITY_CONFIGMAP_ID = "{app.BUILD_IDENTITY_CONFIGMAP_ID}"' in sdk
+    assert f'BUILD_ID_ENV = "{stamp_build_identity.BUILD_ID_ARG}"' in sdk
 
 
 # ── app_id resolution ────────────────────────────────────────────────────────

--- a/.github/scripts/tests/test_stamp_build_identity.py
+++ b/.github/scripts/tests/test_stamp_build_identity.py
@@ -1,0 +1,155 @@
+"""Tests for .github/scripts/stamp_build_identity.py (FND-1684).
+
+The stamp is what makes a pod able to say which build it is, and every failure
+mode of this script is silent: an unstamped image reports no build identity, and
+the e2e version check then falls back to the marketplace install record — the
+circular check this whole change removes. So the cases below are mostly about
+that silence, not about string formatting.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import stamp_build_identity as stamp  # noqa: E402
+
+_SINGLE_STAGE = """\
+# syntax=docker/dockerfile:1
+ARG BASE_IMAGE=registry.atlan.com/public/app-runtime-base:3
+FROM ${BASE_IMAGE}
+WORKDIR /app
+ENV ATLAN_APP_MODULE=app.connector:OpenAPIConnector
+"""
+
+_MULTI_STAGE = """\
+FROM python:3.13 AS builder
+RUN uv sync --locked
+FROM registry.atlan.com/public/app-runtime-base:3
+COPY --from=builder /app/.venv /app/.venv
+"""
+
+
+def _env_line(text: str) -> str:
+    match = re.search(rf"^ENV {stamp.BUILD_ID_ARG}=.*$", text, re.MULTILINE)
+    assert match, f"no ENV {stamp.BUILD_ID_ARG} line in:\n{text}"
+    return match.group(0)
+
+
+def test_the_stanza_declares_the_arg_and_promotes_it_to_an_env() -> None:
+    """A --build-arg alone is invisible at runtime.
+
+    BuildKit ignores a build-arg the Dockerfile does not ARG, and an ARG is not
+    an ENV — so without both lines the image builds cleanly, reports no build
+    identity, and the check degrades with nothing red anywhere.
+    """
+    stamped = stamp.stamp(_SINGLE_STAGE)
+    assert f"ARG {stamp.BUILD_ID_ARG}" in stamped
+    assert _env_line(stamped) == f"ENV {stamp.BUILD_ID_ARG}=${stamp.BUILD_ID_ARG}"
+
+
+def test_the_arg_defaults_to_empty_so_an_unstamped_build_still_builds() -> None:
+    """Local `docker build .` passes no build-arg, and must not break.
+
+    An ARG with no default is not an error either, but the explicit empty default
+    is what makes "this image carries no build identity" the documented value
+    rather than an implementation detail of BuildKit.
+    """
+    assert f'ARG {stamp.BUILD_ID_ARG}=""' in stamp.stamp(_SINGLE_STAGE)
+
+
+def test_the_stanza_lands_after_the_last_stage() -> None:
+    """`buildx build .` with no --target builds the LAST stage.
+
+    Appending inside the builder stage would put the ENV in a layer that is
+    thrown away, which is the same silent nothing as not stamping at all.
+    """
+    stamped = stamp.stamp(_MULTI_STAGE)
+    last_from = stamped.rindex("FROM ")
+    assert stamped.index(f"ENV {stamp.BUILD_ID_ARG}") > last_from
+
+
+def test_everything_above_the_stanza_is_byte_identical() -> None:
+    """The layer cache is the reason this appends rather than rewrites.
+
+    The stamp differs on every commit; touching any earlier line would
+    invalidate the ~2-minute `uv sync` layer on every single build.
+    """
+    stamped = stamp.stamp(_SINGLE_STAGE)
+    assert stamped.startswith(_SINGLE_STAGE.rstrip("\n"))
+
+
+def test_a_dockerfile_that_already_declares_the_arg_is_left_alone() -> None:
+    """A connector may adopt the two lines itself; it must not get them twice."""
+    adopted = _SINGLE_STAGE + f'ARG {stamp.BUILD_ID_ARG}=""\n'
+    assert stamp.stamp(adopted) == adopted
+
+
+def test_stamping_twice_is_a_no_op() -> None:
+    once = stamp.stamp(_SINGLE_STAGE)
+    assert stamp.stamp(once) == once
+
+
+def test_a_dockerfile_with_no_from_is_refused_rather_than_stamped() -> None:
+    """Nothing to stamp into, and a quiet success here reads as a stale pod later."""
+    with pytest.raises(stamp.StampError, match="no FROM instruction"):
+        stamp.stamp("# just a comment\n")
+
+
+def test_a_missing_dockerfile_warns_and_does_not_fail_the_build(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The build step that follows dies on the same file with a better message.
+
+    What this owes the log is the fact that no stamp was applied, so an absent
+    build identity downstream is not misread as a stale pod.
+    """
+    assert stamp.main(["--dockerfile", str(tmp_path / "Dockerfile")]) == 0
+    assert "::warning::" in capsys.readouterr().out
+
+
+def test_main_writes_the_stanza_in_place(tmp_path: Path) -> None:
+    path = tmp_path / "Dockerfile"
+    path.write_text(_SINGLE_STAGE, encoding="utf-8")
+    assert stamp.main(["--dockerfile", str(path)]) == 0
+    assert f"ENV {stamp.BUILD_ID_ARG}" in path.read_text(encoding="utf-8")
+
+
+def test_the_build_action_invokes_this_script_before_the_build() -> None:
+    """Order is load-bearing: buildx reads the Dockerfile as it finds it.
+
+    A step added after the build would leave every image unstamped while looking
+    entirely successful — the exact shape of failure this script exists inside.
+    """
+    action = (
+        Path(__file__).resolve().parents[1].parent
+        / "actions"
+        / "build-app-image"
+        / "action.yaml"
+    ).read_text(encoding="utf-8")
+    stamp_at = action.index("stamp_build_identity.py")
+    build_at = action.index("docker buildx build")
+    assert stamp_at < build_at
+    assert f'--build-arg "{stamp.BUILD_ID_ARG}=' in action
+
+
+def test_the_build_arg_carries_the_unsuffixed_tag() -> None:
+    """`tag-suffix` is per-architecture; the tenant pulls the merged manifest.
+
+    So stamping the suffixed reference would give amd64 and arm64 different
+    identities, and neither would equal what `verify --expected` compares
+    against — which is the un-suffixed tag, via merge-e2e-image's `version`
+    output.
+    """
+    action = (
+        Path(__file__).resolve().parents[1].parent
+        / "actions"
+        / "build-app-image"
+        / "action.yaml"
+    ).read_text(encoding="utf-8")
+    assert f'--build-arg "{stamp.BUILD_ID_ARG}=${{TAG}}"' in action

--- a/.github/workflows/e2e-tenant-install.yaml
+++ b/.github/workflows/e2e-tenant-install.yaml
@@ -286,6 +286,11 @@ jobs:
           SKIPPED: ${{ steps.install.outputs.skipped }}
           INSTALLED: ${{ steps.install.outputs.installed_version }}
           DEPLOYMENT_ID: ${{ steps.install.outputs.deployment_id }}
+          # FND-1684: which layer actually established the installed version.
+          # `install-record` means nothing corroborated LM's own record, so the
+          # run has NOT established that any pod moved.
+          LAYER: ${{ steps.install.outputs.verified_layer }}
+          POD_BUILD_ID: ${{ steps.install.outputs.pod_build_id }}
         run: |
           {
             echo "### E2E tenant install — ${CLOUD}"
@@ -299,4 +304,6 @@ jobs:
             echo "| Release status at install | \`${RELEASE_STATUS:-unreadable}\` |"
             echo "| Deployment | \`${DEPLOYMENT_ID:-none}\` |"
             echo "| Tenant reports installed | \`${INSTALLED:-unreported}\` |"
+            echo "| Established at layer | \`${LAYER:-unknown}\` |"
+            echo "| Pod reports build | \`${POD_BUILD_ID:-not reported}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -1838,6 +1838,13 @@ jobs:
           SKIPPED: ${{ steps.install.outputs.skipped }}
           RELEASE_STATUS: ${{ steps.install.outputs.release_status }}
           INSTALLED: ${{ steps.install.outputs.installed_version }}
+          # FND-1684: which layer actually established the installed version —
+          # `pod` (the running pod reported the build identity stamped into the
+          # image), `deployment` (LM's deployment verdict), or `install-record`
+          # (LM's install record alone, which is the record the install itself
+          # writes and so establishes nothing about any pod).
+          LAYER: ${{ steps.install.outputs.verified_layer }}
+          POD_BUILD_ID: ${{ steps.install.outputs.pod_build_id }}
           CLOUD: ${{ matrix.cloud || 'default' }}
         run: |
           {
@@ -1849,6 +1856,8 @@ jobs:
             echo "| Already current (no-op) | \`${SKIPPED:-unknown}\` |"
             echo "| Release status at install | \`${RELEASE_STATUS:-unreadable}\` |"
             echo "| Tenant reports installed | \`${INSTALLED:-unreported}\` |"
+            echo "| Established at layer | \`${LAYER:-unknown}\` |"
+            echo "| Pod reports build | \`${POD_BUILD_ID:-not reported}\` |"
           } >> "$GITHUB_STEP_SUMMARY"
 
   e2e:

--- a/application_sdk/app/_ep_registration.py
+++ b/application_sdk/app/_ep_registration.py
@@ -11,6 +11,7 @@ from dataclasses import replace
 from typing import TYPE_CHECKING, Any, get_type_hints
 
 from application_sdk.app._artifact_schema_guard import warn_undeclared_artifact_schemas
+from application_sdk.app.build_identity import build_identity
 from application_sdk.app.entrypoint import (
     EntryPointContractError,
     EntryPointMetadata,
@@ -287,6 +288,13 @@ def _apply_app_registration(
     cls._app_registered = True
     cls._app_name = name
     cls._app_version = version
+    # The base-level hook every app inherits with no per-app change (FND-1684).
+    # `version` above is the app's own declared semver, which is identical across
+    # every build of the same source; this is the identity of the IMAGE, stamped
+    # at build time, and it is the only thing a running pod can report that
+    # distinguishes the build under test from one shipped months ago. "" when the
+    # image carries no stamp — see application_sdk.app.build_identity.
+    cls._app_build_id = build_identity()
     cls._input_type = input_type
     cls._output_type = output_type
 

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -897,6 +897,12 @@ class App(ABC):
     # Set by registration
     _app_name: str
     _app_version: str
+    #: The image's build identity (FND-1684), or "" when the image carries no
+    #: stamp. A ClassVar with a default, unlike its two neighbours: those are
+    #: always written by registration, while this must read as "" on any App
+    #: subclass constructed without going through it (test doubles, and every
+    #: app registered by an SDK older than this attribute).
+    _app_build_id: ClassVar[str] = ""
     _app_metadata: AppMetadata
     _original_run: Callable[..., Any]
     _input_type: type[Input]
@@ -1166,6 +1172,16 @@ class App(ABC):
     def get_version(self) -> str:
         """Get the app version."""
         return self._app_version
+
+    def get_build_id(self) -> str:
+        """Get the build identity of the image this process runs from.
+
+        ``""`` when the image carries no stamp. NOT a substitute for
+        :meth:`get_version`: that is the app's declared semver and is the same
+        for every build of the same source, while this changes whenever the
+        image content does. See :mod:`application_sdk.app.build_identity`.
+        """
+        return self._app_build_id
 
     def now(self) -> datetime:
         """Get current time (safe for workflow replay).
@@ -2272,6 +2288,10 @@ def generate_workflow_class(
     output_type = ep.output_type
     app_name = app_cls._app_name
     app_version = app_cls._app_version
+    # Read once here, outside the workflow body: it is an image ENV, constant for
+    # the life of the process, and reading it inside _run would be a non-
+    # deterministic os.environ touch in the Temporal sandbox.
+    app_build_id = app_cls._app_build_id
 
     from application_sdk.execution._temporal.preflight_gate import (  # noqa: PLC0415 — boot-time (not in workflow sandbox); avoids a module-load cycle
         input_type_supports_gate,
@@ -2354,6 +2374,7 @@ def generate_workflow_class(
         context = AppContext(
             app_name=app_name,
             app_version=app_version,
+            build_id=app_build_id,
             run_id=run_id,
             workflow_id=workflow_id,
             correlation_id=correlation_id,

--- a/application_sdk/app/build_identity.py
+++ b/application_sdk/app/build_identity.py
@@ -1,0 +1,78 @@
+"""The build identity of the image this process is running from (FND-1684).
+
+Why this exists
+---------------
+Nothing an app could already report distinguishes *the image built by this CI
+run* from an image built months ago:
+
+* ``App._app_version`` / ``AppContext.app_version`` is a semver declared in the
+  app's own source (``@App(version=...)``). It is identical across every build
+  of that source, so it cannot tell one build from another.
+* The served manifest is ``{dag, execution_mode}`` — no version at all.
+* ``/api/service/configmaps/{name}`` serves committed files verbatim, and the
+  identity CI compares against (the image tag) is minted *after* every committed
+  artifact exists, so no contract or pkl-generated file can carry it.
+
+That gap is what let the e2e version check read its own input: ``install``
+skipped when the marketplace install record already named the expected version,
+and ``verify`` then read the same record. A tenant whose pods had not moved in
+weeks passed the check that exists to catch exactly that.
+
+So the build identity is stamped into the image at build time and read back out
+here. It is the one fact only a *running pod* can report, which is what makes it
+worth reading.
+
+The contract
+------------
+``ATLAN_BUILD_ID`` is set as an image ``ENV`` by whatever builds the image. In
+Atlan CI that is ``.github/actions/build-app-image`` in ``application-sdk``,
+which passes the image tag it just derived (``sdr-test-<commit8>[-<digest8>]``)
+as a ``--build-arg`` and stamps the connector Dockerfile to promote it to an
+``ENV`` — see ``.github/scripts/stamp_build_identity.py``.
+
+It is deliberately **not required**: an image built by hand, by a connector's own
+Dockerfile, or by an older CI simply reports ``""``. Every reader treats an empty
+value as "this image carries no build identity", never as a mismatch.
+
+Reading it
+----------
+Registration copies it onto the App class (``App._app_build_id``) and the
+execution layer copies it onto :class:`~application_sdk.app.context.AppContext`,
+so every app inherits it with no per-app change. The handler serves it on the
+already-proxied configmap route under :data:`BUILD_IDENTITY_CONFIGMAP_ID`, so
+reading it from outside the cluster needs no new Heracles rule.
+"""
+
+from __future__ import annotations
+
+import os
+
+__all__ = [
+    "BUILD_ID_ENV",
+    "BUILD_IDENTITY_CONFIGMAP_ID",
+    "build_identity",
+]
+
+#: Image ``ENV`` carrying the build identity. Stamped at image build time.
+BUILD_ID_ENV = "ATLAN_BUILD_ID"
+
+#: The configmap id the handler answers with the build identity.
+#:
+#: Reserved rather than derived: it must not collide with any generated
+#: ``*.json`` stem, and it must be stable across apps so one CI check can ask
+#: every app the same question. The ``atlan-`` prefix matches the marketplace's
+#: own configmap naming (``atlan-connectors-<source>``), and the handler answers
+#: it *before* the generated-file scan so an app that happens to ship a file of
+#: this name cannot shadow it.
+BUILD_IDENTITY_CONFIGMAP_ID = "atlan-build-identity"
+
+
+def build_identity() -> str:
+    """Return this image's build identity, or ``""`` when it carries none.
+
+    Read from the environment on every call rather than cached at import: the
+    value is an image ``ENV``, so in production it is constant, but tests and
+    local runs set it per-case and a module-level snapshot would freeze whichever
+    value happened to exist at first import.
+    """
+    return os.environ.get(BUILD_ID_ENV, "").strip()

--- a/application_sdk/app/context.py
+++ b/application_sdk/app/context.py
@@ -210,6 +210,16 @@ class AppContext:
 
     app_name: str
     app_version: str
+    #: The build identity of the image this process runs from, or "" when the
+    #: image carries no stamp (FND-1684).
+    #:
+    #: Distinct from ``app_version`` and not interchangeable with it:
+    #: ``app_version`` is the semver the app declares in its own source, so it is
+    #: identical across every build of that source; this changes whenever the
+    #: image content does, which is what makes it able to answer "is this pod
+    #: running the build under test?". Defaulted so no existing construction site
+    #: has to change. See :mod:`application_sdk.app.build_identity`.
+    build_id: str = ""
     run_id: str = field(default_factory=lambda: str(uuid4()))
     workflow_id: str = field(default=LOCAL_WORKFLOW_ID)
     correlation_id: str = field(default="")

--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -20,6 +20,7 @@ from uuid import uuid4
 from temporalio import activity
 
 from application_sdk._runtime.progress import ProgressTracker, bind_progress_tracker
+from application_sdk.app.build_identity import build_identity
 from application_sdk.app.registry import AppRegistry, TaskRegistry
 from application_sdk.app.task import TaskMetadata
 from application_sdk.constants import LOCAL_WORKFLOW_ID, TRACKED_FILE_REFS_KEY
@@ -319,6 +320,9 @@ def create_activity_from_task(
         app_context = AppContext(
             app_name=context.app_name,
             app_version=app_metadata.version,
+            # Activities run outside the workflow sandbox, so the image ENV is
+            # readable directly here (FND-1684).
+            build_id=build_identity(),
             run_id=run_id,
             workflow_id=context.workflow_id,
             correlation_id=correlation_id,

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -62,6 +62,10 @@ from application_sdk.app._generated_tree import (
     eligible_form_configmaps,
     names_entrypoint,
 )
+from application_sdk.app.build_identity import (
+    BUILD_IDENTITY_CONFIGMAP_ID,
+    build_identity,
+)
 from application_sdk.app.entrypoint import canonical_workflow_type
 from application_sdk.common.dispatch import resolve_dispatch_workflow_id
 from application_sdk.common.task_queue import (
@@ -1893,6 +1897,50 @@ def _register_workflow_routes(
 
     @app.get("/workflows/v1/configmap/{config_map_id}")
     async def get_configmap(config_map_id: str) -> JSONResponse:
+        # 0. The reserved build-identity id (FND-1684).
+        #
+        # Answered BEFORE the generated-file scan, deliberately: an app that
+        # happens to ship `atlan-build-identity.json` would otherwise shadow the
+        # one fact only a running pod can report — and it would shadow it with a
+        # committed file, which is exactly the class of answer that cannot tell
+        # this build apart from one shipped months ago.
+        #
+        # Served on THIS route rather than a new one because
+        # `/api/service/configmaps/{name}` is already proxied by Heracles. A new
+        # route would need a new proxy rule, in a repo the e2e fix does not
+        # otherwise touch, before CI could read any of this.
+        #
+        # `build_id` is "" for an image that carries no stamp. That is a valid
+        # answer, not an error: the reader has to distinguish "this pod reports a
+        # different build" from "this pod cannot report one", and a 404 here
+        # would collapse the second into "no such route".
+        if config_map_id == BUILD_IDENTITY_CONFIGMAP_ID:
+            identity: dict[str, Any] = {
+                "build_id": build_identity(),
+                "app_name": _workflow_config.app_name,
+            }
+            return JSONResponse(
+                content=_wrap_response(
+                    cast(
+                        "dict[str, Any]",
+                        {
+                            "kind": "ConfigMap",
+                            "apiVersion": "v1",
+                            "metadata": {"name": config_map_id},
+                            # Same envelope as a real configmap — `data.config`
+                            # is a JSON string — so a generic client needs no
+                            # special case here, with the parsed keys repeated
+                            # alongside it for one that does.
+                            "data": {
+                                "config": orjson.dumps(identity).decode(),
+                                **identity,
+                            },
+                        },
+                    ),
+                    message="Build identity fetched successfully",
+                )
+            )
+
         # 1. Direct match against any generated configmap file stem.
         #    The setup form normally requests the form file by its stem
         #    (e.g. "snowflake-crawler"), which lands here.

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.32.1
-source-sha:    d46dcabd4f14405fb9cbae177d986ce8ec9c4942
-source-date:   2026-09-05T15:43:36+01:00
+source-sha:    69577e76bdfcbcb33208f2ca6368679ecf805d3d
+source-date:   2026-09-05T23:24:30Z
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -18,7 +18,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 
 | Subpackage | Purpose | Exports |
 |---|---|---|
-| `application_sdk.app` | Core developer abstractions — App, @task, @entrypoint, Input, Output, RetryPolicy, mcp_tool | 43 |
+| `application_sdk.app` | Core developer abstractions — App, @task, @entrypoint, Input, Output, RetryPolicy, mcp_tool | 46 |
 | `application_sdk.clients` | Connection clients (SQL, Redis, Azure) and ClientInterface ABC | 12 |
 | `application_sdk.common` | Shared utilities — SQL filters, concurrency helpers, TaskStatistics, DataframeType | 27 |
 | `application_sdk.contracts` | Typed Pydantic Input/Output base classes, payload safety, storage and type helpers | 34 |
@@ -257,6 +257,13 @@ Core developer abstractions — App, @task, @entrypoint, Input, Output, RetryPol
 - **Summary:** Wrap @task methods on an instance to execute as Temporal activities.
 - **Defined in:** `application_sdk/app/base.py`
 
+#### `build_identity`
+
+- **Import:** `from application_sdk.app.build_identity import build_identity`
+- **Signature:** `build_identity() -> str`
+- **Summary:** Return this image's build identity, or ``""`` when it carries none.
+- **Defined in:** `application_sdk/app/build_identity.py`
+
 #### `canonical_workflow_type`
 
 - **Import:** `from application_sdk.app import canonical_workflow_type`
@@ -300,6 +307,20 @@ Core developer abstractions — App, @task, @entrypoint, Input, Output, RetryPol
 - **Signature:** `_app_state_lock`
 - **Summary:** _(no docstring)_
 - **Defined in:** `application_sdk/app/base.py`
+
+#### `BUILD_ID_ENV`
+
+- **Import:** `from application_sdk.app.build_identity import BUILD_ID_ENV`
+- **Signature:** `BUILD_ID_ENV`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/app/build_identity.py`
+
+#### `BUILD_IDENTITY_CONFIGMAP_ID`
+
+- **Import:** `from application_sdk.app.build_identity import BUILD_IDENTITY_CONFIGMAP_ID`
+- **Signature:** `BUILD_IDENTITY_CONFIGMAP_ID`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/app/build_identity.py`
 
 #### `InteractionUnfinishedPolicy`
 

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -731,6 +731,72 @@ side benefit.
 > tenant. With `install-app-to-tenant: false`, that is whatever was last
 > hand-deployed there.
 
+### Where the version check gets its answer from (FND-1684)
+
+`Verify the tenant runs the version under test` used to read exactly one thing:
+LM's marketplace install record, via `/apps/{id}/info`. That is the same record
+`install` writes — and the same record it *skips* on:
+
+```python
+if current and current == args.version:
+    return InstallOutcome(..., skipped=True)      # install
+...
+installed = _installed_version(read_client, app_id)  # verify: the same record
+```
+
+So the check was reading its own input. The expected version is stable per
+connector SHA (`sdr-test-<commit8>[-<digest8>]`, `derive_e2e_image_tag.py`), so
+once that record existed, every later run on that SHA skipped the install *and*
+passed the verify — permanently, whatever the cluster was running. Two openapi
+runs 24 minutes apart did exactly that; neither run's image ever reached the
+tenant, and the tenant was serving a 44-day-old app fleet at the time.
+
+**Three layers, strongest first.** `verify` now reads them in order and the step
+log names which one decided:
+
+| Layer | Read | What it establishes |
+|---|---|---|
+| `pod` | `GET /api/service/configmaps/atlan-build-identity` | The build the **running pod** reports. Decides on its own, both ways. |
+| `deployment` | `GET .../marketplace/apps/deployments/{id}` → `deployment_status` | LM reconciled *something*. Consulted only when the pod cannot answer, and never on its own: LM reporting SUCCEEDED while nothing moves is a known shape (DISTR-921). |
+| `install-record` | `GET .../marketplace/apps/{id}/info` | The weakest, and the one that was being printed as `verified:`. Still checked, but a pass here now says so. |
+
+The install reports the same field: `verified_layer` in `$GITHUB_OUTPUT` and in
+prepare-tenant's step summary, so a skipped install that rested on the record
+alone is visible without reading the log.
+
+**Where the pod's answer comes from.** Nothing an app already exposes could
+answer this. `App._app_version` / `AppContext.app_version` is a semver declared
+in the app's own source, identical across every build of it; the served manifest
+is `{dag, execution_mode}`; `/api/service/configmaps/{name}` serves committed
+files verbatim — and the identity CI compares against is the **image tag**,
+minted after every committed artifact exists. So it enters at image build time:
+
+1. `.github/actions/build-app-image` passes `--build-arg ATLAN_BUILD_ID=<tag>`,
+   the un-suffixed tag (`tag-suffix` is per-architecture and the tenant pulls the
+   merged manifest, so a suffixed value would make each arch report a different
+   identity).
+2. `.github/scripts/stamp_build_identity.py` appends `ARG` + `ENV` to the
+   connector's Dockerfile **in the runner's checkout only** — a build-arg is not
+   an ENV, and an ARG is not inherited across `FROM`, so the two lines have to be
+   in the connector's own file. Nothing is written back to any repo, and a
+   connector that adopts the lines itself is left alone.
+3. `application_sdk.app.build_identity` reads the ENV at app registration, so
+   every app inherits it with no per-app change (`App._app_build_id`,
+   `AppContext.build_id`).
+4. The handler answers the reserved id `atlan-build-identity` on the
+   already-proxied configmap route, *ahead* of the generated-file scan, so a
+   committed file cannot answer in the pod's place.
+
+**During the transition.** The stamp arrives fleet-wide with the action
+(`@main`), but the route is served by the **connector's own pinned SDK**. Until
+an app bumps, its pod 404s and `verify` falls back to the record layers with a
+warning naming what was and was not checked. That is deliberate: hard-failing on
+a 404 would red every connector still on an older pin, for a skew with nothing
+wrong in any app. The warning distinguishes the two causes as far as it honestly
+can — it says whether the SDK on the runner carries the route, while noting that
+`harness-sdk-ref` can pin the harness ahead of the runtime, so that is a lean,
+not proof.
+
 ### Asserting the executed DAG, not just the installed version (FND-129)
 
 The install path verifies the **version** on the tenant (`expected-app-version`,

--- a/tests/unit/app/test_build_identity.py
+++ b/tests/unit/app/test_build_identity.py
@@ -1,0 +1,140 @@
+"""Tests for application_sdk.app.build_identity (FND-1684).
+
+The build identity is the one fact a running pod can report that distinguishes
+the image built by a given CI run from an image built months ago. Everything
+else an app already exposes — the declared semver, the served manifest, the
+generated configmaps — is a function of committed source, so it is identical
+across every build of that source.
+
+The e2e version check used to have no such source to read, and read the
+marketplace install record instead: the same record the install writes and then
+skips on. A tenant whose pods had not moved in 44 days passed it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from application_sdk.app.build_identity import (
+    BUILD_ID_ENV,
+    BUILD_IDENTITY_CONFIGMAP_ID,
+    build_identity,
+)
+from application_sdk.contracts.base import Input, Output
+
+
+def test_build_identity_reads_the_image_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(BUILD_ID_ENV, "sdr-test-abc12345")
+    assert build_identity() == "sdr-test-abc12345"
+
+
+def test_an_unstamped_image_reports_empty_rather_than_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An image built by hand or by an older CI must still start.
+
+    The stamp is added by Atlan CI, not by any connector's own Dockerfile, so
+    "no build identity" is a normal state and every reader treats it as "cannot
+    answer", never as a mismatch.
+    """
+    monkeypatch.delenv(BUILD_ID_ENV, raising=False)
+    assert build_identity() == ""
+
+
+def test_whitespace_is_stripped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stamp is compared for exact equality against an image tag.
+
+    An ENV that picked up a trailing newline from a shell would otherwise turn
+    a correctly reconciled tenant into a loud version mismatch.
+    """
+    monkeypatch.setenv(BUILD_ID_ENV, "  sdr-test-abc12345\n")
+    assert build_identity() == "sdr-test-abc12345"
+
+
+def test_the_value_is_not_frozen_at_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Read per call, not cached.
+
+    In production the value is an image ENV and never changes, so a cache would
+    be safe there and misleading everywhere else — tests and local runs set it
+    per case, and a module-level snapshot would freeze whichever value happened
+    to exist at first import.
+    """
+    monkeypatch.setenv(BUILD_ID_ENV, "first")
+    assert build_identity() == "first"
+    monkeypatch.setenv(BUILD_ID_ENV, "second")
+    assert build_identity() == "second"
+
+
+@dataclass
+class _StampInput(Input):
+    value: str = ""
+
+
+@dataclass
+class _StampOutput(Output):
+    result: str = ""
+
+
+def test_registration_gives_every_app_the_build_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The base-level hook: no per-app change, and no per-app way to miss it."""
+    monkeypatch.setenv(BUILD_ID_ENV, "sdr-test-abc12345")
+
+    from application_sdk.app import App
+
+    class StampedApp(App):
+        async def run(self, input: _StampInput) -> _StampOutput:
+            return _StampOutput(result=input.value)
+
+    assert StampedApp._app_build_id == "sdr-test-abc12345"
+    assert StampedApp.get_build_id(StampedApp) == "sdr-test-abc12345"  # type: ignore[arg-type]
+
+
+def test_an_app_registered_without_a_stamp_reports_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(BUILD_ID_ENV, raising=False)
+
+    from application_sdk.app import App
+
+    class UnstampedApp(App):
+        async def run(self, input: _StampInput) -> _StampOutput:
+            return _StampOutput(result=input.value)
+
+    assert UnstampedApp._app_build_id == ""
+
+
+def test_app_context_carries_it_separately_from_app_version() -> None:
+    """They are not interchangeable, and conflating them is the original defect.
+
+    ``app_version`` is declared in the app's source, so it is the same for every
+    build of that source — which is exactly why it could not answer "is this pod
+    running the build under test?".
+    """
+    from application_sdk.app.context import AppContext
+
+    context = AppContext(
+        app_name="app", app_version="1.0.0", build_id="sdr-test-abc12345"
+    )
+    assert context.app_version == "1.0.0"
+    assert context.build_id == "sdr-test-abc12345"
+
+
+def test_app_context_build_id_defaults_to_empty() -> None:
+    """Defaulted so no existing construction site had to change."""
+    from application_sdk.app.context import AppContext
+
+    assert AppContext(app_name="app", app_version="1.0.0").build_id == ""
+
+
+def test_the_reserved_configmap_id_is_not_a_plausible_generated_stem() -> None:
+    """It is answered ahead of the generated-file scan, so it must not collide.
+
+    A generated artifact is named for its entrypoint or its connector; this is
+    named for the thing it reports, and carries the marketplace's own
+    ``atlan-`` prefix so it reads as a platform id rather than an app's file.
+    """
+    assert BUILD_IDENTITY_CONFIGMAP_ID == "atlan-build-identity"

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -2114,6 +2114,103 @@ class TestConfigMapEndpoints:
         finally:
             svc_module.CONTRACT_GENERATED_DIR = original
 
+    # ── Build identity (FND-1684) ────────────────────────────────────────
+    #
+    # The e2e version check used to read LM's marketplace install record — the
+    # same record the install writes and then skips on — so a tenant whose pods
+    # had not moved in weeks passed the check that exists to catch exactly that.
+    # This route is the fix: it is the one answer only a RUNNING POD can give,
+    # and it rides the already-proxied configmap route so no new Heracles rule
+    # is needed.
+
+    def test_build_identity_is_served_from_the_image_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from application_sdk.app.build_identity import (
+            BUILD_ID_ENV,
+            BUILD_IDENTITY_CONFIGMAP_ID,
+        )
+        from application_sdk.handler import service as svc_module
+
+        monkeypatch.setenv(BUILD_ID_ENV, "sdr-test-abc12345")
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            client = _make_client()
+            response = client.get(
+                f"/workflows/v1/configmap/{BUILD_IDENTITY_CONFIGMAP_ID}"
+            )
+            assert response.status_code == 200
+            data = response.json()["data"]
+            assert data["metadata"]["name"] == BUILD_IDENTITY_CONFIGMAP_ID
+            # Both halves, because the CI reader accepts either: `data.config`
+            # is the envelope every other configmap uses, and the flattened
+            # keys spare a client that does not unwrap it.
+            assert data["data"]["build_id"] == "sdr-test-abc12345"
+            assert json.loads(data["data"]["config"])["build_id"] == (
+                "sdr-test-abc12345"
+            )
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
+    def test_build_identity_is_empty_not_404_for_an_unstamped_image(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ "No stamp" and "no such route" need opposite next steps.
+
+        A 404 would collapse an image built without the stamp into the same
+        answer as an SDK too old to serve the route, and the CI check decides
+        differently on each.
+        """
+        from application_sdk.app.build_identity import (
+            BUILD_ID_ENV,
+            BUILD_IDENTITY_CONFIGMAP_ID,
+        )
+        from application_sdk.handler import service as svc_module
+
+        monkeypatch.delenv(BUILD_ID_ENV, raising=False)
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            client = _make_client()
+            response = client.get(
+                f"/workflows/v1/configmap/{BUILD_IDENTITY_CONFIGMAP_ID}"
+            )
+            assert response.status_code == 200
+            assert response.json()["data"]["data"]["build_id"] == ""
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
+    def test_a_generated_file_cannot_shadow_the_build_identity(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The reserved id is answered before the generated-file scan.
+
+        A committed file cannot distinguish this build from one shipped months
+        ago, which is the whole reason this route exists — so an app that ships
+        a file of this name must not be able to answer in the pod's place.
+        """
+        from application_sdk.app.build_identity import (
+            BUILD_ID_ENV,
+            BUILD_IDENTITY_CONFIGMAP_ID,
+        )
+        from application_sdk.handler import service as svc_module
+
+        (tmp_path / f"{BUILD_IDENTITY_CONFIGMAP_ID}.json").write_text(
+            json.dumps({"config": {"build_id": "committed-lie"}})
+        )
+        monkeypatch.setenv(BUILD_ID_ENV, "sdr-test-abc12345")
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            client = _make_client()
+            response = client.get(
+                f"/workflows/v1/configmap/{BUILD_IDENTITY_CONFIGMAP_ID}"
+            )
+            assert response.json()["data"]["data"]["build_id"] == "sdr-test-abc12345"
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
     def test_configmap_returns_wrapped_k8s_shape(self, tmp_path: Path) -> None:
         from application_sdk.handler import service as svc_module
 


### PR DESCRIPTION
Closes FND-1684.

`Verify the tenant runs the version under test` read exactly one thing: LM's marketplace install record. That is the same record `install` writes — and the same record it **skips** on:

```python
# install()
if current and current == args.version:
    return InstallOutcome(..., skipped=True)

# verify()
installed = _installed_version(read_client, app_id)   # the same record
```

The expected version is stable per connector SHA (`sdr-test-<commit8>[-<digest8>]`), so once that record existed, every later run on that SHA skipped the install **and** passed the verify — permanently, whatever the cluster was running. Two openapi runs 24 minutes apart did exactly that. Neither run's image ever reached the tenant, and the tenant was serving a 44-day-old app fleet at the time (FND-1683); the verify passed on it minutes before the pod-derived setup-route check from FND-1680 failed on the same tenant.

While that check was broken, every e2e leg's result was worth less than it appeared.

## Tier 1 — three layers, and the log says which one decided

| Layer | Read | What it establishes |
|---|---|---|
| `pod` | `GET /api/service/configmaps/atlan-build-identity` | the build the **running pod** reports. Decides on its own, both ways. |
| `deployment` | `.../apps/deployments/{id}` → `deployment_status` | LM reconciled something. Consulted only when the pod cannot answer, and never on its own evidence: LM reporting SUCCEEDED while nothing moves is a known shape (DISTR-921). |
| `install-record` | `.../apps/{id}/info` | the weakest, and the one that was being printed as `verified:`. Still checked — a disagreement here is real — but a pass at this layer alone now says so. |

`InstallOutcome` gained `verified_layer`, `deployment_status` and `pod_build_id`, all written to `$GITHUB_OUTPUT` and surfaced in the step summaries of both `prepare-tenant` and the manual install workflow.

**Where the deployment id comes from.** Threading it from `install` to `verify` is not available — `prepare-tenant` is a matrix job over clouds whose outputs are last-writer-wins, and `expected-app-version` reaches the leg from `merge-e2e-image`, not from the install. So `verify` discovers it from the info payload with a depth-bounded walk. LM does not commit to exposing it, so an absent id is a stated outcome ("the deployment layer could not be consulted"), not a failure.

**A skipped install is still a skip.** Forcing a reinstall would land in LM's `App already installed` branch, which starts no deployment and reads back the same record — a full publish+install to establish nothing new. What changed is that the skip is corroborated where it can be and reported at the layer that did it. A pod contradicting the record now fails the install outright.

## Tier 2 — a signal the pod itself emits

Nothing an app already exposed could answer this. `App._app_version` / `AppContext.app_version` is a semver declared in the app's own source, identical across every build of it; the served manifest is `{dag, execution_mode}`; the configmap route serves committed files verbatim — and the identity CI compares against is the **image tag**, minted after every committed artifact exists. So it enters at image build time:

1. `build-app-image` passes `--build-arg ATLAN_BUILD_ID=${TAG}` — the **un-suffixed** tag. `tag-suffix` is per-architecture and the tenant pulls the merged manifest, so a suffixed value would give each arch a different identity and neither would equal what `verify --expected` compares against.
2. New `.github/scripts/stamp_build_identity.py` appends `ARG` + `ENV` to the connector Dockerfile **in the runner's ephemeral checkout only**. A `--build-arg` is not an image `ENV`, BuildKit ignores a build-arg the Dockerfile does not `ARG`, and an `ARG` is not inherited across `FROM` — so declaring it in the SDK base image does nothing for the connector built on top; the two lines have to be in the connector's own file. Doing it here rather than by a PR per repo means the stamp arrives fleet-wide on the day this merges. Nothing is written back to any repo, and it is idempotent, so a connector that adopts the lines itself is left alone.
3. `application_sdk/app/build_identity.py` reads the env at registration → `App._app_build_id`, `AppContext.build_id`. Base-level, no per-app change. Deliberately separate from `app_version`; conflating the two is the original defect.
4. The handler answers the reserved id `atlan-build-identity` on the **already-proxied** configmap route (no new Heracles rule), **ahead of** the generated-file scan — so an app shipping a file of that name cannot answer in the pod's place with the one class of answer that cannot distinguish builds. An unstamped image returns `build_id: ""` with HTTP 200 rather than a 404: "no stamp" and "no such route" need opposite next steps.

## The one thing this does not close, and why

The stamp rides the action at `@main`, but the route is served by the **connector's own pinned SDK**. Until an app bumps, its pod 404s and `verify` falls back to the record layers with a `::warning::` naming what was and was not checked.

That 404 is deliberately **not** fatal. Hard-failing would red every connector still on an older pin, for a skew with nothing wrong in any app. I looked for a sound way to tell "SDK too old" from "pod is not the build under test" and could not find one — the best available signal (does the runner's own synced SDK carry the module) is a lean, not proof, because `harness-sdk-ref` can pin the harness ahead of the runtime pin. The warning says exactly that and stops there.

So *a tenant whose pods did not move cannot produce a passing verify* holds for any app on a new-enough SDK, and closes for the rest as they bump. Worth a follow-up to flip the 404 to fatal once the fleet has moved.

## Verification

- `.github/scripts/tests`: **4215 passed** — 12 new cases in `test_e2e_tenant_app.py` plus a new `test_stamp_build_identity.py`
- `tests/unit`: **9946 passed**, 9 skipped
- pre-commit (ruff, ruff-format, actionlint, isort, pyright) clean
- capability manifest regenerated

The existing `test_e2e_tenant_app.py` suite gets a default "pod unreachable (404)" route, which is what the whole fleet returns on the day this lands — so each existing test keeps exercising the layer it was written for, and a test that wants the pod layer has to say so.

## Security-relevant notes for review

- `stamp_build_identity.py` mutates a file in the runner's checkout. It appends only, is idempotent, refuses a Dockerfile with no `FROM`, and writes nothing back to any repo.
- The new tenant read is a GET on an existing Heracles-proxied route using the credential the leg already holds. `read_pod_build_identity` never raises — a transport fault degrades to "pod unreachable" rather than reding a leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDY7uyqeJ3qmNn7Ho9phj8
