### PR TITLE
ci(e2e): root-file check must read emitAtlanYaml/emitAppYaml (FND-1723)

### DIFF
--- a/.github/scripts/regenerate_contract.py
+++ b/.github/scripts/regenerate_contract.py
@@ -76,6 +76,14 @@ from pkl_contract_layout import (  # noqa: E402
 # renovate_pkl_sync.py.
 OUTPUT_PATHS = [GENERATED_DIR, *ROOT_FILES]
 
+# Toolkit properties that switch a root file's emission off. Setting one to
+# ``false`` is documented toolkit surface — ``contract-toolkit/src/App.pkl``
+# (``emitAtlanYaml``:217, ``emitAppYaml``:228), ``NativeAppBundle.pkl`` for
+# ``emitAtlanYaml``, and ``contract-toolkit/docs/reference.md`` — so a committed
+# copy of an opted-out file is hand-maintained, never an artifact the toolkit
+# lost. See ``opted_out_root_files``.
+ROOT_FILE_EMIT_FLAGS = {"atlan.yaml": "emitAtlanYaml", "app.yaml": "emitAppYaml"}
+
 # Matches the ``["app-contract-toolkit"]`` dependency entry in a consumer's
 # contract/PklProject, in either the block form
 #   ["app-contract-toolkit"] { uri = "package://...@x.y.z" }
@@ -90,6 +98,13 @@ def run(cmd: list[str], *, check: bool = False) -> subprocess.CompletedProcess:
     """Run a subprocess. Single seam so tests can stub pkl/uvx and let git run
     for real against a throwaway repo."""
     return subprocess.run(cmd, check=check, text=True)
+
+
+def run_capture(cmd: list[str]) -> subprocess.CompletedProcess:
+    """Run a subprocess and capture stdout. A second seam rather than a flag on
+    ``run`` because the emit-flag probe is the only caller that reads output —
+    ``run`` deliberately streams pkl's diagnostics straight into the job log."""
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
 
 
 def override_toolkit(contract_dir: str, toolkit_src: str) -> None:
@@ -140,16 +155,49 @@ def root_files_not_emitted(out_dir: Path) -> list[str]:
     """Root YAMLs the working tree carries that this eval did not emit.
 
     Not a broken tree — ``swap_outputs`` only ever copies root files, so the
-    committed one is still in place — but it does mean the contract (or the
+    committed one is still in place — but it *may* mean the contract (or the
     toolkit under test) stopped producing an artifact the app ships. Worth
     failing on in SDK-level mode: a later sdr-e2e step hard-errors on a missing
     root ``app.yaml``, resolves it *after* this step, and runs with check-drift
-    off, so nothing else would explain it. Informational in app-level mode."""
+    off, so nothing else would explain it. Informational in app-level mode.
+
+    "May", because a contract can also *ask* the toolkit not to emit the file.
+    That is a sanctioned configuration, not a regression, so callers split this
+    list with ``opted_out_root_files`` before reporting — see FND-1723."""
     return [
         name
         for name in ROOT_FILES
         if Path(name).exists() and not (out_dir / name).exists()
     ]
+
+
+def opted_out_root_files(contract_dir: str, names: list[str]) -> set[str]:
+    """Of ``names``, the root files this contract told the toolkit not to emit.
+
+    Answers "would this toolkit emit the file?" rather than "did it". Probed
+    with ``pkl eval -x <flag>`` against the same ``--project-dir`` the main eval
+    uses, so an SDK-level run reads the flag off the *overridden* toolkit — the
+    one whose output we are judging.
+
+    Anything other than a clean ``false`` means "not opted out", which is the
+    conservative answer: it leaves the finding in place. That covers a contract
+    family without the property (``NativeApp.pkl`` has neither flag,
+    ``NativeAppBundle.pkl`` only ``emitAtlanYaml``), where the probe exits
+    non-zero, as well as a toolkit that removed the flag entirely. A probe can
+    therefore never manufacture a green; it can only withdraw a finding the app
+    explicitly asked for."""
+    opted_out = set()
+    app_pkl = str(Path(contract_dir) / "app.pkl")
+    for name in names:
+        flag = ROOT_FILE_EMIT_FLAGS.get(name)
+        if flag is None:
+            continue
+        proc = run_capture(
+            ["pkl", "eval", "--project-dir", contract_dir, "-x", flag, app_pkl]
+        )
+        if proc.returncode == 0 and (proc.stdout or "").strip() == "false":
+            opted_out.add(name)
+    return opted_out
 
 
 def _format_generated(root: Path) -> None:
@@ -276,7 +324,24 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 0
 
-        stale_roots = root_files_not_emitted(tmp)
+        # Committed-but-not-emitted splits two ways: the toolkit stopped
+        # producing a file the app ships (the regression this check exists for)
+        # and the app told the toolkit not to produce it (a sanctioned config).
+        # The probe only runs when there is something to explain.
+        missing_roots = root_files_not_emitted(tmp)
+        opted_out = opted_out_root_files(contract_dir, missing_roots)
+        if opted_out:
+            print(
+                "::notice::"
+                + ", ".join(
+                    f"{name} not emitted because this contract sets "
+                    f"{ROOT_FILE_EMIT_FLAGS[name]} = false"
+                    for name in sorted(opted_out)
+                )
+                + " — the committed file(s) are hand-maintained and left in "
+                "place, not a lost artifact."
+            )
+        stale_roots = [name for name in missing_roots if name not in opted_out]
         if stale_roots:
             if sdk_mode:
                 print(

--- a/.github/scripts/tests/test_regenerate_contract.py
+++ b/.github/scripts/tests/test_regenerate_contract.py
@@ -13,6 +13,14 @@ inlined shell in the regenerate-contract composite action:
   * SDK-level, eval fails                -> fatal (exit 1)
   * SDK-level, no toolkit entry          -> fatal (SystemExit)
 
+and the root-file emit-flag split (FND-1723):
+
+  * opted out + committed                -> notice, never a finding
+  * opted in + committed + not emitted   -> error in SDK-level, warning in
+                                            app-level (the pre-existing tests)
+  * one flag each way                    -> only the opted-in file is reported
+  * probe fails (family without the flag)-> finding stays
+
 `pkl` and `uvx` are stubbed; `git` runs for real against a throwaway repo in
 tmp_path so the drift comparison is exercised end to end.
 """
@@ -104,6 +112,45 @@ def _make_fake_run(
         return real_run(cmd, check=check, text=True, capture_output=True)
 
     return fake_run
+
+
+def _make_fake_capture(flags: dict[str, str] | None = None, *, rc: int = 0):
+    """Stub for `run_capture`, i.e. the `pkl eval -x <flag>` emit-flag probe.
+
+    `flags` maps a flag name to what pkl prints for it; anything unnamed prints
+    `true` (the toolkit default). `rc` non-zero simulates a contract family that
+    has no such property, where pkl exits with "cannot find property". Probe
+    invocations are recorded on `.cmds`."""
+    flags = flags or {}
+    cmds: list[list[str]] = []
+
+    def fake_capture(cmd):
+        cmds.append(cmd)
+        flag = cmd[cmd.index("-x") + 1]
+        return types.SimpleNamespace(
+            returncode=rc, stdout=f"{flags.get(flag, 'true')}\n"
+        )
+
+    fake_capture.cmds = cmds
+    return fake_capture
+
+
+def _probed_flags(capture) -> list[str]:
+    return sorted(cmd[cmd.index("-x") + 1] for cmd in capture.cmds)
+
+
+@pytest.fixture(autouse=True)
+def default_emit_flags(monkeypatch: pytest.MonkeyPatch):
+    """Default every emit flag to the toolkit default (`true`) so no test
+    reaches a real `pkl` binary. Tests about the flags override this."""
+    monkeypatch.setattr(mod, "run_capture", _make_fake_capture())
+
+
+def _sdk_toolkit(tmp_path: Path) -> Path:
+    toolkit = tmp_path / "sdk" / "contract-toolkit" / "src"
+    toolkit.mkdir(parents=True)
+    (toolkit / "PklProject").write_text('amends "pkl:Project"\n')
+    return toolkit
 
 
 def test_missing_app_pkl_self_skips(repo, monkeypatch):
@@ -289,6 +336,125 @@ def test_sdk_level_missing_root_yaml_is_fatal(repo, monkeypatch, tmp_path, capsy
     assert mod.main(["--sdk-toolkit-src", str(toolkit)]) == 1
     out = capsys.readouterr().out
     assert "::error::pkl eval with the SDK PR's contract-toolkit did not" in out
+
+
+def test_sdk_level_opted_out_root_yamls_are_not_findings(
+    repo, monkeypatch, tmp_path, capsys
+):
+    """FND-1723: an app that sets `emitAtlanYaml`/`emitAppYaml` to false is
+    using documented toolkit surface, so a committed copy of either file is
+    hand-maintained — not an artifact the toolkit under test lost. Before the
+    fix this was a hard error, and since SDK-level mode is switched on by the
+    same input that pins the SDK, such an app could not be dispatched at all."""
+    _commit_root_yamls(repo)
+    toolkit = _sdk_toolkit(tmp_path)
+    monkeypatch.setattr(mod, "run", _make_fake_run(repo))
+    capture = _make_fake_capture({"emitAtlanYaml": "false", "emitAppYaml": "false"})
+    monkeypatch.setattr(mod, "run_capture", capture)
+
+    assert mod.main(["--sdk-toolkit-src", str(toolkit)]) == 0
+
+    out = capsys.readouterr().out
+    assert "::error::" not in out
+    assert "atlan.yaml not emitted because this contract sets emitAtlanYaml" in out
+    assert "app.yaml not emitted because this contract sets emitAppYaml" in out
+    assert _probed_flags(capture) == ["emitAppYaml", "emitAtlanYaml"]
+
+
+def test_emit_flag_probe_uses_the_contract_project_dir(
+    repo, monkeypatch, tmp_path, capsys
+):
+    """The probe must read the flag off the same project — hence, in SDK-level
+    mode, the same *overridden* toolkit — that produced the output being
+    judged. A probe against anything else could answer for a different toolkit
+    version than the one under test."""
+    _commit_root_yamls(repo)
+    toolkit = _sdk_toolkit(tmp_path)
+    monkeypatch.setattr(mod, "run", _make_fake_run(repo))
+    capture = _make_fake_capture({"emitAtlanYaml": "false", "emitAppYaml": "false"})
+    monkeypatch.setattr(mod, "run_capture", capture)
+
+    assert mod.main(["--sdk-toolkit-src", str(toolkit)]) == 0
+
+    for cmd in capture.cmds:
+        assert cmd[:2] == ["pkl", "eval"]
+        assert cmd[cmd.index("--project-dir") + 1] == "contract"
+        assert cmd[-1] == str(Path("contract") / "app.pkl")
+
+
+def test_sdk_level_opted_in_root_yaml_still_fatal_beside_an_opted_out_one(
+    repo, monkeypatch, tmp_path, capsys
+):
+    """One flag each way: atlan.yaml is opted out, app.yaml is opted in and not
+    emitted. The regression the check exists for is still caught, and only the
+    opted-in file is named in the error."""
+    _commit_root_yamls(repo)
+    toolkit = _sdk_toolkit(tmp_path)
+    monkeypatch.setattr(mod, "run", _make_fake_run(repo))
+    monkeypatch.setattr(
+        mod, "run_capture", _make_fake_capture({"emitAtlanYaml": "false"})
+    )
+
+    assert mod.main(["--sdk-toolkit-src", str(toolkit)]) == 1
+
+    out = capsys.readouterr().out
+    error = next(ln for ln in out.splitlines() if ln.startswith("::error::"))
+    assert "app.yaml" in error
+    assert "atlan.yaml" not in error
+
+
+def test_app_level_opted_out_root_yaml_drops_the_warning(repo, monkeypatch, capsys):
+    """App-level mode was only ever informational, but the message was still
+    wrong — it claimed the toolkit stopped producing a file the app never asked
+    it to produce."""
+    _commit_root_yamls(repo)
+    monkeypatch.setattr(mod, "run", _make_fake_run(repo))
+    monkeypatch.setattr(
+        mod,
+        "run_capture",
+        _make_fake_capture({"emitAtlanYaml": "false", "emitAppYaml": "false"}),
+    )
+
+    assert mod.main([]) == 0
+
+    out = capsys.readouterr().out
+    assert "::warning::pkl eval did not re-emit" not in out
+    assert "hand-maintained" in out
+
+
+def test_emit_flag_probe_failure_keeps_the_finding(repo, monkeypatch, tmp_path, capsys):
+    """A contract family without the property — `NativeApp.pkl` has neither
+    flag, `NativeAppBundle.pkl` only `emitAtlanYaml` — makes `pkl eval -x` exit
+    non-zero. That must read as "not opted out" so the probe can only ever
+    withdraw a finding an app explicitly asked for, never manufacture a green."""
+    _commit_root_yamls(repo)
+    toolkit = _sdk_toolkit(tmp_path)
+    monkeypatch.setattr(mod, "run", _make_fake_run(repo))
+    monkeypatch.setattr(
+        mod,
+        "run_capture",
+        _make_fake_capture({"emitAtlanYaml": "false", "emitAppYaml": "false"}, rc=1),
+    )
+
+    assert mod.main(["--sdk-toolkit-src", str(toolkit)]) == 1
+    assert "::error::pkl eval with the SDK PR's contract-toolkit did not" in (
+        capsys.readouterr().out
+    )
+
+
+def test_emit_flags_not_probed_when_every_root_yaml_is_accounted_for(
+    repo, monkeypatch, tmp_path
+):
+    """The probe costs two extra `pkl eval` runs, so it only runs when there is
+    something to explain — the fixture commits no root YAMLs, so nothing is."""
+    toolkit = _sdk_toolkit(tmp_path)
+    monkeypatch.setattr(mod, "run", _make_fake_run(repo))
+    capture = _make_fake_capture()
+    monkeypatch.setattr(mod, "run_capture", capture)
+
+    assert mod.main(["--sdk-toolkit-src", str(toolkit)]) == 0
+
+    assert capture.cmds == []
 
 
 def test_drift_warns_on_newly_emitted_untracked_file(repo, monkeypatch, capsys):


### PR DESCRIPTION
## Problem

`.github/scripts/regenerate_contract.py::root_files_not_emitted` flags a committed root YAML that `pkl eval` did not emit. It never consulted the contract-toolkit's own opt-out flags, so an app that deliberately sets `emitAtlanYaml = false` or `emitAppYaml = false` was reported as having lost an artifact it never asked the toolkit to produce.

The predicate is "committed AND not emitted", which conflates two situations:

- the toolkit **stopped** producing a file the app ships — a real regression, and what the check exists for;
- the app **told** the toolkit not to produce it — sanctioned, documented configuration (`contract-toolkit/src/App.pkl:217`/`:228`, carried by `NativeAppBundle.pkl`, in `contract-toolkit/docs/reference.md`).

In app-level mode that only mis-worded a warning. In **SDK-level mode it is a hard error**, and SDK-level mode is switched on by exactly one thing — a non-empty `application-sdk-ref`. So such an app cannot be dispatched against an SDK ref at all: the failure lands before the image is built and takes both `Build e2e image` and `Integration` with it. There is one input, and it selects both "pin the SDK" and "test the toolkit"; an app needing an unreleased SDK feature has no way to ask for the first without the second.

## Fix

Ask *"would this toolkit emit the file?"*, not *"did it"*.

When a committed root YAML is missing from the output, probe the flag with `pkl eval -x <flag> --project-dir <contract> <contract>/app.pkl` — the same project the main eval used, so an SDK-level run reads the flag off the **overridden** toolkit, the one whose output is being judged — and drop the opted-out names before reporting. A `::notice::` names the flag so the log still explains the absence.

Anything other than a clean `false` means "not opted out", which keeps the finding. That covers a contract family without the property (`NativeApp.pkl` has neither flag, `NativeAppBundle.pkl` only `emitAtlanYaml`), where the probe exits non-zero, as well as a toolkit that removed the flag. The probe can therefore only ever *withdraw* a finding an app explicitly asked for — it can never manufacture a green.

The probe runs only when something is missing, so the common case (nothing missing) costs no extra `pkl` invocations.

## Fleet sweep

Asked for in the issue. `gh search code` over `atlanhq` for both flags, then per-repo: is the flag set `false` at the contract's top level, and is the corresponding root file committed?

**Blocked from SDK-level dispatch today** — `emitAtlanYaml = false` + a committed root `atlan.yaml`:

| Repo | Flag |
|---|---|
| `atlan-coalesce-app` | `emitAtlanYaml = false` (the reproduction, run 34058539394) |
| `atlan-mssql-app` | `emitAtlanYaml = false` |
| `atlan-powerbi-app` | `emitAtlanYaml = false` |

**Latent** — opts out of `emitAppYaml` but ships no root `app.yaml`, so the predicate's `Path(name).exists()` keeps it quiet; it would trip the moment one is added: `atlan-coalesce-app`, `atlan-glue-app`, `atlan-mode-app`, `atlan-powercenter-app`.

`atlan-powercenter-app` also sets `emitAtlanYaml = false`, but only on a nested bundle entrypoint — the top-level default (`true`) governs the root `atlan.yaml`, so it is not blocked on that flag.

Caveat: this is read off the contracts, not from running `pkl` against each repo.

## Tests

Red/green verified — reverting just the filter in `main` reds four of the new tests.

- opted out + committed → no finding, both modes (`::notice::` naming the flag)
- one flag each way → still fatal in SDK-level mode, and only the opted-in file is named in the error
- probe fails (family without the property) → finding stays
- the probe's `--project-dir` is the contract project
- nothing missing → probe never runs

The pre-existing "opted in + missing" tests (`test_sdk_level_missing_root_yaml_is_fatal`, `test_app_level_keeps_root_yaml_when_not_reemitted`) still cover the regression branch and are unchanged.

## Unblocks

FND-1703 (coalesce e2e onto `seed_assets`), which needs FND-1648's #3661 from `main` and has no released SDK carrying it.

Closes FND-1723.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECbR97bPX5MoAh1UzuDmrr
