### PR TITLE
fix(testing): bind `lazy` eagerly so the package export is the function, not its submodule

### DIFF
--- a/application_sdk/testing/integration/__init__.py
+++ b/application_sdk/testing/integration/__init__.py
@@ -87,6 +87,21 @@ For detailed documentation, see:
 
 from typing import TYPE_CHECKING
 
+# Imported eagerly, unlike every other re-export below, because ``lazy`` is both
+# an exported function and the name of the submodule defining it. Python binds
+# a submodule onto its package the first time that submodule is loaded, so if
+# the first load happened anywhere other than here — a consumer importing
+# ``application_sdk.testing.integration.lazy`` directly, or ``__getattr__``
+# resolving ``Lazy`` / ``is_lazy`` first — ``integration.lazy`` would be the
+# module and ``from application_sdk.testing.integration import lazy`` would hand
+# back something that is not callable. Loading it here means the first load
+# always happens before anyone can observe it, and the ``from`` rebinds the
+# name to the function. The module is a few stdlib imports, none of the cost
+# the lazy conversion protects against. The names stay in ``_LAZY_EXPORTS``
+# and the ``TYPE_CHECKING`` block so the three parallel lists remain complete;
+# ``__getattr__`` simply never fires for them.
+from .lazy import Lazy, evaluate_if_lazy, is_lazy, lazy
+
 if TYPE_CHECKING:
     # The eager form, for static readers only. griffe builds
     # docs/agents/sdk-capabilities.md from this file's AST and pyright resolves
@@ -270,13 +285,16 @@ def __getattr__(name: str) -> object:
     """Import the submodule owning *name* on first access (PEP 562)."""
     from importlib import import_module  # noqa: PLC0415
 
-    if name in _LAZY_SUBMODULES:
-        value: object = import_module(f".{name}", __name__)
+    # Exports are checked before the submodule shortcut so that a name shared
+    # by a submodule and one of its functions resolves to the function — the
+    # documented import — never to the module.
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is not None:
+        value: object = getattr(import_module(module_name, __name__), name)
+    elif name in _LAZY_SUBMODULES:
+        value = import_module(f".{name}", __name__)
     else:
-        module_name = _LAZY_EXPORTS.get(name)
-        if module_name is None:
-            raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-        value = getattr(import_module(module_name, __name__), name)
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     # Cache on the module so repeat access skips this path entirely.
     globals()[name] = value
     return value

--- a/tests/unit/testing/integration/test_fixtures.py
+++ b/tests/unit/testing/integration/test_fixtures.py
@@ -8,6 +8,7 @@ import inspect
 import os
 import subprocess
 import sys
+import types
 import urllib.request
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -636,6 +637,59 @@ class TestLazyPackage:
         from application_sdk.testing import integration
 
         assert set(integration._LAZY_EXPORTS) == set(integration.__all__)
+
+    def test_names_shared_with_a_submodule_are_bound_eagerly(self) -> None:
+        """A function named like its own submodule must not be left to ``__getattr__``.
+
+        Python binds a submodule onto its package the first time the submodule
+        loads. If a colliding export is resolved lazily, whoever triggers that
+        first load — a direct submodule import, or ``__getattr__`` fetching a
+        sibling name from the same module — leaves the module bound under the
+        function's name, and ``__getattr__`` is never consulted again for it.
+        The only order-independent defence is an eager binding in the package
+        body, so every collision must already be in the module namespace.
+        """
+        from application_sdk.testing import integration
+
+        colliding = set(integration._LAZY_EXPORTS) & integration._LAZY_SUBMODULES
+        assert "lazy" in colliding  # the case that motivated this test
+        for name in colliding:
+            assert name in vars(integration), f"{name!r} is resolved lazily"
+            assert not isinstance(vars(integration)[name], types.ModuleType), name
+
+    def test_lazy_is_the_function_whatever_loads_first(self) -> None:
+        """``from ... import lazy`` is callable regardless of import order.
+
+        Two orders broke before the eager binding: resolving a sibling name
+        (``Lazy``) first, and importing the submodule directly first. Both
+        left ``integration.lazy`` as the module and callers saw
+        ``TypeError: 'module' object is not callable``.
+        """
+        sibling_first = """
+from application_sdk.testing.integration import Lazy
+from application_sdk.testing.integration import lazy
+assert callable(lazy), type(lazy)
+assert isinstance(lazy(lambda: 1), Lazy)
+print("OK")
+"""
+        # ``import a.b.lazy as m`` is deliberately not used here: that form
+        # walks attributes and, with the function bound on the package, would
+        # hand back the function — the same behaviour the pre-lazy eager
+        # ``from .lazy import lazy`` always had. ``from a.b.lazy import ...``
+        # goes through ``sys.modules`` and is the form consumers write.
+        submodule_first = """
+import sys
+from application_sdk.testing.integration.lazy import lazy as from_module
+from application_sdk.testing.integration import lazy
+assert callable(lazy), type(lazy)
+assert lazy is from_module
+assert lazy is sys.modules["application_sdk.testing.integration.lazy"].lazy
+print("OK")
+"""
+        for script in (sibling_first, submodule_first):
+            result = _run_python(script)
+            assert result.returncode == 0, result.stderr
+            assert "OK" in result.stdout
 
     def test_submodules_are_still_reachable_as_attributes(self) -> None:
         """``integration.models.Scenario`` — an access the eager form gave free.


### PR DESCRIPTION
## Problem

Since the lazy conversion of `application_sdk.testing.integration` (3.31.0), the documented import

```python
from application_sdk.testing.integration import lazy
```

returns the **submodule**, not the function, whenever the `lazy` submodule was loaded before that attribute was first read. Scenario files using `lazy(lambda: ...)` in `Scenario.args` then fail at pytest collection:

```
TypeError: 'module' object is not callable
```

Root cause: `lazy` is both an exported function and the name of the submodule defining it. Python binds a submodule onto its package the first time the submodule loads. With nothing loading it eagerly, whoever triggers the first load wins the binding — `__getattr__` resolving a sibling name (`Lazy`, `is_lazy`), or a consumer importing the submodule directly — and `__getattr__` is never consulted for `lazy` again. The package's own docstring still shows the broken import as the example.

Hit in practice by `atlan-bridge-app` on upgrading to 3.31.0 (worked around there with `from application_sdk.testing.integration.lazy import lazy`).

## Fix

- Import `Lazy`, `evaluate_if_lazy`, `is_lazy`, `lazy` eagerly in the package body. The first load of the submodule now always happens there, and the `from` rebinds the name to the function before anything else can observe it. The module is a few stdlib imports, none of the import cost the lazy conversion was protecting against; `from ...integration.fixtures import *` still does not pull in `runner`, `client`, or `validation` (existing test).
- `__getattr__` checks `_LAZY_EXPORTS` before the submodule shortcut, so any future function/submodule name collision resolves to the export.
- `_LAZY_EXPORTS`, `__all__`, and the `TYPE_CHECKING` block are unchanged, so the three parallel lists the existing tests pin still agree.

## Tests

Two additions to `TestLazyPackage`, both fail on `main`:

- `test_names_shared_with_a_submodule_are_bound_eagerly` — every name in both `_LAZY_EXPORTS` and `_LAZY_SUBMODULES` must already be in the package namespace and not be a module.
- `test_lazy_is_the_function_whatever_loads_first` — fresh-interpreter scripts for the two breaking orders (sibling-first, submodule-first) assert `lazy` is callable and is the function from the submodule.

`tests/unit`: 10030 passed. ruff, ruff-format, isort, pyright clean on both files.

## Note

`import application_sdk.testing.integration.lazy as m` walks package attributes and yields the function, exactly as the pre-3.31 eager package did. `from application_sdk.testing.integration.lazy import lazy` goes through `sys.modules` and is unaffected.
