### PR TITLE
feat(testing): teardown through connection-delete, not a hand-rolled purge (FND-1724)

### DIFF
--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -39,7 +39,7 @@ run is graded against. The plumbing it composes is
 :mod:`application_sdk.testing.harness`:
 
 * :mod:`~application_sdk.testing.harness.identity` mints the run id and the
-  ephemeral connection name — including the qualified name teardown purges,
+  ephemeral connection name — including the qualified name teardown deletes,
   which used to come back from ``Connection.creator`` at one-second resolution
   and could collide between two matrix legs;
 * :mod:`~application_sdk.testing.harness.starters` publishes the seed version;
@@ -50,7 +50,9 @@ run is graded against. The plumbing it composes is
   qualified-name depths;
 * :mod:`~application_sdk.testing.harness.preconditions` is the worker-health
   probe behind :meth:`BaseE2ETest.assert_worker_up`;
-* :mod:`~application_sdk.testing.harness.teardown` purges;
+* :mod:`~application_sdk.testing.harness.teardown` reclaims — through the
+  tenant's ``connection-delete`` app, which owns the byte-stores a runner
+  cannot reach, with the ``pyatlan`` purge as its fallback;
 * :mod:`~application_sdk.testing.harness.budgets` carries every timing this
   class' ``ClassVar`` declarations carry.
 
@@ -95,10 +97,10 @@ from application_sdk.common.task_queue import (
     derive_task_queue,
 )
 from application_sdk.contracts.types import ConnectionRef
-from application_sdk.errors.base import safe_traceback
+from application_sdk.errors.base import safe_traceback, sanitize_cause_repr
 from application_sdk.observability.logger_adaptor import get_logger
-from application_sdk.storage.batch import delete_prefix
 from application_sdk.storage.binding import create_store_from_binding_optional
+from application_sdk.storage.ops import delete as delete_object
 from application_sdk.testing.e2e._errors import (
     AmbiguousDAGRunError,
     AtlasReadIndeterminateError,
@@ -179,7 +181,14 @@ from application_sdk.testing.harness.starters import (
     SubmitRetry,
     publish_seed_version,
 )
-from application_sdk.testing.harness.teardown import purge_connection
+from application_sdk.testing.harness.teardown import (
+    ConnectionDeletePlan,
+    ConnectionDeleteReport,
+    DeleteType,
+    connection_delete_task_queue,
+    delete_connection,
+    purge_connection,
+)
 from application_sdk.testing.harness.waiting import poll_until
 
 if TYPE_CHECKING:  # pragma: no cover - typing only; pyatlan is a lazy import
@@ -893,6 +902,39 @@ class BaseE2ETest:
     # int to pin the window; setup_method rejects a pinned value that is not
     # strictly below ae_poll_timeout_seconds.
     dag_progress_stall_seconds: ClassVar[int | None] = None
+    # ---- Teardown, which runs through the ``connection-delete`` app --------
+    #
+    # Teardown submits one ``connection-delete`` DAG per connection the run
+    # touched (see :mod:`application_sdk.testing.harness.teardown`), so it needs
+    # its own two budgets rather than the run's. Both are deliberately smaller
+    # than the DAG budgets above: teardown is post-verdict, its failures never
+    # red a leg, and a leg that sits in cleanup is a leg holding a CI runner for
+    # nothing.
+    #
+    # Ceiling on one connection's delete. Wide enough for the app to drain a
+    # crawl's worth of assets (its own search-and-delete loop is budgeted in
+    # tens of thousands per call), narrow enough that a wedged delete does not
+    # outlast the run that created it. The DAG-progress watchdog is NOT armed on
+    # this poll — connection-delete is a single node that legitimately sits
+    # Running while it drains, which a glyph comparison cannot tell from a wedge
+    # — so this ceiling is the only bound.
+    connection_delete_poll_timeout_seconds: ClassVar[int] = 900
+    # How long to wait for the delete node to be picked up before concluding
+    # that nothing polls the connection-delete queue, and why it is far shorter
+    # than ae_stall_grace_seconds: when nothing does — a scale-to-zero worker
+    # that will not wake, or a tenant without the app installed — EVERY
+    # connection would otherwise burn the full ceiling above before the pyatlan
+    # fallback gets to reclaim the Atlas half. It still has to clear a cold
+    # start: connection-delete's atlan.yaml sets ``keda.minReplicaCount: 0``, so
+    # its queue is legitimately unpolled between runs and KEDA has to scale it
+    # up on queue depth. 0 disables the latch, which means an unpolled queue
+    # waits out the ceiling instead.
+    connection_delete_stall_grace_seconds: ClassVar[int] = 120
+    # How thoroughly teardown deletes. PURGE because that is what the pyatlan
+    # purge this replaced did, and an ephemeral connection is never coming back;
+    # the app's own default is SOFT, which would leave every run's assets
+    # recoverable-and-still-indexed on a shared tenant.
+    connection_delete_type: ClassVar[DeleteType] = DeleteType.PURGE
     atlas_poll_interval_seconds: ClassVar[int] = 30
     atlas_poll_timeout_seconds: ClassVar[int] = 1500
     # Probe errors that can never heal by retrying: a deterministic bug in the
@@ -1432,82 +1474,249 @@ class BaseE2ETest:
         run_sync(self._teardown_method_async(method))
 
     async def _teardown_method_async(self, method: Any) -> None:
-        """Purge this run's connection, then close the clients it opened.
+        """Reclaim this run's connections, then close the clients it opened.
 
-        The purge itself is
-        :func:`~application_sdk.testing.harness.teardown.purge_connection`, which
-        reports rather than raises: the batching that is a correctness bound
-        (``purge_by_guid`` puts one ``guid=`` parameter per asset into one
-        DELETE, and httpx refuses a URL whose query exceeds 64 KiB, so an
-        unbatched purge deletes *nothing*), the read-everything-before-deleting
-        order that offset pagination makes mandatory, and the two independently
-        guarded phases all live there now.
+        The reclaim itself is
+        :func:`~application_sdk.testing.harness.teardown.delete_connection`,
+        which submits a one-node ``connection-delete`` DAG the same way
+        :meth:`seed_assets` submits its publish node — because the app owns the
+        artifacts and runs *on the tenant*, where the byte-stores the harness
+        cannot reach through the s3proxy are ordinary object-store keys. What
+        the harness still deletes itself is the seed NDJSON it wrote, which is
+        no app's to clean up.
+
+        Nothing here raises. Every step reports, and the module those two
+        functions live in explains why that is a stronger guarantee than
+        remembering to wrap the call.
 
         Args:
             method: The test method pytest just ran. Unused; part of the xunit
                 signature.
         """
         try:
-            await self._purge_this_run()
-            await self._purge_seeded_prefixes()
+            await self._delete_connections()
+            await self._delete_seed_objects()
         finally:
             await self._close_clients()
 
-    async def _purge_this_run(self) -> None:
-        """Delete every ephemeral connection this run minted, if there are any.
+    async def _delete_connections(self) -> None:
+        """Delete every ephemeral connection this run touched, if there are any.
 
         The run's own connection first, then every lineage-parent connection
         :meth:`seed_assets` registered — in that order because the run's assets
-        hold lineage *references* into the seeded skeletons, and purging the
+        hold lineage *references* into the seeded skeletons, and deleting the
         referrer before the referent is the direction that cannot strand an
-        edge. Each purge is independently guarded: one connection that will not
-        purge must not orphan the others, for the same reason the two phases
-        inside :func:`~application_sdk.testing.harness.teardown.purge_connection`
-        are independently guarded.
+        edge. That ordering is also why each connection gets its own single-node
+        run rather than all of them sharing one graph: chained ``depends_on``
+        nodes would keep the order and let one stuck delete orphan every later
+        one, parallel nodes would keep them independent and lose the order, and
+        one run per connection keeps both.
+
+        A delete that does not complete falls back to
+        :func:`~application_sdk.testing.harness.teardown.purge_connection`,
+        which reclaims the Atlas half from the runner and nothing else. The
+        fallback is transitional — see the teardown module's docstring for the
+        two silences it covers (a tier with no AE client, and a scale-to-zero
+        worker that does not wake) and for when it should go.
         """
         conn_qn = getattr(self, "connection_qualified_name", "")
         seeded = tuple(getattr(self, "_seeded_connection_qns", ()))
-        for target in (conn_qn, *seeded):
+        for ordinal, target in enumerate((conn_qn, *seeded), start=1):
             if not target:
                 continue
-            try:
-                async with self._atlas_client() as client:
-                    await purge_connection(client, target)
-            # conformance: ignore[E004] teardown boundary — this runs after the assertions have decided the verdict, so a cleanup failure must never replace a real one; it is logged at WARNING with exc_info
-            except Exception:
-                logger.warning(
-                    "e2e cleanup: could not reach the tenant to purge %s — manual "
-                    "purge may be needed",
-                    target,
-                    exc_info=True,
-                )
+            report = await self._delete_connection_via_app(target, ordinal=ordinal)
+            if report is not None and report.complete:
+                continue
+            self._warn_connection_delete_incomplete(target, report)
+            await self._purge_connection_from_runner(target)
 
-    async def _purge_seeded_prefixes(self) -> None:
-        """Delete the object-store prefix each :meth:`seed_assets` call wrote.
+    async def _delete_connection_via_app(
+        self, qualified_name: str, *, ordinal: int
+    ) -> ConnectionDeleteReport | None:
+        """Run the ``connection-delete`` node for one connection.
 
-        Separate from the connection purge and run *after* it: the entities are
-        what a stranded run trips over, the NDJSON is only bytes, and a store the
-        harness cannot reach must not stop the connections from being purged.
-        Guarded per prefix and report-not-raise, on the same teardown-boundary
-        rule as :meth:`_purge_this_run` — cleanup runs after the assertions have
-        decided the verdict and must never replace a real one.
+        Args:
+            qualified_name: The connection to delete.
+            ordinal: Its position in this run's teardown, which is what keeps
+                two teardown runs' AE workflow names apart — see
+                :meth:`_connection_delete_plan`.
+
+        Returns:
+            The report, or ``None`` when this tier has no AE client to submit
+            through at all. ``None`` is a distinct answer from a failed report:
+            there is no missing app to name and nothing to link to, only the
+            fallback.
+        """
+        ae = getattr(self, "_ae", None)
+        if ae is None:
+            # The worker-up-only tier (source_available=False) wires no AE
+            # client. A run there still mints a connection name, and a suite
+            # that created one by other means still needs it reclaimed.
+            return None
+        try:
+            plan = self._connection_delete_plan(ordinal=ordinal)
+        # conformance: ignore[E004] teardown boundary — resolving the plan reads the suite's own class attrs and can raise on a suite that never finished setup; a cleanup failure must never replace the run's verdict
+        except Exception as error:
+            # Reported as a failed delete rather than as "no AE client": the
+            # client is there, and saying otherwise would send a reader looking
+            # at the wrong tier. Logged here for the traceback, which the
+            # report's redacted one-liner cannot carry.
+            logger.warning(
+                "e2e cleanup: could not resolve how to address the "
+                "connection-delete app for %s",
+                qualified_name,
+                exc_info=True,
+            )
+            return ConnectionDeleteReport(
+                qualified_name=qualified_name,
+                errors=(
+                    "could not resolve how to address the connection-delete "
+                    f"app: {sanitize_cause_repr(error)}",
+                ),
+            )
+        return await delete_connection(qualified_name, ae=ae, plan=plan)
+
+    def _warn_connection_delete_incomplete(
+        self, qualified_name: str, report: ConnectionDeleteReport | None
+    ) -> None:
+        """Say what the app did not clean up, and — when it can — why.
+
+        A missing ``connection-delete`` app is called out by name rather than
+        folded into a generic cleanup warning, because it is the failure mode
+        that otherwise reads exactly like a passing run: the leg is green, the
+        assets are gone (the fallback took them), and the byte-stores quietly
+        accumulate on a shared tenant forever. It stays a warning all the same —
+        tenant cleanliness is not what the test is asserting, and a cleanup
+        failure must never become the run's verdict.
+
+        Args:
+            qualified_name: The connection whose delete did not complete.
+            report: What the delete managed, or ``None`` when no AE client
+                existed to run it.
+        """
+        if report is None:
+            logger.warning(
+                "e2e cleanup: no AE client on this tier, so %s could not be "
+                "deleted through the connection-delete app. Falling back to the "
+                "runner-side purge, which reclaims the Atlas assets and leaves "
+                "the connection's byte-stores (connection-cache/%s.sqlite and "
+                "persistent-artifacts/apps/atlan-publish-app/state/%s/) behind",
+                qualified_name,
+                qualified_name,
+                qualified_name,
+            )
+            return
+        if report.app_absent:
+            logger.warning(
+                "e2e cleanup: nothing polled %s, so %s could not be deleted "
+                "through the connection-delete app — either its scale-to-zero "
+                "worker did not wake (keda.minReplicaCount is 0) or the app is "
+                "not installed on this tenant (Global Marketplace app_id "
+                "019ef7f4-de9a-77c3-bad1-7f201fc97052). Falling back to the "
+                "runner-side purge, which reclaims the Atlas assets and leaves "
+                "connection-cache/%s.sqlite and "
+                "persistent-artifacts/apps/atlan-publish-app/state/%s/ behind — "
+                "publish never cleans up its own cache, so those grow without "
+                "bound on a shared tenant. Details: %s",
+                self._connection_delete_task_queue(),
+                qualified_name,
+                qualified_name,
+                qualified_name,
+                "; ".join(report.errors),
+            )
+            return
+        logger.warning(
+            "e2e cleanup: the connection-delete run for %s did not complete "
+            "(slug=%s run_id=%s), so its byte-stores may remain. Falling back to "
+            "the runner-side purge. Details: %s",
+            qualified_name,
+            report.ae_workflow_slug or "<none>",
+            report.ae_run_id or "<none>",
+            "; ".join(report.errors),
+        )
+
+    async def _purge_connection_from_runner(self, qualified_name: str) -> None:
+        """Reclaim the Atlas half of one connection with ``pyatlan``.
+
+        The degraded path, run only when the app could not. Independently
+        guarded, for the same reason the two phases inside
+        :func:`~application_sdk.testing.harness.teardown.purge_connection` are:
+        one connection that will not purge must not orphan the others.
+
+        Args:
+            qualified_name: The connection to purge.
+        """
+        try:
+            async with self._atlas_client() as client:
+                await purge_connection(client, qualified_name)
+        # conformance: ignore[E004] teardown boundary — this runs after the assertions have decided the verdict, so a cleanup failure must never replace a real one; it is logged at WARNING with exc_info
+        except Exception:
+            logger.warning(
+                "e2e cleanup: could not reach the tenant to purge %s — manual "
+                "purge may be needed",
+                qualified_name,
+                exc_info=True,
+            )
+
+    async def _delete_seed_objects(self) -> None:
+        """Delete the object-store keys each :meth:`seed_assets` call wrote.
+
+        The one artifact ``connection-delete`` does not cover: its
+        ``archive_storage`` clears the *app-owned* per-connection stores
+        (``connection-cache/``, ``argo-artifacts/``, ``delta/``, publish's
+        state root), and the seed NDJSON under ``artifacts/apps/<app>/e2e-seed/``
+        is harness-specific — nothing on the tenant knows it exists.
+
+        **By key, never by prefix**, and that is the whole reason this method
+        changed shape. ``delete_prefix`` is a LIST plus a bulk ``POST ?delete``,
+        both *bucket-level* URLs, and the tenant's Kong s3proxy path-matches
+        against an allowlist it cannot apply to a URL whose keys live in the
+        request body — so the call came back ``403 code 1009`` even though
+        ``/artifacts/apps/`` is on that allowlist. A single-object DELETE puts
+        the key in the path, where the allowlist can see it. The harness knows
+        exactly which keys it wrote, so it never needs the listing.
+
+        What that leaves behind is publish's own state under the seed root
+        (``.../publish-state/`` and ``.../current-state/``): the harness did not
+        write those keys and cannot enumerate them from here. They are bounded
+        per seed and outside ``archive_storage``'s prefixes; extending the app
+        to cover them is the fix, not a second listing attempt from the runner.
+
+        Run after the connections, on the same ordering rule as before: the
+        entities are what a stranded run trips over, the NDJSON is only bytes,
+        and a store the harness cannot reach must not stop the deletes.
         """
         prefixes = tuple(getattr(self, "_seeded_prefixes", ()))
         if not prefixes:
             return
+        try:
+            store = self.seed_object_store()
+        # conformance: ignore[E004] teardown boundary — see _purge_connection_from_runner; a store the harness cannot resolve leaves bytes behind, which is strictly less harmful than replacing the run's verdict
+        except Exception:
+            logger.warning(
+                "e2e cleanup: no usable seed object store, so the seed NDJSON "
+                "under %s was left behind — manual cleanup may be needed",
+                ", ".join(prefixes),
+                exc_info=True,
+            )
+            return
         for prefix in prefixes:
-            try:
-                deleted = await delete_prefix(prefix, self.seed_object_store())
+            for key in harness_seed.seed_object_keys(root=prefix):
+                try:
+                    deleted = await delete_object(key, store)
+                # conformance: ignore[E004] teardown boundary — see above
+                except Exception:
+                    logger.warning(
+                        "e2e cleanup: could not delete the seed object %s — "
+                        "manual cleanup may be needed",
+                        key,
+                        exc_info=True,
+                    )
+                    continue
                 logger.info(
-                    "e2e cleanup: deleted %d seed object(s) under %s", deleted, prefix
-                )
-            # conformance: ignore[E004] teardown boundary — see _purge_this_run; a store the harness cannot reach leaves bytes behind, which is strictly less harmful than replacing the run's verdict
-            except Exception:
-                logger.warning(
-                    "e2e cleanup: could not delete the seed prefix %s — manual "
-                    "cleanup may be needed",
-                    prefix,
-                    exc_info=True,
+                    "e2e cleanup: %s seed object %s",
+                    "deleted" if deleted else "found no",
+                    key,
                 )
 
     async def _close_clients(self) -> None:
@@ -2143,6 +2352,68 @@ class BaseE2ETest:
         several tenants in one CI run.
         """
         return f"atlan-publish-{self.resolved_tenant_deployment_name()}"
+
+    def _connection_delete_task_queue(self) -> str:
+        """Task queue the tenant's ``connection-delete`` app polls.
+
+        Derived from :meth:`resolved_tenant_deployment_name` on the same rule as
+        :meth:`_publish_task_queue`: which deployment the tenant registers its
+        apps under is a property of the tenant, and one suite runs against
+        several tenants in one CI run. Resolves to
+        ``atlan-connection-delete-production`` on a standard tenant, mirroring
+        ``atlan-publish-production``.
+
+        Returns:
+            The queue name.
+        """
+        return connection_delete_task_queue(self.resolved_tenant_deployment_name())
+
+    def _connection_delete_plan(self, *, ordinal: int) -> ConnectionDeletePlan:
+        """Resolve how this leg dispatches and waits on one connection's delete.
+
+        Every value is the one this suite's own run uses, so teardown cannot be
+        dispatched to a different tenant than the run it is cleaning up after.
+        The two exceptions are deliberate:
+
+        * **The budgets** are teardown's own
+          (:attr:`connection_delete_poll_timeout_seconds`,
+          :attr:`connection_delete_stall_grace_seconds`) rather than the run's.
+          Teardown is post-verdict, so a leg that sits in cleanup is holding a
+          CI runner for nothing — and the stall grace here is the app-absent
+          detector, which has to be short for exactly that reason.
+        * **The AE workflow name** has to be unique twice over, because
+          ``create_workflow`` is idempotent on the name: against the suite's own
+          run (hence ``-teardown-``) and against the other connections this same
+          teardown deletes (hence *ordinal*). It is the same collision
+          :meth:`_seed_publish_plan` solves, for the same reason, and *ordinal*
+          is used there too rather than a rendering of the QN: a QN's segments
+          are caller-supplied, so any flattening of them into a name is a second
+          encoding that can collide. The QN is not lost — it is on the
+          workflow's description.
+
+        Args:
+            ordinal: This connection's position in the run's teardown, counting
+                from one.
+
+        Returns:
+            The plan.
+        """
+        return ConnectionDeletePlan(
+            connector_short_name=self.connector_short_name,
+            task_queue=self._connection_delete_task_queue(),
+            ae_workflow_name=(
+                f"{self.connector_short_name}-{self.connection_name_prefix}-"
+                f"{self.run_id}-teardown-{ordinal}"
+            ),
+            app_service_url=self.app_service_url,
+            run_id=self.run_id,
+            delete_type=self.connection_delete_type,
+            submit_retry=self._submit_retry(),
+            poll_interval_seconds=self.ae_poll_interval_seconds,
+            poll_timeout_seconds=self.connection_delete_poll_timeout_seconds,
+            stall_grace_seconds=self.connection_delete_stall_grace_seconds,
+            minter=getattr(self, "_minter", None),
+        )
 
     def seed_object_store(self) -> ObjectStore:
         """The object store a seed writes its transformed NDJSON into.

--- a/application_sdk/testing/harness/seed/__init__.py
+++ b/application_sdk/testing/harness/seed/__init__.py
@@ -85,6 +85,7 @@ from application_sdk.testing.harness.seed._publish import (
     SeedPrefixes,
     build_seed_publish_dag,
     build_seed_submit_payload,
+    seed_object_keys,
     seed_prefix_root,
 )
 from application_sdk.testing.harness.seed._spec import (
@@ -130,6 +131,7 @@ __all__ = [
     "connection_entity",
     "ndjson_bytes",
     "seed_assets",
+    "seed_object_keys",
     "seed_prefix_root",
     "skeleton_assets",
     "validate_resolved_spec",
@@ -293,7 +295,10 @@ async def seed_assets(
                     f"{report.total} record(s)"
                 ),
             )
-        key = f"{prefixes.transformed}/{TRANSFORMED_FILE_NAME}"
+        # Unpacked rather than indexed: ``seed_object_keys`` is what teardown
+        # deletes, and a seed that started writing a second file would break
+        # here rather than silently leave the new one behind.
+        (key,) = seed_object_keys(root=prefixes.root)
         await upload_file(key, str(written.path), store)
 
     logger.info(

--- a/application_sdk/testing/harness/seed/_publish.py
+++ b/application_sdk/testing/harness/seed/_publish.py
@@ -27,7 +27,10 @@ from dataclasses import dataclass
 from typing import Any
 
 from application_sdk.contracts.types import ConnectionAttributes, ConnectionRef
-from application_sdk.testing.harness.seed._ndjson import connection_entity
+from application_sdk.testing.harness.seed._ndjson import (
+    TRANSFORMED_FILE_NAME,
+    connection_entity,
+)
 from application_sdk.testing.harness.seed._spec import ResolvedSeedSpec
 
 __all__ = [
@@ -35,6 +38,7 @@ __all__ = [
     "SeedPrefixes",
     "build_seed_publish_dag",
     "build_seed_submit_payload",
+    "seed_object_keys",
 ]
 
 #: The DAG's single node id. Named for what it is rather than "publish" so a
@@ -50,7 +54,9 @@ class SeedPrefixes:
     ``atlan-publish-app`` fails its own config validation when
     ``current_state_prefix`` equals ``transformed_data_prefix`` (DBBI-566), so
     the three are siblings under one root rather than aliases of it. Deriving
-    them from a single root is what keeps teardown a single ``delete_prefix``.
+    them from a single root is what lets a caller name any of them from the one
+    value teardown carries — see :func:`seed_object_keys`, which composes the
+    key it deletes out of exactly this.
 
     Attributes:
         root: The prefix everything for this seed hangs under.
@@ -94,7 +100,8 @@ def seed_prefix_root(*, app_name: str, qualified_name: str) -> str:
       teardown deleting both.
     * **No nesting.** Encoding rather than nesting the QN keeps each root exactly
       one segment deep, so no seed's root can ever be a path prefix of another's
-      — which is what would let one ``delete_prefix`` reach into a sibling seed.
+      — which is what would put one seed's keys inside another seed's tree, and
+      one seed's teardown on top of a sibling's bytes.
 
     ``quote(..., safe="")`` encodes ``%`` as ``%25``, so the mapping is injective
     for any input rather than only for the shapes we expect. The result still
@@ -112,6 +119,37 @@ def seed_prefix_root(*, app_name: str, qualified_name: str) -> str:
     """
     encoded = urllib.parse.quote(qualified_name, safe="")
     return f"artifacts/apps/{app_name}/e2e-seed/{encoded}"
+
+
+def seed_object_keys(*, root: str) -> tuple[str, ...]:
+    """Every object-store key the *harness* wrote under one seed root.
+
+    Teardown deletes these one key at a time rather than deleting the root as a
+    prefix, and that is a correctness requirement rather than a style choice:
+    ``delete_prefix`` is a LIST plus a bulk ``POST ?delete``, both *bucket-level*
+    URLs, and the tenant's Kong s3proxy path-matches against an allowlist it
+    cannot apply to a URL whose keys live in the request body. The call comes
+    back ``403 code 1009 "Invalid Path"`` even though ``/artifacts/apps/`` — the
+    prefix these keys sit under — is on that allowlist. A single-object DELETE
+    puts the key in the path, where the allowlist can read it.
+
+    That works only because the set is knowable without a listing, which is why
+    this function exists at all: it is the one place that states what a seed
+    writes, and :func:`~application_sdk.testing.harness.seed.seed_assets`
+    composes the same key from :class:`SeedPrefixes`.
+
+    What is deliberately absent is everything *publish* writes under the same
+    root (``publish-state/``, ``current-state/``). The harness did not write
+    those keys and cannot enumerate them from a runner; clearing them belongs to
+    an app running on the tenant.
+
+    Args:
+        root: The seed's prefix root, from :func:`seed_prefix_root`.
+
+    Returns:
+        The keys, in the order they were written.
+    """
+    return (f"{SeedPrefixes(root=root).transformed}/{TRANSFORMED_FILE_NAME}",)
 
 
 def build_seed_publish_dag(

--- a/application_sdk/testing/harness/teardown/__init__.py
+++ b/application_sdk/testing/harness/teardown/__init__.py
@@ -1,0 +1,421 @@
+"""Reclaiming what a harness run created — through the app that owns it.
+
+``seed_assets`` seeds *through publish*, because publish owns the entities and
+the cache. Teardown did not follow the same rule: it hand-rolled a ``pyatlan``
+``purge_connection`` plus an obstore ``delete_prefix``, and both halves were
+wrong in the same way — the harness doing an app's job from outside the tenant.
+Symmetry is the point of FND-1724: seeding goes through the app that owns the
+artifact, and so does teardown.
+
+**What the old teardown left behind**, per connection, on a shared e2e tenant:
+
+===================================================  ==========  ==============
+Artifact                                             Owner       Old teardown
+===================================================  ==========  ==============
+Connection + entities in Atlas                       harness     purged
+``persistent-artifacts/apps/atlan-publish-app/       publish     nothing tried
+state/<cqn>/`` — publish-cache-v2, WAL, drift
+``connection-cache/<cqn>.sqlite``                    publish     unreachable
+Seed NDJSON under ``artifacts/apps/<app>/e2e-seed/``  harness     403
+===================================================  ==========  ==============
+
+The 403 and the "unreachable" are the same mechanism, and it is not a
+permissions oversight — :mod:`._dag` has the detail. Nothing about it is fixable
+from a runner, which is why the node is the fix.
+
+Two functions, and which one runs is not a preference:
+
+:func:`delete_connection`
+    The owner. Submits a one-node ``connection-delete`` DAG through AE, exactly
+    as :func:`~application_sdk.testing.harness.seed.seed_assets` submits its
+    publish node — same client, same shape, same wait for a verdict. It runs on
+    the tenant, so it clears the byte-stores as well as Atlas.
+:func:`purge_connection`
+    The degraded path, in :mod:`._purge`. Reclaims the Atlas half from the
+    runner and nothing else — what the harness did for every run before
+    FND-1724.
+
+**Why a fallback at all**, given the app is installed on the e2e tenants
+(FND-1724, 2026-09-07). Two silences it does not close:
+
+* **The worker-up-only tier wires no AE client** (``source_available=false``).
+  There is nothing to submit a delete through, and a connection that tier minted
+  still has to go.
+* **A scaled-to-zero worker that does not wake** looks exactly like an absent app
+  from here. ``connection-delete``'s ``atlan.yaml`` sets
+  ``keda.minReplicaCount: 0``, so its queue is *legitimately* unpolled between
+  runs and "nothing started within the grace" is at least as often a cold start
+  as a missing install.
+
+It is still transitional — leaking bytes is better than leaking whole
+connections, but it is the harness doing an app's job, which is what this whole
+change exists to stop. Drop it once the AE-less tier is gone and cold-start wake
+is boring.
+
+**Nothing here raises.** Teardown runs after the assertions have decided the
+verdict; an exception from cleanup replaces a real failure with a cleanup error
+and loses the diagnosis. Both functions return a report instead — a stronger
+guarantee than "we remembered to wrap the call". That also settles what a
+missing app does: it is reported, loudly and by name, and it never reds a leg.
+Tenant cleanliness is not the thing under test.
+
+**What is deliberately not here** is the policy: which connection to delete, and
+whether to delete at all. Both functions take a qualified name a run minted for
+itself. Pointed at a long-lived shared connection they would delete assets that
+are not the run's to delete, and no guard here can tell the two apart — which is
+why :mod:`application_sdk.testing.harness.identity` mints the ephemeral name in
+the first place, and why a test can predict it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+from application_sdk.errors.base import sanitize_cause_repr
+from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.testing.harness.automation_engine import (
+    AEClient,
+    NoWorkerOnTaskQueueError,
+)
+from application_sdk.testing.harness.identity import Minter
+from application_sdk.testing.harness.starters import AEWorkflowSpec, SubmitRetry
+from application_sdk.testing.harness.starters import (
+    publish_seed_version as _publish_seed_version,
+)
+from application_sdk.testing.harness.teardown._dag import (
+    CONNECTION_DELETE_APP_NAME,
+    CONNECTION_DELETE_NODE_ID,
+    CONNECTION_DELETE_WORKFLOW_TYPE,
+    DeleteType,
+    build_connection_delete_dag,
+    build_connection_delete_submit_payload,
+    connection_delete_task_queue,
+)
+from application_sdk.testing.harness.teardown._purge import (
+    PURGE_BATCH_SIZE,
+    PurgeReport,
+    purge_connection,
+)
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "CONNECTION_DELETE_APP_NAME",
+    "CONNECTION_DELETE_NODE_ID",
+    "CONNECTION_DELETE_WORKFLOW_TYPE",
+    "PURGE_BATCH_SIZE",
+    "ConnectionDeletePlan",
+    "ConnectionDeleteReport",
+    "DeleteType",
+    "PurgeReport",
+    "build_connection_delete_dag",
+    "build_connection_delete_submit_payload",
+    "connection_delete_task_queue",
+    "delete_connection",
+    "purge_connection",
+]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ConnectionDeletePlan:
+    """How one connection's delete run is addressed, dispatched and waited on.
+
+    The run-scoped wiring, kept apart from the DAG builders for the reason
+    :class:`~application_sdk.testing.harness.seed.SeedPublishPlan` is kept apart
+    from :class:`~application_sdk.testing.harness.seed.SeedSpec`: the builders
+    are pure and a unit test can pin them without a tenant, while this is the
+    leg's addressing.
+
+    Attributes:
+        connector_short_name: The suite under test — names the AE workflow and
+            its labels, so a teardown run is attributable to a leg.
+        task_queue: The tenant's connection-delete queue, from
+            :func:`connection_delete_task_queue`.
+        ae_workflow_name: Name for the AE workflow this delete runs under. Must
+            not collide with the suite's own or with another teardown in the
+            same run: ``create_workflow`` is idempotent on the name, so a shared
+            name would publish one graph over the other.
+        app_service_url: HTTP URL AE can reach the app at.
+        run_id: This leg's run identifier.
+        delete_type: How thoroughly to delete. ``PURGE`` for e2e teardown — it
+            is what the ``pyatlan`` purge this replaced did, and an ephemeral
+            connection is never coming back.
+        submit_retry: Cold-start sizing for the submit, or ``None`` to leave
+            ``submit_workflow``'s own default budget in place.
+        poll_interval_seconds: Gap between ``native-status`` reads.
+        poll_timeout_seconds: Ceiling on the whole delete wait.
+        stall_grace_seconds: How long to wait for *any* node to start before
+            concluding that nothing polls :attr:`task_queue`. The reason it is a
+            distinct (short) budget: when nothing does — a worker that will not
+            wake from ``minReplicaCount: 0``, or an app that is not installed —
+            every connection would otherwise burn the full
+            :attr:`poll_timeout_seconds` before the fallback runs. It has to
+            clear a cold start, which is what stops it being shorter still.
+            ``0`` disables the latch.
+        minter: Supplies the AE seed version. ``None`` mints from the real clock.
+    """
+
+    connector_short_name: str
+    task_queue: str
+    ae_workflow_name: str
+    app_service_url: str
+    run_id: int
+    delete_type: DeleteType = DeleteType.PURGE
+    submit_retry: SubmitRetry | None = None
+    poll_interval_seconds: int = 10
+    poll_timeout_seconds: int = 900
+    stall_grace_seconds: int = 120
+    minter: Minter | None = None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ConnectionDeleteReport:
+    """What one ``connection-delete`` run managed to do, and what it did not.
+
+    A report rather than an exception, on the same rule as
+    :class:`PurgeReport`: see the module docstring.
+
+    Attributes:
+        qualified_name: The connection this run targeted.
+        succeeded: Every node of the delete run reached success. The only value
+            on which a caller may skip the fallback.
+        app_absent: Nothing picked the node up off :attr:`ConnectionDeletePlan.task_queue`
+            within the stall grace — the app is not installed on this tenant, or
+            its scale-to-zero worker did not wake. Distinguished from a plain
+            failure because the remediation is completely different (look at the
+            tenant vs. look at the run), and because it is the failure mode that
+            otherwise reads exactly like a passing run.
+        ae_workflow_slug: Slug of the AE workflow the delete ran under.
+        ae_run_id: That run's id — the one link that shows what the app did.
+        errors: One line per failed step, in order. Already secret-redacted: an
+            AE or pyatlan error can quote the request URL, and a report that
+            ships with an evidence bundle is not the place to find that out.
+    """
+
+    qualified_name: str
+    succeeded: bool = False
+    app_absent: bool = False
+    ae_workflow_slug: str = ""
+    ae_run_id: str = ""
+    errors: Sequence[str] = field(default_factory=tuple)
+
+    @property
+    def complete(self) -> bool:
+        """Did the delete finish with nothing failing?
+
+        Returns:
+            ``True`` when the run succeeded and no step errored — the one
+            outcome on which the caller needs no fallback and no warning.
+        """
+        return self.succeeded and not self.errors
+
+
+async def delete_connection(
+    qualified_name: str,
+    *,
+    ae: AEClient,
+    plan: ConnectionDeletePlan,
+) -> ConnectionDeleteReport:
+    """Delete one connection, its assets and its byte-stores, via the app.
+
+    Four steps, mirroring :func:`~application_sdk.testing.harness.seed.seed_assets`
+    step for step, minus the ones that only a seed needs (there is nothing to
+    serialise, validate or upload):
+
+    1. **Create and seed** an AE workflow carrying the one-node DAG.
+    2. **Submit** it, on the suite's own cold-start budget.
+    3. **Wait for a verdict**, with the start-grace latch armed so a tenant
+       without the app is detected in :attr:`ConnectionDeletePlan.stall_grace_seconds`
+       rather than in the full poll ceiling.
+    4. **Report.** Never raise — see the module docstring.
+
+    The progress watchdog is deliberately *not* armed. ``connection-delete``
+    runs as a single node that legitimately sits ``Running`` for as long as the
+    connection takes to drain (its own ``search_and_delete_assets`` loop is
+    budgeted in tens of thousands of assets per call), and a watchdog that
+    compares node glyphs cannot tell that apart from a wedge. The poll ceiling
+    is the bound here.
+
+    Args:
+        qualified_name: The connection to delete. Must be a name the run minted
+            for itself — see the module docstring on why no guard here can check
+            that.
+        ae: An open AE client on *this* event loop. Not closed here — the
+            transport's lifetime stays with whoever opened it.
+        plan: How this delete is addressed, dispatched and waited on.
+
+    Returns:
+        The report. Callers decide from :attr:`ConnectionDeleteReport.complete`
+        whether to fall back to :func:`purge_connection`.
+    """
+    if not qualified_name:
+        return ConnectionDeleteReport(
+            qualified_name=qualified_name,
+            errors=("no connection qualified name to delete",),
+        )
+
+    try:
+        seeded = await _publish_seed_version(
+            AEWorkflowSpec(
+                name=plan.ae_workflow_name,
+                description=(
+                    "Full-DAG e2e harness — teardown for "
+                    f"{plan.connector_short_name}: {qualified_name}"
+                ),
+                seed_dag=build_connection_delete_dag(
+                    connection_qualified_name=qualified_name,
+                    task_queue=plan.task_queue,
+                    delete_type=plan.delete_type,
+                ),
+            ),
+            client=ae,
+            minter=plan.minter,
+        )
+    # conformance: ignore[E004] teardown boundary — this runs after the assertions have decided the verdict, so a cleanup failure is reported rather than raised; the caller warns and falls back
+    except Exception as error:
+        # WARNING with the traceback here, the caller's own summary line
+        # separately — the split ``purge_connection`` already uses. The report
+        # carries a redacted one-liner, which is what a report can carry; the
+        # traceback is what an operator needs and only a log can hold.
+        logger.warning(
+            "harness teardown: could not publish the connection-delete workflow "
+            "for %s",
+            qualified_name,
+            exc_info=True,
+        )
+        return ConnectionDeleteReport(
+            qualified_name=qualified_name,
+            errors=(
+                "could not publish the connection-delete workflow: "
+                f"{sanitize_cause_repr(error)}",
+            ),
+        )
+
+    payload = build_connection_delete_submit_payload(
+        connection_qualified_name=qualified_name,
+        connector_short_name=plan.connector_short_name,
+        display_name=qualified_name.rsplit("/", 1)[-1] or qualified_name,
+        run_id=plan.run_id,
+        ae_workflow_slug=seeded.slug,
+        app_service_url=plan.app_service_url,
+    )
+    retry = plan.submit_retry
+    try:
+        if retry is None:
+            ae_run_id = await ae.submit_workflow(payload, slug=seeded.slug)
+        else:
+            ae_run_id = await ae.submit_workflow(
+                payload,
+                slug=seeded.slug,
+                retries=retry.retries,
+                retry_sleep_seconds=retry.sleep_seconds,
+            )
+    # conformance: ignore[E004] teardown boundary — see above
+    except Exception as error:
+        logger.warning(
+            "harness teardown: could not submit the connection-delete run for "
+            "%s (slug=%s)",
+            qualified_name,
+            seeded.slug,
+            exc_info=True,
+        )
+        return ConnectionDeleteReport(
+            qualified_name=qualified_name,
+            ae_workflow_slug=seeded.slug,
+            errors=(
+                f"could not submit the connection-delete run: "
+                f"{sanitize_cause_repr(error)}",
+            ),
+        )
+
+    try:
+        result = await ae.poll_native_status(
+            ae_run_id,
+            interval_seconds=plan.poll_interval_seconds,
+            timeout_seconds=plan.poll_timeout_seconds,
+            stall_grace_seconds=plan.stall_grace_seconds or None,
+            stall_task_queue=plan.task_queue,
+            # See the docstring: a long-draining single node is indistinguishable
+            # from a wedged one to a glyph comparison.
+            progress_stall_seconds=None,
+        )
+    except NoWorkerOnTaskQueueError as error:
+        # The one failure worth its own field. Everything else is "the delete
+        # did not work"; this is "the app that does the delete is not here".
+        # WARNING here for the traceback; the caller turns the same fact into
+        # the line that names the remediation.
+        logger.warning(
+            "harness teardown: nothing polled %s within %ds, so the "
+            "connection-delete app is not running on this tenant and %s was "
+            "not deleted through it",
+            plan.task_queue,
+            plan.stall_grace_seconds,
+            qualified_name,
+            exc_info=True,
+        )
+        return ConnectionDeleteReport(
+            qualified_name=qualified_name,
+            app_absent=True,
+            ae_workflow_slug=seeded.slug,
+            ae_run_id=ae_run_id,
+            errors=(
+                f"nothing polled {plan.task_queue} within "
+                f"{plan.stall_grace_seconds}s: {sanitize_cause_repr(error)}",
+            ),
+        )
+    # conformance: ignore[E004] teardown boundary — see above
+    except Exception as error:
+        logger.warning(
+            "harness teardown: the connection-delete run for %s reached no "
+            "verdict (slug=%s run_id=%s)",
+            qualified_name,
+            seeded.slug,
+            ae_run_id,
+            exc_info=True,
+        )
+        return ConnectionDeleteReport(
+            qualified_name=qualified_name,
+            ae_workflow_slug=seeded.slug,
+            ae_run_id=ae_run_id,
+            errors=(
+                f"the connection-delete run did not reach a verdict: "
+                f"{sanitize_cause_repr(error)}",
+            ),
+        )
+
+    if result.stopped_watching:
+        return ConnectionDeleteReport(
+            qualified_name=qualified_name,
+            ae_workflow_slug=seeded.slug,
+            ae_run_id=ae_run_id,
+            errors=(
+                f"the connection-delete run had not finished after "
+                f"{plan.poll_timeout_seconds}s (last seen: {result.fingerprint})",
+            ),
+        )
+    if not result.all_nodes_succeeded:
+        return ConnectionDeleteReport(
+            qualified_name=qualified_name,
+            ae_workflow_slug=seeded.slug,
+            ae_run_id=ae_run_id,
+            errors=(
+                f"the connection-delete run did not succeed: "
+                f"AE status={result.status.value} nodes={result.fingerprint}",
+            ),
+        )
+
+    logger.info(
+        "e2e cleanup: %s deleted %s (delete_type=%s) via slug=%s run_id=%s",
+        CONNECTION_DELETE_WORKFLOW_TYPE,
+        qualified_name,
+        plan.delete_type.value,
+        seeded.slug,
+        ae_run_id,
+    )
+    return ConnectionDeleteReport(
+        qualified_name=qualified_name,
+        succeeded=True,
+        ae_workflow_slug=seeded.slug,
+        ae_run_id=ae_run_id,
+    )

--- a/application_sdk/testing/harness/teardown/_dag.py
+++ b/application_sdk/testing/harness/teardown/_dag.py
@@ -1,0 +1,252 @@
+"""The one-node ``connection-delete`` DAG teardown runs, and what it is handed.
+
+Teardown goes *through* the app for the same reason
+:mod:`application_sdk.testing.harness.seed` seeds through publish: the artifacts
+belong to apps, and the harness cannot reach half of them from outside the
+tenant.
+
+**The half it cannot reach is not a permissions oversight — it is the shape of
+the call.** ``delete_prefix`` is a LIST followed by a bulk ``POST ?delete``, and
+both are *bucket-level* URLs. The tenant's Kong s3proxy path-matches every
+request against an allowlist (``/persistent-artifacts/``, ``/artifacts/apps/``,
+``/workflow_file_upload/``), which it cannot apply to a URL whose keys live in
+the request body — so the call comes back ``403 code 1009 "Invalid Path"`` even
+when the prefix being deleted is itself allowlisted. The SDK names the same
+mechanism at :mod:`application_sdk.storage.preflight`. And
+``connection-cache/`` is not on the allowlist at all, so no method reaches it
+from a runner.
+
+``connection-delete`` has no such problem: it runs on the tenant, where its
+object store is the tenant bucket accessed directly with no proxy in front of
+it. One node therefore replaces *both* halves of the old hand-rolled teardown —
+the pyatlan purge and the byte-stores — and picks up two artifacts the harness
+never knew existed:
+
+* ``connection-cache/<cqn>.sqlite`` — the cache a consuming connector reads.
+* ``persistent-artifacts/apps/atlan-publish-app/state/<cqn>/`` — publish's
+  per-connection state (``publish-cache-v2`` blue/green, WAL, drift,
+  statistics).
+
+**Publish never cleans up its own cache**, which is easy to get backwards. It
+only ever writes that prefix; nothing in publish reacts to the assets being
+deleted. Connection deletion is the owner, and it is a separate app. Leaving the
+state behind is not merely untidy: publish's Step-0 resolve auto-discovers
+caches by *connectorType*, not by qualified name, so every orphan from every
+prior run is materialised inside the resolver's memory ladder on the next run.
+
+Every argument on the node is a literal, exactly as in
+:func:`application_sdk.testing.harness.seed.build_seed_publish_dag`: there is no
+producing node to thread ``$.<node>.outputs.*`` references from, and a teardown
+whose target came from a reference would be a teardown the harness could not
+state.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from application_sdk.contracts.types import ConnectionAttributes, ConnectionRef
+
+__all__ = [
+    "CONNECTION_DELETE_APP_NAME",
+    "CONNECTION_DELETE_NODE_ID",
+    "CONNECTION_DELETE_WORKFLOW_TYPE",
+    "DeleteType",
+    "build_connection_delete_dag",
+    "build_connection_delete_submit_payload",
+    "connection_delete_task_queue",
+]
+
+#: The DAG's single node id. Named for the app rather than for "teardown" so a
+#: run list says which app ran, the way ``seed-publish`` does.
+CONNECTION_DELETE_NODE_ID = "connection-delete"
+
+#: What the app's worker registers, per ``app/generated/manifest.json`` in
+#: ``atlanhq/atlan-connection-delete-app``.
+CONNECTION_DELETE_WORKFLOW_TYPE = "connection-delete"
+
+#: Node-level ``app_name``. The app's own generated manifest declares
+#: ``automation-engine`` here — the same value this SDK's proven ``lineage-app``
+#: node carries (:func:`application_sdk.testing.e2e.payload.build_seed_dag`) —
+#: and routing to the worker is done by ``app_task_queue`` regardless. Taking
+#: the app's manifest verbatim is what keeps this node identical to the one the
+#: tenant runs from the marketplace.
+CONNECTION_DELETE_APP_NAME = "automation-engine"
+
+
+class DeleteType(StrEnum):
+    """How thoroughly ``connection-delete`` removes the assets it finds.
+
+    The app validates this string itself and fails the run on anything else
+    (``InvalidDeleteTypeError``), so it is an enum here rather than a ``str``:
+    a typo that would surface minutes later as a failed teardown node is worth
+    catching at the call site instead.
+
+    Attributes:
+        SOFT: Archive. Assets stay recoverable in Atlas — the app's own default,
+            and the wrong one for an ephemeral e2e connection, which is never
+            coming back.
+        HARD: Delete without the archive tombstone.
+        PURGE: Remove outright. What the harness uses, because it is what the
+            ``pyatlan`` purge this replaced did, and a run's leftovers must not
+            keep answering searches on a shared tenant.
+    """
+
+    SOFT = "SOFT"
+    HARD = "HARD"
+    PURGE = "PURGE"
+
+
+def connection_delete_task_queue(deployment_name: str) -> str:
+    """Compose the task queue the tenant's ``connection-delete`` app polls.
+
+    ``atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}``, as every
+    platform app on the tenant resolves it — mirroring ``atlan-publish-production``.
+
+    Args:
+        deployment_name: The deployment the tenant registers its system apps
+            under, e.g. ``production``.
+
+    Returns:
+        The queue name.
+    """
+    return f"atlan-connection-delete-{deployment_name}"
+
+
+def build_connection_delete_dag(
+    *,
+    connection_qualified_name: str,
+    task_queue: str,
+    delete_type: DeleteType = DeleteType.PURGE,
+    delete_assets: bool = True,
+) -> dict[str, Any]:
+    """Build the single-node DAG that deletes one connection and its artifacts.
+
+    One node per connection rather than one DAG carrying every node, because the
+    two properties the hand-rolled teardown had are both worth keeping and no
+    single graph has both. Chained ``depends_on`` nodes would preserve the
+    ordering (a run's own connection holds lineage refs *into* the seeded
+    skeletons, and deleting the referrer first is the direction that cannot
+    strand an edge) but let one stuck delete orphan every later one; parallel
+    nodes would keep them independent and lose the ordering. Submitting one
+    single-node run per connection, in order, keeps both.
+
+    Args:
+        connection_qualified_name: The connection to delete. Must be a name the
+            run minted for itself — never a long-lived shared connection, whose
+            assets are not this run's to delete, and which no guard downstream
+            can tell apart from an ephemeral one.
+        task_queue: The tenant's connection-delete queue, from
+            :func:`connection_delete_task_queue`.
+        delete_type: How thoroughly to delete. ``PURGE`` for e2e teardown.
+        delete_assets: Whether to drain the connection's assets before deleting
+            the Connection entity. ``False`` deletes only the entity, which
+            strands everything under it — present because the app's contract has
+            it, not because a teardown should ever pass it.
+
+    Returns:
+        The graph to publish as the AE workflow's seed version.
+    """
+    return {
+        CONNECTION_DELETE_NODE_ID: {
+            "node_type": "workflow",
+            "activity_name": "execute_workflow",
+            "activity_display_name": "Delete Connection & Assets",
+            "app_name": CONNECTION_DELETE_APP_NAME,
+            "app_task_queue": task_queue,
+            "inputs": {
+                "workflow_type": CONNECTION_DELETE_WORKFLOW_TYPE,
+                "task_queue": task_queue,
+                "args": {
+                    # The three fields the app's UI form carries, and the only
+                    # ones its top-level input reads. Storage params
+                    # (bucket/cloud/azure) and search tuning
+                    # (chunk_size/delete_size) live on its per-task contracts
+                    # with their own defaults, and are deliberately not stated
+                    # here: a teardown that pinned them would drift from the
+                    # app the moment it retuned them.
+                    "connection_qualified_name": connection_qualified_name,
+                    "delete_type": delete_type.value,
+                    "delete_assets": delete_assets,
+                },
+            },
+        }
+    }
+
+
+def build_connection_delete_submit_payload(
+    *,
+    connection_qualified_name: str,
+    connector_short_name: str,
+    display_name: str,
+    run_id: int,
+    ae_workflow_slug: str,
+    app_service_url: str,
+) -> dict[str, Any]:
+    """Build the AE submit body for one connection's delete run.
+
+    The same builder the connector's own submit and the seed's submit use, for
+    the reason stated there: this DAG carries no mustache tokens and no
+    credential, so the body reduces to the envelope plus the connection rows —
+    but a second builder would be a second place for AE's submit shape to drift,
+    on a path exercised far less often than the connector's.
+
+    Args:
+        connection_qualified_name: The connection being deleted.
+        connector_short_name: The suite under test — names the AE workflow and
+            its labels, so a teardown run in an AE run list is attributable to a
+            leg. Not read by the node, which takes the QN as a literal.
+        display_name: Human-readable name for the connection rows.
+        run_id: This leg's run identifier.
+        ae_workflow_slug: The slug AE minted on the create.
+        app_service_url: HTTP URL AE can reach the app at.
+
+    Returns:
+        The dict to POST to ``/api/service/package-workflows?submit=true``.
+    """
+    # Imported here rather than at module scope for the reason the seed's
+    # builder states: ``application_sdk.testing.e2e`` imports ``base``, which
+    # imports this package, so a top-level import closes a cycle through a
+    # partially-initialised package.
+    from application_sdk.testing.e2e.payload import (  # noqa: PLC0415
+        ConnectionSpec,
+        RunMode,
+        build_ae_payload,
+    )
+    from application_sdk.testing.e2e.substitutions import (  # noqa: PLC0415
+        MustacheSubstitutions,
+    )
+
+    connection = ConnectionSpec(
+        name=display_name,
+        qualified_name=connection_qualified_name,
+        connector_name=connector_short_name,
+        source_logo=f"https://assets.atlan.com/assets/{connector_short_name}.png",
+    )
+    return build_ae_payload(
+        run_id=run_id,
+        mode=RunMode.DIRECT,
+        connector_short_name=connector_short_name,
+        argo_package_name=f"@atlan/{connector_short_name}",
+        argo_template_name=f"atlan-{connector_short_name}",
+        app_service_url=app_service_url,
+        connection=connection,
+        mustache_subs=MustacheSubstitutions.model_validate(
+            {
+                "{{connection}}": ConnectionRef(
+                    attributes=ConnectionAttributes(
+                        qualified_name=connection_qualified_name, name=display_name
+                    )
+                ),
+                # No ``payload[]`` rides this submit, so nothing would
+                # substitute the default ``{{credentialGuid}}`` token — and an
+                # unsubstituted token is what ``submit_workflow`` warns about. A
+                # teardown has no credential to create: it names a connection,
+                # not a source.
+                "{{credential-guid}}": "",
+            }
+        ),
+        credential_body=None,
+        ae_workflow_slug=ae_workflow_slug,
+    )

--- a/application_sdk/testing/harness/teardown/_purge.py
+++ b/application_sdk/testing/harness/teardown/_purge.py
@@ -1,4 +1,15 @@
-"""Purging what a harness run created.
+"""Purging a connection from the runner, with ``pyatlan``.
+
+**This is the degraded path.** The owner of connection deletion is the
+``connection-delete`` app, which runs *on the tenant* and clears the byte-stores
+this module cannot reach — see :mod:`application_sdk.testing.harness.teardown`
+for why that distinction is structural rather than stylistic, and
+:func:`~application_sdk.testing.harness.teardown.delete_connection` for the
+node that calls it. What is here runs only when that node could not: no AE
+client on this tier, no worker on the app's task queue, or a delete that did not
+succeed. It reclaims the Atlas half and nothing else, which is what the harness
+did for every run before FND-1724 — strictly better than leaving a connection
+behind, and strictly worse than the app.
 
 Lifted from ``BaseE2ETest.teardown_method``, whose purge path is the part of the
 harness with the least test coverage and the most consequence: assets a failed

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.32.1
-source-sha:    e7c45656e3915d4f070914b5fd2933ba18b3e964
-source-date:   2026-09-06T11:21:19+01:00
+source-sha:    750c913eab936ef886d56f4ca5046b37f39b06f3
+source-date:   2026-09-06T21:39:22Z
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 44 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 7 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 372 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 383 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -3441,6 +3441,20 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** A cluster read reached the API server and did not come back with data.
 - **Defined in:** `application_sdk/testing/harness/cluster/_errors.py`
 
+#### `ConnectionDeletePlan`
+
+- **Import:** `from application_sdk.testing.harness.teardown import ConnectionDeletePlan`
+- **Signature:** `class ConnectionDeletePlan(*, ...)`
+- **Summary:** How one connection's delete run is addressed, dispatched and waited on.
+- **Defined in:** `application_sdk/testing/harness/teardown/__init__.py`
+
+#### `ConnectionDeleteReport`
+
+- **Import:** `from application_sdk.testing.harness.teardown import ConnectionDeleteReport`
+- **Signature:** `class ConnectionDeleteReport(*, ...)`
+- **Summary:** What one ``connection-delete`` run managed to do, and what it did not.
+- **Defined in:** `application_sdk/testing/harness/teardown/__init__.py`
+
 #### `ConnectionIdentity`
 
 - **Import:** `from application_sdk.testing.harness.identity import ConnectionIdentity`
@@ -3550,6 +3564,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `class DataForgeSource(datasource: str, fields: Mapping[str, str])`
 - **Summary:** The integration source's credential fields, read uniformly from env.
 - **Defined in:** `application_sdk/testing/integration/source.py`
+
+#### `DeleteType`
+
+- **Import:** `from application_sdk.testing.harness.teardown import DeleteType`
+- **Signature:** `class DeleteType`
+- **Summary:** How thoroughly ``connection-delete`` removes the assets it finds.
+- **Defined in:** `application_sdk/testing/harness/teardown/_dag.py`
 
 #### `DeploymentState`
 
@@ -4004,9 +4025,9 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `PurgeReport`
 
 - **Import:** `from application_sdk.testing.harness.teardown import PurgeReport`
-- **Signature:** `class PurgeReport(*, purged: int = 0, orphaned: Sequence[str] = tuple(), errors: Sequence[str] = tuple()) -> None`
+- **Signature:** `class PurgeReport(*, purged: int = 0, orphaned: Sequence[str] = tuple(), errors: Sequence[str] = tuple())`
 - **Summary:** What a purge managed to delete, and what it did not.
-- **Defined in:** `application_sdk/testing/harness/teardown.py`
+- **Defined in:** `application_sdk/testing/harness/teardown/_purge.py`
 
 #### `QueueWorkflowSpec`
 
@@ -4565,6 +4586,20 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Deprecated (v4.0) — AE submit body; use ``application_sdk.testing.e2e.payload``.
 - **Defined in:** `application_sdk/testing/full_dag/payload.py`
 
+#### `build_connection_delete_dag`
+
+- **Import:** `from application_sdk.testing.harness.teardown import build_connection_delete_dag`
+- **Signature:** `build_connection_delete_dag(*, *, ...)`
+- **Summary:** Build the single-node DAG that deletes one connection and its artifacts.
+- **Defined in:** `application_sdk/testing/harness/teardown/_dag.py`
+
+#### `build_connection_delete_submit_payload`
+
+- **Import:** `from application_sdk.testing.harness.teardown import build_connection_delete_submit_payload`
+- **Signature:** `build_connection_delete_submit_payload(*, *, ...)`
+- **Summary:** Build the AE submit body for one connection's delete run.
+- **Defined in:** `application_sdk/testing/harness/teardown/_dag.py`
+
 #### `build_seed_dag`
 
 - **Import:** `from application_sdk.testing.full_dag import build_seed_dag`
@@ -4668,6 +4703,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Compare actual extracted metadata against an expected baseline.
 - **Defined in:** `application_sdk/testing/integration/comparison.py`
 
+#### `connection_delete_task_queue`
+
+- **Import:** `from application_sdk.testing.harness.teardown import connection_delete_task_queue`
+- **Signature:** `connection_delete_task_queue(deployment_name: str)`
+- **Summary:** Compose the task queue the tenant's ``connection-delete`` app polls.
+- **Defined in:** `application_sdk/testing/harness/teardown/_dag.py`
+
 #### `connection_entity`
 
 - **Import:** `from application_sdk.testing.harness.seed import connection_entity`
@@ -4738,6 +4780,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `declared_inputs(workflow_config: dict[str, Any]) -> frozenset[str]`
 - **Summary:** Return the input names a generated workflow config declares.
 - **Defined in:** `application_sdk/testing/setup_routes.py`
+
+#### `delete_connection`
+
+- **Import:** `from application_sdk.testing.harness.teardown import delete_connection`
+- **Signature:** `delete_connection(qualified_name: str, *, ae: AEClient, plan: ConnectionDeletePlan) -> ConnectionDeleteReport`
+- **Summary:** Delete one connection, its assets and its byte-stores, via the app.
+- **Defined in:** `application_sdk/testing/harness/teardown/__init__.py`
 
 #### `diff_golden`
 
@@ -5395,9 +5444,9 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `purge_connection`
 
 - **Import:** `from application_sdk.testing.harness.teardown import purge_connection`
-- **Signature:** `purge_connection(client: AsyncAtlanClient, connection_qualified_name: str) -> PurgeReport`
+- **Signature:** `purge_connection(client: AsyncAtlanClient, connection_qualified_name: str)`
 - **Summary:** Delete every asset under *connection_qualified_name*, then the connection.
-- **Defined in:** `application_sdk/testing/harness/teardown.py`
+- **Defined in:** `application_sdk/testing/harness/teardown/_purge.py`
 
 #### `read_app_identity`
 
@@ -5528,6 +5577,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `seed_assets(spec: ResolvedSeedSpec, *, ...)`
 - **Summary:** Serialise *spec*, validate it offline, and publish it as a real run.
 - **Defined in:** `application_sdk/testing/harness/seed/__init__.py`
+
+#### `seed_object_keys`
+
+- **Import:** `from application_sdk.testing.harness.seed import seed_object_keys`
+- **Signature:** `seed_object_keys(*, root: str)`
+- **Summary:** Every object-store key the *harness* wrote under one seed root.
+- **Defined in:** `application_sdk/testing/harness/seed/_publish.py`
 
 #### `seed_prefix_root`
 
@@ -5715,6 +5771,27 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Env var gating ``App.on_complete()``'s file and object-store cleanup.
 - **Defined in:** `application_sdk/testing/integration/fixtures.py`
 
+#### `CONNECTION_DELETE_APP_NAME`
+
+- **Import:** `from application_sdk.testing.harness.teardown import CONNECTION_DELETE_APP_NAME`
+- **Signature:** `CONNECTION_DELETE_APP_NAME`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/testing/harness/teardown/_dag.py`
+
+#### `CONNECTION_DELETE_NODE_ID`
+
+- **Import:** `from application_sdk.testing.harness.teardown import CONNECTION_DELETE_NODE_ID`
+- **Signature:** `CONNECTION_DELETE_NODE_ID`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/testing/harness/teardown/_dag.py`
+
+#### `CONNECTION_DELETE_WORKFLOW_TYPE`
+
+- **Import:** `from application_sdk.testing.harness.teardown import CONNECTION_DELETE_WORKFLOW_TYPE`
+- **Signature:** `CONNECTION_DELETE_WORKFLOW_TYPE`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/testing/harness/teardown/_dag.py`
+
 #### `CONNECTOR_CI`
 
 - **Import:** `from application_sdk.testing.harness import CONNECTOR_CI`
@@ -5834,7 +5911,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Import:** `from application_sdk.testing.harness.teardown import PURGE_BATCH_SIZE`
 - **Signature:** `PURGE_BATCH_SIZE`
 - **Summary:** _(no docstring)_
-- **Defined in:** `application_sdk/testing/harness/teardown.py`
+- **Defined in:** `application_sdk/testing/harness/teardown/_purge.py`
 
 #### `Reading`
 

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -1243,8 +1243,8 @@ Four things to know:
   it. A crawl declared inside a miner suite (`expect_connection = False`) would
   otherwise never observe the connection it just landed.
 - **One connection, one teardown.** All runs share the suite's minted
-  `connection_qualified_name`, and cleanup stays a single purge in
-  `teardown_method` — which pytest runs on pass, fail **and** error. That
+  `connection_qualified_name`, and cleanup stays a single `connection-delete`
+  run in `teardown_method` — which pytest runs on pass, fail **and** error. That
   guarantee is the reason this lives inside one pytest process instead of two
   ordered CI legs sharing a connection, where teardown would have to move to an
   `if: always()` job a cancelled workflow can still skip, on a leased shared tenant.
@@ -1359,8 +1359,9 @@ class TestCoalesceE2E(CrawlerGeneratedE2EBase):
 The seeded tree hangs under a **second** ephemeral connection, minted per run
 exactly like the suite's own. Its QN *and* its object-store prefix are registered
 before the seed runs, so `teardown_method` reclaims both (connections first, the
-run's own before the seeded ones) even when the seed half-fails. Nothing here
-touches a long-lived shared connection.
+run's own before the seeded ones) even when the seed half-fails — see
+[Teardown](#teardown-goes-through-the-app-that-owns-the-artifacts) for what
+"reclaims" covers. Nothing here touches a long-lived shared connection.
 
 #### Three things to get right
 
@@ -1425,8 +1426,79 @@ the suite's own minted connection, which is still right whenever the runs are
 sequenced *because they share state on one connection* (the miner-after-crawl
 case above). Set it for the opposite case: a run that prepares a **different**
 connection for a later one to reference. The QN joins the same teardown registry
-`seed_assets` writes to, so it is purged even if the run that was to consume it
+`seed_assets` writes to, so it is deleted even if the run that was to consume it
 never got that far.
+
+
+### Teardown goes through the app that owns the artifacts
+
+`seed_assets` seeds **through publish**, because publish owns the entities and
+the cache. Teardown follows the same rule for the same reason: `teardown_method`
+submits one `connection-delete` DAG node per connection the run touched, through
+the same `AEClient`, in the same one-node shape, with `delete_type: PURGE`.
+
+**Why the harness cannot do this itself.** A connection leaves four kinds of
+artifact behind, and only one of them is reachable from a CI runner:
+
+| Artifact | Owner | Reachable from the runner? |
+| -- | -- | -- |
+| Connection + entities in Atlas | harness | yes — `pyatlan` |
+| `persistent-artifacts/apps/atlan-publish-app/state/<cqn>/` — publish-cache-v2, WAL, drift, statistics | publish | no |
+| `connection-cache/<cqn>.sqlite` | publish | no — not on the s3proxy allowlist at all |
+| Seed NDJSON under `artifacts/apps/<app>/e2e-seed/<encoded qn>/` | harness | by **key** only |
+
+`delete_prefix` is a LIST plus a bulk `POST ?delete`, and both are *bucket-level*
+URLs. The tenant's Kong s3proxy path-matches every request against an allowlist
+(`/persistent-artifacts/`, `/artifacts/apps/`, `/workflow_file_upload/`) that it
+cannot apply to a URL whose keys live in the request body, so the call comes back
+`403 code 1009 "Invalid Path"` **even when the prefix being deleted is itself
+allowlisted**. The shape of the call is what fails, not the permission. A
+single-object `DELETE` puts the key in the path, where the allowlist can read it
+— which is why the seed NDJSON is deleted by key and nothing else can be.
+
+`connection-delete` has no such problem: it runs on the tenant, where its object
+store is the tenant bucket accessed directly with no proxy in front of it.
+
+**Publish never cleans up its own cache**, which is easy to get backwards. It
+only writes `persistent-artifacts/apps/atlan-publish-app/state/<cqn>/`; nothing
+in publish reacts to the assets being deleted. That matters beyond tidiness:
+publish's Step-0 resolve auto-discovers caches by **connectorType**, not by QN,
+so with `ars_lookup_connection_qns` unset it globs every connection of the
+referenced type — meaning run N+1 materialises every orphan every prior run left,
+inside the resolver's memory ladder. Pin `ars_lookup_connection_qns` on the
+consuming connector's publish node to the seeded QN and the leak is scoped
+regardless.
+
+**An unpolled queue still gets its connections back.** `connection-delete` is a
+marketplace utility (Global Marketplace `app_id
+019ef7f4-de9a-77c3-bad1-7f201fc97052`, `type: utility`) rather than a platform
+service like publish, and it runs at `keda.minReplicaCount: 0`, so it costs
+nothing between runs and its queue is *legitimately* unpolled while nothing is
+using it. It is installed on all three e2e tenants (FND-1724, 2026-09-07). When
+nothing picks the node up off `atlan-connection-delete-<deployment>` within
+`connection_delete_stall_grace_seconds` — a worker that did not wake, or a tenant
+that does not have the app — teardown says so by name, naming the queue and the
+byte-stores being left behind, and falls back to the runner-side `pyatlan`
+purge, which reclaims the Atlas half and nothing else.
+
+That fallback is transitional. Two silences keep it alive: the worker-up-only
+tier (`source_available=false`) wires no AE client to submit a delete through at
+all, and a scale-to-zero worker that fails to wake is indistinguishable from a
+missing install. Drop it once neither is true.
+
+**None of this can red a leg.** Teardown runs after the assertions have decided
+the verdict, so every step reports rather than raises — a missing app, an
+unreachable tenant and a store with no binding are all `WARNING` lines. Tenant
+cleanliness is not what the test is asserting, and a cleanup failure that
+replaced a real verdict would cost more than the bytes it saved.
+
+Three `ClassVar`s tune it, and the defaults suit every connector:
+
+| ClassVar | Default | What it bounds |
+| -- | -- | -- |
+| `connection_delete_poll_timeout_seconds` | `900` | One connection's whole delete. The DAG-progress watchdog is *not* armed — a single node draining a connection legitimately sits `Running` — so this is the only bound. |
+| `connection_delete_stall_grace_seconds` | `120` | How long to wait for the node to be picked up before concluding nothing is polling the queue. Short on purpose — otherwise every connection burns the full ceiling first — but wide enough to clear a `minReplicaCount: 0` cold start. `0` disables the latch. |
+| `connection_delete_type` | `DeleteType.PURGE` | How thoroughly. The app's own default is `SOFT`, which would leave every run's assets recoverable and still indexed on a shared tenant. |
 
 
 ## Onboarding checklist for a new connector

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -1703,12 +1703,21 @@ class TestProgressStallDiagnostics:
 
 
 # ---------------------------------------------------------------------------
-# teardown_method — batched purge (FND-779)
+# teardown_method — the runner-side fallback (FND-779, FND-1724)
 # ---------------------------------------------------------------------------
 
 
-class TestTeardownDelegatesToTheHarnessPurge:
-    """``teardown_method`` decides *what* to purge; the harness decides *how*.
+class TestTeardownFallsBackToTheHarnessPurge:
+    """``teardown_method`` decides *what* to reclaim; the harness decides *how*.
+
+    Since FND-1724 the "how" is the ``connection-delete`` app, and the
+    ``pyatlan`` purge these tests drive is the degraded path — reached here
+    because none of these harnesses has a usable AE client to submit a delete
+    through. That is deliberate rather than incidental: it is the path a tenant
+    without the app installed takes on every run, and the worker-up-only tier
+    takes always, so it is worth pinning on its own. The app path and the
+    hand-off between the two are pinned in
+    ``tests/unit/testing/e2e/test_seed_assets_registry.py``.
 
     The purge mechanics that used to live on this class — batching under httpx's
     URL ceiling, reading the whole listing before deleting anything, the two

--- a/tests/unit/testing/e2e/test_multi_dag_runs.py
+++ b/tests/unit/testing/e2e/test_multi_dag_runs.py
@@ -575,9 +575,17 @@ class TestDeclaredRuns:
             "default/bundle/1"
         }
 
-    def test_teardown_is_still_one_purge(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_teardown_is_still_one_delete(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """N runs, one cleanup — and it stays in ``teardown_method``, which
-        pytest runs on pass, fail and error alike."""
+        pytest runs on pass, fail and error alike.
+
+        One ``connection-delete`` run since FND-1724, not one ``pyatlan`` purge:
+        the shared connection is registered once however many DAGs touched it,
+        and the runner-side purge fires only when the app's run did not
+        complete — which is what ``calls.purged`` being empty says here.
+        """
         harness = _CrawlThenMine()
         ae = _FakeAE(_succeeded("extract", "publish"), _succeeded("extract"))
         calls = _wire(harness, ae, monkeypatch, total=4)
@@ -585,7 +593,9 @@ class TestDeclaredRuns:
         harness.test_full_dag_runs_end_to_end()
         harness.teardown_method(None)
 
-        assert calls.purged == ["default/bundle/1"]
+        teardowns = [name for name in ae.created_names if "-teardown-" in name]
+        assert len(teardowns) == 1
+        assert calls.purged == []
 
     def test_a_failing_run_stops_the_sequence(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/testing/e2e/test_seed_assets_registry.py
+++ b/tests/unit/testing/e2e/test_seed_assets_registry.py
@@ -12,6 +12,14 @@ will not purge cannot orphan the others.
 ``DAGSpec.connection_qualified_name`` lands in the same registry, and is checked
 here for the same reason: it is the other way a run touches a connection this
 suite did not mint.
+
+Since FND-1724 the registry is drained through the ``connection-delete`` app
+rather than through ``pyatlan``, so what the wiring has to show has one more
+step in it: every registered connection reaches
+:func:`~application_sdk.testing.harness.teardown.delete_connection`, a delete
+that does not complete falls back to the runner-side purge (and only then), and
+the seed NDJSON is deleted **by key** — the bulk-prefix delete it replaced is
+what the tenant's s3proxy answers with a 403.
 """
 
 from __future__ import annotations
@@ -27,10 +35,18 @@ from application_sdk.testing.e2e.base import BaseE2ETest, DAGSpec
 from application_sdk.testing.e2e.payload import RunMode
 from application_sdk.testing.e2e.substitutions import MustacheSubstitutions
 from application_sdk.testing.harness import seed as harness_seed
+from application_sdk.testing.harness.teardown import (
+    ConnectionDeletePlan,
+    ConnectionDeleteReport,
+    DeleteType,
+)
 
 _RUN_QN = "default/openapi/1787587123106596"
 _SEED_QN = "default/snowflake/1787587123106596"
 _SEED_PREFIX = "artifacts/apps/openapi/e2e-seed/default%2Fsnowflake%2F1787587123106596"
+#: The one key the harness itself writes under that root. Teardown deletes this,
+#: not the root: see :func:`~application_sdk.testing.harness.seed.seed_object_keys`.
+_SEED_KEY = f"{_SEED_PREFIX}/transformed/assets.json"
 
 
 @asynccontextmanager
@@ -67,17 +83,28 @@ def _harness(
     monkeypatch: pytest.MonkeyPatch,
     *,
     seed_error: BaseException | None = None,
+    delete_reports: dict[str, ConnectionDeleteReport] | None = None,
 ) -> tuple[_SeedingE2ETest, list[str], list[str], list[str]]:
-    """A harness whose seed, purge and prefix delete are recorded, not performed.
+    """A harness whose seed, delete, purge and object delete are recorded.
 
-    ``plans`` and ``specs`` are exposed on the harness rather than returned:
-    only a few tests read them, and widening the tuple would touch every call
-    site.
+    ``plans``, ``specs`` and ``deleted_connections`` are exposed on the harness
+    rather than returned: only a few tests read them, and widening the tuple
+    would touch every call site.
+
+    Args:
+        monkeypatch: pytest's patcher.
+        seed_error: Raised by the patched ``seed_assets`` instead of seeding.
+        delete_reports: Per-QN outcome for the ``connection-delete`` app path.
+            A QN with no entry succeeds, which is the shape every test that is
+            not about the fallback wants — the fallback purge then runs for
+            exactly the connections named here, and for no others.
     """
     seeded: list[str] = []
     purged: list[str] = []
     deleted: list[str] = []
+    deleted_connections: list[str] = []
     plans: list[harness_seed.SeedPublishPlan] = []
+    delete_plans: list[ConnectionDeletePlan] = []
     specs: list[harness_seed.ResolvedSeedSpec] = []
 
     async def _record_seed(
@@ -90,13 +117,23 @@ def _harness(
         plans.append(wiring["plan"])
         return harness_seed.SeededConnection(qualified_name=spec.qualified_name)
 
+    async def _record_delete_connection(
+        qualified_name: str, **wiring: Any
+    ) -> ConnectionDeleteReport:
+        deleted_connections.append(qualified_name)
+        delete_plans.append(wiring["plan"])
+        scripted = (delete_reports or {}).get(qualified_name)
+        return scripted or ConnectionDeleteReport(
+            qualified_name=qualified_name, succeeded=True
+        )
+
     async def _record_purge(client: object, connection_qualified_name: str) -> object:
         purged.append(connection_qualified_name)
         return SimpleNamespace(purged=1, orphaned=(), errors=())
 
-    async def _record_delete(prefix: str, _store: object) -> int:
-        deleted.append(prefix)
-        return 1
+    async def _record_delete(key: str, _store: object) -> bool:
+        deleted.append(key)
+        return True
 
     harness = _SeedingE2ETest()
     harness.run_id = 1787587123
@@ -114,10 +151,13 @@ def _harness(
         "application_sdk.testing.e2e.base.harness_seed.seed_assets", _record_seed
     )
     monkeypatch.setattr(
+        "application_sdk.testing.e2e.base.delete_connection", _record_delete_connection
+    )
+    monkeypatch.setattr(
         "application_sdk.testing.e2e.base.purge_connection", _record_purge
     )
     monkeypatch.setattr(
-        "application_sdk.testing.e2e.base.delete_prefix", _record_delete
+        "application_sdk.testing.e2e.base.delete_object", _record_delete
     )
     monkeypatch.setattr(
         _SeedingE2ETest, "_atlas_client", lambda self: _null_atlas_client()
@@ -125,6 +165,8 @@ def _harness(
     monkeypatch.setattr(_SeedingE2ETest, "seed_object_store", lambda self: object())
     harness.recorded_plans = plans
     harness.recorded_specs = specs
+    harness.recorded_delete_plans = delete_plans
+    harness.deleted_connections = deleted_connections
     return harness, seeded, purged, deleted
 
 
@@ -288,63 +330,122 @@ class TestSeedWorkflowNames:
         assert names[1].endswith("-seed-3-snowflake")
 
 
-class TestPurgeIncludesSeededConnections:
-    """Teardown reaches every connection the run minted, its own first."""
+class TestTeardownIncludesSeededConnections:
+    """Teardown reaches every connection the run minted, its own first.
 
-    def test_seeded_connections_are_purged_after_the_runs_own(
+    Through the ``connection-delete`` app since FND-1724 — which is what makes
+    "reached" mean the byte-stores as well as Atlas. The runner-side purge is
+    the fallback, and each test here says which of the two it expects, because
+    a fallback that fired silently on every connection would look identical to
+    the app path from the outside.
+    """
+
+    def test_seeded_connections_are_deleted_after_the_runs_own(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """The run's assets hold lineage refs *into* the seeded skeletons, so
+        the referrer goes first — the direction that cannot strand an edge."""
         harness, _seeded, purged, _deleted = _harness(monkeypatch)
         harness.seed_assets(_spec())
         harness.teardown_method(method=None)
-        assert purged == [_RUN_QN, _SEED_QN]
+        assert harness.deleted_connections == [_RUN_QN, _SEED_QN]
+        assert purged == []
 
-    def test_the_seed_prefix_is_deleted_after_the_connections(
+    def test_each_connection_gets_its_own_addressed_delete_run(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """One single-node run per connection, each named apart from the other:
+        ``create_workflow`` is idempotent on the name, so two teardowns sharing
+        one would publish each graph over the other."""
+        harness, _seeded, _purged, _deleted = _harness(monkeypatch)
+        harness.seed_assets(_spec())
+        harness.teardown_method(method=None)
+        names = [plan.ae_workflow_name for plan in harness.recorded_delete_plans]
+        assert len(set(names)) == 2
+        assert all("-teardown-" in name for name in names)
+        assert {plan.task_queue for plan in harness.recorded_delete_plans} == {
+            "atlan-connection-delete-production"
+        }
+        assert {plan.delete_type for plan in harness.recorded_delete_plans} == {
+            DeleteType.PURGE
+        }
+
+    def test_the_seed_object_is_deleted_by_key_after_the_connections(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """By key, not by prefix. A bulk-prefix delete is a bucket-level URL the
+        tenant's s3proxy answers with ``403 code 1009`` however allowlisted the
+        prefix is — which is why the old teardown never deleted this at all."""
         harness, _seeded, _purged, deleted = _harness(monkeypatch)
         harness.seed_assets(_spec())
         harness.teardown_method(method=None)
-        assert deleted == [_SEED_PREFIX]
+        assert deleted == [_SEED_KEY]
 
-    def test_a_run_that_seeded_nothing_purges_only_its_own(
+    def test_a_run_that_seeded_nothing_deletes_only_its_own(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        harness, _seeded, purged, deleted = _harness(monkeypatch)
+        harness, _seeded, _purged, deleted = _harness(monkeypatch)
         harness.teardown_method(method=None)
-        assert purged == [_RUN_QN]
+        assert harness.deleted_connections == [_RUN_QN]
         assert deleted == []
 
-    def test_one_failing_purge_does_not_orphan_the_others(
+    def test_an_absent_app_falls_back_to_the_runner_purge(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Report-not-raise, per connection: the run's own purge failing must
-        not skip the seeded ones, and none of it may replace the verdict."""
-        harness, _seeded, _purged, _deleted = _harness(monkeypatch)
-        harness.seed_assets(_spec())
-
-        attempts: list[str] = []
-
-        async def _first_fails(
-            client: object, connection_qualified_name: str
-        ) -> object:
-            attempts.append(connection_qualified_name)
-            if connection_qualified_name == _RUN_QN:
-                raise RuntimeError("tenant hiccup")
-            return SimpleNamespace(purged=1, orphaned=(), errors=())
-
-        monkeypatch.setattr(
-            "application_sdk.testing.e2e.base.purge_connection", _first_fails
+        """``connection-delete`` is a marketplace utility, so a tenant may
+        simply not have it. Leaking a whole connection is worse than leaking
+        bytes, so the Atlas half is still reclaimed — and never by raising."""
+        harness, _seeded, purged, _deleted = _harness(
+            monkeypatch,
+            delete_reports={
+                _RUN_QN: ConnectionDeleteReport(
+                    qualified_name=_RUN_QN,
+                    app_absent=True,
+                    errors=("nothing polled atlan-connection-delete-production",),
+                )
+            },
         )
         harness.teardown_method(method=None)
-        assert attempts == [_RUN_QN, _SEED_QN]
+        assert harness.deleted_connections == [_RUN_QN]
+        assert purged == [_RUN_QN]
 
-    def test_an_unreachable_store_still_leaves_the_connections_purged(
+    def test_one_incomplete_delete_does_not_orphan_the_others(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Report-not-raise, per connection: the run's own delete failing must
+        not skip the seeded ones, and none of it may replace the verdict. Only
+        the connection that failed is purged from the runner — a fallback that
+        ran for the others too would re-walk what the app had already taken."""
+        harness, _seeded, purged, _deleted = _harness(
+            monkeypatch,
+            delete_reports={
+                _RUN_QN: ConnectionDeleteReport(
+                    qualified_name=_RUN_QN, errors=("tenant hiccup",)
+                )
+            },
+        )
+        harness.seed_assets(_spec())
+        harness.teardown_method(method=None)
+        assert harness.deleted_connections == [_RUN_QN, _SEED_QN]
+        assert purged == [_RUN_QN]
+
+    def test_a_tier_without_an_ae_client_still_reclaims_atlas(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The worker-up-only tier wires no AE client, so there is nothing to
+        submit a delete through — and a connection it minted still has to go."""
+        harness, _seeded, purged, _deleted = _harness(monkeypatch)
+        del harness._ae
+        harness.teardown_method(method=None)
+        assert harness.deleted_connections == []
+        assert purged == [_RUN_QN]
+
+    def test_an_unreachable_store_still_leaves_the_connections_deleted(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Bytes left behind are strictly less harmful than a replaced verdict,
         and the entities are what a later run trips over."""
-        harness, _seeded, purged, _deleted = _harness(monkeypatch)
+        harness, _seeded, _purged, _deleted = _harness(monkeypatch)
         harness.seed_assets(_spec())
         monkeypatch.setattr(
             _SeedingE2ETest,
@@ -352,7 +453,7 @@ class TestPurgeIncludesSeededConnections:
             lambda self: (_ for _ in ()).throw(RuntimeError("no binding")),
         )
         harness.teardown_method(method=None)
-        assert purged == [_RUN_QN, _SEED_QN]
+        assert harness.deleted_connections == [_RUN_QN, _SEED_QN]
 
 
 class TestPerRunConnection:
@@ -381,16 +482,16 @@ class TestPerRunConnection:
     def test_a_named_connection_joins_the_teardown_registry(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        harness, _seeded, purged, _deleted = _harness(monkeypatch)
+        harness, _seeded, _purged, _deleted = _harness(monkeypatch)
         with harness._dag_run(DAGSpec(connection_qualified_name=self._OTHER_QN)):
             pass
         harness.teardown_method(method=None)
-        assert purged == [_RUN_QN, self._OTHER_QN]
+        assert harness.deleted_connections == [_RUN_QN, self._OTHER_QN]
 
     def test_the_same_connection_is_registered_once(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Two runs against one prepared connection purge it once, not twice."""
+        """Two runs against one prepared connection delete it once, not twice."""
         harness, _seeded, _purged, _deleted = _harness(monkeypatch)
         for _ in range(2):
             with harness._dag_run(DAGSpec(connection_qualified_name=self._OTHER_QN)):

--- a/tests/unit/testing/harness/seed/test_seed_publish.py
+++ b/tests/unit/testing/harness/seed/test_seed_publish.py
@@ -24,6 +24,7 @@ import pytest
 
 from application_sdk.testing.harness.seed import (
     SEED_PUBLISH_NODE_ID,
+    TRANSFORMED_FILE_NAME,
     DatabaseSpec,
     SchemaSpec,
     SeedPrefixes,
@@ -36,6 +37,7 @@ from application_sdk.testing.harness.seed import (
     build_seed_publish_dag,
     build_seed_submit_payload,
     seed_assets,
+    seed_object_keys,
     seed_prefix_root,
 )
 from application_sdk.validation.assets import AssetValidationReport, ReferentialFailure
@@ -100,8 +102,9 @@ class TestPrefixes:
 
     def test_no_root_can_be_a_path_prefix_of_another(self) -> None:
         """Encoded into one segment rather than nested, so a longer QN's root
-        never sits *inside* a shorter one's — which is what would let one
-        ``delete_prefix`` reach into a sibling seed."""
+        never sits *inside* a shorter one's — which is what would put one seed's
+        keys in another seed's tree, and one seed's teardown on a sibling's
+        bytes."""
         short = seed_prefix_root(
             app_name="coalesce", qualified_name="default/snowflake/123"
         )
@@ -138,6 +141,42 @@ class TestPrefixes:
                 prefixes.publish_state,
                 prefixes.current_state,
             )
+        )
+
+
+class TestSeedObjectKeys:
+    """What teardown deletes by key, because it cannot delete by prefix.
+
+    ``delete_prefix`` is a LIST plus a bulk ``POST ?delete`` — both bucket-level
+    URLs, which the tenant's s3proxy answers ``403 code 1009`` however
+    allowlisted the prefix is. Deleting by key works only while the set is
+    knowable without a listing, and this is the one place that states it.
+    """
+
+    def test_the_key_is_the_one_the_seed_uploads(self) -> None:
+        """``seed_assets`` unpacks this same tuple for its upload, so a drift
+        between what is written and what is deleted cannot happen silently."""
+        assert seed_object_keys(root=_PREFIX_ROOT) == (
+            f"{SeedPrefixes(root=_PREFIX_ROOT).transformed}/{TRANSFORMED_FILE_NAME}",
+        )
+
+    def test_every_key_sits_under_the_seeds_own_root(self) -> None:
+        """The keys are handed to a single-object DELETE with no listing behind
+        it, so nothing downstream would notice one pointing outside the seed."""
+        assert all(
+            key.startswith(f"{_PREFIX_ROOT}/")
+            for key in seed_object_keys(root=_PREFIX_ROOT)
+        )
+
+    def test_publishs_own_state_is_not_claimed(self) -> None:
+        """The harness did not write ``publish-state/`` or ``current-state/``
+        and cannot enumerate them from a runner. Listing them here would be a
+        claim to delete keys whose names nobody knows."""
+        keys = seed_object_keys(root=_PREFIX_ROOT)
+        prefixes = SeedPrefixes(root=_PREFIX_ROOT)
+        assert not any(
+            key.startswith((prefixes.publish_state, prefixes.current_state))
+            for key in keys
         )
 
 

--- a/tests/unit/testing/harness/test_connection_delete.py
+++ b/tests/unit/testing/harness/test_connection_delete.py
@@ -1,0 +1,350 @@
+"""Unit tests for teardown through the ``connection-delete`` app (FND-1724).
+
+Two halves, split the way the seed package's tests are split: the DAG and the
+submit body are pure and pinned exactly, and the orchestration around them is
+checked for the one property teardown actually has to hold — *it never raises,
+and it says which failure happened*.
+
+**The node is pinned field for field against the app's own manifest**, not
+loosely. ``atlan-connection-delete-app``'s ``app/generated/manifest.json``
+declares the workflow type, the queue template and the three args its top-level
+input reads; a node that drifts from those runs a workflow the tenant's worker
+does not recognise, minutes after the assertions have already passed. Nothing
+in a green CI leg would say so — the run's verdict is decided before teardown
+starts — which is exactly why these are asserted here rather than trusted.
+
+**The app-absent case gets its own field, and its own test.** A tenant without
+``connection-delete`` installed is the failure mode that reads identically to a
+clean run: the leg is green, the assets are gone (the runner-side fallback took
+them), and the byte-stores accumulate forever. Distinguishing it from a plain
+failed run is what lets the caller name the missing queue in its warning instead
+of printing a generic cleanup line.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from application_sdk.testing.harness.automation_engine import NoWorkerOnTaskQueueError
+from application_sdk.testing.harness.automation_engine.wire import (
+    DAGNodeResult,
+    DAGNodeStatus,
+    DAGRunResult,
+    DAGRunStatus,
+)
+from application_sdk.testing.harness.teardown import (
+    CONNECTION_DELETE_NODE_ID,
+    ConnectionDeletePlan,
+    DeleteType,
+    build_connection_delete_dag,
+    build_connection_delete_submit_payload,
+    connection_delete_task_queue,
+    delete_connection,
+)
+
+_QN = "default/snowflake/1787587123106596"
+_QUEUE = "atlan-connection-delete-production"
+
+
+def _plan(**overrides: Any) -> ConnectionDeletePlan:
+    """A plan with everything a real leg supplies, overridable per test."""
+    defaults: dict[str, Any] = {
+        "connector_short_name": "coalesce",
+        "task_queue": _QUEUE,
+        "ae_workflow_name": "coalesce-e2e-1787587123-teardown-1",
+        "app_service_url": "http://coalesce.svc",
+        "run_id": 1787587123,
+    }
+    return ConnectionDeletePlan(**{**defaults, **overrides})
+
+
+def _result(
+    *statuses: DAGNodeStatus, run: DAGRunStatus = DAGRunStatus.SUCCEEDED
+) -> DAGRunResult:
+    """A ``native-status`` reading with one node per supplied status."""
+    return DAGRunResult(
+        run_id="run-1",
+        workflow_slug="slug-1",
+        status=run,
+        nodes=[
+            DAGNodeResult(
+                name=CONNECTION_DELETE_NODE_ID,
+                status=status,
+                started_at_ms=None,
+                completed_at_ms=None,
+                error_message=None,
+            )
+            for status in statuses
+        ],
+    )
+
+
+class _FakeAE:
+    """The four AE writes a delete makes, scripted rather than performed."""
+
+    def __init__(
+        self,
+        *,
+        result: DAGRunResult | None = None,
+        poll_error: BaseException | None = None,
+        submit_error: BaseException | None = None,
+        create_error: BaseException | None = None,
+    ) -> None:
+        self._result = result or _result(DAGNodeStatus.SUCCEEDED)
+        self._poll_error = poll_error
+        self._submit_error = submit_error
+        self._create_error = create_error
+        self.created: list[tuple[str, str]] = []
+        self.versions: list[dict[str, Any]] = []
+        self.submits: list[dict[str, Any]] = []
+        self.poll_kwargs: list[dict[str, Any]] = []
+
+    async def create_workflow(self, *, name: str, description: str) -> str:
+        if self._create_error is not None:
+            raise self._create_error
+        self.created.append((name, description))
+        return "slug-1"
+
+    async def wait_for_slug(self, slug: str) -> None:
+        return None
+
+    async def create_version(self, slug: str, body: dict[str, Any]) -> int:
+        self.versions.append(body)
+        return int(body["version"])
+
+    async def publish_version(self, slug: str, version: int) -> None:
+        return None
+
+    async def submit_workflow(self, payload: dict[str, Any], **kwargs: Any) -> str:
+        if self._submit_error is not None:
+            raise self._submit_error
+        self.submits.append(payload)
+        return "run-1"
+
+    async def poll_native_status(self, run_id: str, **kwargs: Any) -> DAGRunResult:
+        self.poll_kwargs.append(kwargs)
+        if self._poll_error is not None:
+            raise self._poll_error
+        return self._result
+
+
+class TestTheNodeMatchesTheAppsManifest:
+    """Every field the tenant's worker reads, pinned against what it declares."""
+
+    def test_the_queue_mirrors_the_publish_queue_shape(self) -> None:
+        """``atlan-{app}-{deployment}``, resolved from the tenant's deployment
+        rather than pinned — one suite runs against several tenants in one CI
+        run, and only one of them is called ``production``."""
+        assert connection_delete_task_queue("production") == _QUEUE
+        assert (
+            connection_delete_task_queue("staging") == "atlan-connection-delete-staging"
+        )
+
+    def test_the_node_carries_the_workflow_type_the_worker_registers(self) -> None:
+        node = build_connection_delete_dag(
+            connection_qualified_name=_QN, task_queue=_QUEUE
+        )[CONNECTION_DELETE_NODE_ID]
+        assert node["inputs"]["workflow_type"] == "connection-delete"
+        assert node["app_task_queue"] == _QUEUE
+        assert node["inputs"]["task_queue"] == _QUEUE
+
+    def test_the_args_are_the_three_the_apps_input_reads(self) -> None:
+        """No more and no fewer. The storage params and search tuning live on
+        the app's per-task contracts with their own defaults, and a teardown
+        that pinned them would drift the moment the app retuned them."""
+        args = build_connection_delete_dag(
+            connection_qualified_name=_QN, task_queue=_QUEUE
+        )[CONNECTION_DELETE_NODE_ID]["inputs"]["args"]
+        assert args == {
+            "connection_qualified_name": _QN,
+            "delete_type": "PURGE",
+            "delete_assets": True,
+        }
+
+    def test_purge_is_the_default_rather_than_the_apps_own_soft(self) -> None:
+        """The app defaults to SOFT, which leaves every run's assets recoverable
+        and still indexed. An ephemeral e2e connection is never coming back, and
+        PURGE is what the ``pyatlan`` purge this replaced did."""
+        args = build_connection_delete_dag(
+            connection_qualified_name=_QN, task_queue=_QUEUE
+        )[CONNECTION_DELETE_NODE_ID]["inputs"]["args"]
+        assert args["delete_type"] == DeleteType.PURGE.value
+
+    def test_every_argument_is_a_literal(self) -> None:
+        """There is no producing node to thread ``$.<node>.outputs.*`` from, and
+        a teardown whose target came from a reference would be one the harness
+        could not state."""
+        node = build_connection_delete_dag(
+            connection_qualified_name=_QN, task_queue=_QUEUE
+        )[CONNECTION_DELETE_NODE_ID]
+        assert not any(
+            isinstance(value, str) and value.startswith("$.")
+            for value in node["inputs"]["args"].values()
+        )
+
+    def test_the_graph_is_one_node(self) -> None:
+        """One run per connection is what keeps teardown both *ordered* (the
+        referrer before the referent) and *independent* (one stuck delete cannot
+        orphan the rest). A multi-node graph has one or the other."""
+        dag = build_connection_delete_dag(
+            connection_qualified_name=_QN, task_queue=_QUEUE
+        )
+        assert list(dag) == [CONNECTION_DELETE_NODE_ID]
+        assert "depends_on" not in dag[CONNECTION_DELETE_NODE_ID]
+
+
+class TestTheSubmitBody:
+    """The connector's own builder, so AE's submit shape has one definition."""
+
+    def _payload(self) -> dict[str, Any]:
+        return build_connection_delete_submit_payload(
+            connection_qualified_name=_QN,
+            connector_short_name="coalesce",
+            display_name="snowflake-seed",
+            run_id=1787587123,
+            ae_workflow_slug="slug-1",
+            app_service_url="http://coalesce.svc",
+        )
+
+    def test_it_carries_the_slug_ae_minted(self) -> None:
+        assert self._payload()["metadata"]["ae_workflow_slug"] == "slug-1"
+
+    def test_no_credential_block_rides_a_teardown(self) -> None:
+        """A delete names a connection, not a source — there is nothing to
+        authenticate to, and a credential block would create one to no end."""
+        assert not self._payload().get("payload")
+
+    def test_the_credential_token_is_emptied_rather_than_left_unsubstituted(
+        self,
+    ) -> None:
+        """Nothing substitutes ``{{credentialGuid}}`` on a submit with no
+        ``payload[]``, and an unsubstituted token is what ``submit_workflow``
+        warns about on every teardown it would otherwise fire on."""
+        task = self._payload()["spec"]["templates"][0]["dag"]["tasks"][0]
+        rows = {p["name"]: p["value"] for p in task["arguments"]["parameters"]}
+        assert rows["credential-guid"] == ""
+
+
+class TestDeleteConnectionReportsRatherThanRaises:
+    """Teardown runs post-verdict, so nothing here may become the verdict."""
+
+    async def test_a_succeeded_run_is_complete(self) -> None:
+        ae = _FakeAE()
+        report = await delete_connection(_QN, ae=ae, plan=_plan())
+        assert report.complete
+        assert report.succeeded
+        assert report.ae_run_id == "run-1"
+        assert report.errors == ()
+
+    async def test_the_workflow_description_names_the_connection(self) -> None:
+        """The name has to be unique and escaping-free, so the QN goes on the
+        description — which is where a reader of an AE run list finds which
+        connection a teardown was for."""
+        ae = _FakeAE()
+        await delete_connection(_QN, ae=ae, plan=_plan())
+        _name, description = ae.created[0]
+        assert _QN in description
+
+    async def test_no_worker_on_the_queue_is_reported_as_an_absent_app(self) -> None:
+        """The one failure with its own field: the remediation is "install the
+        app", not "investigate the run"."""
+        ae = _FakeAE(
+            poll_error=NoWorkerOnTaskQueueError(
+                message="nothing polled the queue", resource=_QUEUE
+            )
+        )
+        report = await delete_connection(_QN, ae=ae, plan=_plan())
+        assert report.app_absent
+        assert not report.complete
+        assert _QUEUE in report.errors[0]
+
+    async def test_the_stall_latch_is_armed_with_the_apps_own_queue(self) -> None:
+        """Armed, or a tenant without the app burns the full ceiling on every
+        connection before the fallback gets to reclaim anything — and named, or
+        the operator is told a queue had no worker without being told which."""
+        ae = _FakeAE()
+        await delete_connection(_QN, ae=ae, plan=_plan(stall_grace_seconds=90))
+        assert ae.poll_kwargs[0]["stall_grace_seconds"] == 90
+        assert ae.poll_kwargs[0]["stall_task_queue"] == _QUEUE
+
+    async def test_the_progress_watchdog_is_not_armed(self) -> None:
+        """``connection-delete`` is a single node that legitimately sits Running
+        while it drains a connection, which a node-glyph comparison cannot tell
+        from a wedge. The poll ceiling is the bound instead."""
+        ae = _FakeAE()
+        await delete_connection(_QN, ae=ae, plan=_plan())
+        assert ae.poll_kwargs[0]["progress_stall_seconds"] is None
+
+    async def test_a_zero_grace_disables_the_latch_rather_than_firing_at_once(
+        self,
+    ) -> None:
+        ae = _FakeAE()
+        await delete_connection(_QN, ae=ae, plan=_plan(stall_grace_seconds=0))
+        assert ae.poll_kwargs[0]["stall_grace_seconds"] is None
+
+    async def test_a_failed_node_is_reported_without_raising(self) -> None:
+        ae = _FakeAE(
+            result=_result(DAGNodeStatus.FAILED, run=DAGRunStatus.FAILED),
+        )
+        report = await delete_connection(_QN, ae=ae, plan=_plan())
+        assert not report.complete
+        assert not report.app_absent
+        assert "did not succeed" in report.errors[0]
+
+    async def test_a_poll_that_ran_out_of_budget_is_not_read_as_a_verdict(
+        self,
+    ) -> None:
+        """``poll_native_status`` returns its last observation when the ceiling
+        expires. Treating those node states as the answer would report a slow
+        delete as a failed one — and, worse, a *stopped-watching* run as a
+        complete one when the last glyphs happened to be green."""
+        timed_out = DAGRunResult(
+            run_id="run-1",
+            workflow_slug="slug-1",
+            status=DAGRunStatus.RUNNING,
+            nodes=_result(DAGNodeStatus.SUCCEEDED).nodes,
+            timed_out_after_seconds=900.0,
+        )
+        report = await delete_connection(
+            _QN, ae=_FakeAE(result=timed_out), plan=_plan()
+        )
+        assert not report.succeeded
+        assert "had not finished" in report.errors[0]
+
+    async def test_a_rejected_create_is_reported(self) -> None:
+        ae = _FakeAE(create_error=RuntimeError("AE rejected the create"))
+        report = await delete_connection(_QN, ae=ae, plan=_plan())
+        assert not report.complete
+        assert "could not publish" in report.errors[0]
+
+    async def test_a_rejected_submit_is_reported(self) -> None:
+        ae = _FakeAE(submit_error=RuntimeError("AE rejected the submit"))
+        report = await delete_connection(_QN, ae=ae, plan=_plan())
+        assert not report.complete
+        assert report.ae_workflow_slug == "slug-1"
+        assert "could not submit" in report.errors[0]
+
+    async def test_an_empty_qualified_name_deletes_nothing(self) -> None:
+        """Blank is never a legitimate target: the app's own guard refuses it
+        because its prefix deletes would otherwise degrade to tenant-wide roots.
+        Refusing here means the submit that would be refused is never made."""
+        ae = _FakeAE()
+        report = await delete_connection("", ae=ae, plan=_plan())
+        assert not report.complete
+        assert ae.created == []
+        assert ae.submits == []
+
+
+@pytest.mark.parametrize(
+    "delete_type", [DeleteType.SOFT, DeleteType.HARD, DeleteType.PURGE]
+)
+def test_every_delete_type_is_one_the_app_accepts(delete_type: DeleteType) -> None:
+    """The app validates the string itself and fails the run on anything else,
+    minutes after the verdict is in — so the enum is the guard at the call
+    site."""
+    args = build_connection_delete_dag(
+        connection_qualified_name=_QN, task_queue=_QUEUE, delete_type=delete_type
+    )[CONNECTION_DELETE_NODE_ID]["inputs"]["args"]
+    assert args["delete_type"] in {"SOFT", "HARD", "PURGE"}


### PR DESCRIPTION
Closes [FND-1724](https://linear.app/atlan-epd/issue/FND-1724/seed-assets-teardown-should-be-a-connection-delete-dag-node-not-a-hand).

`seed_assets` seeds **through publish**, because publish owns the entities and the cache. Teardown did not follow the same rule: it hand-rolled a pyatlan `purge_connection` plus an obstore `delete_prefix`. Both halves are the harness doing an app's job from outside the tenant, and the result is that every seeded run leaked state onto a shared e2e tenant.

## The `delete_prefix` half could never have worked

```
obstore.exceptions.PermissionDeniedError: ... path artifacts/apps/<app>/e2e-seed/...
  uri: ***/api/blobstorage/atlan-bucket?delete
  status: 403
  body: {"code":1009,"error":"Invalid Path", ...}
```

`delete_prefix` is a LIST followed by a bulk `POST ?delete`. Both are **bucket-level** URLs, and the tenant's Kong s3proxy path-matches every request against an allowlist (`/persistent-artifacts/`, `/artifacts/apps/`, `/workflow_file_upload/`) that it cannot apply to a URL whose keys live in the request body. So it 403s **even though the prefix being deleted is itself allowlisted** — the *shape of the call* is what fails, not the permission. `connection-cache/` is not on the allowlist at all. Report-not-raise, so it warned and the leg still passed.

## What changes

`teardown_method` now submits one `connection-delete` DAG node per connection the run touched — same `AEClient`, same one-node shape, same wait-for-verdict as `seed_assets`' publish node. The app runs *on the tenant*, where those byte-stores are ordinary object-store keys, so one node replaces both halves of the old teardown and picks up two artifacts the harness never knew existed:

| Artifact | Owner | Before | After |
| -- | -- | -- | -- |
| Connection + entities in Atlas | harness | purged | deleted (`PURGE`) |
| `persistent-artifacts/apps/atlan-publish-app/state/<cqn>/` | publish | nothing tried | deleted |
| `connection-cache/<cqn>.sqlite` | publish | unreachable | deleted |
| Seed NDJSON under `artifacts/apps/<app>/e2e-seed/<qn>/` | harness | 403 | deleted **by key** |

That last one is harness-specific — no app knows it exists — so it stays here, but a single-object `DELETE` puts the key in the *path* where the allowlist can read it. `seed_object_keys()` is now the one statement of what a seed writes; `seed_assets` unpacks the same tuple for its upload, so what is written and what is deleted cannot drift silently.

**Publish never cleans up its own cache**, which is easy to get backwards: it only ever writes that state prefix, and nothing in publish reacts to the assets being deleted. It matters beyond tidiness — publish's Step-0 resolve discovers caches by *connectorType* rather than by QN, so every orphan from every prior run gets materialised inside the resolver's memory ladder on the next one.

## Design calls

- **One single-node run per connection**, not one graph with N nodes. Chained `depends_on` keeps the ordering (the run's own connection holds lineage refs *into* the seeded skeletons, so the referrer must go first) but lets one stuck delete orphan every later one. Parallel nodes keep them independent and lose the ordering. One run each keeps both.
- **Nothing here can red a leg.** Teardown runs after the assertions have decided the verdict, so every step reports rather than raises. A missing app is called out *by name* — the queue nothing polled, the byte-stores being left behind, the remediation — but it is a `WARNING`, not a failure. Tenant cleanliness is not what the test asserts.
- **The pyatlan purge stays as a fallback**, covering two silences the app's install does not close: the worker-up-only tier (`source_available=false`) wires no AE client to submit through at all, and a scale-to-zero worker that fails to wake is indistinguishable from a missing install. It reclaims the Atlas half exactly as before. Transitional; the module docstring says when to drop it.
- **The node is pinned against the app's own generated manifest** — `workflow_type: connection-delete`, `app_task_queue: atlan-connection-delete-{deployment_name}`, and the three args its top-level input actually reads. Node-level `app_name` is `automation-engine` because that is what the manifest declares (and what this SDK's working `lineage-app` node already uses); routing is by task queue either way. `delete_type` is `PURGE`, not the app's `SOFT` default, which would leave every run's assets recoverable and still indexed.

## Shape

`harness/teardown.py` becomes a package, so every existing import still resolves: `_purge.py` is the lifted pyatlan purge, `_dag.py` the node and submit builders, `__init__.py` the `delete_connection` orchestrator.

Three new `ClassVar`s on `BaseE2ETest`, defaults suiting every connector: `connection_delete_poll_timeout_seconds` (900 — the DAG-progress watchdog is deliberately not armed, since a single node draining a connection legitimately sits `Running`), `connection_delete_stall_grace_seconds` (120 — short so an unpolled queue does not burn the ceiling per connection, wide enough to clear a `minReplicaCount: 0` cold start), and `connection_delete_type` (`PURGE`).

## Not in scope

Pinning `ars_lookup_connection_qns` on the consuming connector's publish node is a change to that connector's manifest, not to the SDK. Documented in `docs/standards/connector-ci-e2e.md` as the thing that makes the cache leak benign rather than merely improbable.

Publish's own state under the seed root (`publish-state/`, `current-state/`) is still left behind: the harness did not write those keys and cannot enumerate them from a runner (listing is bucket-level, same 403), and they fall outside `archive_storage`'s three prefixes. Closing that needs a change in `atlan-connection-delete-app`; noted as a follow-up on the issue.

## Verification

- Unit suite: **10 056 passed**, 9 skipped.
- Conformance C / E / L / D / P: gate passed, zero unsuppressed findings in the changed files.
- `pre-commit run --all-files`: clean. Capability manifest regenerated.
- New tests pin the node field-for-field against the app's manifest, the by-key deletion, the app-absent hand-off to the fallback, and that a poll which ran out of budget is never read as a verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpqB5vsJjW8Lpb4yP7kdnS
