### PR TITLE
fix(filters): allow consecutive hyphens in include/exclude filters

### DIFF
--- a/application_sdk/common/sql_filters.py
+++ b/application_sdk/common/sql_filters.py
@@ -63,22 +63,27 @@ def safe_substitute_placeholders(template: str, mapping: dict[str, str]) -> str:
 #   * ``'`` — string-literal delimiter (would close the surrounding quote)
 #   * ``"`` — identifier delimiter in dialects that allow it
 #   * ``;`` — statement separator (stacked-query injection)
-#   * ``--`` — SQL line comment (eats the rest of the line)
 #   * ``/*`` / ``*/`` — block comment
 #   * ``\x00`` — null byte; some drivers truncate on it
 #
 # Regex meta-characters that legitimately appear in filter values
 # (``^``, ``$``, ``.``, ``*``, ``+``, ``?``, ``|``, ``()``, ``[]``, ``\``,
-# ``{}``, single ``-``) remain allowed. This is a deny-list, not an
-# allow-list — a strict allow-list would break virtually every existing
-# filter pattern.
+# ``{}``, ``-``) remain allowed. This is a deny-list, not an allow-list — a
+# strict allow-list would break virtually every existing filter pattern.
+#
+# ``--`` is deliberately NOT on the list. It opens a SQL line comment only
+# outside a string literal, and templates are required to wrap every
+# substitution in single quotes (see the Warning on ``_prepare_sql``) — so a
+# filter value lands inside a literal, and ``'``, the one sequence that could
+# end that literal, stays forbidden. Meanwhile ``--`` is legal in a source
+# object name: a GCP project id may carry one, and forbidding it rejected
+# valid filters at contract admission, before any activity ran.
 # ---------------------------------------------------------------------------
 
 _FORBIDDEN_FILTER_SEQUENCES: tuple[str, ...] = (
     "'",
     '"',
     ";",
-    "--",
     "/*",
     "*/",
     "\x00",
@@ -86,8 +91,8 @@ _FORBIDDEN_FILTER_SEQUENCES: tuple[str, ...] = (
 
 # Used by Pydantic ``Field(pattern=...)`` on filter-shaped fields. Forbids
 # the single-character members of ``_FORBIDDEN_FILTER_SEQUENCES``;
-# multi-character sequences (``--``, ``/*``, ``*/``) are caught by the
-# dedicated ``validate_filter_no_sql_injection`` validator below.
+# multi-character sequences (``/*``, ``*/``) are caught by the dedicated
+# ``validate_filter_no_sql_injection`` validator below.
 SAFE_FILTER_PATTERN: str = r"^[^'\";\x00]*$"
 _SAFE_FILTER_PATTERN = SAFE_FILTER_PATTERN  # backward-compat alias
 

--- a/application_sdk/templates/sql_metadata_extractor.py
+++ b/application_sdk/templates/sql_metadata_extractor.py
@@ -217,7 +217,9 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
             in single quotes, e.g. ``WHERE name !~ '{normalized_exclude_regex}'``.
             Single quotes in filter values are blocked by the SQL injection guard
             in ``_validate_no_sql_injection``. Templates that omit the surrounding
-            quotes are not protected.
+            quotes are not protected. This requirement is also what lets ``--``
+            stay off the filter deny-list — inside a literal it cannot open a
+            comment (see ``sql_filters._FORBIDDEN_FILTER_SEQUENCES``).
 
             Connectors that perform additional placeholder substitution on the
             returned SQL (e.g. ``{schema_list}``) must use ``str.replace()``

--- a/tests/unit/common/test_sql_filters_injection.py
+++ b/tests/unit/common/test_sql_filters_injection.py
@@ -39,7 +39,6 @@ class TestValidateFilterNoSqlInjection:
             "prefix'injection",  # single quote
             'prefix"injection',  # double quote
             "name; DROP TABLE x",  # statement separator
-            "name-- comment",  # SQL line comment
             "name/* block",  # block comment open
             "name */",  # block comment close
             "name\x00trailing",  # null byte
@@ -56,6 +55,7 @@ class TestValidateFilterNoSqlInjection:
             r"^(prod|stage)_db\.[a-z]+(\.bak)?$",  # full meta-char set
             "",  # empty
             "schema_name",  # plain identifier
+            "my--project",  # consecutive hyphens — legal in a GCP project id
         ],
     )
     def test_clean_string_passes(self, value: str) -> None:
@@ -235,7 +235,7 @@ class TestNormalizeLegacyFilterValue:
             # is still SQL-unsafe and must fail loudly rather than
             # silently round-trip through the helper.
             '"name;drop"',
-            '"a--b","c"',
+            '"a;b","c"',
             '"a","b/*c"',
             '"a","b\x00c"',
         ],

--- a/tests/unit/common/test_sql_filters_json_envelope.py
+++ b/tests/unit/common/test_sql_filters_json_envelope.py
@@ -90,10 +90,8 @@ class TestInjectionStillGetsTheSecurityVerdict:
     @pytest.mark.parametrize(
         "value",
         [
-            '{"^prod--$": []}',
             '{"a"; DROP TABLE x": []}',
             r'{"^a\_b$": []} ; DROP TABLE x --}',
-            r'{"^a\_b--c$": []}',
             r"{\"^a\_b$\": ['x'] }",
             '{"^a\\_b\x00$": []}',
             r'{"^a\_b/*c$": []}',
@@ -120,6 +118,9 @@ class TestUnchangedPaths:
         "value",
         [
             '{"^d\\\\_edw$": []}',
+            # Consecutive hyphens are legal in a source object name (a GCP
+            # project id may carry them) and no longer deny-listed.
+            '{"^prod--$": []}',
             # Brace-wrapped but quote-free: never a JSON attempt, so it keeps
             # raw-regex handling. ``_prepare_sql``'s no-cascade tests rely on
             # exactly this shape.

--- a/tests/unit/templates/test_extraction_input_filters.py
+++ b/tests/unit/templates/test_extraction_input_filters.py
@@ -210,11 +210,13 @@ class TestFilterSQLInjectionGuard:
         with pytest.raises(ValueError, match=r"SQL-unsafe sequence ';'"):
             ExtractionInput.model_validate(payload)
 
-    def test_line_comment_rejected(self):
-        # SQL line comment eats the rest of the line.
-        payload = {"include_filter": "name-- comment"}
-        with pytest.raises(ValueError, match=r"SQL-unsafe sequence '--'"):
-            ExtractionInput.model_validate(payload)
+    def test_consecutive_hyphens_accepted(self):
+        # A doubled hyphen only opens a SQL comment outside a string literal,
+        # and every substitution site quotes the value. It is legal in a
+        # source object name (a GCP project id may carry one), so admitting it
+        # is required, not merely safe.
+        payload = {"include_filter": "my--project"}
+        assert ExtractionInput.model_validate(payload).include_filter == "my--project"
 
     def test_block_comment_open_rejected(self):
         payload = {"include_filter": "name/* injected */"}
@@ -259,7 +261,6 @@ class TestTempTableRegexInjectionGuard:
     @pytest.mark.parametrize(
         "value",
         [
-            "evil--comment",
             "evil/* block",
             "evil */",
         ],
@@ -285,7 +286,7 @@ class TestTempTableRegexInjectionGuard:
 
     def test_task_input_multichar_rejected(self) -> None:
         with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
-            ExtractionTaskInput.model_validate({"temp_table_regex": "evil--"})
+            ExtractionTaskInput.model_validate({"temp_table_regex": "evil/*"})
 
 
 class TestExtractionTaskInputFilters:
@@ -361,10 +362,10 @@ class TestLegacyQuotedCsvNormalisation:
 
     def test_temp_table_regex_legacy_with_forbidden_item_still_rejected(self):
         # Defence in depth: if a legacy item smuggles a forbidden
-        # sequence (e.g. ``--``), the normaliser's post-unwrap check
+        # sequence (e.g. ``/*``), the normaliser's post-unwrap check
         # raises — the bypass route cannot launder injection through
         # the legacy shape.
-        payload = {"temp_table_regex": '"prefix","name--bad"'}
+        payload = {"temp_table_regex": '"prefix","name/*bad"'}
         with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
             ExtractionInput.model_validate(payload)
 

--- a/tests/unit/templates/test_sql_metadata_extractor.py
+++ b/tests/unit/templates/test_sql_metadata_extractor.py
@@ -319,6 +319,21 @@ class TestSqlMetadataExtractorPrepareSql:
         )
         assert result == "^tmp_|^prod_"
 
+    def test_consecutive_hyphens_land_inside_the_quotes(self) -> None:
+        """Why ``--`` is not deny-listed: the template quotes the substitution.
+
+        Both filter encodings compile to one regex, so a key-only exemption
+        would give the same filter two different verdicts.
+        """
+        sql = "WHERE name ~ '{normalized_include_regex}'"
+        nested = self._extractor()._prepare_sql(
+            sql, ExtractionTaskInput(include_filter={"^p$": {"^d--y$": {}}})
+        )
+        listed = self._extractor()._prepare_sql(
+            sql, ExtractionTaskInput(include_filter={"^p$": ["^d--y$"]})
+        )
+        assert nested == listed == "WHERE name ~ '^p\\.d--y$'"
+
     def test_temp_table_fragment_injected_in_table_mode(self) -> None:
         class _E(SqlMetadataExtractor):
             _app_registered = True


### PR DESCRIPTION
## Problem

`--` sits in `_FORBIDDEN_FILTER_SEQUENCES`, so any `include_filter` /
`exclude_filter` containing consecutive hyphens fails contract admission on
`ExtractionInput` — non-retryably, before any activity runs.

Consecutive hyphens are legal in a source object name. A GCP project id may
carry them, so this rejects valid filters.

## Why it is safe to drop

`--` opens a SQL line comment **only outside a string literal**. Templates are
already required to wrap every substitution in single quotes — the requirement
`_prepare_sql`'s docstring states, and the reason `'` is deny-listed:

```python
# sql_metadata_extractor.py — the template contract
"WHERE name !~ '{normalized_exclude_regex}' AND name ~ '{normalized_include_regex}'"
```

Inside that literal `--` is inert. The sequences that could *escape* it (`'`,
`"`) or stack a statement (`;`, `/*`, `*/`, `\x00`) all remain forbidden.

## Why it cannot be exempted for keys only

`normalize_filters` strips the anchors off keys, nested keys and list values
alike and concatenates all three into one regex:

```python
db = filtered_db.strip("^$")                    # the KEY
normalized_filter_list.append(f"^{db}\\..*$")   # concatenated into the regex
```

So a key-only exemption gives two encodings of the same filter opposite
verdicts, even though both compile to `^p\.d--y$`. Hence: uniform.

## Change

One line of behaviour — `"--"` leaves the tuple. The rest of the source diff is
the comment explaining why, plus a pointer from `_prepare_sql`'s Warning to
what now depends on it.

## Tests

| Test | Change |
|---|---|
| `test_sql_filters_injection` — `"name-- comment"` | moved to the clean-string set; `my--project` added |
| `…test_forbidden_item_after_unwrap_raises` | sample `'"a--b","c"'` → `'"a;b","c"'` |
| `test_sql_filters_json_envelope` — 2 unsafe params | `{"^prod--$": []}` moved to the passing set; the `\_b--c` variant dropped, `\_b/*c` already covers "a stray backslash must not hide a forbidden sequence" |
| `test_extraction_input_filters::test_line_comment_rejected` | → `test_consecutive_hyphens_accepted` |
| `…temp_table_regex` — 3 `--` samples | → `/*`, still forbidden |

Each rewritten case keeps asserting that the guard fires; only the sample
changed. New: `_prepare_sql` emits `--` inside the quotes, and the nested and
list encodings produce identical SQL.

`10082 unit passed, 9 skipped`; ruff, ruff-format, isort, pyright clean.

## Not in scope

`get_database_names` returns names for use as **bare identifiers**, so the
deny-list is the wrong shape there — it admits a backtick, a space and a
newline. That is pre-existing and unaffected by this change (a hyphen is not
legal in an unquoted BigQuery identifier, so those templates already quote).
Worth a separate issue.
