### PR TITLE
feat(contract-toolkit): default PublishNode write gates to the asset-publish role

### DIFF
--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -991,18 +991,26 @@ open class PublishNode extends DAGNode {
   /// (miners, BI/dbt lineage builders) resolve asset identifiers by qualified name
   /// without re-crawling the source system.
   ///
-  /// Defaults to `false` as the safe base for direct use (e.g. `extraNodes`).
-  /// When this node is created via the typed `pipeline.publish` step, the
-  /// pipeline injects `true` unless the app contract overrides it explicitly
-  /// on `PublishStep.connectionCacheEnabled`. Must be `false` for any publish
-  /// node that must not overwrite the shared connection-cache index (e.g. lineage publish).
-  connectionCacheEnabled: Boolean = false
+  /// Defaults to `true`, because this class IS the asset-publish role and asset
+  /// publish is what owns the connection-cache index. The default matches
+  /// `PublishStep.connectionCacheEnabled`, so a node built directly under
+  /// `extraNodes` behaves the same as one built by the typed `pipeline.publish`
+  /// step. Set it to `false` explicitly to opt out.
+  ///
+  /// Must be `false` for any publish node that must NOT overwrite the shared
+  /// index — notably lineage publish, which would replace the crawler's
+  /// `Database`/`Schema`/`Table` rows with `Process`/`ColumnProcess` ones and
+  /// break qualified-name lookups for miners and BI lineage builders.
+  /// `LineagePublishNode` therefore defaults it to `false` (BLDX-1299) and that
+  /// asymmetry is deliberate: the default follows the ROLE, not the
+  /// construction path.
+  connectionCacheEnabled: Boolean = true
 
   /// App-level gate for the connection-cache activity, paired with `connectionCacheEnabled`.
   ///
   /// Both flags must be `true` for the connection-cache index to be built and
-  /// uploaded. Same default and injection semantics as `connectionCacheEnabled`.
-  connectionCacheViaAppEnabled: Boolean = false
+  /// uploaded. Same default and rationale as `connectionCacheEnabled`.
+  connectionCacheViaAppEnabled: Boolean = true
 
   /// Whether publish should package and upload the current-state snapshot after writing assets.
   ///
@@ -1012,19 +1020,28 @@ open class PublishNode extends DAGNode {
   /// downstream consumers (e.g. the current-state syncer and on-demand asset caches)
   /// read it to get an up-to-date view without re-crawling.
   ///
-  /// Defaults to `false` as the safe base for direct use (e.g. `extraNodes`).
-  /// When this node is created via the typed `pipeline.publish` step, the
-  /// pipeline injects `true` from `PublishStep.currentStateEnabled`.
-  currentStateEnabled: Boolean = false
+  /// Defaults to `true`, matching `PublishStep.currentStateEnabled`, so a node
+  /// built directly under `extraNodes` behaves the same as one built by the
+  /// typed `pipeline.publish` step. Set it to `false` explicitly to opt out.
+  ///
+  /// This is the MASTER gate on the activity: `currentStateViaAppEnabled` only
+  /// chooses the real path over a dry-run one *inside* it, so with this `false`
+  /// the paired flag has no effect at all.
+  ///
+  /// Note publish-app treats an ABSENT `current_state_enabled` arg as `true`
+  /// (`ATLAN_CURRENT_STATE_ENABLED`), so emitting `false` is not a neutral
+  /// default — it actively overrides a platform default that is on. Defaulting
+  /// this to `false` silently disabled the snapshot for every app that built
+  /// its publish node from this class without setting the flag.
+  currentStateEnabled: Boolean = true
 
   /// App-level gate for the current-state activity, paired with `currentStateEnabled`.
   ///
   /// Both flags must be `true` for the current-state snapshot to be written.
-  /// Same default and injection semantics as `currentStateEnabled`. When `true`
-  /// (via `PublishStep`), publish writes to the real current-state path so the
-  /// next run can diff against it; when `false`, the snapshot is either skipped
-  /// or written to a dry-run path.
-  currentStateViaAppEnabled: Boolean = false
+  /// Same default and rationale as `currentStateEnabled`. When `true`, publish
+  /// writes to the real current-state path so the next run can diff against it;
+  /// when `false`, the snapshot is written to a dry-run path instead.
+  currentStateViaAppEnabled: Boolean = true
 
   /// Connection entity passed to the publish workflow as `args["connection_entity"]`.
   ///

--- a/contract-toolkit/tests/lineage_publish_node_test.pkl
+++ b/contract-toolkit/tests/lineage_publish_node_test.pkl
@@ -83,20 +83,46 @@ facts {
   // Class-level defaults: precise per-type assertions without manifest noise.
   // -----------------------------------------------------------------------
 
-  // PublishNode's base default is false — true is injected by the pipeline
-  // rendering (PublishStep → renderNode) so the pipeline asset publish always
-  // sends true without every app contract having to repeat it. Direct /
-  // extraNodes use of PublishNode is safe by default (false).
-  ["PublishNode base default for connection_cache_enabled is false"] {
-    assetPublishNode.args["connection_cache_enabled"] == false
-    assetPublishNode.args["connection_cache_via_app_enabled"] == false
+  // PublishNode defaults all four write gates to true, MATCHING PublishStep.
+  //
+  // These previously asserted false, on a "safe base for direct use" rationale.
+  // That rationale did not hold up: the defaults follow the publish ROLE, not
+  // the construction path, and PublishNode *is* the asset-publish role. Two
+  // different answers for the same role meant an app that declared its publish
+  // node under `extraNodes` was silently opted out of the asset-publish
+  // defaults — which is how atlan-metabase-app stopped writing its
+  // current-state snapshot (see the class docs on currentStateEnabled).
+  //
+  // Source of truth for `true` here is the 2026-05-14 alignment in
+  // #project-killargo (Faizan Shaik, approved by Niteesh Hegde): all four gates
+  // default true on PublishNode, with explicit opt-out properties. Chris
+  // Grote's role matrix in the same channel (2026-05-22) states the same split
+  // — asset publish true, lineage publish false — and the lineage half already
+  // shipped as BLDX-1299.
+  ["PublishNode base default for connection_cache_enabled is true"] {
+    assetPublishNode.args["connection_cache_enabled"] == true
+    assetPublishNode.args["connection_cache_via_app_enabled"] == true
   }
 
-  // current_state_enabled and current_state_via_app_enabled follow the same
-  // safe-base pattern: PublishNode defaults to false, PublishStep injects true.
-  ["PublishNode base default for current_state_enabled is false"] {
-    assetPublishNode.args["current_state_enabled"] == false
-    assetPublishNode.args["current_state_via_app_enabled"] == false
+  ["PublishNode base default for current_state_enabled is true"] {
+    assetPublishNode.args["current_state_enabled"] == true
+    assetPublishNode.args["current_state_via_app_enabled"] == true
+  }
+
+  // The regression guard: a bare PublishNode must never emit
+  // current_state_enabled = false, because publish-app treats an ABSENT arg as
+  // true, so a false here actively overrides a platform default that is on.
+  ["A bare PublishNode does not silently disable the current-state snapshot"] {
+    assetPublishNode.args["current_state_enabled"] != false
+  }
+
+  // PublishNode and PublishStep must agree on all four gates — they are the
+  // same role, and divergence here is the defect this alignment removes.
+  ["PublishNode and PublishStep agree on all four write gates"] {
+    assetPublishNode.args["connection_cache_enabled"] == defaultPublishArgs["connection_cache_enabled"]
+    assetPublishNode.args["connection_cache_via_app_enabled"] == defaultPublishArgs["connection_cache_via_app_enabled"]
+    assetPublishNode.args["current_state_enabled"] == defaultPublishArgs["current_state_enabled"]
+    assetPublishNode.args["current_state_via_app_enabled"] == defaultPublishArgs["current_state_via_app_enabled"]
   }
 
   // Default pipeline (no pipeline block): PublishStep defaults inject true.


### PR DESCRIPTION
## Problem

`PublishNode` defaults all four publish write gates to `false`, while `PublishStep` defaults the same four to `true` — even though both describe the **same role**, asset publish:

| | `PublishNode` | `PublishStep` |
|---|---|---|
| `connectionCacheEnabled` | `false` | `true` |
| `connectionCacheViaAppEnabled` | `false` | `true` |
| `currentStateEnabled` | `false` | `true` |
| `currentStateViaAppEnabled` | `false` | `true` |

So an app that declares its publish node under `extraNodes` gets different runtime behaviour from one that uses the typed `pipeline.publish` step — and nothing in the generated manifest records which path produced it.

The old defaults were justified in the docstrings as *"the safe base for direct use (e.g. `extraNodes`)"*. That rationale does not hold: **publish-app treats an absent `current_state_enabled` arg as `true`** (`ATLAN_CURRENT_STATE_ENABLED` defaults on), so emitting `false` is not a neutral default — it actively overrides a platform default that is on.

`atlan-metabase-app` stopped writing its current-state snapshot the moment the key began being emitted (#1866), purely because its publish node came from `extraNodes`. Its paired `current_state_via_app_enabled: true` was left dead, since `currentStateEnabled` is the master gate and the paired flag only selects real-vs-dry-run *inside* it.

## What this changes

All four gates default `true` on `PublishNode`, matching `PublishStep`. Explicit values still win, so opting out is `= false`.

This is the **asset-publish half** of the alignment reached in `#project-killargo` on **2026-05-14** (Faizan Shaik, approved by Niteesh Hegde): all four default `true` on `PublishNode` with explicit opt-out properties. Chris Grote's role matrix in the same channel (2026-05-22) states the same split — asset publish `true`, lineage publish `false`. The lineage half shipped as **BLDX-1299**; this is the half that never did.

`LineagePublishNode` keeps `connectionCache*` at `false`, and that asymmetry stays deliberate — lineage publish must not overwrite the crawler's connection-cache index. **The defaults follow the role, not the construction path**, and the docstrings now say so.

## Fleet impact

Measured across the **48 apps** that declare `extraNodes["publish"]`, by comparing each app's committed manifest against whether its contract sets each flag explicitly:

| | apps | effect |
|---|---|---|
| **No change** | 37 | set the flags explicitly (override still wins), or already emit `true` |
| **Behaviour-preserving** | 7 | `current_state_enabled` is currently **absent** from their manifest, so publish-app already resolves it to `true` — making it explicit changes nothing.<br>`adf`, `alloydb-postgres`, `cloudera-impala`, `cloudsql-postgres`, `dataplex`, `hive`, and `metabase` (whose `false` is the bug) |
| ⚠️ **Behaviour change** | **4** | set none of the four, so all four flip: connection caches start being written, and current-state moves off the dry-run path.<br>`anomalo`, `documentdb`, `hightouch`, `soda` |

The four in the last row are the apps the 2026-05-14 decision was aimed at — they've been running with caches off because opting in was manual and easy to miss. Each picks this up only when it bumps the toolkit, so adoption is per-app and opt-in at bump time, **but their owners should confirm before adopting this release.**

`atlan-soda-app` in particular sets all four to `false` today; worth confirming with its owner whether that is deliberate.

## Version

`feat` → **minor** bump (0.25.1 → 0.26.0) via the release bot. Deliberate: a patch would signal "safe, take it without thinking", and four apps change behaviour. No `BREAKING CHANGE:` footer — nothing is removed or retyped, and that footer would force a `1.0.0` major.

## Tests

- The two assertions that pinned `PublishNode`'s defaults to `false` are updated to `true`, and now cite the 2026-05-14 alignment as their source of truth rather than the code — they are not simply bent to match the new behaviour.
- **Added** a regression guard: a bare `PublishNode` must never emit `current_state_enabled = false`, because publish-app reads an absent arg as `true`.
- **Added** an equivalence check: `PublishNode` and `PublishStep` must agree on all four gates, so this cannot silently diverge again.

```
pkl test tests/*.pkl          422 passed, 953 asserts   (was 420 / 948)
scripts/check-invariants.sh   all invariant checks passed
scripts/regenerate-all.sh     no example output changed
```

Regenerating every example being a **no-op** is itself evidence the change is confined to bare `extraNodes` publish nodes — all the examples use the typed `PublishStep`, which already defaulted `true`.

I also confirmed nothing else depends on the old defaults: no class extends `PublishNode`, and no conformance rule references these flags.

## Related

- `atlanhq/atlan-metabase-app#438` — patches metabase directly so it doesn't wait on this release
- Toolkit PR #1866 (`318af06f`) — introduced the divergence, giving `PublishStep` `true` and `PublishNode` `false` in the same commit
- BLDX-1299 — the lineage half of the same alignment
- Worth a follow-up in publish-app: `via_app_enabled=True` + `enabled=False` is not validated. `config_validation.py` hard-flags `via_app` with an empty prefix but not this contradiction, and `current_state_disabled` is only a soft advisory flag — which is why metabase warn-logged this for months without escalating.
