### PR TITLE
feat(contract-toolkit): let AdvancedJDBCUrlGroup offer host-only connection

### DIFF
--- a/contract-toolkit/scripts/check-invariants.sh
+++ b/contract-toolkit/scripts/check-invariants.sh
@@ -761,6 +761,65 @@ if ! echo "$ERR_MSG" | grep -q "isDistinct"; then
 fi
 
 # --------------------------------------------------------------------------
+# 12. FND-1802: connectByOptions must contain connectByDefault. The two are set
+#     independently and each is individually valid, so a contract narrowing the
+#     form to host-only while leaving the default at "url" type-checks fine and
+#     renders a `default` outside its own `enum` — a form whose radio has no
+#     selected option. The guard lives on renderConnectByRadio's evaluation path
+#     rather than in a `hidden` property: a hidden property is never forced, and
+#     neither is an unreferenced `let`, so either shape would compile and never run.
+# --------------------------------------------------------------------------
+echo ":: Checking connectByOptions/connectByDefault agreement invariant..."
+BAD_CONTRACT="$(mktemp "$REPO_ROOT/test-connectby-XXXXXX.pkl")"
+OUT_DIR="$(mktemp -d "$REPO_ROOT/test-connectby-out-XXXXXX")"
+cat > "$BAD_CONTRACT" <<'PKLEOF'
+amends "src/App.pkl"
+
+import "src/Connectors.pkl"
+
+name = "connectby-invariant"
+displayName = "ConnectBy Invariant"
+connector = Connectors.CRATEDB
+icon = "https://example.com/icon.svg"
+
+credentialUrlGroup = new AdvancedJDBCUrlGroup {
+  protocol = ""
+  urlAddonBefore = "driver://"
+  connectByOptions = new Listing { "host" }
+  connectByDefault = "url"
+  hostField = new FieldSpec { name = "host"; displayName = "Host" }
+  portField = new FieldSpec { name = "port"; fieldType = "number"; displayName = "Port"; required = false }
+}
+
+credentialAuthOptions {
+  ["basic"] = new JDBCUrlAuthOption {
+    label = "Basic"
+    nestedLabel = "Basic"
+    urlPartMapping = new UrlPartMapping { hostname = "host"; port = "port" }
+    fields { new FieldSpec { name = "username"; displayName = "Username" } }
+  }
+}
+
+uiConfig = new UIConfig {
+  tasks {
+    ["Credential"] {
+      inputs {
+        ["credential-guid"] = new CredentialInput { credType = "atlan-connectors-connectby-invariant" }
+      }
+    }
+  }
+}
+PKLEOF
+ERR_MSG="$(pkl eval -m "$OUT_DIR" "$BAD_CONTRACT" 2>&1 || true)"
+rm -f "$BAD_CONTRACT"
+rm -rf "$OUT_DIR"
+if ! echo "$ERR_MSG" | grep -q "must be one of the offered"; then
+  echo "FAIL: connectByDefault outside connectByOptions should throw"
+  echo "  Got: $ERR_MSG"
+  fail=1
+fi
+
+# --------------------------------------------------------------------------
 # Done
 # --------------------------------------------------------------------------
 if [ "$fail" -ne 0 ]; then

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -698,6 +698,29 @@ class AdvancedJDBCUrlGroup {
 
   connectByDefault: String(this == "host" || this == "url") = "host"
 
+  /// Connection modes the form offers, in the order the radio renders them.
+  ///
+  /// Defaults to both, which is what every existing consumer already gets — this
+  /// property changes nothing unless a contract narrows it.
+  ///
+  /// Set `new Listing { "host" }` for a source whose credential form has only
+  /// ever collected host/port. URL mode is not free: it adds the `URL` radio
+  /// option, an `extra.compiled_url` field (editable in URL mode, a disabled
+  /// preview in host mode), and a second condition branch on host/port. A
+  /// connector migrating a v2 marketplace configmap that offered Host alone has
+  /// no use for any of it, and rendering it anyway is a visible change to a form
+  /// customers already use.
+  ///
+  /// Narrowing to `{ "host" }` suppresses exactly those three: the enum entry,
+  /// the `extra.compiled_url` property, and the URL branch on host/port. It does
+  /// NOT drop `urlPropertyId` / `protocol` from the group's widget config —
+  /// hand-authored host-only forms in the fleet carry both while declaring no
+  /// `compiled_url` property, so keeping them is the parity-preserving choice.
+  connectByOptions: Listing<String(this == "host" || this == "url")> = new Listing {
+    "host"
+    "url"
+  }
+
   urlLabel: String = "SQLAlchemy Connection URL"
 
   /// Set for sources whose JDBC URL separates its parameters with `;` rather
@@ -2155,6 +2178,7 @@ local function renderCompiledUrlField(
 }
 
 local function renderHostOrPortField(
+  group: AdvancedJDBCUrlGroup,
   f: FieldSpec,
   options: Mapping<String, AuthOption>,
   isPort: Boolean
@@ -2174,10 +2198,16 @@ local function renderHostOrPortField(
         ["type"] = visible["type"]
         ["ui"] = if (isPort) hostUi.put("disabled", false).toMapping() else visible["ui"]
       }
-      new Mapping {
-        ["filter"] = connectByFilter("url", options)
-        ["type"] = visible["type"]
-        ["ui"] = hostUi.filter((k, _) -> k != "rules").put("disabled", true).toMapping()
+      // The URL-mode branch renders host/port as disabled, because in URL mode
+      // they are derived from the compiled URL rather than typed. With URL mode
+      // not offered, the branch can never match — a dead filter that reads as an
+      // intentional condition to the next person.
+      when (group.connectByOptions.toList().contains("url")) {
+        new Mapping {
+          ["filter"] = connectByFilter("url", options)
+          ["type"] = visible["type"]
+          ["ui"] = hostUi.filter((k, _) -> k != "rules").put("disabled", true).toMapping()
+        }
       }
     }
     ["ui"] = new Mapping {}
@@ -2241,9 +2271,14 @@ local function renderJdbcUrlField(
     }
   }
   ["properties"] = new Mapping {
-    ["extra.compiled_url"] = renderCompiledUrlField(group, options)
-    ["host"] = renderHostOrPortField(group.hostField, options, false)
-    ["port"] = renderHostOrPortField(group.portField, options, true)
+    // Only meaningful when URL mode is offered — see `connectByOptions`. A
+    // host-only form has nothing to compile a URL from and no mode in which to
+    // edit one, so emitting it would add a permanently-disabled field.
+    when (group.connectByOptions.toList().contains("url")) {
+      ["extra.compiled_url"] = renderCompiledUrlField(group, options)
+    }
+    ["host"] = renderHostOrPortField(group, group.hostField, options, false)
+    ["port"] = renderHostOrPortField(group, group.portField, options, true)
     ["auth-type"] = renderJdbcAuthTypeField(options)
     for (authKey, opt in options) {
       [authKey] = renderJdbcAuthOption(opt)
@@ -2274,12 +2309,33 @@ local function renderJdbcUrlField(
   }
 }
 
-local function renderConnectByRadio(group: AdvancedJDBCUrlGroup): Mapping<String, Any> = new Mapping {
+local const connectByModeLabels: Mapping<String, String> = new {
+  ["host"] = "Host"
+  ["url"] = "URL"
+}
+
+// Validation lives on the RETURNED value's evaluation path, not in a `hidden`
+// property. A hidden property is never forced on its own, and a `let` binding
+// that is not referenced is not forced either — either shape would compile and
+// silently never run.
+local function renderConnectByRadio(group: AdvancedJDBCUrlGroup): Mapping<String, Any> =
+  let (opts = group.connectByOptions.toList())
+  if (opts.isEmpty)
+    throw("AdvancedJDBCUrlGroup.connectByOptions must offer at least one mode.")
+  else if (opts.distinct.length != opts.length)
+    throw("AdvancedJDBCUrlGroup.connectByOptions must not repeat a mode: \(opts).")
+  else if (!opts.contains(group.connectByDefault))
+    throw(
+      "AdvancedJDBCUrlGroup.connectByDefault is \"\(group.connectByDefault)\" but "
+      + "connectByOptions offers \(opts). The default must be one of the offered "
+      + "modes, or the form renders a default outside its own enum."
+    )
+  else new Mapping {
   ["type"] = "string"
-  ["enum"] = new Listing { "host"; "url" }
+  ["enum"] = new Listing { for (m in opts) { m } }
   ["default"] = group.connectByDefault
   ["required"] = true
-  ["enumNames"] = new Listing { "Host"; "URL" }
+  ["enumNames"] = new Listing { for (m in opts) { connectByModeLabels[m] } }
   ["ui"] = new Mapping {
     ["widget"] = "radio"
     ["hidden"] = false

--- a/contract-toolkit/tests/connect_by_options_test.pkl
+++ b/contract-toolkit/tests/connect_by_options_test.pkl
@@ -1,0 +1,129 @@
+/// `AdvancedJDBCUrlGroup.connectByOptions` — narrowing a credential form to
+/// host-only.
+///
+/// The default offers both modes and is asserted here as a control, so a
+/// regression that drops URL mode for everyone fails loudly rather than showing
+/// up as fleet-wide form drift.
+amends "pkl:test"
+
+import "pkl:json"
+import "../src/App.pkl" as App
+import "../src/Connectors.pkl"
+
+local function appWith(modes: Listing<String>) = (App) {
+  name = "connect-by-test"
+  displayName = "Connect By Test"
+  connector = Connectors.CRATEDB
+  icon = "https://example.com/icon.svg"
+
+  credentialUrlGroup = new App.AdvancedJDBCUrlGroup {
+    protocol = ""
+    urlAddonBefore = "driver://"
+    connectByOptions = modes
+    hostField = new App.FieldSpec {
+      name = "host"
+      displayName = "Host"
+      placeholder = "host.example.com"
+    }
+    portField = new App.FieldSpec {
+      name = "port"
+      fieldType = "number"
+      displayName = "Port"
+      defaultValue = "4200"
+      required = false
+    }
+    extraFields {
+      new App.FieldSpec {
+        name = "database"
+        displayName = "Database"
+        defaultValue = "crate"
+        required = false
+      }
+    }
+  }
+
+  credentialAuthOptions {
+    ["basic"] = new App.JDBCUrlAuthOption {
+      label = "Basic"
+      nestedLabel = "Basic"
+      urlPartMapping = new App.UrlPartMapping {
+        hostname = "host"
+        port = "port"
+        pathname = "extra.database"
+      }
+      fields {
+        new App.FieldSpec { name = "username"; displayName = "Username" }
+        new App.FieldSpec { name = "password"; sensitive = true; displayName = "Password" }
+      }
+    }
+  }
+
+  uiConfig = new App.UIConfig {
+    tasks {
+      ["Credential"] {
+        inputs {
+          ["credential-guid"] = new App.CredentialInput {
+            credType = "atlan-connectors-connect-by-test"
+          }
+        }
+      }
+    }
+  }
+}
+
+local hostOnly = appWith(new Listing { "host" })
+local bothModes = appWith(new Listing { "host"; "url" })
+
+local key = "app/generated/atlan-connectors-connect-by-test.json"
+local parser = new json.Parser { useMapping = true }
+
+local hostOnlyText = hostOnly.output.files[key].text
+local hostOnlyJson = parser.parse(hostOnlyText)
+local bothJson = parser.parse(bothModes.output.files[key].text)
+
+local hostOnlyProps = hostOnlyJson["config"]["properties"]
+local bothProps = bothJson["config"]["properties"]
+
+facts {
+  ["host-only narrows the connectBy radio to a single option"] {
+    hostOnlyProps["connectBy"]["enum"].toList() == List("host")
+    hostOnlyProps["connectBy"]["enumNames"].toList() == List("Host")
+  }
+
+  ["host-only emits no extra.compiled_url property"] {
+    !hostOnlyProps["jdbcUrl"]["properties"].containsKey("extra.compiled_url")
+  }
+
+  ["host-only leaves no dead connectBy:url filter anywhere in the form"] {
+    // A filter naming a mode the enum no longer offers can never match, and
+    // reads as an intentional condition to whoever meets it next.
+    !hostOnlyText.contains("\"connectBy\": \"url\"")
+  }
+
+  ["host-only gives host and port a single condition branch"] {
+    hostOnlyProps["jdbcUrl"]["properties"]["host"]["conditions"].toList().length == 1
+    hostOnlyProps["jdbcUrl"]["properties"]["port"]["conditions"].toList().length == 1
+  }
+
+  ["host-only still renders every input field"] {
+    hostOnlyProps["jdbcUrl"]["properties"].containsKey("host")
+    hostOnlyProps["jdbcUrl"]["properties"].containsKey("port")
+    hostOnlyProps["jdbcUrl"]["properties"].containsKey("auth-type")
+    hostOnlyProps["jdbcUrl"]["properties"].containsKey("basic")
+    hostOnlyProps["jdbcUrl"]["properties"]["extra"]["properties"].containsKey("database")
+  }
+
+  ["host-only keeps urlPropertyId and protocol on the widget"] {
+    // Parity with hand-authored host-only forms, which carry both while
+    // declaring no compiled_url property.
+    hostOnlyProps["jdbcUrl"]["ui"]["urlPropertyId"] == "credential-guid.extra.compiled_url"
+    hostOnlyProps["jdbcUrl"]["ui"].containsKey("protocol")
+  }
+
+  ["CONTROL: the default still offers both modes"] {
+    bothProps["connectBy"]["enum"].toList() == List("host", "url")
+    bothProps["connectBy"]["enumNames"].toList() == List("Host", "URL")
+    bothProps["jdbcUrl"]["properties"].containsKey("extra.compiled_url")
+    bothProps["jdbcUrl"]["properties"]["host"]["conditions"].toList().length == 2
+  }
+}


### PR DESCRIPTION
## Problem

`AdvancedJDBCUrlGroup` always renders both connection modes. For a connector whose credential form has only ever collected host/port — typically one migrating a v2 marketplace configmap — that adds three things to a form customers already use:

- a `URL` option on the Connect-by radio,
- an `extra.compiled_url` field (editable in URL mode, a **disabled preview in host mode**),
- a second condition branch on `host` and `port`.

None of it is reachable or useful for such a connector, and all of it is visible.

## Fix

`connectByOptions: Listing<String>`, defaulting to `{ "host"; "url" }`. Narrowing to `{ "host" }` suppresses exactly those three.

```pkl
credentialUrlGroup = new AdvancedJDBCUrlGroup {
  urlAddonBefore = "crate://"
  connectByOptions = new Listing { "host" }
  ...
}
```

`urlPropertyId` and `protocol` stay on the widget config. Hand-authored host-only forms in the fleet carry both while declaring no `compiled_url` property, so keeping them is the parity-preserving choice rather than an oversight.

**The default is unchanged, so this is inert for every existing consumer** — `regenerate-all.sh` produces zero drift across the examples, which is the proof that postgres/db2/teradata/hive/sapase are untouched.

## Validation

`connectByOptions` and `connectByDefault` are set independently and each is individually valid, so `{ "host" }` with `connectByDefault = "url"` type-checks and renders a `default` outside its own `enum` — a radio with no selected option. `renderConnectByRadio` now rejects that, plus an empty or repeating listing:

```
AdvancedJDBCUrlGroup.connectByDefault is "url" but connectByOptions offers List("host").
The default must be one of the offered modes, or the form renders a default outside its own enum.
```

### One thing worth flagging for a reviewer

The guard sits on the renderer's **evaluation path**, not in a `hidden` property. I tried the `hidden _xCheck` + `let (_c = group._xCheck)` idiom first and it never fired: a hidden property is not forced on its own, and an unreferenced `let` binding is not forced either. Both shapes compile and silently never run.

`renderDependencyCondition` (`App.pkl`) binds `_conditionShapeCheck` through exactly that unused `let` and looks like it has the same problem. I have **not** touched it here — it needs its own verification and PR, but it's worth someone confirming, because `DependencyCondition`'s shape checks may currently be dead.

## Verification

- `pkl test tests/*.pkl` — **427 passed / 965 asserts**, including 7 new facts in `tests/connect_by_options_test.pkl`: host-only narrows the enum, emits no `extra.compiled_url`, leaves **no dead `connectBy: "url"` filter anywhere**, gives host/port a single condition branch, still renders every input field, keeps `urlPropertyId`/`protocol` — plus a **control fixture** asserting the default still offers both modes.
- `./scripts/check-invariants.sh` — passes, with a new case for the default/options disagreement.
- `./scripts/regenerate-all.sh` — no drift.

## Downstream

Against `atlan-cratedb-app`'s contract, host-only reproduces what that repo ships on `main` today:

| | main (hand-authored) | this PR, host-only |
|---|---|---|
| `connectBy` enum / enumNames | `["host"]` / `["Host"]` | identical |
| `jdbcUrl` properties | `auth-type, basic, extra, host, port` | identical |
| `host` / `port` conditions | 1 each | 1 each |
| occurrences of `"url"` | 2 (a dead branch on `database`) | **0** |

Host-mode rendering of `jdbcUrl.host`, `jdbcUrl.port`, `jdbcUrl.extra.database` and `jdbcUrl.extra.__enable_ssl` is byte-identical to main.

Unblocks atlanhq/atlan-cratedb-app#103 (FND-1802).
