### PR TITLE
fix(conformance): default use_ghcr_base to true

### DIFF
--- a/.github/scripts/resolve_base_redirect.py
+++ b/.github/scripts/resolve_base_redirect.py
@@ -1,18 +1,26 @@
 #!/usr/bin/env python3
-"""Resolve the GHCR base-image redirect for an opted-in app build.
+"""Resolve the GHCR base-image redirect for an app build.
 
 Emits the ``build-contexts`` mapping that redirects the SDK base image from
 Harbor to GHCR, after proving the redirect is both *applicable* and *safe*:
 
 1. **Match coverage.** BuildKit's named-context substitution is reference
    specific: it only fires when the Dockerfile's ``FROM`` reference is exactly
-   the mapping's left-hand side. A caller that opts in but pins another tag
-   would silently keep pulling from Harbor and still go green. This script
-   parses the Dockerfile (expanding global ``ARG`` defaults the way BuildKit
-   does) and **fails closed** when it can prove no ``FROM`` matches the
-   supported reference. When a base reference cannot be resolved statically
-   (an ``ARG`` with no default), it warns and emits no mapping rather than
-   blocking a build it cannot reason about.
+   the mapping's left-hand side. This script parses the Dockerfile (expanding
+   global ``ARG`` defaults the way BuildKit does) and, when no ``FROM`` matches
+   the supported reference, **warns and emits no mapping** — the build pulls
+   from Harbor exactly as it did before the redirect existed.
+
+   That used to fail closed, on the reasoning that a caller who opted in and
+   still pulled from Harbor had a silent no-op to fix. The reasoning does not
+   survive the default flipping to true: nobody opts in per app any more, so
+   failing a build the redirect merely cannot *rewrite* punishes an app for a
+   fleet-wide default. A digest-pinned base is the case that made this
+   concrete — conformance I001 accepts it, and it does not match a tag
+   mapping, so a fail-closed preflight would have broken those builds the
+   moment the default turned on. Parity (below) is a different question and
+   still fails closed: that one is about whether the image is *right*, not
+   about whether the redirect applies.
 
 2. **Cross-registry parity.** ``harbor-release.yaml`` pushes both registries
    from one buildx invocation, but the push is not transactional: a GHCR-leg
@@ -435,18 +443,21 @@ def decide(
         supported = ", ".join(f"{harbor_repo}:{t}" for t in supported_tags)
         if unresolved:
             decision.warnings.append(
-                f"use_ghcr_base is set, but no FROM statically matches {supported}, "
+                f"No FROM statically matches {supported}, "
                 f"and {len(unresolved)} reference(s) resolve only inside BuildKit "
                 f"({', '.join(r.raw for r in unresolved)}). Building from Harbor "
                 "unchanged. Confirm the base tag or pass it as a Dockerfile ARG "
                 "default so this check can see it."
             )
             return decision
-        decision.errors.append(
-            f"use_ghcr_base is set, but no FROM in this Dockerfile references "
-            f"{supported}, so the redirect would be a silent no-op and the build "
-            f"would still pull from Harbor. Found: {listed}. Either repin the base "
-            "to a supported reference or unset use_ghcr_base."
+        # Not an error: see the module docstring. With the redirect on by
+        # default, a base this script cannot rewrite is an app spelling its
+        # base differently -- not a misconfiguration to fail the build over.
+        decision.warnings.append(
+            f"No FROM in this Dockerfile references {supported}, so the base "
+            f"cannot be redirected and this build pulls it from Harbor as "
+            f"before. Found: {listed}. Repin the base to a supported reference "
+            "to move this app's base pulls to GHCR."
         )
         return decision
 

--- a/.github/scripts/tests/test_resolve_base_redirect.py
+++ b/.github/scripts/tests/test_resolve_base_redirect.py
@@ -118,18 +118,44 @@ def test_split_ref(ref, expected):
 # ── Finding 1: match coverage ─────────────────────────────────────────────────
 
 
-def test_non_matching_tag_fails_closed():
+def test_non_matching_tag_degrades_to_harbor():
+    # Was fail-closed while the redirect was opt-in. With it on by default, a
+    # base this script cannot rewrite is not the app's fault: warn, build from
+    # Harbor, do not fail. (I001 rejects this tag on its own account.)
     refs = rbr.parse_base_refs(f"FROM {HARBOR}:3.26.1\n")
     decision = rbr.decide(refs, resolve_digest=digests(DIGEST_A, DIGEST_A))
-    assert not decision.ok
+    assert decision.ok
+    assert decision.errors == []
     assert decision.build_contexts == ""
-    assert "silent no-op" in decision.errors[0]
+    assert "cannot be redirected" in decision.warnings[0]
 
 
-def test_digest_pinned_base_fails_closed():
-    refs = rbr.parse_base_refs(f"FROM {HARBOR}@{DIGEST_A}\n")
+def test_digest_pinned_base_degrades_to_harbor():
+    # The case that forced this change: I001 *approves* a digest-pinned base,
+    # and it cannot match a tag mapping. Fail-closed here would have broken
+    # every such app's build the moment the default turned on.
+    refs = rbr.parse_base_refs(f"FROM {HARBOR}:3@{DIGEST_A}\n")
     decision = rbr.decide(refs, resolve_digest=digests(DIGEST_A, DIGEST_A))
+    assert decision.ok
+    assert decision.errors == []
+    assert decision.build_contexts == ""
+
+
+def test_parity_still_fails_closed_now_that_match_coverage_does_not():
+    # The two gates are not the same question. Match coverage asks "can the
+    # redirect apply"; parity asks "is the image we would ride correct". Only
+    # the second is worth failing a build over, and it still does.
+    refs = rbr.parse_base_refs(f"FROM {HARBOR}:3\n")
+    decision = rbr.decide(refs, resolve_digest=digests(DIGEST_A, DIGEST_B))
     assert not decision.ok
+    assert "skew" in decision.errors[0]
+
+
+def test_harbor_unreachable_still_fails_closed():
+    refs = rbr.parse_base_refs(f"FROM {HARBOR}:3\n")
+    decision = rbr.decide(refs, resolve_digest=digests(None, DIGEST_A))
+    assert not decision.ok
+    assert "parity cannot be verified" in decision.errors[0]
 
 
 def test_already_on_ghcr_is_a_noop_not_an_error():

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -88,10 +88,10 @@ on:
         type: boolean
         default: false
       use_ghcr_base:
-        description: "Resolve the SDK base image from GHCR instead of Harbor during the image build. Opt-in while the GHCR path is being rolled out; the default will flip to true once canary apps have soaked, and the flag will then be removed. Setting this runs a preflight that fails the build if the redirect cannot apply to this Dockerfile, or if the two registries have drifted apart on the base tag — see the 'Resolve GHCR base redirect' step for the mechanics and docs/standards/build-security.md for why the mirror exists. Default false — every caller builds from Harbor exactly as before."
+        description: "Resolve the SDK base image from GHCR instead of Harbor during the image build. Default TRUE — the soak is over and the fleet now pulls the base from GHCR, which is free from GitHub-hosted runners where Harbor's S3-backed blobs are not. The base itself is unchanged: harbor-release.yaml publishes both registries at one digest and the preflight verifies that parity per build, failing closed on skew. A Dockerfile the redirect cannot rewrite (a pinned patch tag, a digest-pinned base) is not an error — it warns and builds from Harbor as before, so turning this on fleet-wide cannot fail a build merely because the base is spelled differently. Pass false to pin an app to Harbor. See the 'Resolve GHCR base redirect' step for the mechanics and docs/standards/build-security.md for the two-registry layout."
         required: false
         type: boolean
-        default: false
+        default: true
     secrets:
       ORG_PAT_GITHUB:
         required: true

--- a/docs/standards/build-security.md
+++ b/docs/standards/build-security.md
@@ -76,26 +76,28 @@ than a green build on the wrong base.
 App Dockerfiles keep `FROM registry.atlan.com/public/app-runtime-base:3` — that
 reference is the public interface, and it stays put. (Conformance I001 accepts the
 GHCR mirror `ghcr.io/atlanhq/app-runtime-base:3` as an equal spelling, so a Dockerfile
-that names GHCR directly is not reverted; the redirect then has nothing to do and says so.) Callers of
-`build-and-publish-app.yaml` opt in with `use_ghcr_base: true`, and a BuildKit named
-context rewrites *where the layers come from* without changing what is built.
+that names GHCR directly is not reverted; the redirect then has nothing to do and says so.) `build-and-publish-app.yaml`'s `use_ghcr_base` input, **default `true`**, drives a
+BuildKit named context that rewrites *where the layers come from* without changing what
+is built.
 
-Each app self-selects, on its own schedule — the input's default stays `false` until the
-fleet has soaked. The opt-in is safe to keep in an app's `build-and-publish.yaml` even
-though `bootstrap` fully manages that file: the value is read back off the file on every
-re-run (or set with `atlan-application-sdk-conformance bootstrap --use-ghcr-base true`),
-so a re-sync preserves it instead of reverting the app to Harbor, and conformance C002
-does not report an opted-in app as drifted. To go back to Harbor, delete the line or pass
-`--use-ghcr-base false`.
+The default was `false` through the soak, one app at a time. It is now on for the whole
+fleet: GHCR pulls are free from GitHub-hosted runners, Harbor's S3-backed blobs are not,
+and the base is the same image either way. An app can pin itself back to Harbor by
+passing `use_ghcr_base: false` to the reusable workflow.
 
-The opt-in runs `.github/scripts/resolve_base_redirect.py` first, which fails the
-build rather than let the redirect fail quietly:
+Because the default now covers apps nobody checked individually, the preflight's
+**match-coverage** gate degrades rather than fails: a Dockerfile the redirect cannot
+rewrite — a pinned patch tag, a digest-pinned base — warns and builds from Harbor. A
+digest-pinned base is the case that forced this; conformance I001 approves it, and it
+cannot match a tag mapping, so a fail-closed gate would have broken those builds the
+moment the default turned on. The **parity** gate still fails closed, because that one
+asks whether the image is right, not whether the redirect applies:
 
 | Situation | Outcome |
 |---|---|
 | Dockerfile's base reference matches, digests agree | Redirect applied, **pinned to the immutable digest** |
 | Dockerfile already names the GHCR mirror (`ghcr.io/atlanhq/app-runtime-base`) | Redirect not needed — builds from GHCR directly, nothing emitted |
-| No `FROM` matches the supported reference | **Build fails** — the opt-in would be a silent no-op |
+| No `FROM` matches the supported reference (pinned patch tag, digest-pinned base) | Warns, builds from Harbor |
 | Harbor and GHCR serve different digests for the tag | **Build fails** — see the recovery above |
 | Base reference only resolves inside BuildKit (`ARG` with no default) | Warns, builds from Harbor |
 | GHCR unreachable | Warns, builds from Harbor |

--- a/packages/conformance/conformance/bootstrap/args.py
+++ b/packages/conformance/conformance/bootstrap/args.py
@@ -305,13 +305,15 @@ options:
                               to ever fail a run is T014's question, not C002's.)
   --use-ghcr-base true|false  resolve the SDK base image from GHCR instead of Harbor,
                               rendered into build-and-publish.yaml as the reusable
-                              workflow's use_ghcr_base input. Apps self-select this while
-                              the SDK-side default is still false; C002 does not read an
-                              opt-in as drift. Omit to auto-detect from an existing
-                              build-and-publish.yaml, so a bare re-run preserves the
-                              opt-in instead of reverting it to Harbor — that file is
-                              always-overwrite. Pass false explicitly to REMOVE the
-                              opt-in.
+                              workflow's use_ghcr_base input. NOTE: the SDK-side default
+                              is now true, so a rendered `use_ghcr_base: true` line is
+                              redundant (it restates the default) and `false` here only
+                              REMOVES that line — it does not pin the app to Harbor. To
+                              do that, set `use_ghcr_base: false` on the caller by hand;
+                              this scaffold does not render an opt-OUT. The line and this
+                              flag are both slated for removal now that the default has
+                              flipped. C002 does not read either state as drift. Omit to
+                              auto-detect from an existing build-and-publish.yaml.
   --enforce true|false        0-touch shorthand: sets BOTH granular levers below at
                               once. Omit to auto-detect from an existing
                               conformance.yaml (else hard-gate). Pass explicitly (either


### PR DESCRIPTION
> **Stacked on #3686** (`feat/i001-accept-ghcr-base`) — merge that first. Base retargets to `main` automatically when it lands. Without it, the 4-hourly remediation cron reverts the fleet.

## The flip

`use_ghcr_base` default `false` → **`true`**. The soak is over; the fleet pulls the SDK base image from GHCR.

GHCR pulls are free from GitHub-hosted runners and Harbor's S3-backed blobs are not, and it's the same image either way — `harbor-release.yaml` publishes both registries in one release at an identical digest, and the preflight verifies that parity on every build.

## Flipping the default alone would have broken builds

So this also changes the preflight's **match-coverage** gate from fail-closed to degrade.

That gate refused a build when no `FROM` matched Harbor's `:3`, reasoning that a caller who opted in and still pulled from Harbor had a silent no-op to fix. **That reasoning doesn't survive the flip** — nobody opts in per app any more, so failing a build the redirect merely cannot *rewrite* punishes an app for a fleet-wide default.

A **digest-pinned base** is the case that makes it concrete. I verified it against the script before changing anything:

```
FROM registry.atlan.com/public/app-runtime-base:3@sha256:…
  conformance I001      →  approved, no findings
  redirect preflight    →  BUILD FAILS  ("no FROM references …:3")
```

A digest reference can't match a tag mapping, so every app with a digest-pinned base — a Dockerfile the rule calls *correct* — would have started failing the moment the default turned on.

## What still fails closed

The two gates ask different questions, and only one is worth a red build:

| Gate | Question | Behaviour |
|---|---|---|
| Match coverage | *Can the redirect apply?* | **Warns**, builds from Harbor |
| Digest parity | *Is the image we'd ride correct?* | **Fails closed** |
| Harbor unreachable | *Can parity be verified at all?* | **Fails closed** |
| GHCR unreachable | unknown, not skew | Warns, builds from Harbor |

Both fail-closed cases keep their tests, now pinned explicitly so the distinction can't erode.

## One loose end, deliberately not addressed

`bootstrap` renders an app-side `use_ghcr_base: true` line that is now **redundant** (it restates the default), and `--use-ghcr-base false` only *removes that line* — it does **not** pin the app to Harbor. To do that, set `use_ghcr_base: false` on the caller by hand.

Inverting the scaffold's tri-state to render an opt-*out* would touch `args`, `render`, `extract` and the C002 drift comparison, for a flag `build-security.md` already says is slated for removal now that the default has flipped. `args.py`'s help text states all of this rather than leaving the next reader to infer it.

**If you'd rather have the durable opt-out now, say so and I'll add it** — it's a real call, not an oversight.

## Verification

```
redirect suite            43 passed   (2 rewritten fails-closed → degrades, 2 added)
full .github/scripts      4227 passed
conformance suite         3450 passed, 1 pre-existing failure*
gen-rule-docs --check     clean
pre-commit                clean — ruff, ruff-format, isort, pyright, actionlint
```

\* `test_logging.py::test_l010_fires_when_rebound_via_type_alias` fails **identically on the unmodified base commit** (`c4721ab`) — verified in a clean worktree. Unrelated to this change.

## Rollout

Merging this moves ~70 app repos' base pulls to GHCR on their next build, with no Dockerfile changes. An app that needs Harbor passes `use_ghcr_base: false`. Reverting is the same one-line default.
