### PR TITLE
fix(testing): FND-1725 read the setup form from the app pod, past LM's cache

### DIFF
--- a/application_sdk/testing/setup_routes.py
+++ b/application_sdk/testing/setup_routes.py
@@ -61,14 +61,35 @@ assertion that survives is the one that always carried the weight: fetch the
 card's id, require a 200, and require the served schema to declare what this
 entry point's contract declares.
 
-Both sides of the join are the SDK's
-------------------------------------
-``/api/service/configmaps/<name>`` is Heracles proxying to the app pod's own
-``GET /workflows/v1/configmap/{id}`` — :mod:`application_sdk.handler.service`.
-So the envelope this module unwraps and the file-selection rule it applies are
-read from :mod:`application_sdk.app._generated_tree`, the same authority the
-server reads. Re-deriving either would compare one guess against another and
-drift the moment the exclusion vocabulary grew a prefix.
+Both sides of the join are the SDK's — but not directly
+--------------------------------------------------------
+``/api/service/configmaps/<name>`` is **not** a direct Heracles-to-pod proxy
+(FND-1725 corrects an earlier revision of this docstring that said so). Since
+form-config-v2 (SDK #1747), Local Marketplace sits in between: the served
+form is read from a k8s ConfigMap in the app's namespace, seeded at *publish*
+time from GM's ``versions.app_configs`` blob, and falls through to the app
+pod's own ``GET /workflows/v1/configmap/{id}`` only on a cache miss. On the
+test-only explicit-image deploy path this check's callers actually take — the
+pod image is swapped for the build under test, the publish-time cache is
+not — that cache can disagree with the image under test by construction:
+``openapi-app`` renaming a form field ``extraction_method`` to
+``extraction-method`` in its image once stayed invisible to this exact check
+because Local Marketplace kept serving the pre-rename, snake-case form.
+
+So this check asks for ``?source=app`` (atlanhq/heracles#6473; the same
+handler's existing ``source=es`` is the precedent), which skips *only* the
+Local Marketplace read and forces the app-pod path that already existed. The
+cache itself is not the problem and is not being removed — app pods are KEDA
+scale-to-zero, and every setup-form open would otherwise cost a cold start;
+where it gets seeded *from* is the problem, and reseeding it from the pod
+instead of the catalog is FND-1726, deliberately a separate, Local
+Marketplace-side fix.
+
+The envelope this module unwraps and the file-selection rule it applies are
+still read from :mod:`application_sdk.app._generated_tree`, the same
+authority the app pod's own handler reads. Re-deriving either would compare
+one guess against another and drift the moment the exclusion vocabulary grew
+a prefix.
 
 Skip, don't fail
 ----------------
@@ -140,6 +161,15 @@ __all__ = [
 #: in ~79 app repos.
 MARKETPLACE_APPS_PATH = "/api/service/marketplace/apps"
 CONFIGMAP_PATH = "/api/service/configmaps/{name}"
+
+#: Forces this route past Local Marketplace's publish-time cache onto the app
+#: pod's own ``GET /workflows/v1/configmap/{id}`` — atlanhq/heracles#6473,
+#: precedented by the same handler's existing ``source=es``. See the module
+#: docstring ("Both sides of the join are the SDK's — but not directly") for
+#: why the cache would otherwise assert against the wrong build. Depends on
+#: that heracles PR merging and being deployed; until then this is an
+#: unrecognised query value on that route.
+CONFIGMAP_SOURCE_APP_QUERY = "source=app"
 
 _HTTP_TIMEOUT = 30
 _USER_AGENT = "atlan-application-sdk-setup-routes/1.0"
@@ -1217,9 +1247,16 @@ class TenantRoutes:
         return [entry for entry in apps if isinstance(entry, dict)]
 
     def configmap(self, name: str) -> tuple[int, dict[str, Any]]:
-        """Fetch one configmap by name, exactly as the setup page does."""
+        """Fetch one configmap by name, past Local Marketplace's cache.
+
+        ``?source=app`` (atlanhq/heracles#6473) skips the Local Marketplace
+        read this endpoint otherwise serves from and forces the app-pod path
+        — see the module docstring for why asserting against the cache
+        instead would be asserting against the wrong build.
+        """
         status, body = self.get(
-            CONFIGMAP_PATH.format(name=urllib.parse.quote(name, safe=""))
+            f"{CONFIGMAP_PATH.format(name=urllib.parse.quote(name, safe=''))}"
+            f"?{CONFIGMAP_SOURCE_APP_QUERY}"
         )
         return status, body if isinstance(body, dict) else {}
 

--- a/tests/unit/testing/test_setup_routes.py
+++ b/tests/unit/testing/test_setup_routes.py
@@ -2268,6 +2268,50 @@ class TestTransientRetries:
         assert slept[1] > slept[0]
 
 
+class TestConfigmapAsksPastTheCache:
+    """FND-1725: the served form must come from the app pod, not LM's cache.
+
+    ``TenantRoutes.configmap`` is the only path this check reads a served form
+    through, so pinning the query string here is pinning the whole check's
+    guarantee that it asserts against the build actually under test rather
+    than whatever Local Marketplace cached at the last publish — see the
+    module docstring.
+    """
+
+    def test_configmap_requests_source_app(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        requested: list[str] = []
+
+        class _Response:
+            status = 200
+
+            def read(self) -> bytes:
+                return b'{"ok": true}'
+
+            def __enter__(self) -> "_Response":
+                return self
+
+            def __exit__(self, *exc: object) -> bool:
+                return False
+
+        class _Opener:
+            def open(
+                self, request: urllib.request.Request, timeout: object = None
+            ) -> object:
+                requested.append(request.full_url)
+                return _Response()
+
+        monkeypatch.setattr(setup_routes, "_OPENER", _Opener())
+
+        routes = TenantRoutes(base_url="https://tenant.example.invalid", bearer="t")
+        routes.configmap("atlan-openapi")
+
+        assert requested == [
+            "https://tenant.example.invalid/api/service/configmaps/atlan-openapi?source=app"
+        ]
+
+
 class TestRedirectsAreDeclined:
     """`urlopen` follows redirects by default, and that default is dangerous.
 


### PR DESCRIPTION
### Changelog
- The setup-form e2e check now requests `GET /api/service/configmaps/<name>?source=app` instead of the bare path, so it reads the form the app pod actually serves rather than Local Marketplace's cache.
- Corrects the module docstring in `application_sdk/testing/setup_routes.py` ("Both sides of the join are the SDK's"), which described `/api/service/configmaps/<name>` as a direct Heracles-to-app-pod proxy. That has been false since form-config-v2 (SDK #1747).
- Adds `TestConfigmapAsksPastTheCache` to `tests/unit/testing/test_setup_routes.py`, pinning the `?source=app` query on `TenantRoutes.configmap`.

### Additional context (e.g. screenshots, logs, links)
- Linear: https://linear.app/atlan-epd/issue/FND-1725

**The problem.** Since form-config-v2, `/api/service/configmaps/<name>` is not a direct proxy to the app pod. Local Marketplace serves the form out of a k8s ConfigMap in the app's namespace, seeded at *publish* time from GM's `versions.app_configs` blob, and falls through to the pod's own `GET /workflows/v1/configmap/{id}` only on a cache miss. The SDR/e2e test path this check runs on deploys by swapping the pod's image directly — it does not re-publish, so the cache is left on whatever was published before. That means the check's own request can be answered by a *different* version's form than the image actually under test, by construction. Real observed case: `openapi-app` renamed a form field `extraction_method` → `extraction-method` in the image; Local Marketplace kept serving the pre-rename, snake-case form; the check whose entire job is catching exactly this kind of rename stayed green.

**The cache stays; only where it's seeded from is the bug.** This PR does not remove or bypass the cache for real users — app pods are KEDA scale-to-zero, and every setup-form open would otherwise cost a cold start. `?source=app` is a check-only escape hatch onto the pod path that already existed (precedented by the same handler's existing `source=es`). Reseeding the cache from the pod instead of from the publish-time catalog blob — which would close this gap for everyone, not just this check — is FND-1726, deliberately a separate change in `atlan-local-marketplace-app`.

**Dependency: this PR depends on atlanhq/heracles#6473 (branch `chrishehim/fnd-1725`) merging and being deployed first.** Until then, `?source=app` is an unrecognised query value on that route.

*Interim-behaviour finding*, verified from `handler/configmap.go` on `gh pr diff 6473 --repo atlanhq/heracles`: today's (pre-#6473) handler has no `source != "app"` branch at all — the `source != "es"` check controls only the marketplace-info lookup, and the native-app path unconditionally tries Local Marketplace first before falling back to the pod, regardless of what `source` is. So passing `?source=app` against the current, unmerged handler is a **safe no-op**: it falls straight through to today's default LM-first behaviour, identical to not passing it. This PR is safe to land and merge ahead of the heracles side; the new `?source=app` request just won't yet skip the cache until #6473 ships and deploys.

### Checklist
- [x] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

