### PR TITLE
chore(security): allowlist CVE-2026-79921, CVE-2026-84304 (HIGH, SLA 30d)

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,11 +1,33 @@
 {
   "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Auto-maintained by the vuln-triage rover; CODEOWNERS: SDK/security team + @atlan-ci (auto-merge of allowlist-only PRs).",
   "_base_image": "app-runtime-base:3",
-  "_updated": "2026-08-21",
+  "_updated": "2026-09-07",
   "_renewal_note": "Expiry dates are the remediation SLA per severity, measured from first detection. CRITICAL: 7 days. HIGH: 30 days. MEDIUM/LOW are NOT allowlisted (tracked on Linear tickets only). The gate (check_allowlist.py) passes while an entry is unexpired and fails once it expires. Enforced by .github/scripts/validate_allowlist.py via _expiry_policy below.",
   "_expiry_policy": {
     "CRITICAL": 7,
     "HIGH": 30
   },
-  "_entry_schema": "Each non-underscore key is a CVE/advisory ID. Required: package, severity (CRITICAL|HIGH only), reason, expires, added_by, case (1-4), ticket. Optional: fix_pr. Keep entries minimal but descriptive."
+  "_entry_schema": "Each non-underscore key is a CVE/advisory ID. Required: package, severity (CRITICAL|HIGH only), reason, expires, added_by, case (1-4), ticket. Optional: fix_pr. Keep entries minimal but descriptive.",
+  "CVE-2026-79921": {
+    "package": "dapr-daprd-1.18",
+    "severity": "HIGH",
+    "reason": "Case 4: base-image CVE (Chainguard dapr-daprd-1.18 1.18.3-r5 apk in app-runtime-base:3, not a uv.lock dependency); clears on a base-image rebuild onto dapr-daprd-1.18 1.18.3-r7 or later.",
+    "expires": "2026-10-05",
+    "added_by": "@vaibhavatlan",
+    "case": 4,
+    "ticket": "BLDX-1646",
+    "re_evaluation_trigger": "fix_released",
+    "fix_available_date": "2026-09-05"
+  },
+  "CVE-2026-84304": {
+    "package": "dapr-daprd-1.18",
+    "severity": "HIGH",
+    "reason": "Case 4: base-image CVE (Chainguard dapr-daprd-1.18 1.18.3-r5 apk in app-runtime-base:3, not a uv.lock dependency); clears on a base-image rebuild onto dapr-daprd-1.18 1.18.3-r6 or later.",
+    "expires": "2026-10-05",
+    "added_by": "@vaibhavatlan",
+    "case": 4,
+    "ticket": "BLDX-1645",
+    "re_evaluation_trigger": "fix_released",
+    "fix_available_date": "2026-09-05"
+  }
 }


### PR DESCRIPTION
Allowlists **CVE-2026-79921** and **CVE-2026-84304** (both HIGH) for the 30-day remediation SLA, per `.mothership/vuln-triage/ORCHESTRATION.md`.

Both were reported by the daily security scan on 2026-09-05 and are already tracked on open Linear tickets, but no allowlist PR was opened for either, so the base-image gate is red on every consumer while they stand untracked in `.security/base-allowlist.json`.

| Field | CVE-2026-79921 | CVE-2026-84304 |
|---|---|---|
| Package | `dapr-daprd-1.18` `1.18.3-r5` | `dapr-daprd-1.18` `1.18.3-r5` |
| Fixed in (Chainguard) | `1.18.3-r7` | `1.18.3-r6` |
| Severity | HIGH | HIGH |
| Case | **4** — base-image CVE in `app-runtime-base:3` | **4** — base-image CVE in `app-runtime-base:3` |
| Expires (SLA) | **2026-10-05** (detection 2026-09-05 + 30d) | **2026-10-05** (detection 2026-09-05 + 30d) |
| Ticket | BLDX-1646 | BLDX-1645 |
| Scan run | https://github.com/atlanhq/application-sdk/actions/runs/33989928252 | https://github.com/atlanhq/application-sdk/actions/runs/33952437187 |

### Why Case 4 (not a dependency bump)

`dapr-daprd-1.18` is the Dapr sidecar binary shipped as a Chainguard `os-pkgs` apk in `app-runtime-base:3`. It is not a `uv.lock` dependency; the scan's Python-deps leg reported 0 findings for both CVEs. A fixed Chainguard package exists for each, but per the orchestration doc that is the orthogonal fork: the remediation is a rebuild + republish of `app-runtime-base:3` onto `dapr-daprd-1.18 >= 1.18.3-r7` (which covers both), never an `apk` patch and never a PR in this repo.

### Validation

```
$ python3 .github/scripts/validate_allowlist.py
✅ Allowlist valid: 2 entries, all within policy (CRITICAL ≤ 7d, HIGH ≤ 30d)
```

Touches **only** `.security/base-allowlist.json`. Human-authored, so the `vuln-auto-merge` gate will not approve it (it trusts only the rover identities); it needs one approval from `.security/approvers.json`.
