### PR TITLE
ci(contract-toolkit): warn when regeneration would drop an app's own post-processing

### DIFF
--- a/.github/actions/build-app-image/action.yaml
+++ b/.github/actions/build-app-image/action.yaml
@@ -196,14 +196,24 @@ runs:
     # exercises once the image is installed on the tenant, not just a local
     # seed. See FND-31.
     #
-    # check-drift is false: uv/ruff aren't installed yet, so generated-Python
-    # formatting is skipped here; the warn-only drift gate lives in the
-    # connector-integration-tests job. Self-skips when no contract/app.pkl.
+    # check-drift is ON here (FND-1777). It used to be "false" because uv/ruff
+    # are not installed on this path (the inline install above is conditional on
+    # application-sdk-ref), so generated-Python formatting is skipped and
+    # unformatted *.py read as drift. That argued for skipping the *formatting*
+    # comparison, not the whole one: regenerate_contract.warn_on_drift now drops
+    # exactly the class formatting can fabricate (a content change to a generated
+    # *.py) and still compares manifest.json, the configmaps and the root YAMLs.
+    #
+    # This is the path that bakes app/generated/ into the shipped image, so it
+    # was the one path with no drift signal at all — which is how a connector's
+    # own post-processing being dropped from its manifest reached a tenant and
+    # was misread as a platform defect (FND-1777, via FND-1766).
+    # Warn-only, as everywhere. Self-skips when no contract/app.pkl.
     - name: Regenerate contract artifacts (manifest.json) before image build
       uses: atlanhq/application-sdk/.github/actions/regenerate-contract@main
       with:
         application-sdk-ref: ${{ inputs.application-sdk-ref }}
-        check-drift: "false"
+        check-drift: "true"
 
     # Make the image able to say which build it is (FND-1684).
     #

--- a/.github/actions/regenerate-contract/action.yaml
+++ b/.github/actions/regenerate-contract/action.yaml
@@ -39,9 +39,14 @@ inputs:
     default: "true"
     description: |
       'true' (default) to warn — never fail — when committed app/generated/
-      drifts from freshly-generated output. Set 'false' on pre-build
-      invocations where uv (hence ruff formatting) is not yet available.
-      Ignored when application-sdk-ref is set (drift is expected).
+      drifts from freshly-generated output. Ignored when application-sdk-ref
+      is set (a toolkit change legitimately changes the output).
+
+      'false' turns the comparison off entirely and should now be rare: where
+      uv (hence ruff formatting) is unavailable the check no longer needs to be
+      disabled, because it drops the one class skipped formatting can fabricate
+      (a content change to a generated *.py) and keeps comparing manifest.json,
+      the configmaps and the root YAMLs. See FND-1777.
   pkl-version:
     required: false
     default: "0.27.2"

--- a/.github/scripts/pkl_contract_layout.py
+++ b/.github/scripts/pkl_contract_layout.py
@@ -64,9 +64,11 @@ rather than written to the wrong base; see ``_native_target_is_plausible``.
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 import tempfile
+import tomllib
 from pathlib import Path
 
 # Repo-root files both families emit at the top level of the eval output. They
@@ -100,6 +102,167 @@ RESERVED_GENERATED_SUBDIRS = ("frontend",)
 # pre-test regeneration, and any mismatch shows up as a gate reporting drift the
 # sync would never produce.
 POST_GENERATE_SCRIPT = "post-generate.sh"
+
+# Where apps put generation helpers their own `poe generate` task calls (e.g.
+# `contract/templates/merge.py`). A file here with no sibling
+# post-generate.sh is the signature of post-processing that works locally and
+# is dropped by every CI regeneration — see ``warn_unwired_post_generate``.
+POST_GENERATE_HELPER_GLOB = "templates/**/*.py"
+
+# Task names in ``[tool.poe.tasks]`` that regenerate the contract. An app's
+# generate task is the other place post-processing hides, and it is the one a
+# human naturally reaches for.
+GENERATE_TASK_RE = re.compile(r"^generate([-_].*)?$")
+
+# A command after the eval only counts as post-processing when it runs a
+# *program* over the output — the merge/patch step whose loss changes what the
+# artifacts say. An allowlist, not a denylist, because a sweep of 20 connectors
+# found 15 with *something* after the eval and only 6 of those transforming
+# anything: the rest move files (``mv``/``cp``/``mkdir``/``rm -rf generated``),
+# which regeneration's own layout-aware placement already does, or install the
+# playground into the gitignored ``frontend/`` (a RESERVED_GENERATED_SUBDIR,
+# preserved across a swap). Warning on those trains authors to ignore the
+# annotation, which costs more than the recall it buys.
+POST_GENERATE_INTERPRETERS = (
+    "python",
+    "python3",
+    "uv",
+    "poetry",
+    "node",
+    "sh",
+    "bash",
+    "make",
+    "poe",
+)
+
+# Checked before POST_GENERATE_INTERPRETERS: CI formats the generated Python
+# itself (``regenerate_contract._format_generated``, ``renovate_pkl_sync``), so
+# `uvx ruff format` is not a transformation regeneration drops.
+POST_GENERATE_FORMATTERS = ("ruff", "black", "prettier", "pre-commit")
+
+# Shell operators that chain commands. A generate task is as likely to be one
+# `&&`-joined line as it is one command per line — ``atlan-dbt-app`` puts its
+# post-eval merge after an `&&` — so splitting on newlines alone misses the
+# live shape this detection exists for.
+SHELL_CHAIN_RE = re.compile(r"&&|\|\||;|\n")
+
+
+def _generate_task_commands(pyproject: Path) -> list[str]:
+    """Individual shell commands of the app's ``poe`` generate task(s), in order.
+
+    Best-effort and never raises: an unparseable/absent ``pyproject.toml``, or a
+    poe task shape this does not model, yields ``[]`` — which only withholds a
+    warning, never manufactures one.
+
+    All of poe's string-valued shapes are read (a bare string, ``cmd``,
+    ``shell``, ``script``) plus ``sequence``, because which one an app used says
+    nothing about whether it post-processes.
+    """
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    tasks = (
+        data.get("tool", {}).get("poe", {}).get("tasks", {})
+        if isinstance(data, dict)
+        else {}
+    )
+    if not isinstance(tasks, dict):
+        return []
+    commands: list[str] = []
+    for name, body in tasks.items():
+        if not GENERATE_TASK_RE.match(str(name)):
+            continue
+        for raw in _task_strings(body):
+            commands.extend(SHELL_CHAIN_RE.split(raw))
+    return [c.strip() for c in commands if c.strip() and not c.strip().startswith("#")]
+
+
+def _task_strings(body: object) -> list[str]:
+    """Every shell-command string in one poe task body."""
+    if isinstance(body, str):
+        return [body]
+    if isinstance(body, list):
+        return [item for item in body if isinstance(item, str)]
+    if isinstance(body, dict):
+        out: list[str] = []
+        for key in ("cmd", "shell", "script", "sequence"):
+            out.extend(_task_strings(body.get(key)))
+        return out
+    return []
+
+
+def unwired_post_generate(
+    contract_dir: str = "contract", pyproject: str = "pyproject.toml"
+) -> list[str]:
+    """Signs that this app post-processes its generated output through something
+    other than ``POST_GENERATE_SCRIPT``. Each item is a human-readable signal.
+
+    Two signals, both cheap and mode-independent — neither needs the generated
+    output, let alone a second eval to compare against:
+
+      * a ``contract/templates/**/*.py`` helper, the conventional home for a
+        merge/patch step an app's own generate task calls;
+      * a command after the ``pkl eval`` in a ``[tool.poe.tasks]`` ``generate``
+        task that runs a program over the output (``POST_GENERATE_INTERPRETERS``),
+        whether chained with a newline or an ``&&``.
+
+    Only meaningful when there is no ``post-generate.sh``: with one, the app is
+    wired in and whatever it calls runs. Callers check that first.
+    """
+    signals = []
+    for helper in sorted(Path(contract_dir).glob(POST_GENERATE_HELPER_GLOB)):
+        if helper.is_file():
+            signals.append(str(helper))
+    commands = _generate_task_commands(Path(pyproject))
+    # After the LAST `pkl eval`: a multi-root contract evals once per root, and
+    # only what follows the final one can be post-processing.
+    evals = [i for i, c in enumerate(commands) if "pkl eval" in c]
+    if evals:
+        for command in commands[evals[-1] + 1 :]:
+            words = command.split()[:2]
+            if any(word in POST_GENERATE_FORMATTERS for word in words):
+                continue
+            if any(word in POST_GENERATE_INTERPRETERS for word in words):
+                signals.append(f"`{command}` (in the {pyproject} generate task)")
+    return signals
+
+
+def warn_unwired_post_generate(
+    contract_dir: str = "contract", pyproject: str = "pyproject.toml"
+) -> bool:
+    """Warn when the app post-processes its generated output but has not wired
+    that step into ``POST_GENERATE_SCRIPT``. Returns True when it warned.
+
+    This is the signal FND-1777 was missing. Regeneration *destroys*
+    ``app/generated/`` and replaces it with raw ``pkl eval`` output; a
+    transformation the SDK does not know about is dropped, and the image that
+    ships to a tenant carries the untransformed artifact. The app author gets no
+    hint, because the same step works perfectly under their local
+    ``poe generate``. In the live case (``contract/templates/merge.py``, called
+    only from a ``poe`` task) the dropped step was promoting a deliberately
+    raw-string manifest field to an object, and the failure surfaced as a
+    validation error in a *different* repo minutes into an e2e run.
+
+    Warn-only, and deliberately so: the app may have retired the helper, and a
+    heuristic that can be wrong must not fail a build. It is emitted on every
+    regeneration path — including SDK-level runs, where the drift check is off —
+    because ``run_post_generate`` is the one hook they all share.
+    """
+    signals = unwired_post_generate(contract_dir, pyproject)
+    if not signals:
+        return False
+    print(
+        f"::warning::No {contract_dir}/{POST_GENERATE_SCRIPT}, but this app looks "
+        "like it post-processes its generated contract artifacts: "
+        + ", ".join(signals)
+        + f". Regeneration replaces {GENERATED_DIR}/ with raw `pkl eval` output "
+        f"and runs ONLY {contract_dir}/{POST_GENERATE_SCRIPT}, so any such step "
+        "is silently dropped from the artifacts CI tests and the image bakes. "
+        f"Add {contract_dir}/{POST_GENERATE_SCRIPT} invoking it (and have the "
+        "generate task call that script too, so local and CI agree)."
+    )
+    return True
 
 
 def detect_layout(out_dir: Path) -> str:
@@ -483,7 +646,9 @@ def export_contract_at(ref: str, contract_dir: str, dest: Path) -> bool:
 
 def run_post_generate(contract_dir: str = "contract") -> None:
     """Run ``<contract_dir>/post-generate.sh`` if the app ships one, after
-    ``swap_outputs``. No-op otherwise, which is almost every app.
+    ``swap_outputs``. Otherwise — almost every app — a no-op, except that it
+    warns when the app looks like it post-processes through some other path
+    (``warn_unwired_post_generate``).
 
     Placement is layout-aware but content is not app-aware: some apps install a
     hand-maintained artifact over the toolkit's output for a construct the
@@ -512,6 +677,10 @@ def run_post_generate(contract_dir: str = "contract") -> None:
     untrusted-code-execution path."""
     script = Path(contract_dir) / POST_GENERATE_SCRIPT
     if not script.is_file():
+        # Absent is the norm, but for an app that post-processes elsewhere it is
+        # the FND-1777 silent drop. Every regeneration path reaches this line,
+        # which is why the detection lives here and not in one caller.
+        warn_unwired_post_generate(contract_dir)
         return
     print(f"Running post-generate step: {script}")
     if subprocess.run(["sh", str(script)], text=True).returncode != 0:

--- a/.github/scripts/regenerate_contract.py
+++ b/.github/scripts/regenerate_contract.py
@@ -39,6 +39,14 @@ Safety contract — this can never make CI *worse* than the prior behaviour
     so tests run against the committed manifest exactly as before.
   * Drift is warn-only in app-level mode; it never fails the job.
 
+Regeneration *destroys* the committed ``app/generated/``, so anything the app
+does to that output which is not ``contract/post-generate.sh`` is dropped —
+into the image, silently. ``pkl_contract_layout.warn_unwired_post_generate``
+(reached from ``run_post_generate`` on every regeneration path, in both modes)
+warns when an app looks like it post-processes elsewhere, and the drift
+comparison is now formatting-insensitive so it can also run on the image-build
+path, which is the one that bakes the artifacts. See FND-1777.
+
 Eval writes into a temp dir and is placed by ``pkl_contract_layout.swap_outputs``,
 which handles both contract families: ``App.pkl`` (output keys prefixed
 ``app/generated/``) and ``NativeApp.pkl`` / ``NativeAppBundle.pkl`` (unprefixed
@@ -158,8 +166,9 @@ def root_files_not_emitted(out_dir: Path) -> list[str]:
     committed one is still in place — but it *may* mean the contract (or the
     toolkit under test) stopped producing an artifact the app ships. Worth
     failing on in SDK-level mode: a later sdr-e2e step hard-errors on a missing
-    root ``app.yaml``, resolves it *after* this step, and runs with check-drift
-    off, so nothing else would explain it. Informational in app-level mode.
+    root ``app.yaml``, resolves it *after* this step, and SDK-level mode skips
+    the drift check, so nothing else would explain it. Informational in
+    app-level mode.
 
     "May", because a contract can also *ask* the toolkit not to emit the file.
     That is a sanctioned configuration, not a regression, so callers split this
@@ -200,46 +209,103 @@ def opted_out_root_files(contract_dir: str, names: list[str]) -> set[str]:
     return opted_out
 
 
-def _format_generated(root: Path) -> None:
+def _format_generated(root: Path) -> bool:
     """ruff-fix + format every generated ``*.py``, mirroring
     contract-toolkit/scripts/regenerate-all.sh and renovate_pkl_sync.py, so the
     in-tree artifacts match what the consumer's pre-commit ruff would produce.
 
     Best-effort: skipped when neither ``uvx`` nor ``ruff`` is on PATH (the e2e
     pre-build invocation runs before ``setup-deps`` installs uv) — unformatted
-    but valid generated Python still imports at runtime."""
+    but valid generated Python still imports at runtime.
+
+    Returns True iff the generated Python in the tree is formatted (nothing to
+    format counts). ``warn_on_drift`` needs this: unformatted generated Python
+    reads as drift against a committed tree the app's pre-commit did format, and
+    that false positive is the whole reason the image-build path used to skip the
+    drift comparison outright (FND-1777)."""
     gen = root / "app" / "generated"
     if not gen.is_dir():
-        return
+        return True
     py_files = sorted(str(p) for p in gen.rglob("*.py"))
     if not py_files:
-        return
+        return True
     if shutil.which("uvx"):
         prefix = ["uvx", "ruff"]
     elif shutil.which("ruff"):
         prefix = ["ruff"]
     else:
         print("::notice::ruff/uvx not on PATH — skipping generated-Python formatting.")
-        return
+        return False
     run([*prefix, "check", "--fix", "--select", "F401", "--quiet", *py_files])
     run([*prefix, "format", *py_files])
+    return True
 
 
-def warn_on_drift() -> bool:
+def _porcelain_paths(path: str) -> list[tuple[str, str]]:
+    """``(status, path)`` for everything git reports under ``path``.
+
+    ``git status --porcelain`` rather than ``git diff``, so a path the contract
+    stopped emitting (deletion) and a newly-emitted one (untracked) both show up.
+    ``-z`` because a generated filename may contain anything; a rename entry is
+    ``XY new\\0old\\0``, and the new path is the one we report."""
+    proc = subprocess.run(
+        ["git", "status", "--porcelain", "-z", "--", path],
+        capture_output=True,
+        text=True,
+    )
+    out: list[tuple[str, str]] = []
+    fields = proc.stdout.split("\0")
+    i = 0
+    while i < len(fields):
+        entry = fields[i]
+        i += 1
+        if len(entry) < 4:
+            continue
+        status, name = entry[:2], entry[3:]
+        out.append((status, name))
+        if "R" in status or "C" in status:
+            i += 1  # skip the paired original path
+    return out
+
+
+def _formatting_only(status: str, name: str) -> bool:
+    """Whether this entry could have been produced by *skipped* ruff formatting
+    alone, and so must not be reported as drift when formatting did not run.
+
+    Only a *modification* to a generated ``*.py``: formatting rewrites bytes in
+    files that already exist, so it can never add (``??``), delete or rename one
+    — and it never touches ``manifest.json``, the configmaps or the root YAMLs,
+    which is where a dropped post-processing step or an unregenerated contract
+    shows up. Narrowing to exactly this class is what lets the image-build path
+    compare at all (FND-1777), instead of trading the whole signal away for one
+    false positive."""
+    return name.endswith(".py") and status.strip() in {"M", "MM", "AM"}
+
+
+def warn_on_drift(*, formatted: bool = True) -> bool:
     """Warn (never fail) when the committed contract artifacts differ from the
-    freshly-generated ones. Compares the working tree (just regenerated in
-    place) against HEAD via ``git status --porcelain`` — unlike ``git diff``,
-    that also surfaces a path the contract stopped emitting (deletion) or a
-    newly-emitted file (untracked). Returns True when drift was found."""
-    drifted = [
-        path
-        for path in OUTPUT_PATHS
-        if subprocess.run(
-            ["git", "status", "--porcelain", "--", path],
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
-    ]
+    freshly-generated ones. Returns True when drift was found.
+
+    ``formatted=False`` (generated-Python formatting was skipped — see
+    ``_format_generated``) narrows the comparison to the classes formatting
+    cannot fabricate, rather than skipping it."""
+    drifted: list[str] = []
+    suppressed = 0
+    for path in OUTPUT_PATHS:
+        entries = _porcelain_paths(path)
+        if not formatted:
+            suppressed += sum(1 for s, n in entries if _formatting_only(s, n))
+            entries = [(s, n) for s, n in entries if not _formatting_only(s, n)]
+        if entries:
+            drifted.append(path)
+    if suppressed:
+        print(
+            f"::notice::{suppressed} generated Python file(s) differ from the "
+            "committed tree but generated-Python formatting was skipped on this "
+            "path (no uvx/ruff), so the difference is not reported as drift. "
+            "Everything else — manifest.json, configmaps, root YAMLs — is still "
+            "compared."
+        )
     if drifted:
         print(
             "::warning::Committed contract artifacts are stale vs contract/app.pkl: "
@@ -271,7 +337,9 @@ def main(argv: list[str] | None = None) -> int:
         choices=["true", "false"],
         default="true",
         help="'true' (default) to warn (never fail) when committed app/generated "
-        "drifts from freshly-generated output. Ignored in SDK-level mode.",
+        "drifts from freshly-generated output. Ignored in SDK-level mode. The "
+        "comparison is formatting-insensitive when ruff was unavailable, so "
+        "'false' is rarely needed (FND-1777).",
     )
     args = parser.parse_args(argv)
 
@@ -362,10 +430,15 @@ def main(argv: list[str] | None = None) -> int:
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
 
-    _format_generated(Path("."))
+    formatted = _format_generated(Path("."))
 
+    # Still skipped in SDK-level mode: a toolkit change legitimately changes the
+    # output, so every SDK-dispatched run would warn and the signal would mean
+    # nothing. The class of drift that IS a bug there — the committed tree holds
+    # a transformation the fresh output does not — is caught mode-independently
+    # by run_post_generate's unwired-post-processing warning above (FND-1777).
     if args.check_drift == "true" and not sdk_mode:
-        warn_on_drift()
+        warn_on_drift(formatted=formatted)
 
     return 0
 

--- a/.github/scripts/tests/test_build_app_image_action.py
+++ b/.github/scripts/tests/test_build_app_image_action.py
@@ -603,3 +603,26 @@ def test_the_scan_step_builds_the_runners_own_architecture() -> None:
     assert (
         "runner.arch" in scan["with"]["platforms"]
     ), "the scan platform must follow the runner, not be hardcoded"
+
+
+# ── The drift signal on the path that bakes the image (FND-1777) ─────────────
+
+
+def test_prebuild_regeneration_checks_drift() -> None:
+    """This is the only path that bakes app/generated/ into the shipped image,
+    and it used to pass check-drift: "false" — so a connector whose committed
+    artifacts carried a transformation the regeneration dropped shipped the
+    untransformed manifest with no annotation anywhere. The false positive that
+    bought the "false" (unformatted generated *.py, no ruff on this path) is now
+    handled inside regenerate_contract.warn_on_drift, which narrows rather than
+    skips. Warn-only either way, so turning it on cannot fail a build.
+    """
+    step = _step(
+        _BUILD_ACTION,
+        "Regenerate contract artifacts (manifest.json) before image build",
+    )
+    assert "regenerate-contract" in step["uses"]
+    assert step["with"].get("check-drift") == "true", (
+        "the image-build regeneration must compare against the committed "
+        f"artifacts, got check-drift={step['with'].get('check-drift')!r}"
+    )

--- a/.github/scripts/tests/test_pkl_contract_layout.py
+++ b/.github/scripts/tests/test_pkl_contract_layout.py
@@ -287,6 +287,151 @@ def test_post_generate_failure_warns_and_returns(tree, capsys):
     assert "post-generate.sh failed" in capsys.readouterr().out
 
 
+# ── unwired post-processing (FND-1777) ───────────────────────────────────────
+#
+# Regeneration replaces app/generated/ wholesale and runs only
+# post-generate.sh, so post-processing wired anywhere else is dropped into the
+# shipped image with no signal. These pin the heuristic that says so.
+
+
+def _pyproject(tree: Path, generate_body: str) -> None:
+    (tree / "pyproject.toml").write_text(
+        "[tool.poe.tasks]\ngenerate = " + generate_body + "\n"
+    )
+
+
+def test_unwired_warns_on_contract_templates_helper(tree, capsys):
+    """The live case: contract/templates/merge.py, called only from a poe task."""
+    _write(tree / "contract" / "templates" / "merge.py", "# merge\n")
+
+    mod.run_post_generate("contract")
+
+    out = capsys.readouterr().out
+    assert "::warning::No contract/post-generate.sh" in out
+    assert "contract/templates/merge.py" in out
+
+
+def test_unwired_silent_when_post_generate_script_wires_it(tree, capsys):
+    """A helper plus a post-generate.sh is the wired-in shape — no warning."""
+    _write(tree / "contract" / "templates" / "merge.py", "# merge\n")
+    _write(tree / "contract" / mod.POST_GENERATE_SCRIPT, "true\n")
+
+    mod.run_post_generate("contract")
+
+    assert "::warning::" not in capsys.readouterr().out
+
+
+def test_unwired_warns_on_command_after_pkl_eval_in_generate_task(tree, capsys):
+    (tree / "contract").mkdir()
+    _pyproject(
+        tree,
+        '"""\n'
+        "cd contract && pkl project resolve && cd ..\n"
+        "pkl eval --project-dir contract -m . contract/app.pkl\n"
+        "python contract/templates/merge.py\n"
+        '"""',
+    )
+
+    mod.run_post_generate("contract")
+
+    out = capsys.readouterr().out
+    assert "python contract/templates/merge.py" in out
+    assert "pyproject.toml generate task" in out
+
+
+def test_unwired_warns_on_command_chained_after_pkl_eval_with_and(tree, capsys):
+    """A generate task is as likely to be one `&&`-joined line as one command per
+    line, and the live second case (atlan-dbt-app) is the `&&` shape."""
+    (tree / "contract").mkdir()
+    _pyproject(
+        tree,
+        '"pkl eval --project-dir contract -m app/generated contract/app.pkl '
+        '&& python contract/templates/merge.py && touch app/generated/__init__.py"',
+    )
+
+    signals = mod.unwired_post_generate("contract")
+
+    assert any("python contract/templates/merge.py" in s for s in signals)
+
+
+def test_unwired_ignores_placement_and_navigation_after_the_eval(tree, capsys):
+    """Most connectors move files after the eval; regeneration does that placement
+    itself, so warning on it would train authors to ignore the annotation. A
+    sweep of 20 connectors found 15 with something after the eval and only 6
+    transforming anything — hence the interpreter allowlist."""
+    (tree / "contract").mkdir()
+    _pyproject(
+        tree,
+        '"cd contract && pkl eval -m generated app.pkl '
+        "&& mkdir -p ../app/generated && cp generated/*.json ../app/generated/ "
+        '&& mv ../app/generated/atlan.yaml ../atlan.yaml && rm -rf generated && cd .."',
+    )
+
+    mod.run_post_generate("contract")
+
+    assert capsys.readouterr().out == ""
+
+
+def test_unwired_warns_on_an_interpreter_behind_a_runner(tree):
+    """`uv run python …` is the same merge step with a launcher in front."""
+    (tree / "contract").mkdir()
+    _pyproject(
+        tree,
+        '"pkl eval -m . contract/app.pkl && uv run python contract/merge_manifest.py"',
+    )
+
+    signals = mod.unwired_post_generate("contract")
+
+    assert any("merge_manifest.py" in s for s in signals)
+
+
+def test_unwired_silent_when_generate_task_ends_at_pkl_eval(tree, capsys):
+    (tree / "contract").mkdir()
+    _pyproject(tree, '"pkl eval -m . contract/app.pkl"')
+
+    mod.run_post_generate("contract")
+
+    assert capsys.readouterr().out == ""
+
+
+def test_unwired_ignores_a_trailing_formatter(tree, capsys):
+    """CI formats the generated Python itself, so a ruff line after the eval is
+    not a transformation regeneration drops."""
+    (tree / "contract").mkdir()
+    _pyproject(
+        tree,
+        '"""\npkl eval -m . contract/app.pkl\nuvx ruff format app/generated\n"""',
+    )
+
+    mod.run_post_generate("contract")
+
+    assert capsys.readouterr().out == ""
+
+
+def test_unwired_reads_poe_sequence_and_cmd_shapes(tree):
+    """Which poe shape an app used says nothing about whether it post-processes."""
+    (tree / "contract").mkdir()
+    (tree / "pyproject.toml").write_text(
+        "[tool.poe.tasks.generate]\n"
+        'sequence = ["pkl eval -m . contract/app.pkl", "python contract/patch.py"]\n'
+    )
+
+    signals = mod.unwired_post_generate("contract")
+
+    assert any("python contract/patch.py" in s for s in signals)
+
+
+def test_unwired_survives_an_unparseable_pyproject(tree, capsys):
+    """A heuristic that cannot read the file withholds the warning; it must never
+    raise and take a regeneration down with it."""
+    (tree / "contract").mkdir()
+    (tree / "pyproject.toml").write_text("this is not toml [[[\n")
+
+    mod.run_post_generate("contract")
+
+    assert capsys.readouterr().out == ""
+
+
 # ── override detection (app-post-processed files) ────────────────────────────
 
 

--- a/.github/scripts/tests/test_regenerate_contract.py
+++ b/.github/scripts/tests/test_regenerate_contract.py
@@ -13,6 +13,14 @@ inlined shell in the regenerate-contract composite action:
   * SDK-level, eval fails                -> fatal (exit 1)
   * SDK-level, no toolkit entry          -> fatal (SystemExit)
 
+the formatting-insensitive drift comparison (FND-1777), which is what lets the
+image-build path check drift at all:
+
+  * generated *.py content differs, no ruff -> suppressed (formatting artefact)
+  * same, with ruff available                -> reported
+  * manifest.json differs, no ruff           -> reported (the missing signal)
+  * generated *.py added / deleted, no ruff  -> reported
+
 and the root-file emit-flag split (FND-1723):
 
   * opted out + committed                -> notice, never a finding
@@ -476,6 +484,152 @@ def test_drift_warns_on_newly_emitted_untracked_file(repo, monkeypatch, capsys):
 
     out = capsys.readouterr().out
     assert "::warning::Committed contract artifacts are stale" in out
+
+
+# ── formatting-insensitive drift (FND-1777) ──────────────────────────────────
+#
+# The image-build path has no uv/ruff, so generated *.py land unformatted and
+# read as drift against a tree the app's pre-commit formatted. That false
+# positive used to buy check-drift: "false" on the one path that bakes
+# app/generated/ into the shipped image. Drop only the class formatting can
+# fabricate — a content change to a generated *.py — and keep the rest.
+
+
+def _fake_run_emitting_py(repo: Path, py_source: str, *, manifest: str):
+    """`_make_fake_run`, but the eval's generated `_input.py` gets `py_source`."""
+    inner = _make_fake_run(repo, fresh_manifest=manifest)
+
+    def fake_run(cmd, *, check=False):
+        result = inner(cmd, check=check)
+        if cmd[0] == "pkl" and cmd[1] == "eval":
+            out = Path(cmd[cmd.index("-m") + 1]) / "app" / "generated"
+            (out / "_input.py").write_text(py_source)
+        return result
+
+    return fake_run
+
+
+def test_drift_ignores_generated_py_content_when_formatting_skipped(
+    repo, monkeypatch, capsys
+):
+    monkeypatch.setattr(mod.shutil, "which", lambda name: None)  # no uvx, no ruff
+    monkeypatch.setattr(
+        mod,
+        "run",
+        _fake_run_emitting_py(repo, "import   os\n", manifest=STALE_MANIFEST),
+    )
+
+    assert mod.main(["--check-drift", "true"]) == 0
+
+    out = capsys.readouterr().out
+    assert "::warning::Committed contract artifacts are stale" not in out
+    assert "generated-Python formatting was skipped" in out
+    assert "up to date" in out
+
+
+def test_drift_reports_generated_py_content_when_formatting_ran(
+    repo, monkeypatch, capsys
+):
+    """Same difference, with ruff available: nothing is suppressed."""
+    monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/uvx")
+    monkeypatch.setattr(
+        mod,
+        "run",
+        _fake_run_emitting_py(repo, "import   os\n", manifest=STALE_MANIFEST),
+    )
+
+    assert mod.main(["--check-drift", "true"]) == 0
+
+    assert (
+        "::warning::Committed contract artifacts are stale" in capsys.readouterr().out
+    )
+
+
+def test_drift_reports_manifest_when_formatting_skipped(repo, monkeypatch, capsys):
+    """The signal that was missing on the image-build path: a stale manifest.json
+    (what a dropped post-processing step produces) is reported even with no ruff."""
+    monkeypatch.setattr(mod.shutil, "which", lambda name: None)
+    monkeypatch.setattr(
+        mod,
+        "run",
+        _fake_run_emitting_py(repo, "import   os\n", manifest=FRESH_MANIFEST),
+    )
+
+    assert mod.main(["--check-drift", "true"]) == 0
+
+    out = capsys.readouterr().out
+    assert "::warning::Committed contract artifacts are stale" in out
+    assert "app/generated" in out
+
+
+def test_drift_reports_new_generated_py_when_formatting_skipped(
+    repo, monkeypatch, capsys
+):
+    """Formatting rewrites existing files; it cannot create one. A newly emitted
+    *.py is real drift on every path."""
+    monkeypatch.setattr(mod.shutil, "which", lambda name: None)
+    inner = _make_fake_run(repo, fresh_manifest=STALE_MANIFEST)
+
+    def fake_run(cmd, *, check=False):
+        result = inner(cmd, check=check)
+        if cmd[0] == "pkl" and cmd[1] == "eval":
+            out = Path(cmd[cmd.index("-m") + 1]) / "app" / "generated"
+            (out / "_e2e_base.py").write_text("import os\n")
+        return result
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    assert mod.main(["--check-drift", "true"]) == 0
+
+    assert (
+        "::warning::Committed contract artifacts are stale" in capsys.readouterr().out
+    )
+
+
+def test_drift_reports_deleted_generated_py_when_formatting_skipped(
+    repo, monkeypatch, capsys
+):
+    """A generated *.py the contract stopped emitting is a deletion, which
+    formatting also cannot produce."""
+    monkeypatch.setattr(mod.shutil, "which", lambda name: None)
+    inner = _make_fake_run(repo, fresh_manifest=STALE_MANIFEST)
+
+    def fake_run(cmd, *, check=False):
+        result = inner(cmd, check=check)
+        if cmd[0] == "pkl" and cmd[1] == "eval":
+            (
+                Path(cmd[cmd.index("-m") + 1]) / "app" / "generated" / "_input.py"
+            ).unlink()
+        return result
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    assert mod.main(["--check-drift", "true"]) == 0
+
+    assert (
+        "::warning::Committed contract artifacts are stale" in capsys.readouterr().out
+    )
+
+
+def test_format_generated_reports_whether_it_formatted(tmp_path, monkeypatch):
+    """`warn_on_drift` keys its narrowing off this return value, so it has to
+    distinguish "skipped" from "nothing to do"."""
+    gen = tmp_path / "app" / "generated"
+    gen.mkdir(parents=True)
+    (gen / "_input.py").write_text("import os\n")
+    monkeypatch.setattr(mod, "run", lambda cmd, check=False: None)
+
+    monkeypatch.setattr(mod.shutil, "which", lambda name: None)
+    assert mod._format_generated(tmp_path) is False
+
+    monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/uvx")
+    assert mod._format_generated(tmp_path) is True
+
+    # No generated Python at all: formatting is vacuously complete, so drift
+    # must NOT be narrowed.
+    (gen / "_input.py").unlink()
+    monkeypatch.setattr(mod.shutil, "which", lambda name: None)
+    assert mod._format_generated(tmp_path) is True
 
 
 def test_override_toolkit_rewrites_block_form(tmp_path):

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -3362,6 +3362,59 @@ for the type vocabulary and the per-format mapping.
 
 ---
 
+## Post-processing generated output (`contract/post-generate.sh`)
+
+CI regenerates an app's contract artifacts on several paths — before the
+integration tests, before the **image build** (so the manifest baked into the
+image comes from the current contract, not a stale committed copy), on a
+Renovate toolkit bump, and in the generated-freshness gate. Every one of those
+**replaces `app/generated/` with raw `pkl eval` output**.
+
+If your app transforms that output — a merge step, a hand-maintained artifact
+installed over the toolkit's version, anything at all — the transformation must
+live in **`contract/post-generate.sh`**. That path is a convention, not a
+per-workflow input, so every regeneration entry point picks it up and they
+cannot disagree about what "freshly generated" means:
+
+```sh
+# contract/post-generate.sh — run from the repo root, with `sh`, after
+# regeneration has placed fresh pkl eval output.
+python contract/templates/merge.py
+```
+
+Have your `generate` task call the same script, so local and CI agree:
+
+```toml
+[tool.poe.tasks]
+generate = """
+cd contract && pkl project resolve && cd ..
+pkl eval --project-dir contract -m . contract/app.pkl
+sh contract/post-generate.sh
+"""
+```
+
+Wiring the step **only** into a `poe`/`make` task is the trap: it works
+perfectly locally and is silently dropped by every CI regeneration, so the
+image that ships to a tenant carries the untransformed artifact. Regeneration
+warns when it sees the signature of this (a `contract/templates/*.py`, or a
+command after the `pkl eval` line in a `generate` task, with no
+`post-generate.sh` beside it), but the warning is a heuristic — the
+`post-generate.sh` is the fix.
+
+Notes:
+
+- It runs with `sh` from the repo root, so no executable bit is needed and its
+  paths are the same ones you would use locally.
+- It runs **after** placement and is best-effort: a non-zero exit warns and
+  leaves fresh toolkit output in the tree rather than failing the job.
+- On a Renovate toolkit bump, a generated file whose committed content differs
+  from what the *previous* pin emitted is detected as app-maintained and
+  preserved, so an override survives even before you add the script. That
+  detection needs a baseline pin and therefore does not apply on the test and
+  image-build paths — `post-generate.sh` is what covers those.
+
+---
+
 ## Migration Notes
 
 ### v0.17.0 — nested `deploy`/`pools` API; `deployOverrides` renamed to `overrides`


### PR DESCRIPTION
Closes FND-1777.

`regenerate-contract` replaces `app/generated/` with raw `pkl eval` output on every path — including the one that bakes the tree into the image that ships to tenants — and runs exactly one app-side hook, `contract/post-generate.sh`. An app that wires its post-processing anywhere else (the natural place being a `poe generate` task, which works perfectly locally) had that transformation dropped silently, and the drift signal that would have shown it was off on the image-build path and skipped on SDK-dispatched integration runs.

The live case surfaced as a failing `publish` node in a connector's e2e run and was investigated as a platform defect for a while before the cause turned out to be our own CI.

## Changes

**1. Warn on unwired post-processing.** `pkl_contract_layout.run_post_generate` now warns on its `no post-generate.sh` branch when the app shows signs of post-processing elsewhere: a `contract/templates/**/*.py` helper, or a command after the last `pkl eval` in a `[tool.poe.tasks]` generate task that runs a *program* over the output. It lives in the shared hook, so every regeneration entry point (pre-test, pre-image-build, Renovate sync, freshness gate) emits it, in both app-level and SDK-level mode.

The interpreter allowlist is calibrated, not guessed. "Any command after the `pkl eval`" fires on **15 of 20** connectors: most of what follows the eval is `mv`/`cp`/`mkdir`/`rm -rf generated` (placement, which regeneration's own layout-aware swap already does) or the playground install into the gitignored `frontend/` (a `RESERVED_GENERATED_SUBDIR`, preserved across a swap). Narrowing to interpreters drops it to 6, all genuine merge/patch steps. Splitting on `&&` as well as newlines matters — one affected app chains its merge with `&&`, and a newline-only split misses it.

**2. `build-app-image` checks drift again** (`check-drift: "true"`). The stated reason for `"false"` was that uv/ruff are absent on that path, so unformatted generated `*.py` read as drift. That argued for skipping the *formatting* comparison, not the whole one: `warn_on_drift` now drops only the class skipped formatting can fabricate — a content change to a generated `*.py` — and still compares `manifest.json`, the configmaps, the root YAMLs, and any added/deleted/renamed `*.py`. Warn-only, as everywhere. A wiring test pins the input so it cannot quietly go back.

**3. `not sdk_mode` left as-is, deliberately.** A toolkit change legitimately changes the output, so an SDK-dispatched drift warning would mean nothing. The class that *is* a bug there — the committed tree holds a transformation the fresh output does not — is caught mode-independently by (1), which is what makes the blanket skip defensible rather than merely convenient.

**4. Documented the convention.** `post-generate.sh` appeared in no prose doc anywhere. `contract-toolkit/docs/reference.md` now has a section on it, including that wiring the step only into a `poe`/`make` task is the trap and what to do instead.

## Tests

18 new/changed tests; 146 pass across the five affected modules (`test_pkl_contract_layout`, `test_regenerate_contract`, `test_build_app_image_action`, `test_renovate_pkl_sync`, `test_check_generated_freshness`). Pre-commit clean.

New coverage:

- the two detection signals, the wired case staying silent, the `&&`-chained shape, an interpreter behind a runner (`uv run python …`), placement/navigation staying silent, and an unparseable `pyproject.toml` withholding the warning rather than raising;
- formatting-insensitive drift: `*.py` content suppressed without ruff, reported with it, `manifest.json` reported either way, added/deleted `*.py` reported either way, plus `_format_generated`'s new return value distinguishing "skipped" from "nothing to do";
- a wiring assertion that the image-build regeneration passes `check-drift: "true"`.

## Follow-up (not in this PR)

Six connectors need a one-file `contract/post-generate.sh` in their own repos; the affected list and the per-app steps are in the FND-1777 comment. The freshness gate would not have caught any of them — three pass `check-freshness: false` and four do not wire it at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZvSrq8ciMtTEzChmNUxsd
