### PR TITLE
fix(conformance): register workflow_slug on the SDK contract field mirrors

### DIFF
--- a/packages/conformance/conformance/suite/checks/_sdk_contract_mixins.py
+++ b/packages/conformance/conformance/suite/checks/_sdk_contract_mixins.py
@@ -42,6 +42,7 @@ SDK_CONTRACT_BASE_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("workflow_id", "str", "active"),
         SdkField("correlation_id", "str", "active"),
         SdkField("app_name", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "Output": (
         SdkField("status", "OutputStatus", "active"),
@@ -115,6 +116,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("temp_table_regex", "str", "active"),
         SdkField("total_batches", "int", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "ExecuteColumnBatchOutput": (
         SdkField("artifacts", "dict[str, Any] | None", "active"),
@@ -138,6 +140,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("source_tag_prefix", "str", "active"),
         SdkField("temp_table_regex", "str", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "ExtractionOutput": (
         SdkField("artifacts", "dict[str, Any] | None", "active"),
@@ -175,6 +178,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("source_tag_prefix", "str", "active"),
         SdkField("temp_table_regex", "str", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "ExtractionTaskOutput": (
         SdkField("artifacts", "dict[str, Any] | None", "active"),
@@ -201,6 +205,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("source_tag_prefix", "str", "active"),
         SdkField("temp_table_regex", "str", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "FetchColumnsInput": (
         SdkField("app_name", "str", "active"),
@@ -215,6 +220,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("source_tag_prefix", "str", "active"),
         SdkField("temp_table_regex", "str", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "FetchColumnsOutput": (
         SdkField("artifacts", "dict[str, Any] | None", "active"),
@@ -236,6 +242,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("source_tag_prefix", "str", "active"),
         SdkField("temp_table_regex", "str", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "FetchDatabasesOutput": (
         SdkField("artifacts", "dict[str, Any] | None", "active"),
@@ -254,6 +261,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("prepone_enabled", "bool", "active"),
         SdkField("prepone_hours", "float", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "FetchIncrementalMarkerOutput": (
         SdkField("artifacts", "dict[str, Any] | None", "active"),
@@ -275,6 +283,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("source_tag_prefix", "str", "active"),
         SdkField("temp_table_regex", "str", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "FetchProceduresOutput": (
         SdkField("artifacts", "dict[str, Any] | None", "active"),
@@ -296,6 +305,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("source_tag_prefix", "str", "active"),
         SdkField("temp_table_regex", "str", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "FetchSchemasOutput": (
         SdkField("artifacts", "dict[str, Any] | None", "active"),
@@ -322,6 +332,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("source_tag_prefix", "str", "active"),
         SdkField("temp_table_regex", "str", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "FetchTablesInput": (
         SdkField("app_name", "str", "active"),
@@ -336,6 +347,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("source_tag_prefix", "str", "active"),
         SdkField("temp_table_regex", "str", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "FetchTablesOutput": (
         SdkField("artifacts", "dict[str, Any] | None", "active"),
@@ -358,6 +370,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("source_tag_prefix", "str", "active"),
         SdkField("temp_table_regex", "str", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "FetchViewsOutput": (
         SdkField("artifacts", "dict[str, Any] | None", "active"),
@@ -388,6 +401,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("temp_table_regex", "str", "active"),
         SdkField("upload_concurrency", "int", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "IncrementalExtractionOutput": (
         SdkField("artifacts", "dict[str, Any] | None", "active"),
@@ -435,6 +449,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("source_tag_prefix", "str", "active"),
         SdkField("temp_table_regex", "str", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "PrepareColumnQueriesInput": (
         SdkField("app_name", "str", "active"),
@@ -457,6 +472,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("source_tag_prefix", "str", "active"),
         SdkField("temp_table_regex", "str", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "PrepareColumnQueriesOutput": (
         SdkField("artifacts", "dict[str, Any] | None", "active"),
@@ -486,6 +502,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
             "workflow_args", "dict[str, str | int | float | bool | None]", "active"
         ),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "QueryBatchOutput": (
         SdkField("artifacts", "dict[str, Any] | None", "active"),
@@ -507,6 +524,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("output_path", "str", "active"),
         SdkField("output_prefix", "str", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "QueryExtractionOutput": (
         SdkField("artifacts", "dict[str, Any] | None", "active"),
@@ -528,6 +546,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
             "workflow_args", "dict[str, str | int | float | bool | None]", "active"
         ),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "QueryFetchOutput": (
         SdkField("artifacts", "dict[str, Any] | None", "active"),
@@ -543,6 +562,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("connection_qualified_name", "str", "active"),
         SdkField("correlation_id", "str", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "ReadCurrentStateOutput": (
         SdkField("artifacts", "dict[str, Any] | None", "active"),
@@ -570,6 +590,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("temp_table_regex", "str", "active"),
         SdkField("typename", "str", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "TransformOutput": (
         SdkField("artifacts", "dict[str, Any] | None", "active"),
@@ -587,6 +608,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("correlation_id", "str", "active"),
         SdkField("next_marker_timestamp", "str", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
     ),
     "UpdateMarkerOutput": (
         SdkField("artifacts", "dict[str, Any] | None", "active"),
@@ -617,6 +639,7 @@ SDK_TEMPLATE_CONTRACT_FIELDS: dict[str, tuple[SdkField, ...]] = {
         SdkField("temp_table_regex", "str", "active"),
         SdkField("upload_concurrency", "int", "active"),
         SdkField("workflow_id", "str", "active"),
+        SdkField("workflow_slug", "str", "active"),
         SdkField("workflow_run_id", "str", "active"),
     ),
     "WriteCurrentStateOutput": (

--- a/packages/conformance/uv.lock
+++ b/packages/conformance/uv.lock
@@ -199,7 +199,7 @@ wheels = [
 
 [[package]]
 name = "atlan-application-sdk"
-version = "3.31.0"
+version = "3.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -223,9 +223,9 @@ dependencies = [
     { name = "temporalio" },
     { name = "uvloop", marker = "sys_platform != 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/cd/e2287129cd232712956e710fd7f2f78a8d341e10321392d11ee3796f4986/atlan_application_sdk-3.31.0.tar.gz", hash = "sha256:09236835041ff4988625bde22e7f028d046e07b762a2392330a64d0551efc162", size = 7585486, upload-time = "2026-08-31T23:30:08.814Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/55/47db90c7d0a046fc9ff162503d1c9afccb1e83ead145ef949710f7a9a90c/atlan_application_sdk-3.33.1.tar.gz", hash = "sha256:ee9228e4df212fa0183d531f4a79245399dc732cc16e27e18935fb8fc9196e37", size = 8106602, upload-time = "2026-09-07T16:15:42.549Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/c5/1c1e75fc9f2ce261a7b21dee9dac617e9960c9332f60cbffbfbd07152a65/atlan_application_sdk-3.31.0-py3-none-any.whl", hash = "sha256:e2bcf91b64046c3046b7ac176158ec5b23ea65b08f238fc336352a4c1ff23173", size = 1636928, upload-time = "2026-08-31T23:30:06.602Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/7a/1b1a44b4131e0aa7bc7fe834af85a2b75f2384fa46804b016ab8882f40cf/atlan_application_sdk-3.33.1-py3-none-any.whl", hash = "sha256:ca49274a908e967779f0ab89c5517d8691b0614ffe188fa2381e80183eefdc05", size = 1749014, upload-time = "2026-09-07T16:15:40.531Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What

`SDK_CONTRACT_BASE_FIELDS` and `SDK_TEMPLATE_CONTRACT_FIELDS` in
`packages/conformance/conformance/suite/checks/_sdk_contract_mixins.py` hand-mirror
the SDK's contract fields, because those classes live outside the repo a checker
scans. SDK 3.32.0 added `workflow_slug` to `application_sdk.contracts.base.Input`
and the mirrors never learned about it.

Consequence for consumer apps: `resolve_contract_fields` cannot see a field the
registry does not list, so a consumer contract subclassing an SDK template
contract has its `workflow_slug` ledger entry read as removed (B005) or
unrecorded (B006).

## Changes

- `SdkField("workflow_slug", "str", "active")` registered on `Input` and on the
  22 `Input`-derived entries of `SDK_TEMPLATE_CONTRACT_FIELDS`. No template
  contract was added or removed; `workflow_slug` is the only delta.
- `packages/conformance/uv.lock`: `atlan-application-sdk` 3.31.0 → 3.33.1
  (3 lines, one package).

## Why the lock bump is in the same commit

The two drift guards in `tests/test_sdk_contract_mixins.py` AST-parse the
`atlan-application-sdk` that this package's `test` extra installs and rebuild
both registries from it, so the registry and that pin have to move together:

- registry edit alone, against the locked 3.31.0 → red (one field too many)
- pin bump alone, against the old registry → red (one field too few)

3.33.1 is the version the pending lock refresh resolves to, and it is resolved
here with `uv lock --upgrade-package atlan-application-sdk` — identical sdist and
wheel hashes — so that refresh sees no further change for this package.
`atlan-application-sdk` is already exempt from the release-age bound as a
first-party package.

## Verification

- `packages/conformance`: 3444 passed, 1 xfailed (the same 3444 total the failing
  CI job collected, where 2 of them were these guards).
- Reproduced both directions locally before fixing: the pin bump alone reproduces
  the exact CI failures, and the registry edit alone reds against 3.31.0.
- `uv lock --check` clean at the repo root; `pre-commit` clean on both files.

## Unblocks

`#3623` (`chore(deps): lock file maintenance`), whose `Conformance Suite Tests /
Suite unit tests` job fails only because its refresh moves this pin to 3.33.1.
Once this is on `main`, that PR rebases and goes green with no further action —
the fix could not be pushed onto the renovate branch directly, since the "bot
branches" ruleset blocks non-App pushes to `refs/heads/renovate/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSMcKJioBufLov4idtvAVV
