### PR TITLE
fix(contract-toolkit): sanitize leading underscores in generated Python field names

### DIFF
--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -3109,6 +3109,38 @@ local credentialConfigOutput: FileOutput = new FileOutput {
 
 local function toPyName(k: String): String = k.replaceAll("-", "_")
 
+/// `toPyName` for a name that is emitted as a Python CLASS ATTRIBUTE, as opposed
+/// to a manifest key or a wire alias.
+///
+/// Pydantic rejects a field whose attribute name starts with `_` — it treats the
+/// name as a private attribute and raises at class-creation time:
+///
+///     NameError: Fields must not use names with leading underscores;
+///     e.g., use 'CratedbCredentialBody__enable_ssl' instead of
+///     '_CratedbCredentialBody__enable_ssl'
+///
+/// (the mangled spelling is Python's, applied to any `__name` written inside a
+/// class body). Marketplace credential forms use a leading `__` for
+/// connection-behaviour toggles the source itself does not store — this file's
+/// own reference documents `__enable_ssl` as the canonical `extraFields`
+/// example, and `atlan-trino-app` ships `__jwt_token`,
+/// `__enable_tls_https` and `__disable_ssl_verification`. Passed through
+/// unsanitized, every one of those generates a module that cannot be imported.
+/// It went unnoticed because the apps carrying such fields were all on
+/// `hasCredentialConfig = false` or on a base that emits no e2e codegen;
+/// `atlan-cratedb-app` is the first to combine the two.
+///
+/// Only the attribute is sanitized. The `alias=` stays the raw field name, so
+/// the wire format — what the tenant stores and what the runtime reads — is
+/// unchanged, and `extra.__enable_ssl` keeps working.
+///
+/// Deliberately NOT folded into `toPyName`: that function also builds manifest
+/// arg keys (`[toPyName(paramKey)] = "{{...}}"`), which are wire format, not
+/// identifiers. Stripping there would silently rename a manifest key and break
+/// the substitution it feeds.
+local function toPyFieldName(k: String): String =
+  toPyName(k).replaceFirst(Regex("^_+"), "")
+
 local function getPyDefaultFactoryField(k: String, fieldType: String, factory: String): String =
   let (line = "\(k): \(fieldType) = Field(default_factory=\(factory))")
   if (line.length <= 84)
@@ -3145,7 +3177,7 @@ local function applyLifecycle(fieldLine: String, u: Widgets.UIElement): String =
       fieldLine.replaceFirst(Regex(" = (.+)$"), " = Field(default=$1\(lifecycleKwargs))")
 
 local function getInputPyField(k: String, u: Widgets.UIElement): String =
-  let (k = toPyName(k))
+  let (k = toPyFieldName(k))
   let (baseLine =
     if (u is Widgets.BooleanInput)
       "\(k): bool = \(if ((u as Widgets.BooleanInput).default) "True" else "False")"
@@ -3262,7 +3294,7 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
   local skipFields: Set<String> = extractionInputProvidedFields.toList().toSet()
   local uiFieldLines: String = (new Listing {
     for (k, u in props) {
-      if (u.includeInInput && !skipFields.contains(toPyName(k)))
+      if (u.includeInInput && !skipFields.contains(toPyFieldName(k)))
         "    " + getInputPyField(k.replaceAll("-", "_"), u) + "\n" +
         (if (u.helpText != "") "    \"\"\"" + u.helpText + "\"\"\"\n" else "")
       else
@@ -3271,8 +3303,8 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
   }).toList().fold("", (acc: String, s: String) -> acc + s)
   local objectStringCoercionFields: List<String> = (new Listing {
     for (k, u in props) {
-      when (u.includeInInput && !skipFields.contains(toPyName(k)) && needsJsonObjectStringCoercion(u)) {
-        toPyName(k)
+      when (u.includeInInput && !skipFields.contains(toPyFieldName(k)) && needsJsonObjectStringCoercion(u)) {
+        toPyFieldName(k)
       }
     }
   }).toList()
@@ -3308,8 +3340,8 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
   // py-names already emitted from uiConfig — used to deduplicate the publish scaffold
   local uiPyNames: Set<String> = (new Listing {
     for (k, u in props) {
-      when (u.includeInInput && !skipFields.contains(toPyName(k))) {
-        toPyName(k)
+      when (u.includeInInput && !skipFields.contains(toPyFieldName(k))) {
+        toPyFieldName(k)
       }
     }
   }).toList().toSet()
@@ -3470,7 +3502,7 @@ local function fmtSubsField(pyName: String, typeStr: String, defaultExpr: String
 
 // Returns a typed pydantic Field line for a substitution field, or null to skip.
 local function getSubsFieldLine(k: String, u: Widgets.UIElement): String? =
-  let (pyName = toPyName(k))
+  let (pyName = toPyFieldName(k))
   if (u is Widgets.ConnectionCreator || u is Widgets.ConnectionSelector || u is Widgets.ConnectionRefInput)
     null
   else if (u is Widgets.BooleanInput)
@@ -3714,7 +3746,7 @@ local function generateE2ESubstitutionsPy(): FileOutput? =
   let (skip = e2eSubsSkip())
   let (fieldLines = (new Listing {
     for (k, u in props) {
-      when (!skip.contains(toPyName(k)) && u.includeInInput && getSubsFieldLine(k, u) != null) {
+      when (!skip.contains(toPyFieldName(k)) && u.includeInInput && getSubsFieldLine(k, u) != null) {
         getSubsFieldLine(k, u)!! + "\n"
       }
     }
@@ -3749,7 +3781,7 @@ local function generateE2ESubstitutionsPy(): FileOutput? =
 // Returns a typed Field line for a single FieldSpec in a CredentialBody class.
 // authSpecific=true means the field only appears in some auth options (always use a default).
 local function credFieldLine(f: FieldSpec, authSpecific: Boolean): String =
-  let (pyName = toPyName(f.name))
+  let (pyName = toPyFieldName(f.name))
   let (pyType = if (f.fieldType == "number") "int" else "str")
   let (defExpr =
     if (f.defaultValue != null)
@@ -3882,7 +3914,7 @@ local function generateE2ECredentialPy(): FileOutput? =
 
     local condCommonLines = (new Listing {
       for (f in condCommonSpecs) {
-        "    " + toPyName(f.name) + ": str | None = Field(default=None, alias=\"" + f.name + "\")\n"
+        "    " + toPyFieldName(f.name) + ": str | None = Field(default=None, alias=\"" + f.name + "\")\n"
       }
     }).toList().fold("", (acc: String, s: String) -> acc + s)
 

--- a/contract-toolkit/tests/e2e_credential_pyname_test.pkl
+++ b/contract-toolkit/tests/e2e_credential_pyname_test.pkl
@@ -1,0 +1,122 @@
+/// A credential field whose name begins with `__` must still generate an
+/// importable `_e2e_credential.py`.
+///
+/// Pydantic refuses a model field whose attribute name starts with `_` — it
+/// classifies the name as a private attribute and raises `NameError` at class
+/// creation, so the whole generated module fails on import. Marketplace forms
+/// use a leading `__` for connection-behaviour toggles the source does not
+/// store: this toolkit's own reference documents `__enable_ssl` as the
+/// canonical `AdvancedJDBCUrlGroup.extraFields` example, and atlan-trino-app
+/// ships `__jwt_token`, `__enable_tls_https` and `__disable_ssl_verification`.
+///
+/// The attribute is sanitized; the `alias=` keeps the raw name, so the wire
+/// format the tenant stores and the runtime reads is unchanged.
+amends "pkl:test"
+
+import "../src/App.pkl" as App
+import "../src/Connectors.pkl"
+
+local appDunderCredential = (App) {
+  name = "dunder-credential-test"
+  displayName = "Dunder Credential Test"
+  connector = Connectors.CRATEDB
+  icon = "https://example.com/icon.svg"
+
+  credentialUrlGroup = new App.AdvancedJDBCUrlGroup {
+    protocol = ""
+    urlAddonBefore = "driver://"
+    hostField = new App.FieldSpec {
+      name = "host"
+      displayName = "Host"
+      placeholder = "host.example.com"
+    }
+    portField = new App.FieldSpec {
+      name = "port"
+      fieldType = "number"
+      displayName = "Port"
+      defaultValue = "4200"
+      required = false
+    }
+    extraFields {
+      new App.FieldSpec {
+        name = "database"
+        displayName = "Database"
+        defaultValue = "crate"
+        required = false
+      }
+      // The field under test.
+      new App.FieldSpec {
+        name = "__enable_ssl"
+        displayName = "Encrypt Connection (TLS/SSL)"
+        fieldType = "select"
+        options { "yes"; "no" }
+        optionLabels { ["yes"] = "Yes"; ["no"] = "No" }
+        defaultValue = "no"
+        required = false
+      }
+    }
+  }
+
+  credentialAuthOptions {
+    ["basic"] = new App.JDBCUrlAuthOption {
+      label = "Basic"
+      nestedLabel = "Basic"
+      urlPartMapping = new App.UrlPartMapping {
+        hostname = "host"
+        port = "port"
+        pathname = "extra.database"
+      }
+      fields {
+        new App.FieldSpec { name = "username"; displayName = "Username" }
+        new App.FieldSpec { name = "password"; sensitive = true; displayName = "Password" }
+      }
+    }
+  }
+
+  // The credential configmap is only emitted for a contract that actually
+  // renders a credential input, so declare one — same shape as the JDBC fixture
+  // in credential_field_rendering_test.pkl.
+  uiConfig = new App.UIConfig {
+    tasks {
+      ["Credential"] {
+        inputs {
+          ["credential-guid"] = new App.CredentialInput {
+            credType = "atlan-connectors-dunder-credential-test"
+          }
+        }
+      }
+    }
+  }
+}
+
+local e2eCredentialPy: String =
+  appDunderCredential.output.files["app/generated/_e2e_credential.py"].text
+
+local credentialJson: String =
+  appDunderCredential.output.files["app/generated/atlan-connectors-dunder-credential-test.json"].text
+
+facts {
+  ["a __-prefixed credential field emits a valid Python attribute name"] {
+    e2eCredentialPy.contains("    enable_ssl: str = Field(default=\"no\", alias=\"__enable_ssl\")")
+  }
+
+  ["the raw __ name never reaches the attribute position"] {
+    !e2eCredentialPy.contains("    __enable_ssl:")
+    !e2eCredentialPy.contains("    _enable_ssl:")
+  }
+
+  ["the wire alias keeps the leading underscores"] {
+    e2eCredentialPy.contains("alias=\"__enable_ssl\"")
+  }
+
+  ["sanitizing the attribute does not rename the credential form field"] {
+    // The form — what the tenant fills in and what publish ships — is untouched;
+    // only the generated Python attribute changes.
+    credentialJson.contains("\"__enable_ssl\"")
+  }
+
+  ["ordinary field names are unaffected by the sanitizer"] {
+    e2eCredentialPy.contains("    host: str = Field(alias=\"host\")")
+    e2eCredentialPy.contains("    database: str = Field(default=\"crate\", alias=\"database\")")
+  }
+}


### PR DESCRIPTION
## Problem

A credential field whose name starts with `__` generates an `_e2e_credential.py` that cannot be imported:

```
NameError: Fields must not use names with leading underscores; e.g., use
'CratedbCredentialBody__enable_ssl' instead of '_CratedbCredentialBody__enable_ssl'
```

Pydantic classifies an attribute starting with `_` as a private attribute and raises at class creation, so the failure takes the **whole module**, not just the one field.

This is not an exotic input. Marketplace credential forms use a leading `__` for connection-behaviour toggles the source itself does not store:

- `contract-toolkit/docs/reference.md:1610` documents `__enable_ssl` as the canonical `AdvancedJDBCUrlGroup.extraFields` example.
- `atlan-trino-app` ships `__jwt_token`, `__enable_tls_https`, `__disable_ssl_verification`.
- `atlan-mssql-app`, `atlan-cloudsql-postgres-app`, `atlan-cloudera-impala-app`, `atlan-alloydb-postgres-app` and `atlan-microstrategy-app` all carry `__`-prefixed credential fields.

It stayed hidden because every one of those apps is either on `hasCredentialConfig = false` or on a base that emits no e2e codegen. `atlan-cratedb-app` is the first to combine the two (FND-1802), and hit it immediately.

## Fix

Adds `toPyFieldName` — `toPyName` plus a leading-underscore strip — and applies it **only where a Python class attribute is emitted**:

| Site | Emits |
|---|---|
| `credFieldLine` | credential body attribute |
| `getSubsFieldLine` | substitutions body attribute |
| `getInputPyField` | `_input.py` attribute |
| conditional-common line | credential body attribute |
| the four membership sets those emitters dedupe against | must compare the same spelling |

`alias=` keeps the raw field name, so the wire format is unchanged:

```python
enable_ssl: str = Field(default="no", alias="__enable_ssl")
```

```python
>>> CratedbCredentialBody(name="n", host="h").model_dump(by_alias=True)
{'name': 'n', 'authType': 'basic', 'host': 'h', 'port': 5432,
 'database': 'crate', '__enable_ssl': 'no', 'username': 'admin', 'password': ''}
```

### Why not just change `toPyName`

`toPyName` also builds **manifest arg keys** (`[toPyName(paramKey)] = "{{...}}"`, `App.pkl:3047-3048`) and feeds `reservedUiFieldNames` lookups. Those are wire format, not identifiers. Stripping there would silently rename a manifest key and break the substitution it feeds — so the sanitizer is a separate function used at the identifier sites only.

## Verification

- `pkl test tests/*.pkl` — **420 passed / 948 asserts**, including 5 new facts in `tests/e2e_credential_pyname_test.pkl`.
- `./scripts/regenerate-all.sh` — **no drift**. `git status` is clean apart from the two changed files, so no existing contract's generated output moves.
- `./scripts/check-invariants.sh` — all invariant checks pass.
- `scripts/test-sdk-import.py` — all 41 generated files import.
- Against `atlan-cratedb-app`'s real contract, patched vs unpatched `main` differs by **exactly one line of one file**:

```diff
-    __enable_ssl: str = Field(default="no", alias="__enable_ssl")
+    enable_ssl: str = Field(default="no", alias="__enable_ssl")
```

## Note for reviewers

`scripts/test-sdk-import.py` is the check that *would* have caught this, but no example carries a `__`-prefixed credential field. The new pkl test covers the codegen directly; adding such a field to an example would extend the guard to the import path too, if you'd like that in this PR.

## Downstream

Unblocks `atlanhq/atlan-cratedb-app` (FND-1802), which is moving its hand-authored credential form onto the contract and needs a toolkit release carrying this.
