### PR TITLE
docs(testing): correct the build-identity evidence, keep the argument (FND-1683)

### DIFF
--- a/.github/actions/build-app-image/action.yaml
+++ b/.github/actions/build-app-image/action.yaml
@@ -208,8 +208,9 @@ runs:
     # Make the image able to say which build it is (FND-1684).
     #
     # `verify` in e2e_tenant_app.py used to read the marketplace install record —
-    # the same record `install` writes and then skips on — so a tenant whose pods
-    # had not moved in weeks passed the check that exists to catch exactly that.
+    # the same record `install` writes and then skips on — so once that record
+    # existed for a build the check could only agree with it, whatever the
+    # cluster was actually serving.
     # The only fully-truthful answer comes from the pod, and the identity CI
     # compares against (the image tag) is minted after every committed artifact
     # exists, so it has to enter at build time.

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -758,7 +758,7 @@ def read_pod_build_identity(client: TenantClient) -> PodIdentity:
     a 200 here comes from the POD rather than from a marketplace record. That is
     the whole point: the install record and the deployment record are both
     written by the install and never revisited, so a check that reads them can
-    pass on a tenant whose pods have not moved in weeks.
+    pass on a tenant the deployment never actually reached.
 
     Never raises. Every failure mode collapses to ``reachable=False`` carrying
     the reason, because the caller's decision is the same for all of them — fall
@@ -2261,8 +2261,9 @@ def _converged_outcome(
     the version check read its own input — ``verify`` read the same record
     ``install`` had just skipped on — so once the record existed for a connector
     SHA, every later run on that SHA skipped the install AND passed the verify,
-    whatever the cluster was actually running. Two openapi runs 24 minutes apart
-    did exactly that, and neither run's image ever reached the tenant.
+    whatever the cluster was actually running. One connector SHA can also resolve
+    to more than one image — the tag carries an optional digest suffix — so the
+    record can go on naming a build the tenant no longer runs.
 
     It still skips. Re-publishing and re-installing would land in LM's "App
     already installed" branch, which starts no deployment, so forcing it through
@@ -2582,8 +2583,8 @@ def verify(args: argparse.Namespace) -> str:
     Reads three layers, strongest first, and says which one decided (FND-1684).
     It used to read exactly one — LM's install record — which is the record
     ``install`` writes and then skips on, so the check was reading its own
-    input: a tenant whose pods had not moved in weeks passed it, minutes before
-    a pod-derived check failed on the same tenant.
+    input: once that record existed for a build it could only agree with itself,
+    whatever the cluster was serving.
 
     ``pod``
         ``/api/service/configmaps/atlan-build-identity``, which Heracles proxies

--- a/.github/scripts/stamp_build_identity.py
+++ b/.github/scripts/stamp_build_identity.py
@@ -3,8 +3,8 @@
 
 FND-1684. The e2e version check used to read its own input: ``install`` skipped
 when the marketplace install record already named the expected version, and
-``verify`` then read the same record. A tenant whose pods had not moved in weeks
-passed the check that exists to catch exactly that.
+``verify`` then read the same record. Once that record existed for a build, the
+check could only agree with it, whatever the cluster was actually serving.
 
 The only fully-truthful answer is one the **pod itself** emits, and nothing
 committed to an app repo can carry it: the identity CI compares against is the

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -715,9 +715,10 @@ def test_verify_fails_when_nothing_is_installed(
 # `install` skips when LM's install record already names the expected version,
 # and `verify` used to read the SAME record. Since the expected version is stable
 # per connector SHA, once that record existed every later run on that SHA skipped
-# the install AND passed the verify — permanently, whatever the cluster ran. Two
-# openapi runs 24 minutes apart did exactly that and neither image reached the
-# tenant.
+# the install AND passed the verify — permanently, whatever the cluster ran. One
+# connector SHA can also resolve to more than one image — the tag carries an
+# optional digest suffix — so the record can go on naming a build the tenant no
+# longer runs.
 #
 # The tests below pin the three things that had to become true: the pod is asked
 # first and decides both ways, a skipped install is not reported as a verified
@@ -729,8 +730,8 @@ def test_verify_fails_when_the_pod_reports_a_different_build(
 ) -> None:
     """The install record can agree while the pod disagrees. The pod wins.
 
-    This is the FND-1683 tenant: LM's record named the version under test, and
-    the pods had not moved in 44 days. Under the old check that was a pass.
+    LM's record names the version under test while the pod reports a different
+    build. Under the old check that was a pass.
     """
     transport = _wire(
         monkeypatch,

--- a/application_sdk/app/build_identity.py
+++ b/application_sdk/app/build_identity.py
@@ -15,8 +15,9 @@ run* from an image built months ago:
 
 That gap is what let the e2e version check read its own input: ``install``
 skipped when the marketplace install record already named the expected version,
-and ``verify`` then read the same record. A tenant whose pods had not moved in
-weeks passed the check that exists to catch exactly that.
+and ``verify`` then read the same record. Once that record existed for a build,
+the check could only agree with it — it established nothing about what the
+cluster was actually serving, which is the one thing it exists to establish.
 
 So the build identity is stamped into the image at build time and read back out
 here. It is the one fact only a *running pod* can report, which is what makes it

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -747,9 +747,9 @@ installed = _installed_version(read_client, app_id)  # verify: the same record
 So the check was reading its own input. The expected version is stable per
 connector SHA (`sdr-test-<commit8>[-<digest8>]`, `derive_e2e_image_tag.py`), so
 once that record existed, every later run on that SHA skipped the install *and*
-passed the verify — permanently, whatever the cluster was running. Two openapi
-runs 24 minutes apart did exactly that; neither run's image ever reached the
-tenant, and the tenant was serving a 44-day-old app fleet at the time.
+passed the verify — permanently, whatever the cluster was running. One connector
+SHA can also resolve to more than one image, since the tag carries an optional
+digest suffix, so the record can go on naming a build the tenant no longer runs.
 
 **Three layers, strongest first.** `verify` now reads them in order and the step
 log names which one decided:

--- a/tests/unit/app/test_build_identity.py
+++ b/tests/unit/app/test_build_identity.py
@@ -8,7 +8,8 @@ across every build of that source.
 
 The e2e version check used to have no such source to read, and read the
 marketplace install record instead: the same record the install writes and then
-skips on. A tenant whose pods had not moved in 44 days passed it.
+skips on. Once that record existed for a build, the check could only agree with
+it.
 """
 
 from __future__ import annotations

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -2117,8 +2117,9 @@ class TestConfigMapEndpoints:
     # ── Build identity (FND-1684) ────────────────────────────────────────
     #
     # The e2e version check used to read LM's marketplace install record — the
-    # same record the install writes and then skips on — so a tenant whose pods
-    # had not moved in weeks passed the check that exists to catch exactly that.
+    # same record the install writes and then skips on — so once that record
+    # existed for a build the check could only agree with it, whatever the
+    # cluster was actually serving.
     # This route is the fix: it is the one answer only a RUNNING POD can give,
     # and it rides the already-proxied configmap route so no new Heracles rule
     # is needed.


### PR DESCRIPTION
## What

Comments, docstrings and prose only. No behaviour change, no test-logic change.

FND-1684 shipped a real fix — `install` skips when LM's install record already names the expected version, and `verify` then read that same record, so once the record existed for a build the check could only agree with itself. That mechanism is untouched here, and so is the three-layer `pod` → `deployment` → `install record` resolution it introduced.

What this PR corrects is the **evidence** repeated alongside it in eight files. That evidence was gathered from a tenant that turned out not to be in the e2e rotation: it still serves an `e2e-aws-main`-style hostname, but has taken no e2e install since 2026-08-19/20. The tenant map it was identified from was recorded 2026-08-12 and had since changed, and was trusted without re-verification.

## The claims removed

```
"a tenant whose pods had not moved in weeks / in 44 days passed it"
"two openapi runs 24 minutes apart ... neither image reached the tenant"
```

Both false. The real e2e tenants take the per-run image on every leg; in the run that prompted the original investigation, all three cloud legs installed the identical tag within 11 seconds of each other.

## What replaces them

The read-after-own-write argument, which never depended on the anecdote: once the record exists for a build, the check can only agree with itself, whatever the cluster is serving.

Where a concrete mechanism helped the prose, the **verified** one is used instead: one connector SHA can resolve to more than one image, because the tag carries an optional digest suffix (`sdr-test-<commit8>[-<digest8>]`), so the record can go on naming a build the tenant no longer runs. That is observable on a live e2e tenant, which had both `sdr-test-<sha>` and `sdr-test-<sha>-<digest>` installed twelve hours apart on 2026-09-05.

## Files

| File | Sites |
|---|---|
| `application_sdk/app/build_identity.py` | 1 |
| `.github/scripts/stamp_build_identity.py` | 1 |
| `.github/scripts/e2e_tenant_app.py` | 3 |
| `.github/actions/build-app-image/action.yaml` | 1 |
| `.github/scripts/tests/test_e2e_tenant_app.py` | 2 |
| `tests/unit/app/test_build_identity.py` | 1 |
| `tests/unit/handler/test_service.py` | 1 |
| `docs/standards/connector-ci-e2e.md` | 1 |

## Verification

- `pre-commit` on all eight files: pass (ruff, ruff-format, isort, pyright, check-yaml)
- `pytest tests/unit/app/test_build_identity.py tests/unit/handler/test_service.py`: 363 passed
- `pytest .github/scripts/tests/test_e2e_tenant_app.py .github/scripts/tests/test_stamp_build_identity.py`: 240 passed

## Context

FND-1683 has been rewritten to record the correction and to carry the finding that is actually still open — an aws e2e leg serving underscored form field names where azure and gcp serve hyphenated, on the identical image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196vjavJni2H4Dmzjfih5mC
