### PR TITLE
ci: FND-1788 give generated-freshness the history override detection needs

### DIFF
--- a/.github/workflows/generated-freshness.yaml
+++ b/.github/workflows/generated-freshness.yaml
@@ -82,6 +82,17 @@ jobs:
           # in FND-395. A PklProject module-URI allowlist, if ever added, should
           # still be written to cover every such workflow rather than this one.
           ref: ${{ github.event.pull_request.head.sha }}
+          # Override detection needs ONE parent commit. `baseline_contract_ref`
+          # has two paths: an uncommitted pin change (Renovate's
+          # postUpgradeTasks --no-commit) diffs the worktree against HEAD and
+          # needs no history, but a COMMITTED bump — every human PR — resolves
+          # the parent of the last commit touching contract/PklProject. At the
+          # default depth of 1 that parent does not exist, so the function
+          # returns None, no baseline eval runs, and files the app maintains by
+          # hand inside app/generated/ are reported as stale instead of being
+          # preserved. Full history rather than depth: 2, because the last
+          # commit touching PklProject can be arbitrarily far back.
+          fetch-depth: 0
 
       # Provides `uvx ruff`, used by the driver to format generated Python so the
       # diff compares against ruff-formatted output (matching how the artifacts


### PR DESCRIPTION
Closes FND-1788.

## Problem

`generated-freshness.yaml` checks out at the default depth of **1**, which silently disables the mechanism that lets an app hand-maintain a file inside `app/generated/`.

`baseline_contract_ref` has two paths:

- **Uncommitted** pin change (Renovate's `postUpgradeTasks --no-commit`) — diffs the worktree against `HEAD`, needs no history. Works today.
- **Committed** bump — every human PR — resolves the parent of the last commit touching `contract/PklProject`. At depth 1 that parent is absent, so it returns `None`, `_baseline_output` takes its "no pin change in flight" branch, no baseline eval runs, and app-maintained generated files are reported as drift instead of preserved.

Nothing warns, because returning `None` is also the ordinary no-bump case — the job just prints `Regenerated contract artifacts.` and then the diff.

## Impact

**13 connector apps** set `hasCredentialConfig = false` and carry a hand-maintained credential configmap inside `app/generated/`, so every one hits this on the PR that baselines it: alloydb-postgres, azure-event-hub, cloudsql-postgres, coalesce, cratedb, db2, dbt, hello-world, hive, looker, mssql, powercenter, teradata.

Observed on `atlan-alloydb-postgres-app#108`: `app/generated/atlan-connectors-alloydb-postgres.json` reported stale, while that repo's 8 preceding `renovate/app-contract-toolkit` branches all passed — they took the uncommitted path. That app is opting out with `check-freshness: false` until this lands.

## Why `fetch-depth: 0` and not `2`

The last commit touching `PklProject` can be arbitrarily far back, so a fixed shallow depth would still miss its parent.

## Note for the reviewer

The baseline eval compares by output path, so an app migrating `NativeApp.pkl` → `App.pkl` in the same commit as the pin bump also changes the generated layout (bare filenames → `app/generated/…`). This PR restores the history the mechanism needs; whether detection behaves well across a layout change is a separate question worth confirming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
