### PR TITLE
feat(contract-toolkit): FND-1776 typed ZeroOutSpec on PublishNode

### DIFF
--- a/.agents/skills/make-contract/SKILL.md
+++ b/.agents/skills/make-contract/SKILL.md
@@ -390,7 +390,7 @@ git ls-files 'contract-toolkit/examples/*/app.pkl' | sed 's#.*/examples/##;s#/ap
 At the time of writing the tracked set is: `minimal` (smallest contract, start
 here), `full` (every overridable feature), `bundle` (multi-entrypoint), `card-split`
 (multi-entrypoint where only one entrypoint is a card), `connection-ref`
-(ConnectionRefInput), `publish-controls` (publish toggles), `fanin` (fan-in via
+(ConnectionRefInput), `publish-controls` (publish toggles, zero-out spec), `fanin` (fan-in via
 `dependsOn`), `deploy` (single-pool KEDA/resources), `pools` (named worker
 pools), `scheduled` (cron background job), `behind-the-scenes`
 (`marketplaceCard = false`), `agent-e2e` (agent-mode codegen). Re-run the command

--- a/.claude/skills/make-contract/SKILL.md
+++ b/.claude/skills/make-contract/SKILL.md
@@ -390,7 +390,7 @@ git ls-files 'contract-toolkit/examples/*/app.pkl' | sed 's#.*/examples/##;s#/ap
 At the time of writing the tracked set is: `minimal` (smallest contract, start
 here), `full` (every overridable feature), `bundle` (multi-entrypoint), `card-split`
 (multi-entrypoint where only one entrypoint is a card), `connection-ref`
-(ConnectionRefInput), `publish-controls` (publish toggles), `fanin` (fan-in via
+(ConnectionRefInput), `publish-controls` (publish toggles, zero-out spec), `fanin` (fan-in via
 `dependsOn`), `deploy` (single-pool KEDA/resources), `pools` (named worker
 pools), `scheduled` (cron background job), `behind-the-scenes`
 (`marketplaceCard = false`), `agent-e2e` (agent-mode codegen). Re-run the command

--- a/contract-toolkit/AGENTS.md
+++ b/contract-toolkit/AGENTS.md
@@ -58,7 +58,7 @@ examples/
 |-- fanin/                 # DependencyCondition and fan-in
 |-- openapi/               # OpenAPI loader with extra object-store credential
 |-- postgres/              # Basic open-source SQL datasource
-|-- publish-controls/      # Publish toggles
+|-- publish-controls/      # Publish toggles, zeroOutConfig
 `-- trino/                 # Multi-catalog SQL connector
 tests/
 `-- *_test.pkl

--- a/contract-toolkit/CLAUDE.md
+++ b/contract-toolkit/CLAUDE.md
@@ -61,7 +61,7 @@ demonstrates distinct feature surface, verified by `tests/*.pkl`.
 - `deploy`: single-pool migration example — KEDA, resources, env, pool-level `overrides`; shows v0.16.x → v0.17.0 migration path.
 - `pools`: `pools` map (preferred) — named hot/cold worker pools with per-pool `cooldownPeriod` and resources.
 - `connection-ref`: `ConnectionRefInput` widget, `pipeline.publish = null`.
-- `publish-controls`: publish toggles, `includeInputFields`, `errorHandling`.
+- `publish-controls`: publish toggles, `includeInputFields`, `errorHandling`, `zeroOutConfig`.
 - `fanin`: multi-parent fan-in via `dependsOn`, explicit `DependencyCondition`.
 - `artifact-schemas`: `artifactSchemas` data hand-off declarations — parquet + NDJSON, nested paths, arrays of structs (`[]` element step), an input artifact.
 

--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -102,7 +102,7 @@ The `examples/` directory contains executable contracts that teach stable toolki
 - [`examples/deploy/`](examples/deploy/) — single-pool deployment: KEDA, resources, env, and per-pool `overrides` under `deploy.pools["default"]`.
 - [`examples/pools/`](examples/pools/) — `pools` map (preferred): named hot/cold worker pools with per-pool KEDA `cooldownPeriod` and resources.
 - [`examples/connection-ref/`](examples/connection-ref/) — `ConnectionRefInput` widget, `pipeline.publish = null`.
-- [`examples/publish-controls/`](examples/publish-controls/) — publish toggles, `includeInputFields`, `errorHandling`.
+- [`examples/publish-controls/`](examples/publish-controls/) — publish toggles, `includeInputFields`, `errorHandling`, `zeroOutConfig`.
 - [`examples/fanin/`](examples/fanin/) — multi-parent fan-in via `dependsOn`, explicit `DependencyCondition`.
 - [`examples/agent-e2e/`](examples/agent-e2e/) — agent/SDR e2e codegen: `_e2e_credential.py` emits both `<Name>CredentialBody` (direct) and `<Name>AgentCredentialBody` (lightweight), plus an `extraction-method` ConditionalInput whose `overrideEnum` widens the substitutions `Literal` to `["direct", "agent"]`.
 - [`examples/scheduled/`](examples/scheduled/) — cron background job via `schedules`; renders `triggers.schedules` into `manifest.json` (multiple schedules, non-UTC timezone, a `PAUSED` one). See [Schedules](docs/reference.md#schedules-background-jobs).
@@ -310,6 +310,13 @@ pipeline {
     // transformedNonDataPrefix: default null (arg omitted). Set it when the
     // extract workflow emits non-data payloads (see below).
     transformedNonDataPrefix = "$.extract.outputs.transformed_nondata_prefix"
+    // zeroOutConfig: default null (arg omitted, zero-out off in publish).
+    // Set it on a cross-connection enricher (see below).
+    zeroOutConfig = new ZeroOutSpec {
+      exclude { "Process"; "ColumnProcess" }
+      attrs { ["sqlCoalesceNodeStatus"] = null }
+      rootAttrs { ["classifications"] = new Listing {} }
+    }
   }
 }
 ```
@@ -321,6 +328,36 @@ Every node ships with a default `errorHandling.startToCloseTimeoutSeconds`: **1 
 `PublishStep.connectionEntity` (also settable directly on `PublishNode`) controls the publish node's `connection_entity` arg — the full connection entity JSON used for connection creation. It defaults to the `"{{connection}}"` form placeholder. Setting it to `null` omits `connection_entity` from the generated args entirely, and because the field is **linked** to `connection_creation_enabled` (which defaults to `connectionEntity != null`), a `null` entity also disables connection creation — publish then targets an already-existing connection and creates nothing. Override `connectionCreationEnabled` explicitly on the node to disable creation even when an entity is present.
 
 `PublishStep.transformedNonDataPrefix` (also settable directly on `PublishNode`) controls the publish node's optional `transformed_nondata_prefix` arg — the object-store prefix holding the run's transformed **non-data** payloads, alongside the asset rows publish reads from `transformed_data_prefix`. It defaults to `null`, which omits the arg entirely, so apps that do not set it generate byte-identical manifests. Set it — normally to an output reference such as `"$.extract.outputs.transformed_nondata_prefix"`, though a literal prefix or form placeholder is passed through verbatim — only when the upstream node actually emits non-data payloads. It leaves `transformed_data_prefix` and every other publish arg untouched.
+
+### Zero-out for cross-connection enrichers
+
+`PublishStep.zeroOutConfig` (also settable directly on `PublishNode`) controls the publish node's optional `zero_out_config` arg. It defaults to `null`, which omits the arg entirely — and an absent `zero_out_config` is exactly how zero-out stays off in publish, so apps that do not set it generate byte-identical manifests.
+
+A **cross-connection enricher** (Coalesce, dbt, Monte Carlo) writes its own namespaced attributes onto assets another connector owns. When one of those assets falls out of the enricher's run, publish's default is a hard Atlas DELETE — which destroys a still-live asset the enricher only enriches, taking its downstream lineage and its user-curated tags and descriptions with it. A zero-out spec replaces that DELETE with an UPSERT that clears just the enricher's own attributes:
+
+```pkl
+zeroOutConfig = new ZeroOutSpec {
+  // Types this app owns outright — these keep being hard-deleted.
+  exclude { "Process"; "ColumnProcess" }
+  // attribute -> zero value, written inside entity.attributes as-is.
+  attrs {
+    ["sqlCoalesceNodeStatus"] = null
+    ["sqlCoalesceProjectId"] = null
+  }
+  // Same shape, for entity-root fields.
+  rootAttrs { ["classifications"] = new Listing {} }
+}
+```
+
+`attrs` is a value map, never a list of attribute names: publish writes each value as-is, so a connector's natural zero can be `null` for a scalar, an empty listing for a list-valued attribute, or `""` (publish deliberately keeps falsy-but-valid values). `rootAttrs` is the same shape for entity-root fields and renders under the publish app's wire name, `root_attrs`.
+
+`exclude` is required. It is declared nullable only because Pkl gives every `Listing`-typed property an implicit empty default, and an empty `exclude` carries real meaning — "zero out every type", correct for an enricher whose cache only ever holds types it enriches. Write `exclude {}` to opt into that; leaving `exclude` unset fails generation rather than silently becoming it. Do not construct an empty spec to *disable* zero-out either — leave `zeroOutConfig` unset.
+
+Attribute and type names are charset-checked (`[A-Za-z_][A-Za-z0-9_]*`), and the keys publish reserves are rejected outright rather than silently discarded: `attrs` cannot set `qualifiedName` or `isPartial` (publish assigns both after applying `attrs`), and `rootAttrs` cannot set `typeName` or `attributes`.
+
+**Why this is a typed class rather than a raw mapping.** Inside a single publish args block, `null` is used with two opposite meanings. The connection-cache / current-state flags are nulled out by some enricher contracts to make the keys **absent** — publish defaults an absent `current_state_enabled` to `true`, and their mere presence morphs `Process` entities into rejected `PartialObject`s — which relies on the manifest's stock `JsonRenderer` stripping nulls. `zero_out_config.attrs`, by contrast, needs its nulls **preserved**: they are the zero values being written. Flipping `omitNullProperties` on the manifest output would emit the flags as `null` and break publish, so the toolkit serializes the spec through a `RenderDirective` with its own null-preserving renderer, scoped to that one value. Both behaviours then hold in the same args block. Setting `zeroOutConfig` changes nothing else — the prefixes, the connection args and the state flags are untouched.
+
+Because a raw `ZeroOutSpec` dropped straight into an `args` mapping would render with Pkl property names and with its zero values stripped — a manifest that generates cleanly and then misbehaves in publish — generation fails with a pointer to `zeroOutConfig` instead. Apps that previously hand-wrote this JSON as a raw Pkl string plus a post-generate merge script should delete both and set the typed property. See [`examples/publish-controls/`](examples/publish-controls/).
 
 The toolkit can append a run-level notification node when an app opts in:
 

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -590,6 +590,7 @@ class PublishStep {
   includeInputFields: Boolean = true     // generates output_dir/load_to_atlan/publish_dry_run in _input.py
   connectionEntity: String? = "{{connection}}"  // args["connection_entity"]; null omits it AND sets connection_creation_enabled=false
   transformedNonDataPrefix: String? = null      // args["transformed_nondata_prefix"]; null omits it
+  zeroOutConfig: ZeroOutSpec? = null            // args["zero_out_config"]; null omits it (zero-out off in publish)
   lineagePublish: LineagePublishStep?    // opt-in lineage publish (default-off)
   errorHandling: ErrorHandlingConfig? = new ErrorHandlingConfig {
     startToCloseTimeoutSeconds = 259200  // 72h default — AE's 2h is too tight for large tenants
@@ -2193,6 +2194,7 @@ class PublishNode extends DAGNode {
   connectionEntity: String? = "{{connection}}"
   connectionCreationEnabled: Boolean = connectionEntity != null
   transformedNonDataPrefix: String? = null
+  zeroOutConfig: ZeroOutSpec? = null
   displayName = "Publish to Atlas"
   workflowType = "PublishWorkflow"
   appName = "publish"
@@ -2206,6 +2208,9 @@ class PublishNode extends DAGNode {
     when (connectionEntity != null) { ["connection_entity"] = connectionEntity }
     when (transformedNonDataPrefix != null) {
       ["transformed_nondata_prefix"] = transformedNonDataPrefix
+    }
+    when (zeroOutConfig != null) {
+      ["zero_out_config"] = <RenderDirective serializing the spec>
     }
   }
   dependsOn { upstream }
@@ -2248,6 +2253,113 @@ pointing it at an output key the extract workflow never populates leaves publish
 resolving a prefix that does not exist. It does not affect
 `transformed_data_prefix`, the publish state / current-state args, or any other
 node. See [`examples/publish-controls/`](../examples/publish-controls/).
+
+#### `ZeroOutSpec` — zero-out for cross-connection enrichers
+
+A **cross-connection enricher** (Coalesce, dbt, Monte Carlo) writes its own
+namespaced attributes onto assets another connector owns. When one of those
+assets falls out of the enricher's run, publish's default is a hard Atlas
+DELETE — which destroys a still-live asset the enricher only enriches, taking
+its downstream lineage and its user-curated tags and descriptions with it. A
+zero-out spec replaces that DELETE with an UPSERT that clears just the
+enricher's own attributes:
+
+```pkl
+class ZeroOutSpec {
+  exclude: Listing<AtlasIdentifier>?             // required; `exclude {}` = zero out every type
+  attrs: Mapping<AtlasIdentifier, Any> = new Mapping {}      // -> entity.attributes
+  rootAttrs: Mapping<AtlasIdentifier, Any> = new Mapping {}  // -> entity root, emitted as root_attrs
+}
+
+typealias AtlasIdentifier = String(matches(Regex("[A-Za-z_][A-Za-z0-9_]*")))
+```
+
+Set it via `PublishNode.zeroOutConfig` or, on the typed pipeline,
+`PublishStep.zeroOutConfig`:
+
+```pkl
+pipeline {
+  publish {
+    zeroOutConfig = new ZeroOutSpec {
+      // Types this app owns outright — these keep being hard-deleted.
+      exclude { "Process"; "ColumnProcess" }
+      attrs {
+        ["sqlCoalesceNodeStatus"] = null
+        ["sqlCoalesceProjectId"] = null
+      }
+      rootAttrs { ["classifications"] = new Listing {} }
+    }
+  }
+}
+```
+
+which generates:
+
+```json
+"zero_out_config": {"exclude":["Process","ColumnProcess"],"attrs":{"sqlCoalesceNodeStatus":null,"sqlCoalesceProjectId":null},"root_attrs":{"classifications":[]}},
+```
+
+`exclude` names the types that still receive a hard DELETE — the enricher's own
+native types, which it owns outright. Every other type in the stale diff gets
+the zero-out UPSERT.
+
+`attrs` is `attribute -> value`, **never a list of attribute names**: publish
+writes each value as-is, so a connector's natural zero can be `null` for a
+scalar, an empty listing for a list-valued attribute such as
+`sqlCoalesceTags`, or `""` — publish uses `is not None` rather than truthiness
+precisely so that falsy-but-valid Atlas values survive. `rootAttrs` is the same
+shape for entity-root fields (`classifications` being the usual one) and renders
+under the publish app's wire name, `root_attrs`.
+
+The default `null` **omits the arg entirely**, and an absent `zero_out_config`
+is exactly how zero-out stays off in publish — so apps that never set it
+generate byte-identical manifests. Do not construct an empty spec to disable it.
+
+`exclude` is required, and is declared nullable only because Pkl gives every
+`Listing`-typed property an implicit empty default. An empty `exclude` carries
+real meaning — "zero out every type", correct for an enricher whose cache only
+ever holds types it enriches — so it has to stay distinguishable from unset.
+Write `exclude {}` to opt into it; leaving `exclude` unset fails generation.
+
+Keys publish reserves are rejected rather than silently discarded: `attrs`
+cannot set `qualifiedName` or `isPartial` (publish assigns both after applying
+`attrs`), and `rootAttrs` cannot set `typeName` or `attributes`.
+
+**Why a typed class and not a plain `Mapping`.** Inside one publish args block,
+`null` is used with two opposite meanings, and no single renderer setting serves
+both:
+
+* The connection-cache / current-state flags are nulled out by some enricher
+  contracts to make the keys **absent**. Publish defaults an absent
+  `current_state_enabled` to `true`, and their mere presence morphs `Process`
+  entities into rejected `PartialObject`s. That relies on the manifest's stock
+  `JsonRenderer` **stripping** nulls.
+* `zero_out_config.attrs` needs its nulls **preserved** — they are the zero
+  values being written, splatted verbatim into the synthesized entity.
+
+Flipping `omitNullProperties = false` on `manifestOutput` is therefore not the
+fix: it would emit the four flags as `null` and break publish. Instead the
+toolkit serializes the spec through a `RenderDirective` whose `text` is emitted
+verbatim, using a null-preserving, single-line `JsonRenderer` scoped to that one
+value. Both behaviours then hold in the same args block. Setting `zeroOutConfig`
+changes nothing else — the prefixes, connection args and state flags are
+untouched.
+
+A raw `ZeroOutSpec` dropped straight into an `args` mapping would render with
+Pkl property names (`rootAttrs`, not `root_attrs`) and with its zero values
+stripped — a manifest that generates cleanly and then misbehaves in publish — so
+generation fails with a pointer to `zeroOutConfig` instead. Apps that previously
+hand-wrote this JSON as a raw Pkl string plus a post-generate merge script should
+delete both and set the typed property; a hand-written string is spliced
+unparsed, so a typo produces a broken manifest with no error at eval time.
+
+Not offered on `LineagePublishNode`: its stale diff is the connector's own
+`Process` / `ColumnProcess` entities, precisely the types an enricher
+hard-deletes, so a spec there would exclude everything it saw. If a lineage
+publish ever genuinely needs one, add the property rather than routing a raw
+JSON string through `LineagePublishNode.extraArgs`.
+
+See [`examples/publish-controls/`](../examples/publish-controls/).
 
 If the workflow form contains `enable-tags`, `PublishNode` also emits
 `tag_pipeline_enabled = "{{enable-tags}}"` and

--- a/contract-toolkit/examples/publish-controls/app.pkl
+++ b/contract-toolkit/examples/publish-controls/app.pkl
@@ -1,6 +1,7 @@
 /// Minimal example demonstrating publish input opt-out, publish executor
-/// templating, the optional non-data prefix hand-off, compact activity labels,
-/// and workflow-safe error handling for toolkit-managed extract/publish nodes.
+/// templating, the optional non-data prefix hand-off, the typed zero-out spec,
+/// compact activity labels, and workflow-safe error handling for
+/// toolkit-managed extract/publish nodes.
 ///
 /// The app keeps the standard extract -> publish DAG, suppresses toolkit
 /// scaffolding fields from _input.py, and declares its own load-to-atlan UI
@@ -30,6 +31,24 @@ pipeline {
     // `transformed_nondata_prefix` output alongside the asset rows. Apps that
     // emit only asset rows leave this unset and the arg is omitted.
     transformedNonDataPrefix = "$.extract.outputs.transformed_nondata_prefix"
+    // Zero-out instead of hard-delete for assets that fall out of a run. This
+    // is the cross-connection-enricher control: publish clears the listed
+    // attributes on the stale asset rather than deleting an asset this app only
+    // enriches. `exclude` names the types it does own outright, which keep
+    // being hard-deleted. Apps that own everything they publish leave
+    // `zeroOutConfig` unset and the arg is omitted.
+    zeroOutConfig = new ZeroOutSpec {
+      exclude { "Process"; "ColumnProcess" }
+      // attribute -> zero value, written as-is: `null` for a scalar, an empty
+      // listing for a list-valued attribute.
+      attrs {
+        ["trinoJobStatus"] = null
+        ["trinoJobRunAt"] = null
+      }
+      rootAttrs {
+        ["classifications"] = new Listing {}
+      }
+    }
     errorHandling = new ErrorHandlingConfig {
       startToCloseTimeoutSeconds = 14400
     }

--- a/contract-toolkit/examples/publish-controls/app/generated/manifest.json
+++ b/contract-toolkit/examples/publish-controls/app/generated/manifest.json
@@ -42,6 +42,7 @@
           "executor_enabled": "{{load-to-atlan}}",
           "connection_entity": "{{connection}}",
           "transformed_nondata_prefix": "$.extract.outputs.transformed_nondata_prefix",
+          "zero_out_config": {"exclude":["Process","ColumnProcess"],"attrs":{"trinoJobStatus":null,"trinoJobRunAt":null},"root_attrs":{"classifications":[]}},
           "connection_cache_enabled": true,
           "connection_cache_via_app_enabled": true,
           "current_state_enabled": true,

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -840,6 +840,136 @@ class ErrorHandlingConfig {
     else null
 }
 
+/// Atlas type or attribute name. Both are Java-identifier-shaped in Atlas, so
+/// one charset covers `ZeroOutSpec.exclude` type names and the attribute names
+/// used as `attrs` / `rootAttrs` keys. Rejects the silent-failure typos —
+/// trailing whitespace, a stray quote from hand-written JSON — that publish
+/// would otherwise accept and then never match against a real entity.
+typealias AtlasIdentifier = String(matches(Regex("[A-Za-z_][A-Za-z0-9_]*")))
+
+/// Zero-out spec for cross-connection enrichers — the publish app's
+/// `args["zero_out_config"]`.
+///
+/// A cross-connection enricher (Coalesce, dbt, Monte Carlo) writes its own
+/// namespaced attributes onto assets another connector owns. When one of those
+/// assets falls out of the enricher's run, publish's default behaviour is a hard
+/// Atlas DELETE — which destroys a still-live asset the enricher only enriches.
+/// A zero-out spec replaces that DELETE with an UPSERT that clears just the
+/// enricher's own attributes and leaves the asset (and its user-curated tags and
+/// descriptions) intact.
+///
+/// Set it via `PublishNode.zeroOutConfig` (or `PublishStep.zeroOutConfig` on the
+/// typed pipeline). Leaving it unset omits the arg entirely, which is what
+/// disables zero-out in publish — there is no "empty spec means off" form, so do
+/// not construct a `ZeroOutSpec` to turn it off.
+///
+/// ### Why this is a typed class and not a plain `Mapping`
+///
+/// A publish args block uses `null` with two opposite meanings, and no single
+/// renderer setting serves both. The connection-cache / current-state flags are
+/// nulled out by some contracts to make the keys **absent** (publish defaults an
+/// absent `current_state_enabled` to `true`, and their presence morphs `Process`
+/// entities into rejected `PartialObject`s), which relies on the stock
+/// `JsonRenderer` stripping nulls. `zero_out_config.attrs`, by contrast, needs
+/// its nulls **preserved**: they are the zero values being written, splatted
+/// verbatim into the synthesized entity. Flipping `omitNullProperties` on the
+/// manifest output would emit the flags as `null` and break publish.
+///
+/// The toolkit resolves that by serializing this spec through a `RenderDirective`
+/// with its own null-preserving renderer, so a spec's nulls survive while its
+/// sibling args keep being stripped. Apps used to hand-write the same JSON as a
+/// raw Pkl string — spliced unparsed, so a typo produced a broken manifest with
+/// no error at eval time. This class type-checks the same shape instead.
+class ZeroOutSpec {
+  /// Type names that keep receiving a hard Atlas DELETE instead of a zero-out
+  /// UPSERT. Pass the enricher's own native types (e.g. `Process` /
+  /// `ColumnProcess` for a lineage-producing enricher, `DbtModel` / `DbtSource`
+  /// for dbt) — it owns those entities outright, so deleting them is correct.
+  /// Every other type in the stale diff gets the zero-out UPSERT.
+  ///
+  /// Required. Declared nullable only because Pkl gives every `Listing`-typed
+  /// property an implicit empty default, and here an empty listing carries real
+  /// meaning — "zero out every type", correct for an enricher whose cache only
+  /// ever holds types it enriches. Leaving `exclude` unset therefore has to fail
+  /// rather than silently become that. Write `exclude {}` to opt into it.
+  exclude: Listing<AtlasIdentifier>?
+
+  /// `attribute -> zero value`, written inside the synthesized entity's
+  /// `attributes`.
+  ///
+  /// The value is written **as-is**, so it is the connector's own choice of zero:
+  /// `null` for a scalar it namespaces, `new Listing {}` for a list-valued one.
+  /// Publish deliberately keeps falsy-but-valid values (empty string included),
+  /// so this is a value map, never a list of attribute names.
+  ///
+  /// `qualifiedName` and `isPartial` are set by publish after this splat and
+  /// cannot be zeroed here — declaring either is an error rather than a silent
+  /// no-op. Defaults to empty.
+  attrs: Mapping<AtlasIdentifier, Any> = new Mapping {}
+
+  /// `attribute -> value` for entity-root fields rather than `attributes`
+  /// members — `classifications` being the usual one. Same value semantics as
+  /// `attrs`.
+  ///
+  /// `typeName` and `attributes` are reserved by publish and ignored if present,
+  /// so declaring either is an error here. Defaults to empty.
+  rootAttrs: Mapping<AtlasIdentifier, Any> = new Mapping {}
+
+  hidden _specCheck: Any =
+    let (clobberedAttrs = attrs.toMap().keys.findOrNull((k) -> k == "qualifiedName" || k == "isPartial"))
+    let (reservedRootAttrs = rootAttrs.toMap().keys.findOrNull((k) -> k == "typeName" || k == "attributes"))
+    if (exclude == null)
+      throw("ZeroOutSpec.exclude is required. List the type names that should still be hard-deleted "
+            + "(the enricher's own native types), or write `exclude {}` to zero out every type.")
+    else if (clobberedAttrs != null)
+      throw("ZeroOutSpec.attrs cannot set \"\(clobberedAttrs)\": publish assigns it after applying attrs, "
+            + "so the declared value would be silently discarded.")
+    else if (reservedRootAttrs != null)
+      throw("ZeroOutSpec.rootAttrs cannot set \"\(reservedRootAttrs)\": publish reserves it for the "
+            + "synthesized entity's own structure and drops the declared value.")
+    else null
+}
+
+/// Null-preserving, single-line JSON renderer used only to serialize a
+/// `ZeroOutSpec` into a `RenderDirective`.
+///
+/// `omitNullProperties = false` is what keeps the `attrs` zero values in the
+/// output; scoping it to this one value (rather than the manifest's own
+/// renderer) is what lets the publish node's sibling args keep being stripped
+/// when a contract nulls them. `indent = ""` collapses the result onto one line
+/// so the directive splices cleanly into the surrounding pretty-printed JSON.
+const local zeroOutConfigRenderer: JsonRenderer = new JsonRenderer {
+  omitNullProperties = false
+  indent = ""
+}
+
+/// Serialize a `ZeroOutSpec` into the verbatim JSON text emitted as
+/// `args["zero_out_config"]`. Keys are the publish app's wire names, so
+/// `rootAttrs` becomes `root_attrs`.
+const local function renderZeroOutConfig(spec: ZeroOutSpec): RenderDirective =
+  let (_zeroOutSpecCheck = spec._specCheck)
+  new RenderDirective {
+    text = zeroOutConfigRenderer.renderValue(new Mapping {
+      ["exclude"] = spec.exclude!!
+      ["attrs"] = spec.attrs
+      ["root_attrs"] = spec.rootAttrs
+    })
+  }
+
+/// Reject a `ZeroOutSpec` placed directly into a node's `args` mapping.
+///
+/// The stock manifest renderer would emit it with Pkl property names
+/// (`rootAttrs`, not `root_attrs`) and with the `attrs` zero values stripped —
+/// a manifest that generates cleanly and then misbehaves in publish. Point the
+/// author at the typed property instead.
+local function checkNoRawZeroOutSpecArgs(node: DAGNode): Any =
+  let (rawKey = node.args.toMap().keys.findOrNull((k) -> node.args[k] is ZeroOutSpec))
+  if (rawKey == null) null
+  else throw("args[\"\(rawKey)\"] is a ZeroOutSpec. A ZeroOutSpec cannot be rendered as a plain args "
+             + "value — its zero values would be stripped and its keys emitted with Pkl names. Set "
+             + "PublishNode.zeroOutConfig (or PublishStep.zeroOutConfig) instead, which serializes it "
+             + "into args[\"zero_out_config\"] with the publish app's wire shape.")
+
 /// Pre-built publish node.
 open class PublishNode extends DAGNode {
   hidden upstream: String = "extract"
@@ -937,6 +1067,33 @@ open class PublishNode extends DAGNode {
   /// other node.
   transformedNonDataPrefix: String? = null
 
+  /// Zero-out spec emitted as `args["zero_out_config"]` when non-null.
+  ///
+  /// Set it on a cross-connection enricher (Coalesce, dbt, Monte Carlo) so that
+  /// an asset dropping out of the run has the enricher's own attributes cleared
+  /// instead of being hard-deleted from Atlas. See `ZeroOutSpec` for the shape
+  /// and for why it is a typed class rather than a raw mapping.
+  ///
+  /// Defaults to `null`, which **omits the arg entirely** — and an absent
+  /// `zero_out_config` is exactly how zero-out stays off in publish, so
+  /// generated manifests for apps that do not set it are byte-identical to
+  /// before this property existed. Do not construct an empty `ZeroOutSpec` to
+  /// disable it; `exclude = new Listing {}` means "zero out every type".
+  ///
+  /// Settable directly on the node (`extraNodes["publish"]`) or, for the typed
+  /// pipeline, via `PublishStep.zeroOutConfig`. It changes nothing else: the
+  /// prefixes, the connection args and the connection-cache / current-state
+  /// flags are untouched, and a contract that nulls those flags to keep them out
+  /// of the manifest keeps that behaviour — the spec's own nulls are preserved
+  /// by a renderer scoped to this one value.
+  ///
+  /// Not offered on `LineagePublishNode`: its stale diff is the connector's own
+  /// `Process` / `ColumnProcess` entities, which are precisely the types an
+  /// enricher hard-deletes, so a spec there would exclude everything it saw. If
+  /// a lineage publish ever genuinely needs one, add the property rather than
+  /// routing a raw JSON string through `LineagePublishNode.extraArgs`.
+  zeroOutConfig: ZeroOutSpec? = null
+
   displayName = "Publish to Atlas"
   workflowType = "PublishWorkflow"
   appName = "publish"
@@ -950,6 +1107,9 @@ open class PublishNode extends DAGNode {
     when (connectionEntity != null) { ["connection_entity"] = connectionEntity }
     when (transformedNonDataPrefix != null) {
       ["transformed_nondata_prefix"] = transformedNonDataPrefix
+    }
+    when (zeroOutConfig != null) {
+      ["zero_out_config"] = renderZeroOutConfig(zeroOutConfig!!)
     }
     ["connection_cache_enabled"] = connectionCacheEnabled
     ["connection_cache_via_app_enabled"] = connectionCacheViaAppEnabled
@@ -1623,6 +1783,17 @@ class PublishStep {
   /// `PublishNode.transformedNonDataPrefix` for the full semantics; this
   /// property is passed straight through to the generated node.
   transformedNonDataPrefix: String? = null
+
+  /// Zero-out spec for the generated publish node, emitted as its
+  /// `args["zero_out_config"]`.
+  ///
+  /// Defaults to `null`, which omits the arg entirely and leaves zero-out off in
+  /// publish, so existing generated manifests are unchanged. Set it on a
+  /// cross-connection enricher so a stale asset has the enricher's own
+  /// attributes cleared rather than being hard-deleted. See `ZeroOutSpec` for
+  /// the shape and `PublishNode.zeroOutConfig` for the full semantics; this
+  /// property is passed straight through to the generated node.
+  zeroOutConfig: ZeroOutSpec? = null
 
   /// Optional lineage-publish sub-step. When set, adds a `"lineage-publish"`
   /// node after the main publish step.
@@ -2585,6 +2756,7 @@ local function generateDAG(): Mapping<String, Any> = new Mapping {
           currentStateViaAppEnabled = ps.currentStateViaAppEnabled
           connectionEntity = ps.connectionEntity
           transformedNonDataPrefix = ps.transformedNonDataPrefix
+          zeroOutConfig = ps.zeroOutConfig
         })
   }
   when (pipeline.publish != null && pipeline.publish!!.lineagePublish != null) {
@@ -2637,6 +2809,7 @@ local function renderNode(node: DAGNode): Mapping<String, Any> =
   let (_popularityCheck = if (node is PopularityNode) (node as PopularityNode)._popularityDependencyCheck else null)
   let (_popularityFormRefCheck = if (node is PopularityNode) validatePopularityFormRefs(node as PopularityNode) else null)
   let (_ehCheck = if (node.errorHandling != null) node.errorHandling._timeoutOrderingCheck else null)
+  let (_rawZeroOutCheck = checkNoRawZeroOutSpecArgs(node))
   new Mapping {
   ["activity_name"] = "execute_workflow"
   ["activity_display_name"] = node.displayName

--- a/contract-toolkit/tests/fixtures/publish_zero_out.pkl
+++ b/contract-toolkit/tests/fixtures/publish_zero_out.pkl
@@ -1,0 +1,49 @@
+/// Fixture: cross-connection enricher whose typed publish step declares a
+/// zero-out spec.
+///
+/// Exercises the pipeline path with `pipeline.publish.zeroOutConfig` set, which
+/// must thread the spec through `generateDAG()` onto the generated publish node
+/// as `args["zero_out_config"]` — serialized through a `RenderDirective` so the
+/// spec's own `null` zero values survive the manifest renderer while the node's
+/// sibling args keep being rendered normally.
+amends "../../src/App.pkl"
+
+name = "publish-zero-out"
+displayName = "Publish Zero Out"
+icon = "https://assets.atlan.com/assets/fullscreen-exit.svg"
+hasCredentialConfig = false
+
+pipeline = new Pipeline {
+  publish = new PublishStep {
+    zeroOutConfig = new ZeroOutSpec {
+      // Lineage entities this connector owns outright: hard-delete them.
+      exclude { "Process"; "ColumnProcess" }
+      // Everything else in the stale diff keeps its asset and gets only the
+      // connector-namespaced attributes cleared.
+      attrs {
+        ["sqlCoalesceNodeStatus"] = null
+        ["sqlCoalesceProjectId"] = null
+        // A non-null zero: publish writes the value as-is, so a list-valued
+        // attribute zeroes to an empty list, not to null.
+        ["sqlCoalesceTags"] = new Listing {}
+        // A falsy-but-valid scalar, which publish preserves rather than drops.
+        ["sqlCoalesceProjectName"] = ""
+      }
+      rootAttrs {
+        ["classifications"] = new Listing {}
+      }
+    }
+  }
+}
+
+uiConfig = new UIConfig {
+  tasks {
+    ["Configuration"] {
+      inputs {
+        ["connection"] = new ConnectionCreator {
+          placeholderText = "Connection Name"
+        }
+      }
+    }
+  }
+}

--- a/contract-toolkit/tests/fixtures/publish_zero_out_override.pkl
+++ b/contract-toolkit/tests/fixtures/publish_zero_out_override.pkl
@@ -1,0 +1,54 @@
+/// Fixture: the cross-connection-enricher shape in full — an
+/// `extraNodes["publish"]` override that both nulls the connection-cache /
+/// current-state flags out of the manifest AND declares a zero-out spec.
+///
+/// This is the case that forces the design: inside one args block, the four
+/// flags rely on the manifest renderer STRIPPING nulls (publish rejects
+/// `Process` entities when the keys are present at all), while
+/// `zero_out_config.attrs` needs its nulls PRESERVED (they are the zero values
+/// being written). One `omitNullProperties` setting cannot serve both, so the
+/// spec is serialized through a `RenderDirective` with its own null-preserving
+/// renderer scoped to that single value.
+amends "../../src/App.pkl"
+
+name = "publish-zero-out-override"
+displayName = "Publish Zero Out Override"
+icon = "https://assets.atlan.com/assets/fullscreen-exit.svg"
+hasCredentialConfig = false
+
+pipeline {
+  publish = new PublishStep {}
+}
+
+extraNodes {
+  ["publish"] = new PublishNode {
+    zeroOutConfig = new ZeroOutSpec {
+      exclude { "Process"; "ColumnProcess" }
+      attrs {
+        ["sqlCoalesceNodeStatus"] = null
+        ["sqlCoalesceProjectId"] = null
+      }
+    }
+    args {
+      // Must be ABSENT, not false: publish's lineage-type handling morphs
+      // Process entities into rejected PartialObjects when these keys are
+      // present, and it defaults an absent current_state_enabled to true.
+      ["connection_cache_enabled"] = null
+      ["connection_cache_via_app_enabled"] = null
+      ["current_state_enabled"] = null
+      ["current_state_via_app_enabled"] = null
+    }
+  }
+}
+
+uiConfig = new UIConfig {
+  tasks {
+    ["Configuration"] {
+      inputs {
+        ["connection"] = new ConnectionCreator {
+          placeholderText = "Connection Name"
+        }
+      }
+    }
+  }
+}

--- a/contract-toolkit/tests/fixtures/publish_zero_out_raw_args.pkl
+++ b/contract-toolkit/tests/fixtures/publish_zero_out_raw_args.pkl
@@ -1,0 +1,41 @@
+/// Fixture: MISUSE — a `ZeroOutSpec` dropped straight into a node's `args`
+/// mapping instead of onto `PublishNode.zeroOutConfig`.
+///
+/// The stock manifest renderer would emit it with Pkl property names
+/// (`rootAttrs`, not `root_attrs`) and with the `attrs` zero values stripped:
+/// a manifest that generates cleanly and then misbehaves in publish. Generation
+/// must fail instead, so this fixture exists only to be caught by
+/// `publish_zero_out_test.pkl`.
+amends "../../src/App.pkl"
+
+name = "publish-zero-out-raw-args"
+displayName = "Publish Zero Out Raw Args"
+icon = "https://assets.atlan.com/assets/fullscreen-exit.svg"
+hasCredentialConfig = false
+
+pipeline {
+  publish = new PublishStep {}
+}
+
+extraNodes {
+  ["publish"] = new PublishNode {
+    args {
+      ["zero_out_config"] = new ZeroOutSpec {
+        exclude { "Process" }
+        attrs { ["sqlCoalesceNodeStatus"] = null }
+      }
+    }
+  }
+}
+
+uiConfig = new UIConfig {
+  tasks {
+    ["Configuration"] {
+      inputs {
+        ["connection"] = new ConnectionCreator {
+          placeholderText = "Connection Name"
+        }
+      }
+    }
+  }
+}

--- a/contract-toolkit/tests/publish_zero_out_test.pkl
+++ b/contract-toolkit/tests/publish_zero_out_test.pkl
@@ -1,0 +1,261 @@
+// Tests the typed zero-out construct on the built-in PublishNode:
+// `ZeroOutSpec` + `PublishNode.zeroOutConfig` / `PublishStep.zeroOutConfig`,
+// emitted as the publish node's `args["zero_out_config"]`.
+//
+// Background: a cross-connection enricher (Coalesce, dbt, Monte Carlo) writes
+// namespaced attributes onto assets another connector owns. Publish's default
+// for an asset that falls out of the run is a hard Atlas DELETE, which destroys
+// a still-live asset; a zero-out spec replaces that with an UPSERT clearing
+// only the enricher's own attributes.
+//
+// The load-bearing behaviour, and the reason this is a typed class rather than
+// a plain Mapping: inside ONE publish args block, `null` carries two opposite
+// meanings. The connection-cache / current-state flags are nulled by enricher
+// contracts to make the keys absent, which needs the manifest renderer to STRIP
+// nulls. `zero_out_config.attrs` needs its nulls PRESERVED — they are the zero
+// values publish splats into the synthesized entity. The spec is therefore
+// serialized through a `RenderDirective` with its own null-preserving renderer,
+// so both survive under the manifest's stock `JsonRenderer`. Apps previously
+// hand-wrote this JSON as a raw Pkl string, spliced unparsed and unvalidated.
+
+amends "pkl:test"
+
+import "pkl:json"
+import "fixtures/default_pipeline.pkl" as defaultPipelineApp
+import "fixtures/publish_zero_out.pkl" as zeroOutApp
+import "fixtures/publish_zero_out_override.pkl" as zeroOutOverrideApp
+import "fixtures/publish_zero_out_raw_args.pkl" as rawArgsApp
+import "fixtures/extra_nodes_publish_override.pkl" as overrideApp
+import "../src/App.pkl" as App
+
+local function publishArgsOf(manifestText: String) =
+  new json.Parser { useMapping = true }.parse(manifestText)["dag"]["publish"]["inputs"]["args"]
+
+// Default (undeclared) pipeline: the publish node must not carry the arg.
+local defaultPublishArgs = publishArgsOf(
+  defaultPipelineApp.output.files["app/generated/manifest.json"].text
+)
+
+// Typed pipeline with `pipeline.publish.zeroOutConfig` set.
+local zeroOutPublishArgs = publishArgsOf(
+  zeroOutApp.output.files["app/generated/manifest.json"].text
+)
+
+// `extraNodes["publish"]` override that both nulls the state flags out of the
+// manifest and declares a zero-out spec.
+local zeroOutOverrideArgs = publishArgsOf(
+  zeroOutOverrideApp.output.files["app/generated/manifest.json"].text
+)
+
+// App that replaces publish wholesale without setting the property: the arg
+// must stay absent there too.
+local overridePublishArgs = publishArgsOf(
+  overrideApp.output.files["app/generated/manifest.json"].text
+)
+
+local coalesceSpec: App.ZeroOutSpec = new {
+  exclude { "Process"; "ColumnProcess" }
+  attrs {
+    ["sqlCoalesceNodeStatus"] = null
+    ["sqlCoalesceProjectId"] = null
+  }
+}
+
+facts {
+  // ---- Spec shape --------------------------------------------------------------
+
+  // An empty listing means "zero out every type", which is meaningful, so it
+  // must stay distinguishable from "not configured". Pkl gives every
+  // `Listing`-typed property an implicit empty default, so `exclude` is declared
+  // nullable and unset has to fail loudly instead.
+  ["ZeroOutSpec requires exclude"] {
+    module.catch(() -> (new App.ZeroOutSpec {})._specCheck).contains("ZeroOutSpec.exclude is required")
+  }
+
+  // The spec's own checks must run on the render path too, and reach the author
+  // as the explanatory message rather than as a bare non-null-assertion failure.
+  ["An unset exclude fails rendering with the explanatory message"] {
+    module.catch(() ->
+      new App.PublishNode { zeroOutConfig = new App.ZeroOutSpec {} }.args["zero_out_config"].text
+    ).contains("ZeroOutSpec.exclude is required")
+  }
+
+  ["A reserved attrs key fails rendering with the explanatory message"] {
+    module.catch(() ->
+      new App.PublishNode {
+        zeroOutConfig = new App.ZeroOutSpec { exclude {}; attrs { ["qualifiedName"] = null } }
+      }.args["zero_out_config"].text
+    ).contains("publish assigns it after applying attrs")
+  }
+
+  ["ZeroOutSpec accepts an empty exclude — zero out every type"] {
+    module.catchOrNull(() -> (new App.ZeroOutSpec { exclude {} })._specCheck) == null
+    new App.ZeroOutSpec { exclude {} }.exclude!!.isEmpty
+  }
+
+  ["ZeroOutSpec defaults attrs and rootAttrs to empty"] {
+    local spec = new App.ZeroOutSpec { exclude {} }
+    spec.attrs.toMap().isEmpty
+    spec.rootAttrs.toMap().isEmpty
+  }
+
+  // attrs is `attribute -> value`, never a list of names: publish writes the
+  // value as-is, so a connector's natural zero can be null, `[]` or `""`.
+  ["ZeroOutSpec attrs keeps non-null zero values"] {
+    local spec = new App.ZeroOutSpec {
+      exclude {}
+      attrs {
+        ["a"] = null
+        ["b"] = new Listing {}
+        ["c"] = ""
+      }
+    }
+    spec.attrs["a"] == null
+    spec.attrs["b"].isEmpty
+    spec.attrs["c"] == ""
+  }
+
+  ["ZeroOutSpec rejects a non-identifier type name"] {
+    module.catch(() -> (new App.ZeroOutSpec { exclude { "Process " } }).exclude!!.toList()) != null
+  }
+
+  ["ZeroOutSpec rejects a non-identifier attribute name"] {
+    module.catch(() ->
+      (new App.ZeroOutSpec { exclude {}; attrs { ["not a name"] = null } }).attrs.toMap()
+    ) != null
+  }
+
+  // Publish assigns qualifiedName/isPartial after splatting attrs, and reserves
+  // typeName/attributes at the entity root — so declaring them is an error here
+  // rather than a value that silently disappears in publish.
+  ["ZeroOutSpec rejects attrs publish overwrites"] {
+    module.catch(() ->
+      (new App.ZeroOutSpec { exclude {}; attrs { ["qualifiedName"] = null } })._specCheck
+    ) != null
+    module.catch(() ->
+      (new App.ZeroOutSpec { exclude {}; attrs { ["isPartial"] = null } })._specCheck
+    ) != null
+  }
+
+  ["ZeroOutSpec rejects reserved rootAttrs"] {
+    module.catch(() ->
+      (new App.ZeroOutSpec { exclude {}; rootAttrs { ["typeName"] = null } })._specCheck
+    ) != null
+    module.catch(() ->
+      (new App.ZeroOutSpec { exclude {}; rootAttrs { ["attributes"] = null } })._specCheck
+    ) != null
+  }
+
+  // ---- Direct class instances -------------------------------------------------
+
+  ["PublishNode omits zero_out_config by default"] {
+    new App.PublishNode {}.args.toMap().containsKey("zero_out_config") == false
+  }
+
+  // Explicit null is the same shape as "never declared" — one omission, not two.
+  ["PublishNode with an explicit null omits the arg"] {
+    new App.PublishNode { zeroOutConfig = null }.args.toMap().containsKey("zero_out_config") == false
+  }
+
+  ["PublishNode emits zero_out_config as a RenderDirective when set"] {
+    new App.PublishNode { zeroOutConfig = coalesceSpec }.args["zero_out_config"] is RenderDirective
+  }
+
+  // Setting the spec must not disturb any sibling arg.
+  ["PublishNode keeps the other publish args independent of the spec"] {
+    local node = new App.PublishNode { zeroOutConfig = coalesceSpec }
+    node.args["transformed_data_prefix"] == "$.extract.outputs.transformed_data_prefix"
+    node.args["publish_state_prefix"] == "$.extract.outputs.publish_state_prefix"
+    node.args["current_state_prefix"] == "$.extract.outputs.current_state_prefix"
+    node.args["connection_entity"] == "{{connection}}"
+    node.args["executor_enabled"] == true
+  }
+
+  // ---- Typed pipeline (PublishStep) -------------------------------------------
+
+  ["PublishStep defaults zeroOutConfig to null"] {
+    new App.PublishStep {}.zeroOutConfig == null
+  }
+
+  ["Default pipeline generates a publish node without zero_out_config"] {
+    defaultPublishArgs.toMap().containsKey("zero_out_config") == false
+  }
+
+  // Regression guard: `generateDAG()` copies PublishStep fields onto PublishNode
+  // one by one, so a field missing from that copy block is silently dropped for
+  // every app on the typed pipeline path.
+  ["PublishStep.zeroOutConfig reaches the generated publish node"] {
+    zeroOutPublishArgs.toMap().containsKey("zero_out_config")
+    zeroOutPublishArgs["zero_out_config"]["exclude"].toList() == List("Process", "ColumnProcess")
+  }
+
+  // The whole point: the nulls in `attrs` are values being written, and they
+  // must survive the manifest renderer.
+  ["Generated zero_out_config preserves null zero values"] {
+    local attrs = zeroOutPublishArgs["zero_out_config"]["attrs"]
+    attrs.toMap().containsKey("sqlCoalesceNodeStatus")
+    attrs["sqlCoalesceNodeStatus"] == null
+    attrs.toMap().containsKey("sqlCoalesceProjectId")
+    attrs["sqlCoalesceProjectId"] == null
+  }
+
+  ["Generated zero_out_config preserves non-null zero values"] {
+    local attrs = zeroOutPublishArgs["zero_out_config"]["attrs"]
+    attrs["sqlCoalesceTags"].toList().isEmpty
+    attrs["sqlCoalesceProjectName"] == ""
+  }
+
+  // `rootAttrs` renders under the publish app's wire name, not the Pkl name.
+  ["Generated zero_out_config renders rootAttrs as root_attrs"] {
+    local zoc = zeroOutPublishArgs["zero_out_config"]
+    zoc.toMap().containsKey("root_attrs")
+    zoc.toMap().containsKey("rootAttrs") == false
+    zoc["root_attrs"]["classifications"].toList().isEmpty
+  }
+
+  // It is a JSON object in the manifest, not the raw JSON string the pre-typed
+  // contracts emitted and then post-processed.
+  ["Generated zero_out_config is an object, not a string"] {
+    zeroOutPublishArgs["zero_out_config"] is Mapping
+  }
+
+  ["Setting the spec preserves the other generated publish args"] {
+    zeroOutPublishArgs["transformed_data_prefix"] == "$.extract.outputs.transformed_data_prefix"
+    zeroOutPublishArgs["connection_qualified_name"] != null
+    zeroOutPublishArgs["connection_entity"] == "{{connection}}"
+    zeroOutPublishArgs["connection_cache_enabled"] == true
+    zeroOutPublishArgs["current_state_enabled"] == true
+  }
+
+  // ---- extraNodes override path -----------------------------------------------
+
+  ["extraNodes publish override omits zero_out_config when unset"] {
+    overridePublishArgs.toMap().containsKey("zero_out_config") == false
+  }
+
+  ["extraNodes publish override emits the spec"] {
+    zeroOutOverrideArgs["zero_out_config"]["exclude"].toList() == List("Process", "ColumnProcess")
+    zeroOutOverrideArgs["zero_out_config"]["attrs"]["sqlCoalesceNodeStatus"] == null
+  }
+
+  // The load-bearing coexistence: the spec's nulls are kept while the sibling
+  // args nulled by the same contract are still stripped from the manifest.
+  ["Sibling null args are still stripped alongside a zero-out spec"] {
+    zeroOutOverrideArgs.toMap().containsKey("connection_cache_enabled") == false
+    zeroOutOverrideArgs.toMap().containsKey("connection_cache_via_app_enabled") == false
+    zeroOutOverrideArgs.toMap().containsKey("current_state_enabled") == false
+    zeroOutOverrideArgs.toMap().containsKey("current_state_via_app_enabled") == false
+    zeroOutOverrideArgs["zero_out_config"]["attrs"]["sqlCoalesceProjectId"] == null
+  }
+
+  // ---- Misuse guard -----------------------------------------------------------
+
+  // A spec dropped straight into args would render with Pkl property names and
+  // with its zero values stripped — a manifest that generates cleanly and then
+  // misbehaves in publish. Generation must fail instead.
+  ["A ZeroOutSpec placed directly in args is rejected"] {
+    module.catch(() ->
+      rawArgsApp.output.files["app/generated/manifest.json"].text
+    ).contains("PublishNode.zeroOutConfig")
+  }
+}

--- a/docs/guides/pkl-contracts.md
+++ b/docs/guides/pkl-contracts.md
@@ -244,6 +244,46 @@ extraNodes {
 }
 ```
 
+### Zero-Out Instead of Delete (Cross-Connection Enrichers)
+
+If your app enriches assets another connector owns — writing its own namespaced
+attributes onto them rather than creating them — publish's default handling of an
+asset that falls out of a run is wrong for you. It issues a hard Atlas DELETE,
+destroying a still-live asset along with its downstream lineage and its
+user-curated tags and descriptions.
+
+Declare a `ZeroOutSpec` so publish clears just your attributes instead:
+
+```pkl
+pipeline {
+  publish {
+    zeroOutConfig = new ZeroOutSpec {
+      // Types your app owns outright — these keep being hard-deleted.
+      exclude { "Process"; "ColumnProcess" }
+      // attribute -> zero value, written as-is inside entity.attributes.
+      attrs {
+        ["myConnectorNodeStatus"] = null
+        ["myConnectorProjectId"] = null
+      }
+      // Same shape, for entity-root fields.
+      rootAttrs { ["classifications"] = new Listing {} }
+    }
+  }
+}
+```
+
+Also settable directly on `PublishNode` when you override the node via
+`extraNodes["publish"]`. Leave it unset and the arg is omitted, which is how
+zero-out stays off — do not build an empty spec to disable it.
+
+Do **not** hand-write this as a raw JSON string in Pkl: a string is spliced
+unparsed, so a typo yields a broken manifest with no error at generation time,
+and it needs a post-generate merge script that CI's single hook may not run. The
+typed spec type-checks and needs no post-processing. See
+[the toolkit reference](https://github.com/atlanhq/application-sdk/blob/main/contract-toolkit/docs/reference.md)
+for the full semantics, including why `attrs` is a value map rather than a list
+of names.
+
 ## Widget Reference
 
 | Widget | When to Use |


### PR DESCRIPTION
Closes FND-1776.

`zero_out_config` was the last publish arg an app had to hand-write as raw JSON. The publish app reads it as a typed `ZeroOutSpec` (`exclude`, `attrs`, `root_attrs`), but the toolkit exposed nothing for it — so a cross-connection enricher spliced a JSON string into the args mapping, unparsed and unvalidated, where a typo produces a broken manifest with no error at `pkl eval` time. That gap has cost one connector twice.

## API

```pkl
pipeline {
  publish {
    zeroOutConfig = new ZeroOutSpec {
      // Types this app owns outright — these keep being hard-deleted.
      exclude { "Process"; "ColumnProcess" }
      // attribute -> zero value, written as-is inside entity.attributes.
      attrs { ["sqlCoalesceNodeStatus"] = null; ["sqlCoalesceProjectId"] = null }
      // Same shape, for entity-root fields.
      rootAttrs { ["classifications"] = new Listing {} }
    }
  }
}
```

`ZeroOutSpec` + `PublishNode.zeroOutConfig` + `PublishStep.zeroOutConfig`. Generated output:

```json
"zero_out_config": {"exclude":["Process","ColumnProcess"],"attrs":{"sqlCoalesceNodeStatus":null,"sqlCoalesceProjectId":null},"root_attrs":{"classifications":[]}},
"connection_cache_enabled": true,
```

`attrs` and `rootAttrs` stay `attribute -> value` maps rather than lists of names, because publish writes each value as-is and deliberately preserves falsy-but-valid zeros (`is not None`, not truthiness). A connector's natural zero can be `null`, `[]` or `""`.

## Why a `RenderDirective` and not a renderer flag

Inside one publish args block, `null` carries two opposite meanings:

- The connection-cache / current-state flags are nulled by enricher contracts to make the keys **absent** — publish defaults an absent `current_state_enabled` to `true`, and their mere presence morphs `Process` entities into rejected `PartialObject`s. That needs nulls **stripped**.
- `zero_out_config.attrs` needs its nulls **written** — they are the zero values splatted into the synthesized entity.

`omitNullProperties = false` on `manifestOutput` cannot serve both; it would emit the four flags as `null` and break publish. So the spec is serialized through a `RenderDirective` whose `text` is emitted verbatim, using a null-preserving single-line `JsonRenderer` scoped to that one value. `manifestOutput`'s own renderer is untouched.

Test `Sibling null args are still stripped alongside a zero-out spec` pins the coexistence directly: the four flags absent and the `attrs` nulls present, in one generated manifest.

## Misuse fails at generation, not in production

- A `ZeroOutSpec` dropped straight into an `args` mapping is rejected with a pointer to the typed property. Unguarded it would render `rootAttrs` (not `root_attrs`) with the zero values stripped — a manifest that generates cleanly and then misbehaves in publish.
- `exclude` is required. It is declared `Listing<…>?` only because Pkl gives every `Listing`-typed property an implicit empty default (verified empirically), and an empty `exclude` means "zero out every type" — a real configuration that has to stay distinguishable from unset. Write `exclude {}` to opt into it.
- Type and attribute names are charset-checked against `[A-Za-z_][A-Za-z0-9_]*`.
- Keys publish reserves are refused rather than silently discarded: `attrs` cannot set `qualifiedName`/`isPartial` (publish assigns both after the `**spec.attrs` splat), `rootAttrs` cannot set `typeName`/`attributes`.

## Scope notes

Not added to `LineagePublishNode`: its stale diff is the connector's own `Process`/`ColumnProcess` entities, precisely the types an enricher excludes, so a spec there would exclude everything it saw. The doc comment says to add the property if that ever changes, rather than routing a raw string through `extraArgs`.

Unset leaves the arg omitted — and an absent `zero_out_config` is exactly how zero-out stays off in publish — so every existing generated manifest is byte-identical.

## Validation

Checked against `atlan-publish-app` directly: `app/models/publish_app_config.py` (`exclude: List[str]` with no default, `attrs`/`root_attrs` as `Dict[str, Any] = {}`) and `app/lib/diff/processor.py` (the splat, the `is not None` preservation, the reserved root keys).

- 26 new facts in `contract-toolkit/tests/publish_zero_out_test.pkl` across 3 new fixtures; 415/415 toolkit pkl tests pass
- `scripts/regenerate-all.sh`, `scripts/check-invariants.sh`, `scripts/test-sdk-import.py` all green
- Docs updated: `contract-toolkit/README.md`, `contract-toolkit/docs/reference.md`, `docs/guides/pkl-contracts.md`, plus the `publish-controls` example blurbs in `CLAUDE.md` / `AGENTS.md` and both mirrored `make-contract` SKILL.md copies

## Follow-up, not in this PR

A conformance rule flagging `"zero_out_config"` present as a *string* in a generated manifest would catch the FND-1703 failure mode directly — every built image carried the string while the committed tree carried the object, because the post-processing ran only from the local `poe generate` task and never from CI's one hook. That needs a new rule ID and docs regeneration in `packages/conformance`, so it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmVCW5Uw1cf4KtkeGBC72Z
