### PR TITLE
fix(testing): FND-1766 submit the seed's DAG to AE, not through Heracles

### DIFF
--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -1693,20 +1693,31 @@ class BaseE2ETest:
         state root), and the seed NDJSON under ``artifacts/apps/<app>/e2e-seed/``
         is harness-specific — nothing on the tenant knows it exists.
 
-        **By key, never by prefix**, and that is the whole reason this method
-        changed shape. ``delete_prefix`` is a LIST plus a bulk ``POST ?delete``,
-        both *bucket-level* URLs, and the tenant's Kong s3proxy path-matches
-        against an allowlist it cannot apply to a URL whose keys live in the
-        request body — so the call came back ``403 code 1009`` even though
-        ``/artifacts/apps/`` is on that allowlist. A single-object DELETE puts
-        the key in the path, where the allowlist can see it. The harness knows
-        exactly which keys it wrote, so it never needs the listing.
+        **By key, never by prefix** — though on current evidence neither
+        reaches the store. ``delete_prefix`` is a LIST plus a bulk
+        ``POST ?delete``, both *bucket-level* URLs, and the tenant's Kong
+        s3proxy path-matches against an allowlist it cannot apply to a URL
+        whose keys live in the request body, so it came back
+        ``403 code 1009``. The per-key DELETE was the fix for that — the
+        allowlist can read a path — and a live e2e run on 2026-09-07
+        (FND-1766's three-cloud A/B) came back ``403`` on it too. The
+        allowlist does not grant DELETE under ``/artifacts/apps/`` to a runner
+        in any request shape.
 
-        What that leaves behind is publish's own state under the seed root
-        (``.../publish-state/`` and ``.../current-state/``): the harness did not
-        write those keys and cannot enumerate them from here. They are bounded
-        per seed and outside ``archive_storage``'s prefixes; extending the app
-        to cover them is the fix, not a second listing attempt from the runner.
+        This method therefore expects to fail, and is written to fail
+        harmlessly: each key is attempted, a refusal is logged with the key
+        named, and the run's verdict is untouched. Keeping it is still worth
+        more than deleting it — it will start working the moment the allowlist
+        or the store binding changes, and its log line is what names the
+        leftover.
+
+        **The actual fix is on the tenant, not here.** ``connection-delete``'s
+        ``archive_storage`` already clears the app-owned per-connection stores
+        from inside the cluster, where no proxy sits in front of the bucket;
+        bringing the seed root into its scope deletes these keys and publish's
+        own state under the same root (``.../publish-state/``,
+        ``.../current-state/``) in one go. Both are bounded per seed. A third
+        URL shape from the runner is not the answer.
 
         Run after the connections, on the same ordering rule as before: the
         entities are what a stranded run trips over, the NDJSON is only bytes,

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -2360,9 +2360,14 @@ class BaseE2ETest:
                 f"{self.connector_short_name}-{self.connection_name_prefix}-"
                 f"{self.run_id}-seed-{ordinal}-{spec.connector_type}"
             ),
-            app_service_url=self.app_service_url,
             run_id=self.run_id,
-            submit_retry=self._submit_retry(),
+            # No cold-start budget and no app address. Since FND-1766 the seed
+            # submits straight to AE and calls no app pod, so there is nothing
+            # to cold-start-wait on — the suite's own submit still carries
+            # ``_submit_retry()``, which is where waiting on the app under test
+            # belongs. Leaving ``submit_retry`` unset takes
+            # ``submit_published_version``'s publish-replication budget, which
+            # is the only wait this submit actually has.
             poll_interval_seconds=self.ae_poll_interval_seconds,
             poll_timeout_seconds=self.ae_poll_timeout_seconds,
             progress_stall_seconds=self._resolved_progress_stall_seconds(),

--- a/application_sdk/testing/harness/automation_engine/client.py
+++ b/application_sdk/testing/harness/automation_engine/client.py
@@ -5,11 +5,21 @@ The AE half of ``testing/e2e/client.py``, lifted here and converted to
 
 * ``POST /automation/api/v1/workflows`` and its ``/versions`` children — create
   the workflow and publish the seed DAG.
-* ``POST /api/service/package-workflows?submit=true`` — the submit. The one
-  non-idempotent write in the harness, and the reason
+* two submits, and which one a caller wants depends on whose graph must run.
+  Both are non-idempotent, which is the reason
   :mod:`application_sdk.testing.harness.automation_engine.retry` exists.
+
+  * ``POST /api/service/package-workflows?submit=true`` — through Heracles, for
+    the app under test. Heracles re-derives the graph from the app's served
+    manifest and publishes it over whatever the harness published, which is
+    the point when the graph being tested is the app's own.
+  * ``POST /automation/api/v1/workflows/<slug>/submit`` — straight to AE, for a
+    graph the harness wrote itself. AE runs its currently published version
+    with no manifest fetch, so a harness DAG cannot be replaced by an app's
+    (FND-1766).
 * ``GET /api/service/package-workflows/native-status/<run_id>`` — the DAG run's
-  per-node breakdown, and the poll over it.
+  per-node breakdown, and the poll over it. A pass-through over AE's own run
+  record, so it reads a run from either submit identically.
 
 **Why async.** Decision D1: everything below the pytest boundary is ``async``,
 and the one bridge back to blocking code is
@@ -34,7 +44,7 @@ from __future__ import annotations
 import asyncio
 import math
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Collection
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from types import TracebackType
@@ -185,6 +195,17 @@ _RESUBMIT_WHEN_AE_REPORTS_NO_RUN = False
 # a slower-than-usual index actually gets to use.
 _SLUG_INDEX_TIMEOUT_SECONDS = 30
 _SLUG_INDEX_INTERVAL_SECONDS = 1
+
+# Attempts ``submit_published_version`` gives AE to serve a version that was
+# published seconds earlier. AE resolves the published version *at submit time*
+# and answers 404 until the write has replicated through the metastore —
+# Heracles' own AE client budgets 5 retries at 5/10/15/15/15s for exactly this,
+# on exactly this endpoint (``pkg/ae/client.go``, ``SubmitWorkflow``). Matched
+# rather than re-derived: one origin, one lag, and a second number here would be
+# a second answer to the same question. 6 x 12s covers the same ~60s in the
+# fixed-gap shape ``_post_with_retry`` takes.
+_PUBLISH_REPLICATION_ATTEMPTS = 6
+_PUBLISH_REPLICATION_SLEEP_SECONDS = 12
 
 # ``_HEARTBEAT_SECONDS`` (imported from ``_poll``) is the cadence for "still
 # polling" heartbeat log lines in ``poll_native_status`` — lineage stages take
@@ -1110,6 +1131,66 @@ class AEClient:
             dag=dag if isinstance(dag, dict) else {},
         )
 
+    async def foreign_published_dag(
+        self, slug: str, *, expected: Collection[str]
+    ) -> str:
+        """Describe the DAG AE serves for *slug* when its nodes are not *expected*.
+
+        The read half of the invariant a harness-published DAG relies on. A
+        submit through Heracles re-derives the graph from an app's served
+        manifest and publishes it over whatever the harness published; this
+        cannot see that write, but it can see the version AE serves afterwards
+        — the same read
+        :meth:`~application_sdk.testing.e2e.base.BaseE2ETest._assert_deployed_manifest_matches`
+        uses for the mirror-image assertion.
+
+        **Node names, not version numbers.** A version number only says AE
+        published something, which it always does. The names say *whose graph*
+        it is, which is the question — and it is the reason a harness node id
+        is chosen deliberately: teardown's is the delete app's own, so a
+        republish of that app's manifest is the *other correct* outcome rather
+        than a foreign graph, while the seed's is unique to the seed, so any
+        other name at all is foreign.
+
+        Never raises, and never guesses. :meth:`get_published_version` answers
+        ``None`` for a read that did not get through, and an empty DAG says
+        nothing either; both mean "unanswered" and return ``""``, so a caller
+        goes on to poll exactly as it would without this check. A post-poll
+        check on the run's own node names is what covers those.
+
+        Args:
+            slug: The workflow slug the caller published its DAG under.
+            expected: Every node name the caller's own graph carries — and, where
+                a republish of a *known* app's manifest is an acceptable
+                outcome, that manifest's node names too.
+
+        Returns:
+            A one-line description of the foreign graph, or ``""`` when the
+            graph is the caller's or the question went unanswered.
+        """
+        try:
+            published = await self.get_published_version(slug)
+        # conformance: ignore[E004] guard boundary — a check that cannot read AE must degrade to "unanswered", never replace the caller's verdict with a read error
+        except Exception:
+            logger.warning(
+                "published-DAG guard for slug %s could not read AE, so whether "
+                "the %s node(s) are what runs stays unverified until the run's "
+                "own node names come back",
+                slug,
+                ", ".join(sorted(expected)) or "(none)",
+                exc_info=True,
+            )
+            return ""
+        if published is None or not published.dag:
+            return ""
+        nodes = sorted(name for name in published.dag if isinstance(name, str))
+        if nodes == sorted(expected):
+            return ""
+        return (
+            f"AE serves version {published.version!r} with node(s) "
+            f"{', '.join(nodes) or '(none)'}"
+        )
+
     async def find_run_created_since(
         self,
         slug: str,
@@ -1501,6 +1582,161 @@ class AEClient:
             ", ".join(
                 f"{name} -> {{{{{token}}}}}" for name, token in sorted(leftover.items())
             ),
+        )
+
+    async def submit_published_version(
+        self,
+        slug: str,
+        *,
+        retries: int = _PUBLISH_REPLICATION_ATTEMPTS - 1,
+        retry_sleep_seconds: int = _PUBLISH_REPLICATION_SLEEP_SECONDS,
+    ) -> str:
+        """POST ``/automation/api/v1/workflows/<slug>/submit`` — run *our* DAG.
+
+        The submit for a DAG the harness published itself, and the one place a
+        caller can be sure the graph that runs is the graph it wrote.
+        :meth:`submit_workflow` cannot promise that: it goes through Heracles'
+        ``/api/service/package-workflows``, whose native path *always*
+        re-derives the graph from an app's served manifest —
+        ``GetManifest`` → ``CreateVersion`` → ``PublishVersion`` → submit — so
+        the harness's published version is superseded on every call. Which
+        graph then executes depends only on whether AE's submit has seen the
+        new published version yet, and that is a metastore replication lag, not
+        a decision anything here makes. FND-1766.
+
+        This endpoint takes AE's *currently published* version and starts it.
+        There is no manifest fetch, so there is no envelope, no app identity to
+        pick, and no app under test in the path at all — the whole class of
+        "which app's manifest wins" cannot arise. Three consequences worth
+        stating, because they are what makes this a smaller call rather than a
+        parallel one:
+
+        * **Nothing Heracles injects is load-bearing for a harness DAG.**
+          ``user-id``, ``app_id``, ``argo_workflow_slug``, the flat
+          ``connection.*`` rows and the mustache substitution pass all exist to
+          fill placeholders in a manifest graph. A harness DAG's arguments are
+          literals (see
+          :func:`~application_sdk.testing.harness.seed.build_seed_publish_dag`),
+          so there is nothing to substitute and no payload to carry.
+        * **No cold-start budget.** The only tenant pod Heracles touched at
+          submit was the app under test's — ``GetManifest`` against :8000, which
+          is what :class:`AppNotReadyError` names. Nothing on this path calls an
+          app, so a caller that submits a harness DAG no longer waits on a pod
+          it is not testing. Whether the *worker* is up is a different question,
+          and :meth:`poll_native_status`'s start-grace latch is where it is
+          asked.
+        * **Same poll, same run.** ``native-status?execution_mode=automation-engine``
+          is a pass-through over AE's own run record, so the GUID returned here
+          polls identically to one from :meth:`submit_workflow`.
+
+        Retries mirror :meth:`submit_workflow`'s discipline exactly, because
+        this is the same kind of write — non-idempotent, and a blind re-POST
+        spawns a duplicate run:
+
+        * ``retry_network_errors=False``, so an ambiguous failure is never
+          re-sent on a guess;
+        * ``recover_ambiguous``, so it is resolved by asking AE what landed;
+        * the ``already active`` conflict is terminal rather than a retryable
+          5xx.
+
+        The one addition is **404**, which is retryable here and nowhere else:
+        AE resolves the published version at submit time, and a version
+        published seconds ago has not necessarily replicated
+        (:data:`_PUBLISH_REPLICATION_ATTEMPTS`).
+
+        Args:
+            slug: The workflow slug whose published version to run. The caller
+                must already have published a version under it — see
+                :func:`~application_sdk.testing.harness.starters.publish_seed_version`.
+            retries: Retries on top of the initial attempt.
+            retry_sleep_seconds: Fixed gap between attempts.
+
+        Returns:
+            The run GUID AE assigned.
+
+        Raises:
+            AtlanAEWorkflowAlreadyActiveError: A run of this workflow is
+                already active. Terminal — a retry would spawn a duplicate.
+            AtlanApiResponseInvariantError: AE accepted the submit but named no
+                run GUID.
+            AtlanApiHttpError: AE rejected the submit.
+        """
+        submitted_at = datetime.now(UTC)
+
+        async def _recover_from_ae() -> WriteRecovery:
+            """Ask AE whether the submit whose response we lost took effect."""
+            lookup = await self.find_run_created_since(slug, submitted_at)
+            if lookup.run_id is not None:
+                logger.warning(
+                    "submit_published_version: the response was lost but AE "
+                    "has run %s under slug %s — adopting it rather than "
+                    "re-submitting",
+                    lookup.run_id,
+                    slug,
+                )
+                # Shaped as AE's own envelope so the extraction below has one
+                # path rather than one per origin.
+                return WriteRecovery(body={"data": {"guid": lookup.run_id}})
+            return WriteRecovery(
+                proven_absent=lookup.conclusive and _RESUBMIT_WHEN_AE_REPORTS_NO_RUN
+            )
+
+        status, body = await self._post_with_retry(
+            f"/automation/api/v1/workflows/{quote(slug, safe='')}/submit",
+            # Both fields default server-side, so an empty body would be
+            # accepted — stated anyway because a test run is a different thing
+            # (it publishes to the StateStore eagerly and is triggered as
+            # ``TriggeredBy.TEST``) and the harness must never accidentally be
+            # one.
+            body={"is_test_run": False},
+            total_attempts=retries + 1,
+            sleep_seconds=retry_sleep_seconds,
+            retryable=lambda s, b: (
+                s == 404 or (s >= 500 and not is_already_active_run(s, b))
+            ),
+            op_name="submit_published_version",
+            retry_network_errors=False,
+            recover_ambiguous=_recover_from_ae,
+        )
+        if is_already_active_run(status, body):
+            raise AtlanAEWorkflowAlreadyActiveError(
+                message=(
+                    "AE rejected the submit to POST /automation/api/v1/"
+                    f"workflows/{slug}/submit: a run for this workflow is "
+                    "already active (AE-WF-409-03). A run IS executing, but "
+                    "its run_id is unrecoverable from this response. Not "
+                    "retrying — a retry would spawn a duplicate Skipped run.\n"
+                    f"response={body!r}"
+                ),
+            )
+        if status < 300 and isinstance(body, dict):
+            data = body.get("data") if isinstance(body.get("data"), dict) else body
+            # AE names its run ``guid``; Heracles' submit response renames it
+            # ``run_id``. Both are read so a caller cannot be broken by which
+            # origin answered a recovery.
+            run_id = None
+            if isinstance(data, dict):
+                run_id = data.get("guid") or data.get("run_id")
+            if run_id:
+                return str(run_id)
+            raise AtlanApiResponseInvariantError(
+                message=f"AE submit returned no run guid\nresponse={body!r}",
+                expectation="data.guid present in submit response",
+            )
+        raise AtlanApiHttpError(
+            message=(
+                f"AE submit failed: HTTP {status}\nresponse={body!r}"
+                if status != 404
+                else (
+                    f"AE has no published version for slug {slug} after "
+                    f"{retries + 1} attempt(s) over ~"
+                    f"{retries * retry_sleep_seconds}s. Either nothing was "
+                    "published under it, or the publish never replicated.\n"
+                    f"response={body!r}"
+                )
+            ),
+            target=(f"POST /automation/api/v1/workflows/{slug}/submit HTTP {status}"),
+            retry_after_seconds=requested_retry_after(body),
         )
 
     async def get_native_status(self, run_id: str) -> DAGRunResult:

--- a/application_sdk/testing/harness/seed/__init__.py
+++ b/application_sdk/testing/harness/seed/__init__.py
@@ -67,6 +67,7 @@ from application_sdk.storage.batch import upload_file
 from application_sdk.testing.harness.automation_engine import AEClient
 from application_sdk.testing.harness.identity import Minter
 from application_sdk.testing.harness.seed._errors import (
+    SeedDagSupersededError,
     SeedPublishEmptyError,
     SeedPublishFailedError,
     SeedSegmentInvalidError,
@@ -84,7 +85,6 @@ from application_sdk.testing.harness.seed._publish import (
     SEED_PUBLISH_NODE_ID,
     SeedPrefixes,
     build_seed_publish_dag,
-    build_seed_submit_payload,
     seed_object_keys,
     seed_prefix_root,
 )
@@ -115,6 +115,7 @@ __all__ = [
     "DatabaseSpec",
     "ResolvedSeedSpec",
     "SchemaSpec",
+    "SeedDagSupersededError",
     "SeedPrefixes",
     "SeedPublishEmptyError",
     "SeedPublishFailedError",
@@ -127,7 +128,6 @@ __all__ = [
     "SeededConnection",
     "TableSpec",
     "build_seed_publish_dag",
-    "build_seed_submit_payload",
     "connection_entity",
     "ndjson_bytes",
     "seed_assets",
@@ -188,21 +188,31 @@ class SeedPublishPlan:
         ae_workflow_name: Name for the AE workflow this seed runs under. Must not
             collide with the suite's own, or AE would carry two graphs on one
             workflow and the run list would not say which ran.
-        app_service_url: HTTP URL AE can reach the app at.
         run_id: This leg's run identifier, for the AE workflow name and labels.
-        submit_retry: Cold-start sizing for the submit, or ``None`` to leave
-            ``submit_workflow``'s own default budget in place.
+        submit_retry: How long to let AE keep answering 404 while the seed's
+            freshly published version replicates, or ``None`` for
+            :meth:`~application_sdk.testing.harness.automation_engine.AEClient.submit_published_version`'s
+            own budget. **Not** a cold-start budget: since FND-1766 the seed's
+            submit goes straight to AE and calls no app pod, so there is no
+            pod to wait for — a cold-start-sized value here only delays the
+            report of a slug that has nothing published under it.
         poll_interval_seconds: Gap between ``native-status`` reads.
         poll_timeout_seconds: Ceiling on the whole publish wait.
         progress_stall_seconds: Progress-watchdog window, or ``None`` to disable.
         minter: Supplies the AE seed version. ``None`` mints from the real clock.
+        app_service_url: Ignored.
+
+            .. deprecated:: 3.34.0
+               The seed no longer submits through Heracles, so no address is
+               named and nothing reads this. Removed in v4.0. See FND-1766 and
+               :mod:`application_sdk.testing.harness.seed._publish`.
     """
 
     app_name: str
     publish_task_queue: str
     ae_workflow_name: str
-    app_service_url: str
     run_id: int
+    app_service_url: str = ""
     submit_retry: SubmitRetry | None = None
     poll_interval_seconds: int = 10
     poll_timeout_seconds: int = 1800
@@ -328,21 +338,39 @@ async def seed_assets(
         client=ae,
         minter=plan.minter,
     )
-    payload = build_seed_submit_payload(
-        spec=spec,
-        run_id=plan.run_id,
-        ae_workflow_slug=seeded.slug,
-        app_service_url=plan.app_service_url,
-    )
+    # Straight to AE, not through Heracles' package-workflows. The graph AE has
+    # to run is the one published two lines up, and Heracles' native path
+    # re-derives the graph from the app under test's manifest and publishes it
+    # over exactly that — see FND-1766 and ``_publish``'s module docstring.
     retry = plan.submit_retry
     if retry is None:
-        ae_run_id = await ae.submit_workflow(payload, slug=seeded.slug)
+        ae_run_id = await ae.submit_published_version(seeded.slug)
     else:
-        ae_run_id = await ae.submit_workflow(
-            payload,
-            slug=seeded.slug,
+        ae_run_id = await ae.submit_published_version(
+            seeded.slug,
             retries=retry.retries,
             retry_sleep_seconds=retry.sleep_seconds,
+        )
+
+    if foreign := await ae.foreign_published_dag(
+        seeded.slug, expected=(SEED_PUBLISH_NODE_ID,)
+    ):
+        # Before the poll, because the poll is the expensive half: a graph that
+        # is not the seed's is some app's crawl, which spends minutes failing
+        # (or, worse, succeeding against the connection under test) while
+        # nothing seeds.
+        raise SeedDagSupersededError(
+            message=(
+                f"the DAG AE will run for the {spec.qualified_name} seed is "
+                f"not the {SEED_PUBLISH_NODE_ID!r} node this seed published, "
+                "so nothing would be seeded and the graph that ran would be "
+                "some other app's. Not polling it. This should be impossible "
+                "on the AE-native submit — if it fired, something republished "
+                f"over the seed's version. {foreign}. Seed run: "
+                f"slug={seeded.slug} run_id={ae_run_id}"
+            ),
+            resource=spec.qualified_name,
+            actual_state=foreign,
         )
 
     result = await ae.poll_native_status(
@@ -351,6 +379,25 @@ async def seed_assets(
         timeout_seconds=plan.poll_timeout_seconds,
         progress_stall_seconds=plan.progress_stall_seconds,
     )
+    ran = {node.name for node in result.nodes}
+    if ran and ran != {SEED_PUBLISH_NODE_ID}:
+        # The pre-poll read can be too early — a substitution lands around the
+        # submit, and an unreadable or not-yet-updated version answers
+        # "unanswered" by design. The names on the run itself cannot be early,
+        # and they are checked *before* success: a superseded run that happens
+        # to go green is the shape that greens a leg while seeding nothing.
+        raise SeedDagSupersededError(
+            message=(
+                f"the run AE executed for the {spec.qualified_name} seed ran "
+                f"node(s) {', '.join(sorted(ran))} rather than this seed's "
+                f"{SEED_PUBLISH_NODE_ID!r} node (AE status="
+                f"{result.status.value}), so that run is some other app's DAG "
+                "and nothing was seeded. Nothing under test has run yet. Seed "
+                f"run: slug={seeded.slug} run_id={ae_run_id}"
+            ),
+            resource=spec.qualified_name,
+            actual_state=f"nodes={', '.join(sorted(ran))}",
+        )
     if not result.all_nodes_succeeded:
         raise SeedPublishFailedError(
             message=(

--- a/application_sdk/testing/harness/seed/_errors.py
+++ b/application_sdk/testing/harness/seed/_errors.py
@@ -20,6 +20,7 @@ from typing import ClassVar
 from application_sdk.errors.leaves import InvalidInputError, PreconditionError
 
 __all__ = [
+    "SeedDagSupersededError",
     "SeedPublishEmptyError",
     "SeedPublishFailedError",
     "SeedSegmentInvalidError",
@@ -113,3 +114,28 @@ class SeedPublishEmptyError(PreconditionError):
 
     code: ClassVar[str] = "PRECONDITION_SEED_PUBLISH_EMPTY"
     expected_state: str | None = "at least one seeded asset present in Atlas"
+
+
+@dataclass(kw_only=True)
+class SeedDagSupersededError(PreconditionError):
+    """AE ran some other app's graph in place of the seed's one node.
+
+    The failure this exists to *name*. Before FND-1766 the seed submitted
+    through Heracles, whose native path re-derives the graph from the app under
+    test's served manifest and publishes it over the harness's version — so the
+    connector's own ``extract`` / ``publish`` ran instead of the seed, and the
+    only signal was :class:`SeedPublishFailedError` reporting ``AE
+    status=Failed``. Accurate and unactionable: it reads as "publish failed"
+    rather than "the wrong graph ran", and it sent at least one investigation
+    looking for tenant drift.
+
+    The seed now submits straight to AE
+    (:meth:`~application_sdk.testing.harness.automation_engine.AEClient.submit_published_version`),
+    which has no manifest fetch in it, so nothing should ever raise this. That
+    is the point: it is the assertion that the property holds on a live tenant,
+    on the two readings that can see a substitution — the version AE serves
+    after the submit, and the node names on the run itself.
+    """
+
+    code: ClassVar[str] = "PRECONDITION_SEED_DAG_SUPERSEDED"
+    expected_state: str | None = "the seed's own one-node DAG is what AE ran"

--- a/application_sdk/testing/harness/seed/_publish.py
+++ b/application_sdk/testing/harness/seed/_publish.py
@@ -18,6 +18,25 @@ no artifact the harness has to author or keep in sync.
 ``publish`` needs no new deployment for this: it is a platform service already
 on every tenant, addressed exactly as the connector's own DAG addresses it (see
 :func:`application_sdk.testing.e2e.payload.build_seed_dag`).
+
+**There is no submit payload here, and that absence is the fix for FND-1766.**
+A submit through Heracles' ``/api/service/package-workflows`` carries an
+envelope naming an app, and Heracles' native path re-derives the graph from that
+app's served manifest and publishes it over whatever the caller published — so
+the seed's node was replaced by the connector's own ``extract`` / ``publish``
+whenever AE's submit had already seen the republish. The seed therefore submits
+straight to AE
+(:meth:`~application_sdk.testing.harness.automation_engine.AEClient.submit_published_version`),
+which runs the currently published version and fetches no manifest. Nothing
+names an app, so nothing can name the wrong one.
+
+Picking a *different* identity was the other candidate and it does not work:
+``atlan-publish-app`` is a marketplace app (``atlan.yaml``: ``name: publish``),
+but it has no ``app/generated/``, no programmatic manifest and no
+``@entrypoint``, so its ``/workflows/v1/manifest`` answers 404 — and Heracles
+treats a failed manifest fetch as fatal *before* it writes anything, so a seed
+submit naming publish is an unconditional HTTP 500 rather than a seed that
+survives by absence.
 """
 
 from __future__ import annotations
@@ -26,7 +45,6 @@ import urllib.parse
 from dataclasses import dataclass
 from typing import Any
 
-from application_sdk.contracts.types import ConnectionAttributes, ConnectionRef
 from application_sdk.testing.harness.seed._ndjson import (
     TRANSFORMED_FILE_NAME,
     connection_entity,
@@ -37,7 +55,6 @@ __all__ = [
     "SEED_PUBLISH_NODE_ID",
     "SeedPrefixes",
     "build_seed_publish_dag",
-    "build_seed_submit_payload",
     "seed_object_keys",
 ]
 
@@ -227,81 +244,3 @@ def build_seed_publish_dag(
             },
         }
     }
-
-
-def build_seed_submit_payload(
-    *,
-    spec: ResolvedSeedSpec,
-    run_id: int,
-    ae_workflow_slug: str,
-    app_service_url: str,
-) -> dict[str, Any]:
-    """Build the AE submit body for a seed's publish run.
-
-    Deliberately the *same* builder the connector's own submit uses. The seed's
-    DAG carries no mustache tokens and no credential, so the body reduces to the
-    envelope plus the connection rows — but routing it through a second builder
-    would be a second place for AE's submit shape to drift, on a path that is
-    exercised far less often than the connector's.
-
-    Args:
-        spec: The resolved spec, which is also the seeded connection's identity.
-        run_id: This leg's run identifier, for the AE workflow name and labels.
-        ae_workflow_slug: The slug AE minted on the create.
-        app_service_url: HTTP URL AE can reach the app at.
-
-    Returns:
-        The dict to POST to ``/api/service/package-workflows?submit=true``.
-    """
-    # Imported here rather than at module scope: ``application_sdk.testing.e2e``
-    # imports ``base``, which imports this package, so a top-level import of an
-    # ``e2e`` submodule closes a cycle through a partially-initialised package.
-    from application_sdk.testing.e2e.payload import (  # noqa: PLC0415
-        ConnectionSpec,
-        RunMode,
-        build_ae_payload,
-    )
-    from application_sdk.testing.e2e.substitutions import (  # noqa: PLC0415
-        MustacheSubstitutions,
-    )
-
-    connector = spec.connector_type
-    connection = ConnectionSpec(
-        name=spec.display_name,
-        qualified_name=spec.qualified_name,
-        connector_name=connector,
-        source_logo=f"https://assets.atlan.com/assets/{connector}.png",
-        admin_users=spec.admin_users,
-        admin_groups=spec.admin_groups,
-        admin_roles=spec.admin_roles,
-    )
-    return build_ae_payload(
-        run_id=run_id,
-        mode=RunMode.DIRECT,
-        connector_short_name=connector,
-        argo_package_name=f"@atlan/{connector}",
-        argo_template_name=f"atlan-{connector}",
-        app_service_url=app_service_url,
-        connection=connection,
-        # Built through the aliases rather than the field names because the
-        # aliases *are* the manifest mustache literals this model exists to
-        # express (see its class docstring) — and they are the names its
-        # ``__init__`` actually takes.
-        mustache_subs=MustacheSubstitutions.model_validate(
-            {
-                "{{connection}}": ConnectionRef(
-                    attributes=ConnectionAttributes(
-                        qualified_name=spec.qualified_name, name=spec.display_name
-                    )
-                ),
-                # No ``payload[]`` rides this submit, so nothing would substitute
-                # the default ``{{credentialGuid}}`` token — and an
-                # unsubstituted token is what ``submit_workflow`` warns about. A
-                # seed has no credential to create: it reads an object-store
-                # prefix, not a source.
-                "{{credential-guid}}": "",
-            }
-        ),
-        credential_body=None,
-        ae_workflow_slug=ae_workflow_slug,
-    )

--- a/application_sdk/testing/harness/seed/_publish.py
+++ b/application_sdk/testing/harness/seed/_publish.py
@@ -142,18 +142,32 @@ def seed_object_keys(*, root: str) -> tuple[str, ...]:
     """Every object-store key the *harness* wrote under one seed root.
 
     Teardown deletes these one key at a time rather than deleting the root as a
-    prefix, and that is a correctness requirement rather than a style choice:
-    ``delete_prefix`` is a LIST plus a bulk ``POST ?delete``, both *bucket-level*
-    URLs, and the tenant's Kong s3proxy path-matches against an allowlist it
-    cannot apply to a URL whose keys live in the request body. The call comes
-    back ``403 code 1009 "Invalid Path"`` even though ``/artifacts/apps/`` — the
-    prefix these keys sit under — is on that allowlist. A single-object DELETE
-    puts the key in the path, where the allowlist can read it.
+    prefix, because ``delete_prefix`` cannot work from a runner at all:
+    it is a LIST plus a bulk ``POST ?delete``, both *bucket-level* URLs, and
+    the tenant's Kong s3proxy path-matches against an allowlist it cannot apply
+    to a URL whose keys live in the request body. That call comes back
+    ``403 code 1009 "Invalid Path"`` even though ``/artifacts/apps/`` — the
+    prefix these keys sit under — is on that allowlist.
 
-    That works only because the set is knowable without a listing, which is why
-    this function exists at all: it is the one place that states what a seed
-    writes, and :func:`~application_sdk.testing.harness.seed.seed_assets`
-    composes the same key from :class:`SeedPrefixes`.
+    **The per-key DELETE does not get through either, and this docstring used to
+    claim it did.** Putting the key in the path was the expected fix — the
+    allowlist can read a path — but a live e2e run on 2026-09-07 (FND-1766's
+    three-cloud A/B) came back ``403`` on the single-object DELETE of
+    ``artifacts/apps/<app>/e2e-seed/<qn>/transformed/assets.json`` as well. So
+    the allowlist is not refusing a *URL shape*; it does not grant DELETE under
+    ``/artifacts/apps/`` to a runner in any form. No rearrangement of the
+    request from outside the tenant will fix that, and the next reader should
+    not spend the afternoon finding a third URL shape.
+
+    Which makes this function's remaining value the *enumeration*, not the
+    deletion: it is the one place that states what a seed writes, and
+    :func:`~application_sdk.testing.harness.seed.seed_assets` composes the same
+    key from :class:`SeedPrefixes`. The real fix is to bring the seed root into
+    an on-tenant app's scope — ``connection-delete``'s ``archive_storage``,
+    which already clears the app-owned per-connection stores — so the keys are
+    deleted by something that is not behind the proxy. Until then the delete is
+    attempted and its failure logged, which leaves bounded bytes behind rather
+    than reding a leg.
 
     What is deliberately absent is everything *publish* writes under the same
     root (``publish-state/``, ``current-state/``). The harness did not write

--- a/application_sdk/testing/harness/teardown/__init__.py
+++ b/application_sdk/testing/harness/teardown/__init__.py
@@ -222,60 +222,6 @@ class ConnectionDeleteReport:
         return self.succeeded and not self.errors
 
 
-async def _foreign_published_dag(ae: AEClient, slug: str) -> str:
-    """Describe the DAG AE serves for *slug* when it is not the one we published.
-
-    The read half of the invariant :mod:`._dag` states. Heracles' submit-time
-    manifest fetch replaces the published version with *some* app's manifest, and
-    the harness cannot see that fetch — but it can see the version AE serves
-    afterwards, on the same read
-    :meth:`~application_sdk.testing.e2e.base.BaseE2ETest._assert_deployed_manifest_matches`
-    uses for the mirror-image assertion.
-
-    Compares *node names*, not version numbers, and this is why the harness's
-    node id is the app manifest's own: a republish of the delete app's manifest
-    carries the same node and is therefore **not** foreign — it is the other
-    correct outcome. A version number could not make that distinction; it only
-    says AE published something, which it always does.
-
-    Never raises, and never guesses:
-    :meth:`~application_sdk.testing.harness.automation_engine.AEClient.get_published_version`
-    answers ``None`` for a read that did not get through, an empty DAG says
-    nothing either, and both mean "unanswered" — the delete goes on to poll,
-    exactly as it did before this guard existed. The post-poll check on the
-    run's own node names is what covers those.
-
-    Args:
-        ae: An open AE client on this event loop.
-        slug: The workflow slug the delete published its DAG under.
-
-    Returns:
-        A one-line description of the foreign graph, or ``""`` when the graph is
-        ours or the question went unanswered.
-    """
-    try:
-        published = await ae.get_published_version(slug)
-    # conformance: ignore[E004] teardown boundary — a guard that cannot read AE must degrade to "unanswered", never replace the run's verdict with a cleanup error
-    except Exception:
-        logger.warning(
-            "harness teardown: could not read back the DAG AE published for "
-            "slug %s, so whether the connection-delete node is what runs stays "
-            "unverified until the run's own node names come back",
-            slug,
-            exc_info=True,
-        )
-        return ""
-    if published is None or not published.dag:
-        return ""
-    nodes = sorted(name for name in published.dag if isinstance(name, str))
-    if nodes == [CONNECTION_DELETE_NODE_ID]:
-        return ""
-    return (
-        f"AE serves version {published.version!r} with node(s) "
-        f"{', '.join(nodes) or '(none)'}"
-    )
-
-
 async def delete_connection(
     qualified_name: str,
     *,
@@ -291,7 +237,8 @@ async def delete_connection(
     1. **Create and seed** an AE workflow carrying the one-node DAG.
     2. **Submit** it, on the suite's own cold-start budget.
     3. **Check that the graph AE will run is ours** — see
-       :func:`_foreign_published_dag` and the invariant :mod:`._dag` states. The
+       :meth:`~application_sdk.testing.harness.automation_engine.AEClient.foreign_published_dag`
+       and the invariant :mod:`._dag` states. The
        submit names the delete app so that whichever version wins the republish
        race is a delete; this is the step that does not take that on trust, and
        it runs before the poll because a *third* graph costs minutes and deletes
@@ -406,7 +353,9 @@ async def delete_connection(
             ),
         )
 
-    foreign = await _foreign_published_dag(ae, seeded.slug)
+    foreign = await ae.foreign_published_dag(
+        seeded.slug, expected=(CONNECTION_DELETE_NODE_ID,)
+    )
     if foreign:
         # Before the poll, because the poll is the expensive half: a graph that
         # is neither delete is some app's crawl, which takes minutes to fail (or,

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.32.1
-source-sha:    750c913eab936ef886d56f4ca5046b37f39b06f3
-source-date:   2026-09-06T21:39:22Z
+sdk-version:   3.33.0
+source-sha:    445a7501b91f2a64c74d9511d6042a591b00e75e
+source-date:   2026-09-07T12:28:32+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -4130,6 +4130,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** One schema and the tables/views under it.
 - **Defined in:** `application_sdk/testing/harness/seed/_spec.py`
 
+#### `SeedDagSupersededError`
+
+- **Import:** `from application_sdk.testing.harness.seed import SeedDagSupersededError`
+- **Signature:** `class SeedDagSupersededError(*, ...)`
+- **Summary:** AE ran some other app's graph in place of the seed's one node.
+- **Defined in:** `application_sdk/testing/harness/seed/_errors.py`
+
 #### `SeededConnection`
 
 - **Import:** `from application_sdk.testing.harness.seed import SeededConnection`
@@ -4612,13 +4619,6 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Import:** `from application_sdk.testing.harness.seed import build_seed_publish_dag`
 - **Signature:** `build_seed_publish_dag(*, spec: ResolvedSeedSpec, prefixes: SeedPrefixes, publish_task_queue: str)`
 - **Summary:** Build the single-node DAG that publishes the seed.
-- **Defined in:** `application_sdk/testing/harness/seed/_publish.py`
-
-#### `build_seed_submit_payload`
-
-- **Import:** `from application_sdk.testing.harness.seed import build_seed_submit_payload`
-- **Signature:** `build_seed_submit_payload(*, spec: ResolvedSeedSpec, run_id: int, ae_workflow_slug: str, app_service_url: str)`
-- **Summary:** Build the AE submit body for a seed's publish run.
 - **Defined in:** `application_sdk/testing/harness/seed/_publish.py`
 
 #### `capture_preflight_outcomes`

--- a/tests/unit/testing/e2e/test_multi_dag_runs.py
+++ b/tests/unit/testing/e2e/test_multi_dag_runs.py
@@ -57,6 +57,7 @@ from application_sdk.testing.e2e.client import (
     PublishedVersion,
 )
 from application_sdk.testing.harness import atlas as atlas_api
+from application_sdk.testing.harness.automation_engine import AEClient
 from application_sdk.testing.harness.identity import Minter
 from application_sdk.testing.harness.outcome import Settled
 from application_sdk.testing.harness.teardown import CONNECTION_DELETE_NODE_ID
@@ -168,6 +169,10 @@ class _FakeAE:
 
     async def get_published_version(self, slug: str) -> None:
         return None
+
+    # The real guard, over this fake's scripted read — see
+    # ``_PublishingAE``, which is the subclass that makes it answer something.
+    foreign_published_dag = AEClient.foreign_published_dag
 
     async def probe_run_is_listed(self, slug: str, run_id: str) -> None:
         return None

--- a/tests/unit/testing/harness/automation_engine/test_writes.py
+++ b/tests/unit/testing/harness/automation_engine/test_writes.py
@@ -1,4 +1,4 @@
-"""The three AE write endpoints, and the parsers that keep them forward-compatible.
+"""The AE write endpoints, and the parsers that keep them forward-compatible.
 
 These paths existed before FND-242 but were never counted: they lived in
 ``testing/e2e/client.py``, which coverage omits because it only runs against a
@@ -22,18 +22,22 @@ import pytest
 
 from application_sdk.testing.harness._poll import fake_clock
 from application_sdk.testing.harness.automation_engine._errors import (
+    AtlanAEWorkflowAlreadyActiveError,
     AtlanApiHttpError,
     AtlanApiResponseInvariantError,
     AtlanApiTimeoutError,
+    RequestDelivery,
 )
 from application_sdk.testing.harness.automation_engine.client import AEClient
 from application_sdk.testing.harness.automation_engine.retry import (
+    RunLookup,
     parse_run_timestamp,
     rotate_submit_credential_name,
 )
 from application_sdk.testing.harness.automation_engine.wire import (
     DAGNodeStatus,
     DAGRunStatus,
+    PublishedVersion,
     safe_int,
     safe_node_status,
     safe_run_status,
@@ -389,3 +393,165 @@ class TestDefensiveParsers:
             {"payload": [{"body": {}}]},
         ):
             rotate_submit_credential_name(body)  # type: ignore[arg-type]
+
+
+class TestSubmitPublishedVersion:
+    """The AE-native submit: our graph, or a named refusal — never an app's."""
+
+    async def test_it_posts_to_aes_own_route_with_no_envelope(self) -> None:
+        """The whole point of this endpoint. A Heracles submit carries an
+        envelope naming an app, and Heracles re-derives the graph from that
+        app's manifest and publishes it over ours; there is nothing here to
+        name an app with (FND-1766)."""
+        client = _client()
+        with patch.object(
+            client, "_request", return_value=(200, {"data": {"guid": "run-9"}})
+        ) as req:
+            assert await client.submit_published_version("slug-1") == "run-9"
+        (method, path), kwargs = req.call_args
+        assert method == "POST"
+        assert path == "/automation/api/v1/workflows/slug-1/submit"
+        assert kwargs["body"] == {"is_test_run": False}
+
+    async def test_the_slug_is_percent_encoded(self) -> None:
+        """A slug is AE-minted, but it reaches this call as a string and a
+        stray ``/`` would silently address a different route."""
+        client = _client()
+        with patch.object(
+            client, "_request", return_value=(200, {"data": {"guid": "r"}})
+        ) as req:
+            await client.submit_published_version("a/b?c")
+        assert req.call_args[0][1] == ("/automation/api/v1/workflows/a%2Fb%3Fc/submit")
+
+    async def test_it_never_submits_a_test_run(self) -> None:
+        """``is_test_run`` is a different thing: AE triggers it as
+        ``TriggeredBy.TEST`` and writes the workflow to the StateStore eagerly.
+        A harness run must never accidentally be one."""
+        client = _client()
+        with patch.object(
+            client, "_request", return_value=(200, {"data": {"guid": "r"}})
+        ) as req:
+            await client.submit_published_version("s")
+        assert req.call_args[1]["body"]["is_test_run"] is False
+
+    async def test_a_404_is_retried_because_the_publish_may_not_have_replicated(
+        self,
+    ) -> None:
+        """AE resolves the published version *at submit time*, and a version
+        published seconds earlier answers 404 until it replicates — the same
+        lag Heracles' own AE client budgets for on this endpoint."""
+        client = _client()
+        answers = [
+            (404, {"error": "no published version"}),
+            (200, {"data": {"guid": "run-late"}}),
+        ]
+        with (
+            patch.object(client, "_request", side_effect=answers),
+            patch(_SLEEP),
+        ):
+            assert await client.submit_published_version("s") == "run-late"
+
+    async def test_an_exhausted_404_says_nothing_was_published(self) -> None:
+        """The two causes are "the caller published nothing" and "the publish
+        never replicated", and a bare HTTP 404 names neither."""
+        client = _client()
+        with (
+            patch.object(client, "_request", return_value=(404, {"error": "nope"})),
+            patch(_SLEEP),
+            pytest.raises(AtlanApiHttpError) as caught,
+        ):
+            await client.submit_published_version("s", retries=1)
+        assert "no published version for slug s" in str(caught.value)
+
+    async def test_an_already_active_run_is_terminal(self) -> None:
+        """A retry would spawn a duplicate AE marks ``Skipped`` and returns
+        under a fresh id, so the harness would poll a phantom."""
+        client = _client()
+        body = {"error": "AE-WF-409-03 run already active"}
+        with (
+            patch.object(client, "_request", return_value=(409, body)) as req,
+            patch(_SLEEP),
+            pytest.raises(AtlanAEWorkflowAlreadyActiveError),
+        ):
+            await client.submit_published_version("s")
+        assert req.call_count == 1
+
+    async def test_a_2xx_without_a_guid_is_an_invariant_failure(self) -> None:
+        """AE answered, and the answer was unusable. Naming it here stops it
+        surfacing as a poll against the empty string."""
+        client = _client()
+        with (
+            patch.object(client, "_request", return_value=(200, {"data": {}})),
+            pytest.raises(AtlanApiResponseInvariantError, match="no run guid"),
+        ):
+            await client.submit_published_version("s")
+
+    async def test_an_ambiguous_failure_adopts_aes_own_record(self) -> None:
+        """Same discipline as ``submit_workflow``: this write is not idempotent,
+        so an ambiguous transport failure is resolved by asking AE what landed
+        rather than by re-POSTing on a guess."""
+        client = _client()
+        timeout = AtlanApiTimeoutError(
+            message="lost", operation="submit", delivery=RequestDelivery.AMBIGUOUS
+        )
+        with (
+            patch.object(client, "_request", side_effect=timeout),
+            patch.object(
+                client,
+                "find_run_created_since",
+                return_value=RunLookup(run_id="run-adopted", conclusive=True),
+            ),
+            patch(_SLEEP),
+        ):
+            assert await client.submit_published_version("s") == "run-adopted"
+
+
+class TestForeignPublishedDag:
+    """Which graph AE will run, read back by node name rather than by version."""
+
+    async def test_our_own_nodes_are_not_foreign(self) -> None:
+        client = _client()
+        published = PublishedVersion(version=3, dag={"seed-publish": {}})
+        with patch.object(client, "get_published_version", return_value=published):
+            assert (
+                await client.foreign_published_dag("s", expected=("seed-publish",))
+                == ""
+            )
+
+    async def test_another_apps_nodes_are_described(self) -> None:
+        client = _client()
+        published = PublishedVersion(version=4, dag={"extract": {}, "publish": {}})
+        with patch.object(client, "get_published_version", return_value=published):
+            described = await client.foreign_published_dag(
+                "s", expected=("seed-publish",)
+            )
+        assert "extract, publish" in described
+        assert "4" in described
+
+    async def test_expected_may_name_more_than_one_node(self) -> None:
+        """The policy parameter is what lets one implementation serve both
+        callers: teardown's node id is the delete app's own, so a republish of
+        that manifest is the *other correct* outcome rather than a foreign
+        graph."""
+        client = _client()
+        published = PublishedVersion(version=1, dag={"b": {}, "a": {}})
+        with patch.object(client, "get_published_version", return_value=published):
+            assert await client.foreign_published_dag("s", expected=("a", "b")) == ""
+
+    async def test_an_unanswered_read_is_not_a_foreign_graph(self) -> None:
+        """``None`` means "no answer", which is not "no match" — a caller must
+        go on to poll exactly as it would without this check, and the run's own
+        node names are what cover the case."""
+        client = _client()
+        for answer in (None, PublishedVersion(version=1, dag={})):
+            with patch.object(client, "get_published_version", return_value=answer):
+                assert await client.foreign_published_dag("s", expected=("x",)) == ""
+
+    async def test_a_read_that_raised_degrades_to_unanswered(self) -> None:
+        """A guard that cannot read AE must never replace the caller's verdict
+        with its own read error."""
+        client = _client()
+        with patch.object(
+            client, "get_published_version", side_effect=RuntimeError("boom")
+        ):
+            assert await client.foreign_published_dag("s", expected=("x",)) == ""

--- a/tests/unit/testing/harness/seed/test_seed_publish.py
+++ b/tests/unit/testing/harness/seed/test_seed_publish.py
@@ -11,6 +11,11 @@ The sequence is the part worth a test. A seed that uploads a batch it has not
 checked publishes partially, and a seed that reports success on a failed publish
 hands the connector under test a connection with no cache — the exact shape that
 greens a leg while dropping lineage.
+
+The third thing pinned here is *which graph ran*. The seed submits straight to
+AE precisely so no app's manifest can be published over its node (FND-1766), and
+both readings that could catch a substitution — the version AE serves after the
+submit, and the node names on the run itself — must refuse rather than proceed.
 """
 
 from __future__ import annotations
@@ -27,6 +32,7 @@ from application_sdk.testing.harness.seed import (
     TRANSFORMED_FILE_NAME,
     DatabaseSpec,
     SchemaSpec,
+    SeedDagSupersededError,
     SeedPrefixes,
     SeedPublishEmptyError,
     SeedPublishFailedError,
@@ -35,7 +41,6 @@ from application_sdk.testing.harness.seed import (
     SeedTreeInvalidError,
     TableSpec,
     build_seed_publish_dag,
-    build_seed_submit_payload,
     seed_assets,
     seed_object_keys,
     seed_prefix_root,
@@ -71,7 +76,6 @@ def _plan() -> SeedPublishPlan:
         app_name="coalesce",
         publish_task_queue="atlan-publish-production",
         ae_workflow_name="coalesce-e2e-42-seed-snowflake",
-        app_service_url="http://coalesce.svc",
         run_id=42,
         poll_interval_seconds=1,
         poll_timeout_seconds=5,
@@ -254,53 +258,43 @@ class TestSeedPublishNode:
         assert SEED_PUBLISH_NODE_ID != "publish"
 
 
-class TestSubmitPayload:
-    """The submit body carries the slug and no token nothing will substitute."""
-
-    def test_the_slug_is_carried_and_no_credential_is_created(self) -> None:
-        payload = build_seed_submit_payload(
-            spec=_resolved(),
-            run_id=42,
-            ae_workflow_slug="slug-1",
-            app_service_url="http://x",
-        )
-        assert payload["metadata"]["ae_workflow_slug"] == "slug-1"
-        assert "payload" not in payload
-
-    def test_no_unsubstituted_credential_token_rides_the_submit(self) -> None:
-        """With no ``payload[]`` there is nothing to substitute
-        ``{{credentialGuid}}`` with, and an unsubstituted token is what
-        ``submit_workflow`` warns about."""
-        from application_sdk.testing.harness.automation_engine.retry import (
-            unsubstituted_parameter_tokens,
-        )
-
-        payload = build_seed_submit_payload(
-            spec=_resolved(),
-            run_id=42,
-            ae_workflow_slug="slug-1",
-            app_service_url="http://x",
-        )
-        assert unsubstituted_parameter_tokens(payload) == {}
-
-
 class _FakeAE:
-    """Records the submit and answers one scripted ``native-status``."""
+    """Records the submit and answers one scripted ``native-status``.
 
-    def __init__(self, *, all_succeeded: bool = True) -> None:
-        self.submitted: list[tuple[dict[str, Any], str]] = []
+    ``submit_published_version`` rather than ``submit_workflow``: the seed's
+    submit takes no payload at all, because there is no envelope to name an app
+    with (FND-1766). A fake that still accepted one would let a regression back
+    onto the Heracles path unnoticed.
+    """
+
+    def __init__(
+        self,
+        *,
+        all_succeeded: bool = True,
+        ran_nodes: tuple[str, ...] = (SEED_PUBLISH_NODE_ID,),
+        foreign: str = "",
+    ) -> None:
+        self.submitted: list[str] = []
+        self.guarded: list[tuple[str, tuple[str, ...]]] = []
         self._all_succeeded = all_succeeded
+        self._ran_nodes = ran_nodes
+        self._foreign = foreign
 
-    async def submit_workflow(
-        self, payload: dict[str, Any], *, slug: str, **_: Any
-    ) -> str:
-        self.submitted.append((payload, slug))
+    async def submit_published_version(self, slug: str, **_: Any) -> str:
+        self.submitted.append(slug)
         return "ae-run-1"
+
+    async def foreign_published_dag(
+        self, slug: str, *, expected: tuple[str, ...]
+    ) -> str:
+        self.guarded.append((slug, tuple(expected)))
+        return self._foreign
 
     async def poll_native_status(self, run_id: str, **_: Any) -> SimpleNamespace:
         return SimpleNamespace(
             run_id=run_id,
             all_nodes_succeeded=self._all_succeeded,
+            nodes=[SimpleNamespace(name=name) for name in self._ran_nodes],
             status=SimpleNamespace(
                 value="Success" if self._all_succeeded else "Failed"
             ),
@@ -326,6 +320,8 @@ def _wire(
     *,
     report: AssetValidationReport | None = None,
     all_succeeded: bool = True,
+    ran_nodes: tuple[str, ...] = (SEED_PUBLISH_NODE_ID,),
+    foreign: str = "",
 ) -> tuple[_FakeAE, list[tuple[str, str]]]:
     """Patch the three collaborators a seed reaches for, recording each."""
     uploaded: list[tuple[str, str]] = []
@@ -348,7 +344,8 @@ def _wire(
             "application_sdk.testing.harness.seed.validate_transformed_dir",
             lambda *_a, **_k: report,
         )
-    return _FakeAE(all_succeeded=all_succeeded), uploaded
+    fake = _FakeAE(all_succeeded=all_succeeded, ran_nodes=ran_nodes, foreign=foreign)
+    return fake, uploaded
 
 
 class TestSeedAssetsSequence:
@@ -511,3 +508,80 @@ class TestSeedAssetsSequence:
                 _resolved(), store=object(), ae=ae, plan=_plan(), verify=_record
             )
         assert calls == []
+
+
+class TestTheGraphThatRuns:
+    """The seed's own node, or nothing — never some app's crawl."""
+
+    @pytest.mark.asyncio
+    async def test_the_submit_names_only_the_slug(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No envelope, so no app identity, so no manifest for Heracles to
+        publish over the seed. That absence is the whole fix: naming the app
+        under test ran its ``extract`` / ``publish`` instead of the seed, and
+        naming publish instead is an unconditional 500 (publish serves no
+        manifest)."""
+        ae, _uploaded = _wire(monkeypatch)
+        await seed_assets(
+            _resolved(), store=object(), ae=ae, plan=_plan(), verify=_verifier(4)
+        )
+        assert ae.submitted == ["slug-1"]
+
+    @pytest.mark.asyncio
+    async def test_the_guard_asks_for_the_seeds_own_node(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The seed's node id is unique to the seed, so — unlike teardown's,
+        which is the delete app's own — any other name at all is foreign."""
+        ae, _uploaded = _wire(monkeypatch)
+        await seed_assets(
+            _resolved(), store=object(), ae=ae, plan=_plan(), verify=_verifier(4)
+        )
+        assert ae.guarded == [("slug-1", (SEED_PUBLISH_NODE_ID,))]
+
+    @pytest.mark.asyncio
+    async def test_a_substituted_version_is_refused_before_the_poll(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The poll is the expensive half: a connector's crawl spends minutes
+        failing — or succeeding against the connection under test — while
+        nothing seeds."""
+        ae, _uploaded = _wire(
+            monkeypatch, foreign="AE serves version 7 with node(s) extract, publish"
+        )
+        with pytest.raises(SeedDagSupersededError) as caught:
+            await seed_assets(
+                _resolved(), store=object(), ae=ae, plan=_plan(), verify=_verifier(4)
+            )
+        assert "extract, publish" in str(caught.value)
+        assert SEED_PUBLISH_NODE_ID in str(caught.value)
+
+    @pytest.mark.asyncio
+    async def test_a_foreign_run_is_refused_even_when_it_went_green(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The pre-poll read can be too early; the run's own node names cannot
+        be. Checked *before* success, because a substituted run that happens to
+        succeed is the shape that greens a leg while seeding nothing — and
+        before FND-1766 the only signal was ``AE status=Failed``, which reads as
+        "publish failed" rather than "the wrong graph ran"."""
+        ae, _uploaded = _wire(monkeypatch, ran_nodes=("extract", "publish"))
+        with pytest.raises(SeedDagSupersededError) as caught:
+            await seed_assets(
+                _resolved(), store=object(), ae=ae, plan=_plan(), verify=_verifier(4)
+            )
+        assert "extract, publish" in str(caught.value)
+        assert "ae-run-1" in str(caught.value)
+
+    @pytest.mark.asyncio
+    async def test_a_run_reporting_no_nodes_is_not_treated_as_foreign(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty node list is an unanswered read, not a substitution. Failing
+        on one would turn a status blip into a seed defect."""
+        ae, _uploaded = _wire(monkeypatch, ran_nodes=())
+        seeded = await seed_assets(
+            _resolved(), store=object(), ae=ae, plan=_plan(), verify=_verifier(4)
+        )
+        assert seeded.ae_run_id == "ae-run-1"

--- a/tests/unit/testing/harness/test_connection_delete.py
+++ b/tests/unit/testing/harness/test_connection_delete.py
@@ -27,7 +27,10 @@ from typing import Any
 
 import pytest
 
-from application_sdk.testing.harness.automation_engine import NoWorkerOnTaskQueueError
+from application_sdk.testing.harness.automation_engine import (
+    AEClient,
+    NoWorkerOnTaskQueueError,
+)
 from application_sdk.testing.harness.automation_engine.wire import (
     DAGNodeResult,
     DAGNodeStatus,
@@ -151,6 +154,12 @@ class _FakeAE:
         if self._published_error is not None:
             raise self._published_error
         return self._published
+
+    # The real guard, over this fake's scripted read. Borrowed rather than
+    # re-scripted: the decision it makes (which node names are foreign, and
+    # what "unanswered" degrades to) is the thing under test here, and a
+    # second copy of it in a fake would only ever agree with itself.
+    foreign_published_dag = AEClient.foreign_published_dag
 
     async def poll_native_status(self, run_id: str, **kwargs: Any) -> DAGRunResult:
         self.poll_kwargs.append(kwargs)

--- a/uv.lock
+++ b/uv.lock
@@ -483,7 +483,7 @@ requires-dist = [
 provides-extras = ["test"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = "==0.16.5" }]
+dev = [{ name = "ruff", specifier = "==0.16.6" }]
 
 [[package]]
 name = "attrs"


### PR DESCRIPTION
## What broke

`seed_assets` published a one-node `seed-publish` DAG and submitted it through Heracles' `/api/service/package-workflows`. That submit's envelope named **the app under test**, so Heracles' native path re-derived the graph from that app's served manifest and published it over the seed's — the connector's own `extract` → `publish` ran instead, the seed never seeded, and the leg died on `SeedPublishFailedError` ("AE status=Failed"), which reads as *publish failed* rather than *the wrong graph ran*.

Reproduced on `atlan-coalesce-app` run [34105880480](https://github.com/atlanhq/atlan-coalesce-app/actions/runs/34105880480): one commit, three legs, two green with `seed-publish` and one red with `extract` + `publish`.

## It is not a race between two writers

FND-1724 read this as a race. It isn't. Heracles' native path is unconditional — `GetManifest` → `CreateVersion` → `PublishVersion` → submit — so the harness's published version is superseded on **every** call. The only variable is whether AE's submit has *seen* the new published version yet: AE resolves the published version at submit time and answers 404 until the write replicates through the metastore, which is what Heracles' own AE client budgets 5×(5/10/15/15/15s) for on that same endpoint.

So the seed surviving was the **lagging** path. That inverts the reading of the evidence and explains its shape — one tenant failing twice consecutively while two passed consistently is a stable per-tenant replication bias, not pod warmth or ConfigMap drift.

## The obvious fix does not work

Naming a *different* app in the envelope — publish, so the fetch resolves nothing — was the leading candidate. `atlan-publish-app` **is** a marketplace app (`atlan.yaml`: `name: publish`, `type: system`), but it has no `app/generated/`, no programmatic manifest and no `@entrypoint`, so its `/workflows/v1/manifest` falls through to `404 "No manifest available"`. Heracles treats a failed manifest fetch as fatal *before* it writes anything, so that route is an unconditional HTTP 500 — not a seed that survives by absence.

## What this does instead

Submits the seed straight to AE: `POST /automation/api/v1/workflows/<slug>/submit`. AE runs its currently published version and fetches no manifest, so there is no envelope, no app identity to pick, and no app under test in the path. Nothing names an app, so nothing can name the wrong one — and that fixes the **class**, for any future harness-published DAG rather than just the seed.

Two side effects, both wanted:

- **The seed stops depending on the connector pod.** Heracles' `GetManifest` against `:8000` was the only reason a seed carried a cold-start budget; seeding is not about that pod. `submit_retry` is dropped from the seed plan, and `SeedPublishPlan.app_service_url` becomes an ignored field (deprecated, removal v4.0 — kept so construction doesn't break).
- **`_RESUBMIT_WHEN_AE_REPORTS_NO_RUN`'s precondition is met on this path.** An AE-submitted run carries AE's own fields, so the reconcile read can see it. Not flipping the flag here — the connector's own submit still goes through Heracles — but noting it.

### The pieces

| | |
|---|---|
| `AEClient.submit_published_version` | Keeps `submit_workflow`'s discipline for a non-idempotent write: no blind re-POST on an ambiguous failure, recovery by asking AE what landed, already-active terminal. Adds **404 as retryable on this path only**, 6×12s, matched to Heracles' budget for the same lag rather than a number invented here. |
| `AEClient.foreign_published_dag(slug, expected=…)` | One guard for both callers, node names as a policy parameter. Teardown's private `_foreign_published_dag` is gone. The tuple can name more than one node, which is how teardown keeps a republish of the delete app's own manifest expressible as its *second correct* outcome. |
| `SeedDagSupersededError` | Raised on both readings that can see a substitution: the version AE serves after the submit (before the poll, the expensive half) and the run's own node names (before the success check, so a substituted run that goes green cannot report as a seed). |
| `build_seed_submit_payload` | **Removed.** It built the envelope and nothing else, and there is no correct envelope for a seed — deprecating it would leave a builder whose only use is the path this fixes. No external caller; landed in 3.33.0 one day ago. |

`SeedDagSupersededError` should now be unreachable. That is the point of it: it asserts the determinism above on a live tenant, and turns `AE status=Failed` into a message that names the actual failure.

## Teardown is deliberately left on Heracles

FND-1724's design (name the delete app, make the harness's node a verbatim copy of that app's manifest node) makes both republish outcomes a delete — so teardown is *harmless* where the seed was *broken*, and it succeeded even on the leg that failed here. Converting it onto `submit_published_version` would retire that whole apparatus (the verbatim node id, the delete-app envelope, `ConnectionDeleteSubstitutions`, `dag_superseded`) and be a net deletion, but it belongs in its own change rather than riding behind an endpoint with no live evidence yet. Raised as a follow-up.

## No retries around the submit

A resubmit re-rolls the same weighted die, which is why the failing leg failed twice in a row. Determinism is the fix.

## Verification

**Read against both sides** — heracles (`handler/workflow.go`, `pkg/ae/client.go`), atlan-automation-engine-app (`routes/v1/workflows.py`, `services/submission_service.py`), atlan-publish-app (`atlan.yaml`, `main.py`), and this SDK's `handler/service.py`. Full write-up on FND-1766.

**Unit-tested here**: the AE-native submit (route, empty-envelope, slug encoding, never-a-test-run, 404 replication retry, exhausted-404 message, already-active terminal, missing-guid invariant, ambiguous-failure adoption), the shared guard (ours / foreign / multi-node `expected` / unanswered / read-raised), and both seed guard halves. `2149 passed` in `tests/unit/testing`, `10086 passed` across `tests/unit`. Both fakes that script `get_published_version` now borrow the real `foreign_published_dag` rather than re-scripting its decision.

**Not yet verified live.** Two things a real call decides and code reading cannot: whether Kong routes `/submit` for an API token the way it routes the create/version/publish calls the harness already makes, and whether `inject_username_context` (a `Depends` on that route, absent from the other three) is satisfied by a bearer token. Both fail closed and loudly. A three-cloud A/B is running from the coalesce side against `hritikarajput/fnd-402-coalesce-e2e` with `application_sdk_ref` on this branch, baselined on run 34105880480; a 401/403 at the submit answers that question and sends this back to a Heracles-plus-guard shape.

## Notes for review

- `uv.lock` carries a one-line `requires-dev` reconciliation that `uv sync` produces from the already-committed pyproject (ruff 0.16.6, from #3672). No dependency change.
- `docs/agents/sdk-capabilities.md` still lists `build_seed_submit_payload`. It is stale independently of this PR (`source-sha` predates main) and its own header says re-run the skill rather than hand-edit, so `/capability-manifest` wants a separate refresh.
- Worth retitling #3677 — its title ("teardown must name no app, or its DAG is replaced") describes the abandoned first attempt, not what shipped, and reading it as the fix leads straight to the disproved route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BspoNHu7L6fW3yNQ4hHnYW
