### PR TITLE
refactor(testing): FND-1775 submit the teardown's DAG to AE, not through Heracles

### DIFF
--- a/.claude/skills/capability-manifest/SKILL.md
+++ b/.claude/skills/capability-manifest/SKILL.md
@@ -15,7 +15,7 @@ optional_triggers:
   - "what does the SDK expose"
   - "list public methods of the SDK"
 owner: connector-platform-team
-last_updated: "2026-08-31"
+last_updated: "2026-09-07"
 staleness_days: 30
 inputs:
   - mode: "create | refresh | verify (auto-detected from existing state)"

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -1588,8 +1588,8 @@ class BaseE2ETest:
         accumulate on a shared tenant forever. A *superseded* DAG
         (:attr:`~application_sdk.testing.harness.teardown.ConnectionDeleteReport.dag_superseded`)
         gets the same treatment for a sharper reason: it reads like a tenant
-        problem while being an SDK one, and it is what FND-1724 shipped and had
-        to fix. It stays a warning all the same —
+        problem while being an SDK one, and since FND-1775 it should not be
+        reachable at all. It stays a warning all the same —
         tenant cleanliness is not what the test is asserting, and a cleanup
         failure must never become the run's verdict.
 
@@ -1632,14 +1632,13 @@ class BaseE2ETest:
         if report.dag_superseded:
             logger.warning(
                 "e2e cleanup: %s was not deleted through the connection-delete "
-                "app because the graph AE ran was neither the delete node the "
-                "teardown published nor the delete app's own manifest (slug=%s "
-                "run_id=%s). At submit, Heracles publishes a manifest over the "
-                "seed version; the teardown submit names the delete app so that "
-                "either winner of that race is a delete, so a third graph means "
-                "Heracles resolved a different app from the same envelope — an "
-                "SDK-side problem, not a tenant one. Until it is fixed this leg "
-                "falls back to the runner-side purge and leaks "
+                "app because the graph AE ran was not the delete node the "
+                "teardown published (slug=%s run_id=%s). The teardown submits "
+                "its own published version straight to AE, which fetches no "
+                "manifest, so something republished over that version — an "
+                "SDK-side or AE-side problem, not a tenant one, and one that "
+                "should be impossible. Until it is understood this leg falls "
+                "back to the runner-side purge and leaks "
                 "connection-cache/%s.sqlite and "
                 "persistent-artifacts/apps/atlan-publish-app/state/%s/. "
                 "Details: %s",
@@ -2453,7 +2452,13 @@ class BaseE2ETest:
             ),
             run_id=self.run_id,
             delete_type=self.connection_delete_type,
-            submit_retry=self._submit_retry(),
+            # No cold-start budget. Since FND-1775 the teardown submits straight
+            # to AE and calls no app pod, so there is nothing to cold-start-wait
+            # on — whether the delete app's worker is up is asked by
+            # ``stall_grace_seconds`` below, and leaving ``submit_retry`` unset
+            # takes ``submit_published_version``'s publish-replication budget,
+            # which is the only wait this submit actually has. Same reasoning as
+            # ``_seed_publish_plan``.
             poll_interval_seconds=self.ae_poll_interval_seconds,
             poll_timeout_seconds=self.connection_delete_poll_timeout_seconds,
             stall_grace_seconds=self.connection_delete_stall_grace_seconds,

--- a/application_sdk/testing/e2e/substitutions.py
+++ b/application_sdk/testing/e2e/substitutions.py
@@ -8,9 +8,6 @@ Hierarchy:
 
 * :class:`MustacheSubstitutions` — universal three every AE-orchestrated
   connector needs: credential, credential-guid, connection.
-* :class:`ConnectionDeleteSubstitutions` — what a *teardown* submit carries, so
-  the delete app's manifest tokens resolve if Heracles publishes that manifest
-  over the harness's DAG.
 * :class:`SQLMustacheSubstitutions` — SQL additions: extraction-method,
   agent-json, filters, preflight-check.
 * Per-connector subclasses live in ``app/generated/_e2e_substitutions.py``
@@ -26,13 +23,6 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from application_sdk.contracts.types import ConnectionRef
 from application_sdk.testing.e2e.credential import CredentialBody
-
-# Module-level, and it has to be this direction: ``harness`` imports nothing
-# from ``e2e`` at module scope, so this edge is one-way. The mirror import — a
-# ``harness.teardown`` module importing this one at module scope — closes a
-# cycle through ``e2e/__init__`` → ``base`` → ``harness.teardown``, which is why
-# ``_dag`` reaches this module from inside a function instead.
-from application_sdk.testing.harness.teardown._dag import DeleteType
 
 
 class MustacheSubstitutions(BaseModel):
@@ -58,38 +48,6 @@ class MustacheSubstitutions(BaseModel):
         default="{{credentialGuid}}", alias="{{credential-guid}}"
     )
     connection: ConnectionRef = Field(alias="{{connection}}")
-
-
-class ConnectionDeleteSubstitutions(MustacheSubstitutions):
-    """The three mustache keys ``atlan-connection-delete-app``'s manifest declares.
-
-    Not decoration, and not for a connector: this is what a *teardown* submit
-    carries. At submit Heracles may publish the delete app's own manifest over
-    the DAG the harness published (see
-    :mod:`application_sdk.testing.harness.teardown._dag` for why that is a race
-    the harness cannot win, only defuse), and that manifest's ``args`` are
-    ``{{connection-qualified-name}}``, ``{{delete-type}}`` and
-    ``{{delete-assets}}``, substituted from these parameter rows. Without them
-    the app falls back to its own manifest defaults — and its ``delete_type``
-    default is ``SOFT``, which archives every e2e run's assets instead of
-    removing them and leaves them answering searches on a shared tenant.
-
-    Aliases are the manifest's literals, as everywhere in this hierarchy, so
-    what a reviewer diffs against the app's ``manifest.json`` is a declaration
-    rather than rows assembled at a call site.
-
-    Attributes:
-        connection_qualified_name: The connection to delete. Must be one the run
-            minted for itself.
-        delete_type: How thoroughly. ``PURGE`` for teardown — see
-            :class:`~application_sdk.testing.harness.teardown.DeleteType`.
-        delete_assets: Whether to drain the connection's assets before deleting
-            the Connection entity.
-    """
-
-    connection_qualified_name: str = Field(alias="{{connection-qualified-name}}")
-    delete_type: DeleteType = Field(default=DeleteType.PURGE, alias="{{delete-type}}")
-    delete_assets: bool = Field(default=True, alias="{{delete-assets}}")
 
 
 class SQLMustacheSubstitutions(MustacheSubstitutions):

--- a/application_sdk/testing/harness/seed/__init__.py
+++ b/application_sdk/testing/harness/seed/__init__.py
@@ -188,7 +188,12 @@ class SeedPublishPlan:
         ae_workflow_name: Name for the AE workflow this seed runs under. Must not
             collide with the suite's own, or AE would carry two graphs on one
             workflow and the run list would not say which ran.
-        run_id: This leg's run identifier, for the AE workflow name and labels.
+        run_id: Ignored.
+
+            .. deprecated:: 3.34.0
+               It was the submit envelope's run label; the AE workflow's name
+               comes from :attr:`ae_workflow_name`. Since FND-1766 the seed
+               builds no envelope, so nothing reads this. Removed in v4.0.
         submit_retry: How long to let AE keep answering 404 while the seed's
             freshly published version replicates, or ``None`` for
             :meth:`~application_sdk.testing.harness.automation_engine.AEClient.submit_published_version`'s

--- a/application_sdk/testing/harness/teardown/__init__.py
+++ b/application_sdk/testing/harness/teardown/__init__.py
@@ -41,11 +41,13 @@ Two functions, and which one runs is not a preference:
 * **The worker-up-only tier wires no AE client** (``source_available=false``).
   There is nothing to submit a delete through, and a connection that tier minted
   still has to go.
-* **A third graph.** Heracles republishes *a* manifest over the seed at submit,
-  and the harness cannot stop it — so the submit names the delete app and mirrors
-  its manifest node, making both possible winners a delete (:mod:`._dag` has the
-  mechanism and the legs that proved it). If what AE runs is neither, the delete
-  reports :attr:`ConnectionDeleteReport.dag_superseded` and the fallback runs.
+* **A graph that is not ours.** Since FND-1775 the submit goes straight to AE
+  and fetches no manifest, so the version published moments earlier is the
+  version that runs and nothing can be published over it (:mod:`._dag`'s
+  historical note has what this replaced). The read-back stays anyway, on the
+  same rule as the seed's: if what AE runs is *not* this teardown's node the
+  delete reports :attr:`ConnectionDeleteReport.dag_superseded` and the fallback
+  runs, so an impossible outcome degrades instead of quietly deleting nothing.
 * **A scaled-to-zero worker that does not wake** looks exactly like an absent app
   from here. ``connection-delete``'s ``atlan.yaml`` sets
   ``keda.minReplicaCount: 0``, so its queue is *legitimately* unpolled between
@@ -94,7 +96,6 @@ from application_sdk.testing.harness.teardown._dag import (
     CONNECTION_DELETE_WORKFLOW_TYPE,
     DeleteType,
     build_connection_delete_dag,
-    build_connection_delete_submit_payload,
     connection_delete_task_queue,
 )
 from application_sdk.testing.harness.teardown._purge import (
@@ -115,7 +116,6 @@ __all__ = [
     "DeleteType",
     "PurgeReport",
     "build_connection_delete_dag",
-    "build_connection_delete_submit_payload",
     "connection_delete_task_queue",
     "delete_connection",
     "purge_connection",
@@ -141,12 +141,21 @@ class ConnectionDeletePlan:
             not collide with the suite's own or with another teardown in the
             same run: ``create_workflow`` is idempotent on the name, so a shared
             name would publish one graph over the other.
-        run_id: This leg's run identifier.
+        run_id: Ignored.
+
+            .. deprecated:: 3.34.0
+               It was the submit envelope's run label. The teardown no longer
+               builds an envelope, so nothing reads this. Removed in v4.0. See
+               FND-1775 and :mod:`._dag`'s historical note.
         delete_type: How thoroughly to delete. ``PURGE`` for e2e teardown — it
             is what the ``pyatlan`` purge this replaced did, and an ephemeral
             connection is never coming back.
-        submit_retry: Cold-start sizing for the submit, or ``None`` to leave
-            ``submit_workflow``'s own default budget in place.
+        submit_retry: How long to let AE keep answering 404 while the
+            just-published version replicates, or ``None`` to leave
+            ``submit_published_version``'s own budget in place. It is *not* a
+            cold-start budget any more: since FND-1775 this submit calls no app
+            pod, and whether the delete app's worker is up is asked by
+            :attr:`stall_grace_seconds` instead.
         poll_interval_seconds: Gap between ``native-status`` reads.
         poll_timeout_seconds: Ceiling on the whole delete wait.
         stall_grace_seconds: How long to wait for *any* node to start before
@@ -189,13 +198,15 @@ class ConnectionDeleteReport:
             failure because the remediation is completely different (look at the
             tenant vs. look at the run), and because it is the failure mode that
             otherwise reads exactly like a passing run.
-        dag_superseded: The graph AE ran is neither the node this teardown
-            published nor the delete app's own — Heracles published *some other*
-            app's manifest over the seed at submit (see :mod:`._dag`). Its own
-            field for the same reason :attr:`app_absent` has one, and a sharper
-            one: what ran is another app's DAG, so it can report success. Read as
-            a plain failure it would mean skipping the fallback and telling an
-            operator a connection was deleted that is still there.
+        dag_superseded: The graph AE ran is not the node this teardown
+            published — something republished over the version it submitted.
+            Since FND-1775 that should be impossible, which is the point of the
+            field rather than an argument against it: it asserts the
+            AE-native submit's determinism on a live tenant. Its own field for
+            the same reason :attr:`app_absent` has one, and a sharper one: what
+            ran is another app's DAG, so it can report success. Read as a plain
+            failure it would mean skipping the fallback and telling an operator
+            a connection was deleted that is still there.
         ae_workflow_slug: Slug of the AE workflow the delete ran under.
         ae_run_id: That run's id — the one link that shows what the app did.
         errors: One line per failed step, in order. Already secret-redacted: an
@@ -230,19 +241,19 @@ async def delete_connection(
 ) -> ConnectionDeleteReport:
     """Delete one connection, its assets and its byte-stores, via the app.
 
-    Four steps, mirroring :func:`~application_sdk.testing.harness.seed.seed_assets`
+    Five steps, mirroring :func:`~application_sdk.testing.harness.seed.seed_assets`
     step for step, minus the ones that only a seed needs (there is nothing to
     serialise, validate or upload):
 
     1. **Create and seed** an AE workflow carrying the one-node DAG.
-    2. **Submit** it, on the suite's own cold-start budget.
+    2. **Submit** it straight to AE — no envelope, no manifest fetch, so no
+       app under test in the path and nothing that can publish over it.
     3. **Check that the graph AE will run is ours** — see
        :meth:`~application_sdk.testing.harness.automation_engine.AEClient.foreign_published_dag`
-       and the invariant :mod:`._dag` states. The
-       submit names the delete app so that whichever version wins the republish
-       race is a delete; this is the step that does not take that on trust, and
-       it runs before the poll because a *third* graph costs minutes and deletes
-       nothing.
+       and the invariant :mod:`._dag` states. Step 2 is what makes this
+       unreachable, and this is the step that does not take that on trust; it
+       runs before the poll because a graph that is not ours costs minutes and
+       deletes nothing.
     4. **Wait for a verdict**, with the start-grace latch armed so a tenant
        without the app is detected in :attr:`ConnectionDeletePlan.stall_grace_seconds`
        rather than in the full poll ceiling. The run's own node names are checked
@@ -311,27 +322,19 @@ async def delete_connection(
             ),
         )
 
-    payload = build_connection_delete_submit_payload(
-        connection_qualified_name=qualified_name,
-        connector_short_name=plan.connector_short_name,
-        display_name=qualified_name.rsplit("/", 1)[-1] or qualified_name,
-        run_id=plan.run_id,
-        ae_workflow_slug=seeded.slug,
-        # The same two values the node above carries as literals. Either the
-        # seed runs and reads the literals, or the delete app's republished
-        # manifest runs and reads these rows — so a teardown that let them
-        # diverge would delete differently depending on who won a race.
-        delete_type=plan.delete_type,
-        delete_assets=True,
-    )
+    # Straight to AE, not through Heracles' package-workflows. The graph AE
+    # has to run is the one published above, and Heracles' native path
+    # re-derives the graph from an app's manifest and publishes it over exactly
+    # that — see FND-1775 and ``_dag``'s historical note. Nothing names an app
+    # here, so there is no payload: the node carries its three values as
+    # literals and no token needs substituting.
     retry = plan.submit_retry
     try:
         if retry is None:
-            ae_run_id = await ae.submit_workflow(payload, slug=seeded.slug)
+            ae_run_id = await ae.submit_published_version(seeded.slug)
         else:
-            ae_run_id = await ae.submit_workflow(
-                payload,
-                slug=seeded.slug,
+            ae_run_id = await ae.submit_published_version(
+                seeded.slug,
                 retries=retry.retries,
                 retry_sleep_seconds=retry.sleep_seconds,
             )
@@ -357,15 +360,15 @@ async def delete_connection(
         seeded.slug, expected=(CONNECTION_DELETE_NODE_ID,)
     )
     if foreign:
-        # Before the poll, because the poll is the expensive half: a graph that
-        # is neither delete is some app's crawl, which takes minutes to fail (or,
-        # worse, succeeds) while the connection this call exists to delete sits
-        # there.
+        # Before the poll, because the poll is the expensive half: a graph
+        # that is not this node is some app's crawl, which takes minutes to fail
+        # (or, worse, succeeds) while the connection this call exists to delete
+        # sits there.
         logger.warning(
-            "harness teardown: the DAG AE will run for %s carries neither the "
-            "%r node this teardown published nor the delete app's own (slug=%s "
-            "run_id=%s) — Heracles published a third app's manifest over the "
-            "seed version at submit. Not polling it: %s",
+            "harness teardown: the DAG AE will run for %s is not the %r node "
+            "this teardown published (slug=%s run_id=%s) — something "
+            "republished over the version it submitted, which should be "
+            "impossible on the AE-native submit. Not polling it: %s",
             qualified_name,
             CONNECTION_DELETE_NODE_ID,
             seeded.slug,
@@ -440,17 +443,18 @@ async def delete_connection(
 
     ran = {node.name for node in result.nodes}
     if ran and ran != {CONNECTION_DELETE_NODE_ID}:
-        # The pre-poll read can be too early — Heracles publishes over the seed
-        # around the submit, and an unreadable or not-yet-updated version answers
-        # "unanswered" by design. The names on the run itself cannot be early,
-        # and they are checked *before* success: a superseded run that happens to
-        # go green would otherwise be reported as a delete that never happened.
+        # The pre-poll read can be too early — a substitution would land
+        # around the submit, and an unreadable or not-yet-updated version
+        # answers "unanswered" by design. The names on the run itself cannot be
+        # early, and they are checked *before* success: a superseded run that
+        # happens to go green would otherwise be reported as a delete that
+        # never happened.
         logger.warning(
-            "harness teardown: the run AE executed for %s ran node(s) %s, which "
-            "is neither the %r node this teardown published nor the delete "
-            "app's own (slug=%s run_id=%s) — Heracles published a third app's "
-            "manifest over the seed version, so this run is that app's DAG and "
-            "%s was not deleted through it",
+            "harness teardown: the run AE executed for %s ran node(s) %s "
+            "rather than the %r node this teardown published (slug=%s "
+            "run_id=%s) — something republished over the version it submitted, "
+            "so this run is some other app's DAG and %s was not deleted "
+            "through it",
             qualified_name,
             ", ".join(sorted(ran)),
             CONNECTION_DELETE_NODE_ID,

--- a/application_sdk/testing/harness/teardown/_dag.py
+++ b/application_sdk/testing/harness/teardown/_dag.py
@@ -40,37 +40,35 @@ producing node to thread ``$.<node>.outputs.*`` references from, and a teardown
 whose target came from a reference would be a teardown the harness could not
 state.
 
-**The submit must name the delete app, not the app under test, and the DAG must
-be the delete app's own.** At submit, Heracles fetches a manifest and publishes
-it *over* the workflow's published version — the mechanism
-:meth:`~application_sdk.testing.e2e.base.BaseE2ETest._assert_deployed_manifest_matches`
-exists to assert on, and the reason a connector's seed DAG is described as a
-placeholder. Which app it fetches comes off the submit envelope's *identity*
-(``package.argoproj.io/name``, ``atlanName``, ``templateRef``), so a teardown
-that carries the suite's identity has the suite's crawl published over its
-delete.
+**The harness submits this DAG straight to AE**, through
+:meth:`~application_sdk.testing.harness.automation_engine.AEClient.submit_published_version`
+(``POST /automation/api/v1/workflows/<slug>/submit``), which starts the version
+published two calls earlier and fetches no manifest. The graph that runs is
+therefore the graph built here: no envelope, no app identity, and no second
+candidate. Which is what leaves this module a DAG builder and nothing else —
+there is no submit body to build, because a submit that names nothing has no
+body to get right.
 
-**Whether the republish beats the run is a race, and that is the load-bearing
-fact.** FND-1724 first shipped this submit carrying the app under test's
-identity, and one SDK commit produced both outcomes on the same app *and* the
-same tenant — openapi's ``connection-create-gcp`` leg ran the delete while its
-``connection-reuse-gcp`` leg had ``extract`` → ``publish`` published over it
-minutes later. Omitting ``app_service_url`` (the first fix attempt) changed
-nothing, which is what proved the fetch is not keyed on that field. A race
-cannot be won by naming the field differently; it can only be made *harmless*,
-by making both possible outcomes a delete:
+**Historical note, because believing otherwise leads straight back to a
+disproved fix.** Until FND-1775 this teardown submitted through Heracles'
+``/api/service/package-workflows``, whose native path *always* re-derives the
+graph from an app's served manifest and publishes it over the harness's own
+version. FND-1724 could not stop that, so it made it harmless: the envelope
+named the delete app and this node was a verbatim copy of that app's manifest
+node, so whichever version AE ended up serving was a delete either way.
+FND-1766 then established that the deciding variable was metastore replication
+lag rather than a race between two writers, and that submitting to AE removes
+the class outright rather than defusing one instance of it. The envelope
+builder, the delete app's package and template names, and
+``ConnectionDeleteSubstitutions`` went with it.
 
-* Heracles' fetch wins → the graph that runs is the delete app's own manifest
-  DAG, with its ``{{connection-qualified-name}}`` / ``{{delete-type}}`` /
-  ``{{delete-assets}}`` tokens substituted from this submit's parameter rows.
-* The seed survives → the graph that runs is this module's copy of that same
-  node, with the same three values as literals.
-
-Which is why :data:`CONNECTION_DELETE_NODE_ID` is the app manifest's own node id
-and every other field is copied from it verbatim: the two versions are meant to
-be indistinguishable. The guard in
-:func:`application_sdk.testing.harness.teardown.delete_connection` then has one
-job left — catching a *third* graph, which is no longer a race but a bug.
+What survives of that design is :data:`CONNECTION_DELETE_NODE_ID`'s *value* and
+the read-back guard in
+:func:`application_sdk.testing.harness.teardown.delete_connection`. The guard is
+not left over: it is the assertion that the determinism above holds on a live
+tenant, on the same rule as
+:class:`~application_sdk.testing.harness.seed.SeedDagSupersededError` — it
+should now be unreachable, and being unreachable is what it is for.
 """
 
 from __future__ import annotations
@@ -78,41 +76,21 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Any
 
-from application_sdk.contracts.types import ConnectionAttributes, ConnectionRef
-
 __all__ = [
     "CONNECTION_DELETE_APP_NAME",
     "CONNECTION_DELETE_NODE_ID",
-    "CONNECTION_DELETE_PACKAGE_NAME",
-    "CONNECTION_DELETE_TEMPLATE_NAME",
     "CONNECTION_DELETE_WORKFLOW_TYPE",
     "DeleteType",
     "build_connection_delete_dag",
-    "build_connection_delete_submit_payload",
     "connection_delete_task_queue",
 ]
 
 #: The DAG's single node id, taken from the app's own
-#: ``app/generated/manifest.json``. **Not** a teardown-flavoured name: whichever
-#: of the two versions AE ends up running (see the module docstring's race), the
-#: node has to be the same one, or the harness would have to tell a delete it
-#: published from a delete the app published.
+#: ``app/generated/manifest.json``. It was verbatim because FND-1724 needed the
+#: node the harness published and the node the app published to be
+#: indistinguishable (the module docstring's historical note has why); it stays
+#: verbatim now only because renaming a released constant buys nothing.
 CONNECTION_DELETE_NODE_ID = "delete"
-
-#: Envelope identity — ``package.argoproj.io/name`` and, through
-#: ``connector_short_name``, ``atlanName``, the run label and
-#: ``metadata.name``. This is what decides *which app's manifest* Heracles
-#: fetches and publishes over the seed, so it names the delete app rather than
-#: the suite under test. Attribution to a leg is not lost: it lives on the AE
-#: workflow's name and description, which
-#: :class:`~application_sdk.testing.harness.teardown.ConnectionDeletePlan`
-#: composes from the connector.
-CONNECTION_DELETE_PACKAGE_NAME = "@atlan/connection-delete"
-
-#: The cluster-scoped ``templateRef`` name, on the same rule as
-#: :data:`CONNECTION_DELETE_PACKAGE_NAME`. Native execution does not run an Argo
-#: template, but the envelope carries one and it must not name the suite's.
-CONNECTION_DELETE_TEMPLATE_NAME = "atlan-connection-delete"
 
 #: The app's own ``start_to_close`` for the delete activity — three days, from
 #: its manifest's ``error_handling``. Copied rather than left to AE's default
@@ -230,11 +208,12 @@ def build_connection_delete_dag(
                     "connection_qualified_name": connection_qualified_name,
                     "delete_type": delete_type.value,
                     "delete_assets": delete_assets,
-                    # Also on the app's manifest, inside ``args`` as well as on
-                    # the node. Kept because the goal is a node byte-identical
-                    # to the one the tenant runs from the marketplace, not a
-                    # minimal one — see the module docstring on why the two
-                    # versions must be indistinguishable.
+                    # Also on the app's manifest, inside ``args`` as well as
+                    # on the node. Kept even though FND-1775 removed the reason
+                    # the whole node had to be byte-identical: whether the app's
+                    # own input model reads it here is the app's business, and
+                    # copying its manifest is how this node stays correct
+                    # without asserting on internals the harness cannot see.
                     "app_name": CONNECTION_DELETE_APP_NAME,
                 },
             },
@@ -243,116 +222,3 @@ def build_connection_delete_dag(
             },
         }
     }
-
-
-def build_connection_delete_submit_payload(
-    *,
-    connection_qualified_name: str,
-    connector_short_name: str,
-    display_name: str,
-    run_id: int,
-    ae_workflow_slug: str,
-    delete_type: DeleteType = DeleteType.PURGE,
-    delete_assets: bool = True,
-) -> dict[str, Any]:
-    """Build the AE submit body for one connection's delete run.
-
-    The same builder the connector's own submit and the seed's submit use, for
-    the reason stated there: this DAG carries no mustache tokens and no
-    credential, so the body reduces to the envelope plus the connection rows —
-    but a second builder would be a second place for AE's submit shape to drift,
-    on a path exercised far less often than the connector's.
-
-    **It names the delete app, not the suite**, which is the one place this body
-    must differ from the connector's — the envelope's identity is what decides
-    which manifest Heracles fetches and publishes over the seed, and the module
-    docstring has the evidence. Three consequences, all deliberate:
-
-    * ``package.argoproj.io/name`` is :data:`CONNECTION_DELETE_PACKAGE_NAME` and
-      ``templateRef`` is :data:`CONNECTION_DELETE_TEMPLATE_NAME`, so a fetch that
-      resolves resolves to the delete app.
-    * the parameter rows carry
-      :class:`~application_sdk.testing.e2e.substitutions.ConnectionDeleteSubstitutions`,
-      so that manifest's ``{{connection-qualified-name}}`` / ``{{delete-type}}``
-      / ``{{delete-assets}}`` tokens resolve to *this* teardown's values instead
-      of the app's ``SOFT`` default.
-    * ``app_service_url`` stays absent. Omitting it was the first fix attempt and
-      it did not stop the republish, which is what proved the fetch is not keyed
-      on it — but a teardown still has no reason to name an address, and a
-      guessed in-cluster URL would be one more thing to be wrong.
-
-    Args:
-        connection_qualified_name: The connection being deleted.
-        connector_short_name: The suite under test. Names the connection rows
-            (``connectorName``, the source logo), so an AE run list still shows
-            whose connection this is; it deliberately no longer reaches the
-            envelope's package or template.
-        display_name: Human-readable name for the connection rows.
-        run_id: This leg's run identifier.
-        ae_workflow_slug: The slug AE minted on the create.
-        delete_type: How thoroughly to delete, for the substitution rows. The
-            node's own literal comes from :func:`build_connection_delete_dag`,
-            and both have to say the same thing — which is why the caller passes
-            one value into both rather than each defaulting on its own.
-        delete_assets: Whether to drain the connection's assets first, likewise.
-
-    Returns:
-        The dict to POST to ``/api/service/package-workflows?submit=true``.
-    """
-    # Imported here rather than at module scope for the reason the seed's
-    # builder states: ``application_sdk.testing.e2e`` imports ``base``, which
-    # imports this package, so a top-level import closes a cycle through a
-    # partially-initialised package.
-    from application_sdk.testing.e2e.payload import (  # noqa: PLC0415
-        ConnectionSpec,
-        RunMode,
-        build_ae_payload,
-    )
-    from application_sdk.testing.e2e.substitutions import (  # noqa: PLC0415
-        ConnectionDeleteSubstitutions,
-    )
-
-    connection = ConnectionSpec(
-        name=display_name,
-        qualified_name=connection_qualified_name,
-        connector_name=connector_short_name,
-        source_logo=f"https://assets.atlan.com/assets/{connector_short_name}.png",
-    )
-    return build_ae_payload(
-        run_id=run_id,
-        mode=RunMode.DIRECT,
-        # The delete app is what this submit runs, so it is what the envelope
-        # names — labels, ``atlanName`` and ``metadata.name`` included. The leg
-        # stays identifiable through the AE workflow's own name and description,
-        # and through the connection rows built above.
-        connector_short_name=CONNECTION_DELETE_WORKFLOW_TYPE,
-        argo_package_name=CONNECTION_DELETE_PACKAGE_NAME,
-        argo_template_name=CONNECTION_DELETE_TEMPLATE_NAME,
-        # Not the app under test's URL, and not "" — no key at all. The
-        # module docstring has the mechanism.
-        app_service_url=None,
-        connection=connection,
-        mustache_subs=ConnectionDeleteSubstitutions.model_validate(
-            {
-                # The three the delete app's manifest reads. Present so a
-                # republished manifest resolves to this teardown's values; the
-                # seed carries the same three as literals.
-                "{{connection-qualified-name}}": connection_qualified_name,
-                "{{delete-type}}": delete_type,
-                "{{delete-assets}}": delete_assets,
-                "{{connection}}": ConnectionRef(
-                    attributes=ConnectionAttributes(
-                        qualified_name=connection_qualified_name, name=display_name
-                    )
-                ),
-                # No ``payload[]`` rides this submit, so nothing would
-                # substitute the default ``{{credentialGuid}}`` token — and an
-                # unsubstituted token is what ``submit_workflow`` warns about. A
-                # teardown has no credential to create: it names a connection,
-                # not a source.
-                "{{credential-guid}}": "",
-            }
-        ),
-        credential_body=None,
-        ae_workflow_slug=ae_workflow_slug,
-    )

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.33.0
-source-sha:    445a7501b91f2a64c74d9511d6042a591b00e75e
-source-date:   2026-09-07T12:28:32+01:00
+source-sha:    3c3a651a421692823eb320baff6bdb78542db197
+source-date:   2026-09-07T15:10:25+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 44 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 7 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 383 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 382 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -4598,13 +4598,6 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Import:** `from application_sdk.testing.harness.teardown import build_connection_delete_dag`
 - **Signature:** `build_connection_delete_dag(*, *, ...)`
 - **Summary:** Build the single-node DAG that deletes one connection and its artifacts.
-- **Defined in:** `application_sdk/testing/harness/teardown/_dag.py`
-
-#### `build_connection_delete_submit_payload`
-
-- **Import:** `from application_sdk.testing.harness.teardown import build_connection_delete_submit_payload`
-- **Signature:** `build_connection_delete_submit_payload(*, *, ...)`
-- **Summary:** Build the AE submit body for one connection's delete run.
 - **Defined in:** `application_sdk/testing/harness/teardown/_dag.py`
 
 #### `build_seed_dag`

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -1459,17 +1459,22 @@ single-object `DELETE` puts the key in the path, where the allowlist can read it
 `connection-delete` has no such problem: it runs on the tenant, where its object
 store is the tenant bucket accessed directly with no proxy in front of it.
 
-**The teardown submit names the delete app, because the republish cannot be
-stopped.** At submit, Heracles fetches a manifest and publishes it **over** the
-workflow's published version — the same mechanism `assert_deployed_manifest`
-asserts on for the run itself, and the reason a connector's own seed DAG is only
-a placeholder. Which app it fetches comes off the submit envelope's *identity*
-(`package.argoproj.io/name`, `atlanName`, `templateRef`), not off
-`app_service_url`; omitting that field changed nothing.
+**The teardown submits its own published version straight to AE.**
+`POST /automation/api/v1/workflows/<slug>/submit` starts the version the harness
+published moments earlier and fetches no manifest, so the graph that runs is the
+graph the harness wrote. There is no envelope, no app identity and no submit
+body — a submit that names nothing has no body to get wrong. FND-1775.
 
-**Whether the republish beats the run is a race.** FND-1724 first shipped this
-submit carrying the app under test's identity, and one SDK commit produced both
-outcomes on the same app *and* the same tenant:
+**What this replaced, because believing the old mechanism is live leads back to
+a disproved fix.** Until FND-1775 teardown went through Heracles'
+`/api/service/package-workflows`, whose native path *always* re-derives the
+graph from an app's served manifest and publishes it **over** the workflow's
+published version — the same mechanism `assert_deployed_manifest` asserts on for
+the run itself. Which app it fetched came off the submit envelope's *identity*
+(`package.argoproj.io/name`, `atlanName`, `templateRef`), not off
+`app_service_url`; omitting that field changed nothing. FND-1724 first shipped
+that submit carrying the app under test's identity, and one SDK commit produced
+both outcomes on the same app *and* the same tenant:
 
 | Leg (one SDK commit) | What ran as "teardown" |
 | -- | -- |
@@ -1478,26 +1483,23 @@ outcomes on the same app *and* the same tenant:
 | metabase azure | `delete` |
 | metabase aws / gcp, mysql ×3 | the suite's own 5-node crawl |
 
-A race cannot be won by naming a field differently — it can only be made
-harmless, by arranging for **both** possible winners to be a delete:
+FND-1724 could not stop the republish, so it made it harmless: the envelope
+named the delete app and the harness's node was a verbatim copy of that app's
+manifest node, so **both** possible winners were a delete. FND-1766 then
+established that the deciding variable was metastore replication lag rather than
+a race between two writers, and that submitting to AE removes the class outright
+instead of defusing one instance of it — so the envelope builder, the delete
+app's package and template names, and `ConnectionDeleteSubstitutions` all went.
 
-- Heracles' fetch wins → the graph that runs is the delete app's own manifest
-  DAG, and this submit's `connection-qualified-name` / `delete-type` /
-  `delete-assets` parameter rows are what its mustache tokens resolve to. Those
-  rows are why the app does not fall back to its manifest default of
-  `delete_type: SOFT`, which would archive every run's assets instead of
-  removing them.
-- The seed survives → the graph that runs is the harness's copy of that same
-  node, carrying the same three values as literals.
-
-Which is why the harness's node id is `delete`, the app manifest's own, and every
-other field on it (`app_name: automation-engine`, the three-day
-`start_to_close`) is copied verbatim: the two versions are meant to be
-indistinguishable. `delete_connection` then has one job left — catching a
-*third* graph, which is a bug rather than a race. It reads back the version AE
-serves before polling and re-checks the run's own node names after, and reports
+What survives is the harness node id `delete` — still the app manifest's own,
+now only because renaming a released constant buys nothing — and the read-back
+guard. That guard is not left over: it is the assertion that the AE-native
+submit's determinism holds on a live tenant, on the same rule as the seed's
+`SeedDagSupersededError`. `delete_connection` reads back the version AE serves
+before polling and re-checks the run's own node names after, and reports
 `dag_superseded` (with the fallback) rather than polling, or grading, a run that
-is some other app's DAG.
+is some other app's DAG. It should now be unreachable, and being unreachable is
+what it is for.
 
 **Publish never cleans up its own cache**, which is easy to get backwards. It
 only writes `persistent-artifacts/apps/atlan-publish-app/state/<cqn>/`; nothing

--- a/tests/unit/testing/e2e/test_multi_dag_runs.py
+++ b/tests/unit/testing/e2e/test_multi_dag_runs.py
@@ -141,6 +141,7 @@ class _FakeAE:
         self.created_names: list[str] = []
         self.published: list[tuple[str, int]] = []
         self.submits: list[_Submit] = []
+        self.submitted_versions: list[str] = []
 
     async def create_workflow(self, *, name: str, description: str) -> str:
         self.created_names.append(name)
@@ -163,6 +164,15 @@ class _FakeAE:
             )
         )
         return f"run-{len(self.submits)}"
+
+    async def submit_published_version(self, slug: str, **_kwargs: Any) -> str:
+        """The teardown's submit since FND-1775 — its own list, not
+        :attr:`submits`, because it is a different endpoint with no envelope to
+        read an entrypoint off. The connector's own submit stays on
+        ``submit_workflow`` above, so a test can tell which path a call took.
+        """
+        self.submitted_versions.append(slug)
+        return f"run-{len(self.submits) + len(self.submitted_versions)}"
 
     async def poll_native_status(self, run_id: str, **_kwargs: Any) -> DAGRunResult:
         return self._results.pop(0) if len(self._results) > 1 else self._results[0]
@@ -611,6 +621,10 @@ class TestDeclaredRuns:
         teardowns = [name for name in ae.created_names if "-teardown-" in name]
         assert len(teardowns) == 1
         assert calls.purged == []
+        # And it went to AE's own submit, not through Heracles: the delete's
+        # graph is the one the harness published, which is FND-1775.
+        assert len(ae.submitted_versions) == 1
+        assert [s.entrypoint for s in ae.submits] == ["crawler", "miner"]
 
     def test_a_failing_run_stops_the_sequence(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/testing/harness/test_connection_delete.py
+++ b/tests/unit/testing/harness/test_connection_delete.py
@@ -1,9 +1,16 @@
 """Unit tests for teardown through the ``connection-delete`` app (FND-1724).
 
-Two halves, split the way the seed package's tests are split: the DAG and the
-submit body are pure and pinned exactly, and the orchestration around them is
-checked for the one property teardown actually has to hold — *it never raises,
-and it says which failure happened*.
+Two halves, split the way the seed package's tests are split: the DAG is pure
+and pinned exactly, and the orchestration around it is checked for the one
+property teardown actually has to hold — *it never raises, and it says which
+failure happened*.
+
+**There is no submit body to pin any more.** Since FND-1775 the teardown submits
+its own published version straight to AE, which fetches no manifest — so nothing
+names an app and there is no envelope to get right. The fake below therefore
+implements ``submit_published_version`` and *not* ``submit_workflow``, which is
+what stops a regression drifting back onto the Heracles path unnoticed: the call
+would fail rather than quietly pass a payload nothing reads.
 
 **The node is pinned field for field against the app's own manifest**, not
 loosely. ``atlan-connection-delete-app``'s ``app/generated/manifest.json``
@@ -38,12 +45,12 @@ from application_sdk.testing.harness.automation_engine.wire import (
     DAGRunStatus,
     PublishedVersion,
 )
+from application_sdk.testing.harness.starters import SubmitRetry
 from application_sdk.testing.harness.teardown import (
     CONNECTION_DELETE_NODE_ID,
     ConnectionDeletePlan,
     DeleteType,
     build_connection_delete_dag,
-    build_connection_delete_submit_payload,
     connection_delete_task_queue,
     delete_connection,
 )
@@ -56,9 +63,11 @@ _OUR_PUBLISHED = PublishedVersion(
     version=1787587123, dag={CONNECTION_DELETE_NODE_ID: {"node_type": "workflow"}}
 )
 
-#: What AE served on the openapi leg of FND-1724: the app under test's own
-#: two-node graph, published over the seed by Heracles' submit-time manifest
-#: fetch. Pinned as data because it is the shape the guard exists for.
+#: What AE served on the openapi leg of FND-1724, when the teardown still went
+#: through Heracles: the app under test's own two-node graph, published over the
+#: harness's version by the submit-time manifest fetch. FND-1775 removed that
+#: path, so this shape should now be unreachable — pinned as data anyway,
+#: because an unreachable outcome the guard cannot recognise is not a guard.
 _SUPERSEDED_BY_THE_APP = PublishedVersion(
     version=1787587199,
     dag={"extract": {"node_type": "workflow"}, "publish": {"node_type": "workflow"}},
@@ -125,7 +134,8 @@ class _FakeAE:
         self._published_error = published_error
         self.created: list[tuple[str, str]] = []
         self.versions: list[dict[str, Any]] = []
-        self.submits: list[dict[str, Any]] = []
+        self.submitted: list[str] = []
+        self.submit_kwargs: list[dict[str, Any]] = []
         self.poll_kwargs: list[dict[str, Any]] = []
 
     async def create_workflow(self, *, name: str, description: str) -> str:
@@ -144,10 +154,12 @@ class _FakeAE:
     async def publish_version(self, slug: str, version: int) -> None:
         return None
 
-    async def submit_workflow(self, payload: dict[str, Any], **kwargs: Any) -> str:
+    async def submit_published_version(self, slug: str, **kwargs: Any) -> str:
+        """Deliberately not ``submit_workflow`` — see the module docstring."""
         if self._submit_error is not None:
             raise self._submit_error
-        self.submits.append(payload)
+        self.submitted.append(slug)
+        self.submit_kwargs.append(kwargs)
         return "run-1"
 
     async def get_published_version(self, slug: str) -> PublishedVersion | None:
@@ -252,80 +264,6 @@ class TestTheNodeMatchesTheAppsManifest:
         assert "depends_on" not in dag[CONNECTION_DELETE_NODE_ID]
 
 
-class TestTheSubmitBody:
-    """The connector's own builder, so AE's submit shape has one definition."""
-
-    def _payload(self) -> dict[str, Any]:
-        return build_connection_delete_submit_payload(
-            connection_qualified_name=_QN,
-            connector_short_name="coalesce",
-            display_name="snowflake-seed",
-            run_id=1787587123,
-            ae_workflow_slug="slug-1",
-        )
-
-    def test_it_carries_the_slug_ae_minted(self) -> None:
-        assert self._payload()["metadata"]["ae_workflow_slug"] == "slug-1"
-
-    def _rows(self) -> dict[str, Any]:
-        task = self._payload()["spec"]["templates"][0]["dag"]["tasks"][0]
-        return {p["name"]: p["value"] for p in task["arguments"]["parameters"]}
-
-    def test_the_envelope_names_the_delete_app_not_the_suite(self) -> None:
-        """The envelope's identity is what decides which manifest Heracles
-        fetches and publishes over the seed. Carrying the suite's identity is
-        what made a teardown re-run the suite's crawl, on the legs where the
-        republish beat the run."""
-        payload = self._payload()
-        assert (
-            payload["metadata"]["annotations"]["package.argoproj.io/name"]
-            == "@atlan/connection-delete"
-        )
-        template_ref = payload["spec"]["templates"][0]["dag"]["tasks"][0]["templateRef"]
-        assert template_ref["name"] == "atlan-connection-delete"
-        assert "coalesce" not in payload["metadata"]["name"]
-
-    def test_it_carries_the_apps_three_mustache_rows(self) -> None:
-        """The other half of defusing the race: when Heracles' republished
-        manifest is what runs, these rows are what its
-        ``{{connection-qualified-name}}`` / ``{{delete-type}}`` /
-        ``{{delete-assets}}`` tokens resolve to. Without them the app falls back
-        to its own default of SOFT, and every run's assets would be archived
-        rather than removed."""
-        rows = self._rows()
-        assert rows["connection-qualified-name"] == _QN
-        assert rows["delete-type"] == "PURGE"
-        assert rows["delete-assets"] is True
-
-    def test_the_connection_rows_still_name_the_leg(self) -> None:
-        """Attribution does not go away with the package name: which leg's
-        connection is being deleted stays readable off the submit."""
-        assert self._rows()["connection.connectorName"] == "coalesce"
-
-    def test_it_names_no_app(self) -> None:
-        """Omitting ``metadata.app_service_url`` was the first attempt and did
-        not stop the republish — Heracles keys the fetch on the envelope
-        identity, which is what now names the delete app. The key still stays
-        absent (not empty: an empty string is still a URL AE can try) because
-        a teardown has no service URL to name."""
-        assert "app_service_url" not in self._payload()["metadata"]
-
-    def test_no_credential_block_rides_a_teardown(self) -> None:
-        """A delete names a connection, not a source — there is nothing to
-        authenticate to, and a credential block would create one to no end."""
-        assert not self._payload().get("payload")
-
-    def test_the_credential_token_is_emptied_rather_than_left_unsubstituted(
-        self,
-    ) -> None:
-        """Nothing substitutes ``{{credentialGuid}}`` on a submit with no
-        ``payload[]``, and an unsubstituted token is what ``submit_workflow``
-        warns about on every teardown it would otherwise fire on."""
-        task = self._payload()["spec"]["templates"][0]["dag"]["tasks"][0]
-        rows = {p["name"]: p["value"] for p in task["arguments"]["parameters"]}
-        assert rows["credential-guid"] == ""
-
-
 class TestDeleteConnectionReportsRatherThanRaises:
     """Teardown runs post-verdict, so nothing here may become the verdict."""
 
@@ -336,6 +274,36 @@ class TestDeleteConnectionReportsRatherThanRaises:
         assert report.succeeded
         assert report.ae_run_id == "run-1"
         assert report.errors == ()
+
+    async def test_the_submit_names_only_the_slug(self) -> None:
+        """No envelope, so no app identity, so nothing for a manifest fetch to
+        resolve and publish over the version this teardown just published.
+        FND-1724 could only make both outcomes of that fetch a delete; FND-1775
+        removes the fetch, and this is the assertion that it stays removed."""
+        ae = _FakeAE()
+        await delete_connection(_QN, ae=ae, plan=_plan())
+        assert ae.submitted == ["slug-1"]
+
+    async def test_an_unset_retry_leaves_aes_own_replication_budget(self) -> None:
+        """``submit_published_version`` retries 404 while the just-published
+        version replicates, on a budget matched to Heracles' own for the same
+        lag. Passing nothing is how a teardown takes it — the plan's field is an
+        override, not the default."""
+        ae = _FakeAE()
+        await delete_connection(_QN, ae=ae, plan=_plan())
+        assert ae.submit_kwargs == [{}]
+
+    async def test_a_retry_override_is_forwarded_to_the_submit(self) -> None:
+        """The field survives the conversion because the replication budget is
+        still a knob; what it stopped being is a *cold-start* budget, since this
+        submit calls no app pod at all."""
+        ae = _FakeAE()
+        await delete_connection(
+            _QN,
+            ae=ae,
+            plan=_plan(submit_retry=SubmitRetry(retries=3, sleep_seconds=7)),
+        )
+        assert ae.submit_kwargs == [{"retries": 3, "retry_sleep_seconds": 7}]
 
     async def test_the_workflow_description_names_the_connection(self) -> None:
         """The name has to be unique and escaping-free, so the QN goes on the
@@ -486,7 +454,7 @@ class TestDeleteConnectionReportsRatherThanRaises:
         report = await delete_connection("", ae=ae, plan=_plan())
         assert not report.complete
         assert ae.created == []
-        assert ae.submits == []
+        assert ae.submitted == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why now, and not in #3684

#3684 moved the **seed** onto `AEClient.submit_published_version` (`POST /automation/api/v1/workflows/<slug>/submit`), which starts AE's currently published version and fetches no manifest. Teardown was deliberately left on `submit_workflow`: FND-1724's design made *both* outcomes of Heracles' republish a delete, so teardown was **harmless** where the seed was **broken** — it succeeded even on the leg the seed died on. Had the new endpoint turned out unreachable, that apparatus would have been load-bearing after all.

It is reachable. Run [34117013818](https://github.com/atlanhq/atlan-coalesce-app/actions/runs/34117013818), three clouds, `seed-publish` ran and succeeded on all three: no 401, 403 or 5xx at the submit, so Kong routes it for the harness's API token and `inject_username_context` is satisfied by a bearer token. Teardown's conversion was queued behind exactly that answer.

## What this does

Teardown submits its own published version straight to AE. Nothing names an app, so nothing can name the wrong one — and everything FND-1724 built to *defuse* the republish then has no race left to defuse.

**Net −190 lines.** The docstrings that taught the race as a live mechanism are the larger half of that, and removing them is the point rather than a side effect: FND-1766 documents a reader following #3677's title straight back into the disproved fix. What is left in both `_dag.py` and `docs/standards/connector-ci-e2e.md` is a short historical note that says plainly which mechanism is dead.

| Removed | Why |
|---|---|
| `build_connection_delete_submit_payload` | built the envelope and nothing else; there is no correct envelope where nothing names an app |
| `CONNECTION_DELETE_PACKAGE_NAME` / `CONNECTION_DELETE_TEMPLATE_NAME` | envelope identity — only that builder read them |
| `ConnectionDeleteSubstitutions` | existed so a *republished* manifest's `{{connection-qualified-name}}` / `{{delete-type}}` / `{{delete-assets}}` resolved. No republish, no substitution pass. Also drops `substitutions.py`'s module-scope import of `DeleteType` from `harness/teardown/_dag` — the one edge in that direction |
| `submit_retry=self._submit_retry()` at the teardown call site | that budget covered Heracles' `GetManifest` against the **delete app's** pod, whose `keda.minReplicaCount: 0` makes a cold start real. Nothing on this path calls an app pod; worker wake is still asked by `stall_grace_seconds`. Same change `_seed_publish_plan` already made |

All four shipped in **3.33.0** and go without a deprecation, on the precedent `build_seed_submit_payload` set one day later in #3684: harness-internal builders with no consumer outside this repo. **Verified rather than assumed** — `gh search code` across `atlanhq` for each name returns only this repo (the function, its `__init__` re-export, its test, the capability manifest).

## Three decisions that went against the plan

**1. `ConnectionDeleteReport.dag_superseded` stays.** FND-1766's follow-up note predicted it would be retired with the rest. It should not be: the seed kept `SeedDagSupersededError` on the reasoning that the guard *is* the assertion that the determinism holds on a live tenant, and that it turns `AE status=Failed` into a message naming the real failure. Retiring teardown's twin would answer one design question two ways in two modules. Its **meaning** changes — from "Heracles published a third app's manifest over the seed" to "something republished over our version, which should be impossible" — not its existence, and not the fallback it triggers.

`foreign_published_dag`'s `expected` tuple keeps its multi-node capability even though no caller now needs it. It is one parameter on a shared guard, and it was built as a policy seam.

**2. `run_id` is dead on *both* plans, so both are deprecated, not one.** `ConnectionDeletePlan.run_id` was read only by the removed builder. While confirming that, `SeedPublishPlan.run_id` turned out to have gone unread in #3684 and been left documented as *"This leg's run identifier, for the AE workflow name and labels"* — which it is not: the name comes from `ae_workflow_name`, and the labels were the envelope's. Same one-line omission, fixed here rather than left for a third pass.

Neither is **removed**. Both shipped, both are `kw_only`, and construction would break — so both become ignored fields deprecated for removal in v4.0, mirroring how #3684 handled `SeedPublishPlan.app_service_url`.

**3. `CONNECTION_DELETE_NODE_ID` keeps its name and its value.** What it loses is the *constraint*: it no longer has to be the delete app's own manifest node id so that the two published versions are indistinguishable. It is simply this teardown's node id now. Renaming a released constant buys nothing.

## Tests

`_FakeAE` implements `submit_published_version` and deliberately **not** `submit_workflow`, so an edit that drifts back onto the Heracles path fails at the call rather than quietly passing a payload nothing reads — the same shape the seed's fake already uses. That is the regression guard; the assertions are the readable half.

`TestTheSubmitBody`'s eight envelope tests are **deleted rather than adapted** — there is no envelope left to pin. Three replace them: the slug-only submit, an unset budget taking `submit_published_version`'s own replication window, and a forwarded override. `test_multi_dag_runs` additionally asserts the teardown went to AE's submit *while* the connector's two runs went through Heracles, so the split cannot silently collapse in either direction.

`10083 passed` across `tests/unit` — exactly `10086 − 8 removed + 5 added`. `2098 passed` in `tests/unit/testing`. Pre-commit clean, pyright included.

## Notes for review

- **The manifest regeneration is a clean signal.** Its only content change is the removed symbol and `application_sdk.testing` 383 → 382. No unrelated drift, which independently confirms #3684's own correction that the manifest was current at `445a7501` rather than stale. Coverage re-validated: 1059 `__all__` entries in Section 2 + 65 rendered as contracts = 1124, no unexplained gaps. `last_updated` on the skill bumped in the same commit.
- **`docs/standards/connector-ci-e2e.md`'s seed section was checked for the same staleness** and needs nothing: it only says the seed "submits one `PublishWorkflow` node", which is still accurate.
- **Not verified live, and no A/B is available.** Unlike the seed, teardown has no failing leg to baseline against — it succeeded on every leg, including the one #3684 died on, so a green run would prove only that it still works. What a live run *would* settle is whether `POST /submit` is routed for the teardown's slug the same way it is for the seed's: the same Kong question #3684 answered, on a different workflow slug. It fails closed and loudly and falls back to the runner-side `pyatlan` purge, so the cost of finding that out on a real leg is a leaked byte-store, not a red leg.

Follow-ups from FND-1766 that this does **not** touch: bringing the seed root into `connection-delete`'s `archive_storage` scope, flipping `_RESUBMIT_WHEN_AE_REPORTS_NO_RUN`, and the platform-side `zero_out_config` and per-tenant `routingConfig.currentVersion` divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjKU3iKYa7cVa3SrrYGxvc
