### PR TITLE
fix(conformance): give upload retries their own artifact name

### DIFF
--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -471,12 +471,25 @@ runs:
           coverage.json
         retention-days: 14
 
+    # A finalize 403 comes from an intermediary having a moment, and the
+    # retry runs about a second later — well inside the same window. Wait
+    # it out, so the two attempts fail independently or not at all.
+    - name: Wait before the upload retry
+      if: steps.upload-integration-results.outcome == 'failure'
+      shell: bash
+      run: sleep 20
+
     - name: Upload test results (retry)
       if: steps.upload-integration-results.outcome == 'failure'
       continue-on-error: true
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
-        name: integration-test-results
+        # A DISTINCT name, never the first attempt's: a FinalizeArtifact
+        # failure leaves an unfinalized record holding that name for the whole
+        # run. The list API cannot see it, so `overwrite` cannot clear it and
+        # CreateArtifact 409s — a same-named retry could never have worked.
+        # Consumers resolve this artifact by `<name>*` glob, not exact name.
+        name: integration-test-results-retry
         # coverage.json is written at the repo root by --cov-report=json; include
         # it alongside results/ so the scorecard aggregation job can read the
         # integration tier's coverage.

--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -470,6 +470,12 @@ runs:
           results/
           coverage.json
         retention-days: 14
+        # Overwrite on the FIRST attempt too. Artifacts survive across attempts of
+        # a run, so re-running a failed job would otherwise 409 here and burn the
+        # retry on a conflict that has nothing to do with a finalize failure. It is
+        # also what holds the invariant every consumer of this upload globs on:
+        # at most ONE live artifact ever matches `<name>*`.
+        overwrite: true
 
     # A finalize 403 comes from an intermediary having a moment, and the
     # retry runs about a second later — well inside the same window. Wait

--- a/.github/actions/connector-unit-tests/action.yaml
+++ b/.github/actions/connector-unit-tests/action.yaml
@@ -157,12 +157,25 @@ runs:
           results/
         retention-days: 14
 
+    # A finalize 403 comes from an intermediary having a moment, and the
+    # retry runs about a second later — well inside the same window. Wait
+    # it out, so the two attempts fail independently or not at all.
+    - name: Wait before the upload retry
+      if: steps.upload-unit-coverage.outcome == 'failure'
+      shell: bash
+      run: sleep 20
+
     - name: Upload coverage artifacts (retry)
       if: steps.upload-unit-coverage.outcome == 'failure'
       continue-on-error: true
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
-        name: unit-test-coverage
+        # A DISTINCT name, never the first attempt's: a FinalizeArtifact
+        # failure leaves an unfinalized record holding that name for the whole
+        # run. The list API cannot see it, so `overwrite` cannot clear it and
+        # CreateArtifact 409s — a same-named retry could never have worked.
+        # Consumers resolve this artifact by `<name>*` glob, not exact name.
+        name: unit-test-coverage-retry
         path: |
           coverage.xml
           coverage.json

--- a/.github/actions/connector-unit-tests/action.yaml
+++ b/.github/actions/connector-unit-tests/action.yaml
@@ -156,6 +156,12 @@ runs:
           htmlcov/
           results/
         retention-days: 14
+        # Overwrite on the FIRST attempt too. Artifacts survive across attempts of
+        # a run, so re-running a failed job would otherwise 409 here and burn the
+        # retry on a conflict that has nothing to do with a finalize failure. It is
+        # also what holds the invariant every consumer of this upload globs on:
+        # at most ONE live artifact ever matches `<name>*`.
+        overwrite: true
 
     # A finalize 403 comes from an intermediary having a moment, and the
     # retry runs about a second later — well inside the same window. Wait

--- a/.github/actions/e2e-apps/action.yaml
+++ b/.github/actions/e2e-apps/action.yaml
@@ -440,7 +440,7 @@ runs:
         set -uo pipefail
         artifact_id=$(gh api \
           "repos/atlanhq/${REPO_NAME}/actions/runs/${RUN_ID}/artifacts" \
-          --jq '.artifacts[] | select(.name | test("results$")) | .id' \
+          --jq '.artifacts[] | select(.name | test("results(-retry)?$")) | .id' \
           | head -1)
         body_path=""
         if [ -n "${artifact_id}" ]; then

--- a/.github/actions/parity-extract/action.yaml
+++ b/.github/actions/parity-extract/action.yaml
@@ -165,6 +165,12 @@ runs:
         name: ${{ inputs.artifact-name }}
         path: ./parity-output/
         retention-days: 7
+        # Overwrite on the FIRST attempt too. Artifacts survive across attempts of
+        # a run, so re-running a failed job would otherwise 409 here and burn the
+        # retry on a conflict that has nothing to do with a finalize failure. It is
+        # also what holds the invariant every consumer of this upload globs on:
+        # at most ONE live artifact ever matches `<name>*`.
+        overwrite: true
 
     # A finalize 403 comes from an intermediary having a moment, and the
     # retry runs about a second later — well inside the same window. Wait

--- a/.github/actions/parity-extract/action.yaml
+++ b/.github/actions/parity-extract/action.yaml
@@ -166,11 +166,24 @@ runs:
         path: ./parity-output/
         retention-days: 7
 
+    # A finalize 403 comes from an intermediary having a moment, and the
+    # retry runs about a second later — well inside the same window. Wait
+    # it out, so the two attempts fail independently or not at all.
+    - name: Wait before the upload retry
+      if: steps.upload-parity.outcome == 'failure'
+      shell: bash
+      run: sleep 20
+
     - name: Upload parity output (retry)
       if: steps.upload-parity.outcome == 'failure'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: ${{ inputs.artifact-name }}
+        # A DISTINCT name, never the first attempt's: a FinalizeArtifact
+        # failure leaves an unfinalized record holding that name for the whole
+        # run. The list API cannot see it, so `overwrite` cannot clear it and
+        # CreateArtifact 409s — a same-named retry could never have worked.
+        # Consumers resolve this artifact by `<name>*` glob, not exact name.
+        name: ${{ inputs.artifact-name }}-retry
         path: ./parity-output/
         retention-days: 7
         overwrite: true

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -1440,6 +1440,14 @@ runs:
         path: results/
         retention-days: 14
 
+    # A finalize 403 comes from an intermediary having a moment, and the
+    # retry runs about a second later — well inside the same window. Wait
+    # it out, so the two attempts fail independently or not at all.
+    - name: Wait before the upload retry
+      if: steps.upload-e2e-results.outcome == 'failure'
+      shell: bash
+      run: sleep 20
+
     - name: Upload test results (retry)
       if: steps.upload-e2e-results.outcome == 'failure'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -1447,7 +1455,12 @@ runs:
         # artifact-suffix keeps parallel matrix legs from colliding on this
         # name (upload-artifact rejects duplicate names within a run); empty
         # suffix preserves the historical single-artifact name.
-        name: sdr-integration-tests-${{ inputs.app-name }}${{ inputs.artifact-suffix != '' && format('-{0}', inputs.artifact-suffix) || '' }}-results
+        # A DISTINCT name, never the first attempt's: a FinalizeArtifact
+        # failure leaves an unfinalized record holding that name for the whole
+        # run. The list API cannot see it, so `overwrite` cannot clear it and
+        # CreateArtifact 409s — a same-named retry could never have worked.
+        # Consumers resolve this artifact by `<name>*` glob, not exact name.
+        name: sdr-integration-tests-${{ inputs.app-name }}${{ inputs.artifact-suffix != '' && format('-{0}', inputs.artifact-suffix) || '' }}-results-retry
         path: results/
         retention-days: 14
         overwrite: true

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -1439,6 +1439,12 @@ runs:
         name: sdr-integration-tests-${{ inputs.app-name }}${{ inputs.artifact-suffix != '' && format('-{0}', inputs.artifact-suffix) || '' }}-results
         path: results/
         retention-days: 14
+        # Overwrite on the FIRST attempt too. Artifacts survive across attempts of
+        # a run, so re-running a failed job would otherwise 409 here and burn the
+        # retry on a conflict that has nothing to do with a finalize failure. It is
+        # also what holds the invariant every consumer of this upload globs on:
+        # at most ONE live artifact ever matches `<name>*`.
+        overwrite: true
 
     # A finalize 403 comes from an intermediary having a moment, and the
     # retry runs about a second later — well inside the same window. Wait

--- a/.github/scripts/fetch_conformance_sarif.py
+++ b/.github/scripts/fetch_conformance_sarif.py
@@ -60,6 +60,11 @@ import sys
 
 ARTIFACT_PREFIX = "conformance-"
 ARTIFACT_SUFFIX = "-sarif"
+# The suite's upload retry cannot reuse the first attempt's artifact name (a
+# failed FinalizeArtifact holds that name for the whole run and CreateArtifact
+# then 409s), so a series whose SARIF landed on the second attempt is published
+# as `conformance-<series>-sarif-retry`. Both names carry the same `<series>.sarif`.
+RETRY_SUFFIX = "-retry"
 
 
 def run_gh(args: list[str]) -> tuple[int, str]:
@@ -75,11 +80,17 @@ def run_gh(args: list[str]) -> tuple[int, str]:
 def series_name(artifact_name: str) -> str | None:
     """``conformance-<series>-sarif`` -> ``<series>``; None if it doesn't match.
 
+    ``conformance-<series>-sarif-retry`` maps to the same series: it is the
+    upload's second attempt, which is forced onto a distinct artifact name (see
+    ``RETRY_SUFFIX``), and it carries identical content.
+
     Guards against a zero-length series (``conformance--sarif``) and against
     the affixes overlapping on a too-short name.
     """
     if not artifact_name.startswith(ARTIFACT_PREFIX):
         return None
+    if artifact_name.endswith(RETRY_SUFFIX):
+        artifact_name = artifact_name[: -len(RETRY_SUFFIX)]
     if not artifact_name.endswith(ARTIFACT_SUFFIX):
         return None
     inner = artifact_name[len(ARTIFACT_PREFIX) : -len(ARTIFACT_SUFFIX)]
@@ -199,25 +210,34 @@ def download(repo: str, run_id: int, series: list[str], dest: str, gh=run_gh):
 
     Each series is fetched separately so one unretrievable artifact does not
     cost us the rest of the run's evidence.
+
+    Two candidate names per series, the plain one first: the series' SARIF is
+    published under ``-sarif-retry`` when the first upload attempt hit the
+    artifact service's finalize 403. Exactly one of the two exists in a run, so
+    the first name failing is the expected path on a retried leg, not an error
+    — only both failing is warned about.
     """
     os.makedirs(dest, exist_ok=True)
     got: list[str] = []
     for name in series:
-        rc, _ = gh(
-            [
-                "run",
-                "download",
-                str(run_id),
-                "--repo",
-                repo,
-                "--name",
-                f"{ARTIFACT_PREFIX}{name}{ARTIFACT_SUFFIX}",
-                "--dir",
-                dest,
-            ]
-        )
-        if rc == 0:
-            got.append(name)
+        base = f"{ARTIFACT_PREFIX}{name}{ARTIFACT_SUFFIX}"
+        for artifact_name in (base, f"{base}{RETRY_SUFFIX}"):
+            rc, _ = gh(
+                [
+                    "run",
+                    "download",
+                    str(run_id),
+                    "--repo",
+                    repo,
+                    "--name",
+                    artifact_name,
+                    "--dir",
+                    dest,
+                ]
+            )
+            if rc == 0:
+                got.append(name)
+                break
         else:
             print(f"::warning::series '{name}' failed to download from run {run_id}")
     return got

--- a/.github/scripts/tests/test_artifact_upload_retry.py
+++ b/.github/scripts/tests/test_artifact_upload_retry.py
@@ -315,6 +315,29 @@ def test_first_attempt_never_fails_the_job_before_the_retry_runs():
     )
 
 
+def test_first_attempts_overwrite_so_only_one_artifact_is_ever_live():
+    """Both attempts overwrite, and the first attempt is the load-bearing one.
+
+    Artifacts survive across attempts of a run. Without overwrite on the first
+    attempt, re-running a failed job in a run that already carries the artifact
+    409s there, hands the upload to the retry, and leaves BOTH `<name>` (from
+    the earlier attempt) and `<name>-retry` live. Consumers glob `<name>*`, so
+    a `merge-multiple` download then flattens two files of the same inner name
+    in undefined order — for `docker-image` that means Trivy scanning the
+    previous attempt's image. Overwrite here is what keeps at most one live
+    artifact per name, which is the invariant those globs rest on.
+    """
+    bad = [
+        _label(rel, scope, step)
+        for rel, scope, step, _ in _live_first_attempts()
+        if _with(step).get("overwrite") is not True
+    ]
+    assert not bad, (
+        "The first upload attempt must set `overwrite: true` as well:\n  "
+        + "\n  ".join(bad)
+    )
+
+
 def test_retries_overwrite_so_a_job_rerun_cannot_block_them():
     """Re-running a failed job keeps the run's existing artifacts, so a retry
     landing on a name the run already carries needs overwrite. (It does NOT
@@ -479,6 +502,108 @@ def test_a_retry_in_another_job_does_not_satisfy_the_pairing():
     other_first, other_retries = by_scope["job elsewhere"]
     assert len(other_first) == 1
     assert not other_retries
+
+
+def _retried_literal_names() -> set[str]:
+    """Artifact names that have a retry, expression-free so they can be grepped."""
+    names = set()
+    for _, _, steps in _scopes():
+        first_attempts, retries = _classify(steps)
+        for step in first_attempts:
+            if not step.get("id") or step["id"] not in retries:
+                continue
+            name = _artifact_name(step)
+            if name and "${{" not in name:
+                names.add(name)
+    return names
+
+
+def _addresses_by_bare_name(text: str, name: str) -> bool:
+    """Does `text` use `name` as a whole token, i.e. as an artifact address?
+
+    Artifact names collide with filenames and flags built from the same words
+    (`trivy-results.json`, `--trivy-results`, `docker-image://…`), none of
+    which read an artifact. So the name must stand alone: no word character,
+    dot or dash on the left, and no word character, dot, colon, slash or dash
+    on the right. Excluding a trailing dash is also what stops the retry name
+    from registering as a mention of its own base.
+
+    The one dash allowed on the left is a shell default (`${NAME:-<base>}`),
+    which is an artifact address like any other.
+    """
+    pattern = rf"(?:(?<![\w.-])|(?<=:-)){re.escape(name)}(?![\w.:/-])"
+    return re.search(pattern, text) is not None
+
+
+def _consumer_files() -> list[Path]:
+    """Everything in .github/ that could address an artifact by name.
+
+    Workflows and composites cover `download-artifact` steps and `run:` blocks;
+    the scripts cover the `gh run download` / artifact-listing callers. This
+    suite's own files are excluded — they name artifacts as fixtures.
+    """
+    files = _yaml_files()
+    files += sorted(p for p in (ROOT / "scripts").glob("*.py"))
+    return files
+
+
+def test_no_consumer_addresses_a_retried_artifact_by_base_name_alone():
+    """The class the `-retry` name creates, checked across every consumer.
+
+    Anything that reads a retried artifact has to cope with the second name:
+    a `download-artifact` glob (`<name>*`), a `--name` resolved from the run's
+    artifact listing, or a jq/regex that accepts either. A file that mentions
+    the base name and nowhere mentions the retry name or a glob of it is
+    reading only the first attempt's artifact — which is exactly the artifact
+    that is missing whenever the retry was needed.
+
+    Both cross-run `gh run download --name trivy-results` callers (the
+    dashboard publish and the vulnerability auto-fix) shipped in that state and
+    are what this guard exists to catch.
+    """
+    names = _retried_literal_names()
+    assert len(names) >= 5, f"retried-name discovery collapsed: {sorted(names)}"
+
+    problems = []
+    for path in _consumer_files():
+        text = path.read_text()
+        for name in sorted(names):
+            if not _addresses_by_bare_name(text, name):
+                continue
+            if f"{name}{RETRY_SUFFIX}" in text or f"{name}*" in text:
+                continue
+            problems.append(f"{_rel(path)}: names '{name}' with no retry-aware read")
+    assert not problems, (
+        "A consumer of a retried artifact must accept the retry name too — glob "
+        f"`<name>*`, resolve `--name` from the run's artifact listing, or match "
+        f"`<name>{RETRY_SUFFIX}` explicitly:\n  " + "\n  ".join(problems)
+    )
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        'gh run download "$RUN_ID" --name trivy-results --dir /tmp',
+        "          name: trivy-results\n",
+        "--jq '.artifacts[] | select(.name == \"trivy-results\")'",
+        "${ARTIFACT_NAME:-trivy-results}",
+    ],
+)
+def test_the_bare_name_matcher_catches_an_artifact_address(text: str):
+    assert _addresses_by_bare_name(text, "trivy-results")
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "--output trivy-results.json",  # a file it writes, not an artifact
+        "python3 check_allowlist.py --trivy-results results.json",  # a flag
+        "gh run download --name trivy-results-retry",  # the retry's own name
+        "trivy-container-results.json",  # a different artifact entirely
+    ],
+)
+def test_the_bare_name_matcher_ignores_lookalikes(text: str):
+    assert not _addresses_by_bare_name(text, "trivy-results")
 
 
 def test_exemptions_still_point_at_real_uploads():

--- a/.github/scripts/tests/test_artifact_upload_retry.py
+++ b/.github/scripts/tests/test_artifact_upload_retry.py
@@ -25,9 +25,35 @@ had an outcome guard. Both let a genuinely unretried upload keep the guard green
 
 Here a retry is an `actions/upload-artifact` step whose `if:` is guarded on
 `steps.<id>.outcome == 'failure'` where `<id>` is another upload step **in the
-same job or composite**, and which uploads the same artifact name and path. That
-is checked, not assumed: a companion step that guards on the right outcome but
-uploads something else, or is not an upload at all, does not satisfy the pairing.
+same job or composite**, and which uploads the same path under the first
+attempt's name plus `-retry`. That is checked, not assumed: a companion step
+that guards on the right outcome but uploads something else, or is not an upload
+at all, does not satisfy the pairing.
+
+Why the retry must NOT reuse the first attempt's name
+-----------------------------------------------------
+It was written that way originally, with `overwrite: true` believed to clear
+whatever the failed attempt left behind. It cannot, and the retry could
+therefore never succeed against the very failure it exists for:
+
+    Upload test results          FinalizeArtifact -> (403) Forbidden   [warning]
+    Upload test results (retry)  CreateArtifact   -> (409) Conflict:
+                                 an artifact with this name already exists
+
+A failed *finalize* leaves an artifact record that holds the name for the rest
+of the run but never becomes visible: it is absent from the run's artifact
+listing (verified against the run above — the leg's artifact was simply not
+there), and `overwrite` deletes by looking the name up in that same listing, so
+it finds nothing to delete and `CreateArtifact` then 409s on the record it could
+not see. The name is burnt for the whole run; only a different one can land.
+
+`overwrite: true` stays on the retry for the case it does handle — re-running a
+failed job inside a run that already holds that artifact — which is why it is
+still asserted below.
+
+And the retry waits before it runs: the 403 comes from an intermediary having a
+moment, and firing the second attempt a second later puts it inside the same
+window. That backoff is asserted too.
 """
 
 from __future__ import annotations
@@ -43,6 +69,10 @@ UPLOAD_ACTION = "actions/upload-artifact"
 
 # `steps.<id>.outcome == 'failure'` — the only shape that makes a step a retry.
 OUTCOME_GUARD_RE = re.compile(r"steps\.([A-Za-z0-9_-]+)\.outcome\s*==\s*'failure'")
+
+# What a retry appends to the first attempt's artifact name. Consumers resolve
+# these artifacts by `<name>*` glob because of it.
+RETRY_SUFFIX = "-retry"
 
 # Uploads that do NOT need retry hardening, each with the reason it is exempt.
 # Keyed by (path suffix, artifact name) so an exemption cannot silently widen to
@@ -246,12 +276,14 @@ def test_every_gating_upload_has_a_matching_retry_upload():
             )
             continue
 
-        # A companion that uploads a different artifact is not a retry of this one.
+        # A companion that uploads a different artifact is not a retry of this
+        # one — but it must not reuse the name either: same-named retries 409.
         for companion in companions:
-            if _artifact_name(companion) != _artifact_name(step):
+            expected = _artifact_name(step) + RETRY_SUFFIX
+            if _artifact_name(companion) != expected:
                 problems.append(
                     f"{where}: its retry uploads artifact "
-                    f"'{_artifact_name(companion)}', not '{_artifact_name(step)}'"
+                    f"'{_artifact_name(companion)}', not '{expected}'"
                 )
             if _artifact_path(companion) != _artifact_path(step):
                 problems.append(
@@ -264,8 +296,8 @@ def test_every_gating_upload_has_a_matching_retry_upload():
     assert not problems, (
         "Every artifact upload on a gating path needs a companion "
         f"`{UPLOAD_ACTION}` step, in the same job/composite, guarded on the first "
-        "attempt's outcome and uploading the same name and path (see any "
-        "conformance-*.yaml for the pattern) — or an EXEMPT entry with a "
+        f"attempt's outcome and uploading the same path under `<name>{RETRY_SUFFIX}` "
+        "(see any conformance-*.yaml for the pattern) — or an EXEMPT entry with a "
         "reason:\n  " + "\n  ".join(problems)
     )
 
@@ -283,9 +315,11 @@ def test_first_attempt_never_fails_the_job_before_the_retry_runs():
     )
 
 
-def test_retries_overwrite_so_a_partial_artifact_cannot_block_them():
-    """A failed finalize can leave a same-named artifact behind; without
-    overwrite the retry 409s on it and the hardening is worthless."""
+def test_retries_overwrite_so_a_job_rerun_cannot_block_them():
+    """Re-running a failed job keeps the run's existing artifacts, so a retry
+    landing on a name the run already carries needs overwrite. (It does NOT
+    rescue a same-named retry after a finalize 403 — see the module docstring;
+    that is what the distinct name below is for.)"""
     bad = []
     for rel, scope, steps in _scopes():
         _, retries = _classify(steps)
@@ -294,6 +328,66 @@ def test_retries_overwrite_so_a_partial_artifact_cannot_block_them():
                 if _with(companion).get("overwrite") is not True:
                     bad.append(_label(rel, scope, companion))
     assert not bad, "Retry attempts must set `overwrite: true`:\n  " + "\n  ".join(bad)
+
+
+def test_no_retry_reuses_its_first_attempts_artifact_name():
+    """The whole point, stated over the repo rather than over one pairing.
+
+    A retry on the first attempt's name is guaranteed to fail with 409 against
+    the finalize 403 it exists to absorb, so it is worse than no retry: it
+    turns a warning into a red job on a gating path.
+    """
+    bad = []
+    for rel, scope, steps in _scopes():
+        first_attempts, retries = _classify(steps)
+        by_id = {s.get("id"): s for s in first_attempts if s.get("id")}
+        for target_id, companions in retries.items():
+            first = by_id.get(target_id)
+            if first is None:
+                continue
+            for companion in companions:
+                if _artifact_name(companion) == _artifact_name(first):
+                    bad.append(
+                        f"{_label(rel, scope, companion)}: uploads "
+                        f"'{_artifact_name(first)}', the name the failed attempt "
+                        f"already burnt for the run"
+                    )
+    assert not bad, (
+        "A retry must upload under its own name "
+        f"(`<first name>{RETRY_SUFFIX}`):\n  " + "\n  ".join(bad)
+    )
+
+
+def _guards_on(step: dict, step_id: str) -> bool:
+    return step_id in OUTCOME_GUARD_RE.findall(str(step.get("if", "")))
+
+
+def test_every_retry_waits_before_it_runs():
+    """A finalize 403 is an intermediary having a moment. The retry fires about
+    a second after the first attempt, so with no pause it lands in the same
+    window and both attempts fail together — which is the one case that still
+    reddens the job."""
+    problems = []
+    for rel, scope, steps in _scopes():
+        _, retries = _classify(steps)
+        for target_id, companions in retries.items():
+            waits = [
+                s
+                for s in steps
+                if "run" in s
+                and "sleep" in str(s.get("run", ""))
+                and _guards_on(s, target_id)
+            ]
+            if not waits:
+                for companion in companions:
+                    problems.append(
+                        f"{_label(rel, scope, companion)}: no `run: sleep …` step "
+                        f"guarded on steps.{target_id}.outcome == 'failure'"
+                    )
+    assert not problems, (
+        "Each retry needs a backoff step ahead of it, guarded on the same "
+        "outcome as the retry itself:\n  " + "\n  ".join(problems)
+    )
 
 
 def test_a_retry_is_not_identified_by_its_name():

--- a/.github/scripts/tests/test_fetch_conformance_sarif.py
+++ b/.github/scripts/tests/test_fetch_conformance_sarif.py
@@ -318,7 +318,9 @@ def test_downloads_every_series_the_run_published(tmp_path, monkeypatch):
 
 def test_partial_download_still_publishes_what_landed(tmp_path, monkeypatch):
     def rc_for(args):
-        return 1 if "conformance-security-sarif" in args else 0
+        # Both candidate names for the series, so the retry-name fallback is
+        # exercised and still ends up dropping the series.
+        return 1 if any("conformance-security-sarif" in arg for arg in args) else 0
 
     gh = FakeGh(
         runs=json.dumps([{"databaseId": 5, "conclusion": "success"}]),
@@ -333,6 +335,40 @@ def test_partial_download_still_publishes_what_landed(tmp_path, monkeypatch):
     assert rc == 0
     assert out["has_artifacts"] == "true"
     assert out["series"] == "ci"
+
+
+def test_a_series_published_only_under_the_retry_name_still_lands(
+    tmp_path, monkeypatch
+):
+    """The upload's second attempt cannot reuse the first attempt's artifact
+    name — a failed FinalizeArtifact holds that name for the whole run and
+    CreateArtifact then 409s — so it publishes `conformance-<series>-sarif-retry`.
+    That is the only copy of the series' SARIF in such a run, and both the
+    series discovery and the download have to recognise it."""
+
+    def rc_for(args):
+        # Only the retry name exists in this run, as after a finalize 403.
+        return 0 if "conformance-ci-sarif-retry" in args else 1
+
+    gh = FakeGh(
+        runs=json.dumps([{"databaseId": 9, "conclusion": "success"}]),
+        artifacts_by_run={9: _artifacts([("conformance-ci-sarif-retry", False)])},
+        download_rc=rc_for,
+    )
+    rc, out = _run_main(gh, tmp_path, monkeypatch)
+
+    assert rc == 0
+    assert out["has_artifacts"] == "true"
+    assert out["series"] == "ci"
+    assert "conformance-ci-sarif-retry" in gh.downloaded_names()
+
+
+def test_series_name_maps_a_retry_artifact_to_its_series():
+    assert fcs.series_name("conformance-ci-sarif-retry") == "ci"
+    assert fcs.series_name("conformance-ci-sarif") == "ci"
+    # Still not a conformance SARIF artifact just because it ends in -retry.
+    assert fcs.series_name("unit-test-coverage-retry") is None
+    assert fcs.series_name("conformance--sarif-retry") is None
 
 
 def test_no_run_is_a_clean_skip_not_a_failure(tmp_path, monkeypatch):

--- a/.github/scripts/tests/test_scorecard_e2e_wiring.py
+++ b/.github/scripts/tests/test_scorecard_e2e_wiring.py
@@ -90,8 +90,13 @@ def test_e2e_evidence_is_downloaded_by_pattern_not_exact_name(
     # Since FND-6 each leg's artifact is suffixed with the leg name (which now
     # includes the cloud), so the historical exact name matches nothing and the
     # download quietly no-ops under continue-on-error.
+    #
+    # The trailing `*` matters as much as the middle one: a leg whose first
+    # upload attempt hit the artifact service's finalize 403 publishes under
+    # `…-results-retry`, and a pattern anchored on `-results` would skip that
+    # leg's junit entirely.
     with_ = _e2e_download(scorecard)["with"]
-    assert with_["pattern"].endswith("*-results")
+    assert with_["pattern"].endswith("*-results*")
     assert "name" not in with_
 
 
@@ -124,7 +129,8 @@ def test_the_callback_download_matches_the_per_leg_names_too(
         if "sdr-integration-tests" in str(s.get("with", {}))
     ]
     assert len(download) == 1
-    assert download[0]["with"]["pattern"].endswith("*-results")
+    # Trailing `*` for the retry-named artifact, as above.
+    assert download[0]["with"]["pattern"].endswith("*-results*")
 
 
 # ── Argument selection stays in the tested script ────────────────────────────

--- a/.github/workflows/auto-fix-vulnerabilities.yaml
+++ b/.github/workflows/auto-fix-vulnerabilities.yaml
@@ -122,8 +122,18 @@ jobs:
             exit 1
           fi
 
-          echo "Downloading scan results from run $RUN_ID"
-          gh run download "$RUN_ID" --name trivy-results --dir /tmp/scan-artifacts || echo "No trivy results"
+          # `trivy-results` or `trivy-results-retry`: build-and-scan's upload
+          # retry cannot reuse the first attempt's name (a failed
+          # FinalizeArtifact holds it for the whole run and CreateArtifact then
+          # 409s), so a scan whose artifact landed on the second attempt is
+          # only reachable under the retry name. Newest match wins, so a later
+          # attempt's artifact is preferred over an earlier one's leftover.
+          ARTIFACT_NAME=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts" \
+            --jq '[.artifacts[] | select(.expired == false) | select(.name == "trivy-results" or .name == "trivy-results-retry")] | sort_by(.created_at) | last | .name // ""')
+
+          echo "Downloading scan results from run $RUN_ID (artifact: ${ARTIFACT_NAME:-none live})"
+          gh run download "$RUN_ID" --name "${ARTIFACT_NAME:-trivy-results}" --dir /tmp/scan-artifacts || echo "No trivy results"
 
       - name: Identify fixable vulnerabilities
         id: identify

--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -138,11 +138,23 @@ jobs:
           path: /tmp/image.tar
           retention-days: 7
 
+      # A finalize 403 comes from an intermediary having a moment, and the
+      # retry runs about a second later — well inside the same window. Wait
+      # it out, so the two attempts fail independently or not at all.
+      - name: Wait before the upload retry
+        if: steps.upload-image.outcome == 'failure'
+        run: sleep 20
+
       - name: Upload image artifact (retry)
         if: steps.upload-image.outcome == 'failure'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: docker-image
+          # A DISTINCT name, never the first attempt's: a FinalizeArtifact
+          # failure leaves an unfinalized record holding that name for the whole
+          # run. The list API cannot see it, so `overwrite` cannot clear it and
+          # CreateArtifact 409s — a same-named retry could never have worked.
+          # Consumers resolve this artifact by `<name>*` glob, not exact name.
+          name: docker-image-retry
           path: /tmp/image.tar
           retention-days: 7
           overwrite: true
@@ -159,7 +171,13 @@ jobs:
         if: inputs.image == ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: docker-image
+          # `pattern` + merge-multiple, not the bare name: the upload's retry
+          # attempt lands under `docker-image-retry` (it has to — see that
+          # step), and exactly one of the two names ever exists in a run, so
+          # the glob resolves to a single artifact flattened into /tmp either
+          # way.
+          pattern: docker-image*
+          merge-multiple: true
           path: /tmp
 
       - name: Load local image
@@ -231,12 +249,24 @@ jobs:
           path: /tmp/trivy_results.json
           retention-days: 7
 
+      # A finalize 403 comes from an intermediary having a moment, and the
+      # retry runs about a second later — well inside the same window. Wait
+      # it out, so the two attempts fail independently or not at all.
+      - name: Wait before the upload retry
+        if: steps.upload-trivy.outcome == 'failure'
+        run: sleep 20
+
       - name: Upload Trivy results (retry)
         if: steps.upload-trivy.outcome == 'failure'
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: trivy-results
+          # A DISTINCT name, never the first attempt's: a FinalizeArtifact
+          # failure leaves an unfinalized record holding that name for the whole
+          # run. The list API cannot see it, so `overwrite` cannot clear it and
+          # CreateArtifact 409s — a same-named retry could never have worked.
+          # Consumers resolve this artifact by `<name>*` glob, not exact name.
+          name: trivy-results-retry
           path: /tmp/trivy_results.json
           retention-days: 7
           overwrite: true
@@ -274,7 +304,10 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         continue-on-error: true
         with:
-          name: trivy-results
+          # Glob, not the bare name: the upload's retry attempt lands under
+          # `trivy-results-retry`. Only one of the two ever exists in a run.
+          pattern: trivy-results*
+          merge-multiple: true
           path: /tmp
 
       - name: Check against allowlist

--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -137,6 +137,12 @@ jobs:
           name: docker-image
           path: /tmp/image.tar
           retention-days: 7
+          # Overwrite on the FIRST attempt too. Artifacts survive across attempts of
+          # a run, so re-running a failed job would otherwise 409 here and burn the
+          # retry on a conflict that has nothing to do with a finalize failure. It is
+          # also what holds the invariant every consumer of this upload globs on:
+          # at most ONE live artifact ever matches `<name>*`.
+          overwrite: true
 
       # A finalize 403 comes from an intermediary having a moment, and the
       # retry runs about a second later — well inside the same window. Wait
@@ -173,9 +179,14 @@ jobs:
         with:
           # `pattern` + merge-multiple, not the bare name: the upload's retry
           # attempt lands under `docker-image-retry` (it has to — see that
-          # step), and exactly one of the two names ever exists in a run, so
-          # the glob resolves to a single artifact flattened into /tmp either
-          # way.
+          # step), so the glob is what finds a retried upload at all.
+          #
+          # It resolves to ONE artifact because both upload attempts set
+          # `overwrite: true`. Without that on the first attempt, re-running a
+          # failed job in a run that already carried `docker-image` would 409
+          # there, publish `docker-image-retry`, and leave two live image.tars
+          # for merge-multiple to flatten in undefined order — Trivy could then
+          # scan the previous attempt's image.
           pattern: docker-image*
           merge-multiple: true
           path: /tmp
@@ -248,6 +259,12 @@ jobs:
           name: trivy-results
           path: /tmp/trivy_results.json
           retention-days: 7
+          # Overwrite on the FIRST attempt too. Artifacts survive across attempts of
+          # a run, so re-running a failed job would otherwise 409 here and burn the
+          # retry on a conflict that has nothing to do with a finalize failure. It is
+          # also what holds the invariant every consumer of this upload globs on:
+          # at most ONE live artifact ever matches `<name>*`.
+          overwrite: true
 
       # A finalize 403 comes from an intermediary having a moment, and the
       # retry runs about a second later — well inside the same window. Wait
@@ -305,7 +322,8 @@ jobs:
         continue-on-error: true
         with:
           # Glob, not the bare name: the upload's retry attempt lands under
-          # `trivy-results-retry`. Only one of the two ever exists in a run.
+          # `trivy-results-retry`. One live match only, for the reason the
+          # image download above spells out — both attempts overwrite.
           pattern: trivy-results*
           merge-multiple: true
           path: /tmp

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -118,12 +118,24 @@ jobs:
           path: codeql-results/
           retention-days: 30
 
+      # A finalize 403 comes from an intermediary having a moment, and the
+      # retry runs about a second later — well inside the same window. Wait
+      # it out, so the two attempts fail independently or not at all.
+      - name: Wait before the upload retry
+        if: steps.upload-codeql-sarif.outcome == 'failure'
+        run: sleep 20
+
       - name: Upload SARIF as artifact (retry)
         if: steps.upload-codeql-sarif.outcome == 'failure'
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: codeql-sarif
+          # A DISTINCT name, never the first attempt's: a FinalizeArtifact
+          # failure leaves an unfinalized record holding that name for the whole
+          # run. The list API cannot see it, so `overwrite` cannot clear it and
+          # CreateArtifact 409s — a same-named retry could never have worked.
+          # Consumers resolve this artifact by `<name>*` glob, not exact name.
+          name: codeql-sarif-retry
           path: codeql-results/
           retention-days: 30
           overwrite: true

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -117,6 +117,12 @@ jobs:
           name: codeql-sarif
           path: codeql-results/
           retention-days: 30
+          # Overwrite on the FIRST attempt too. Artifacts survive across attempts of
+          # a run, so re-running a failed job would otherwise 409 here and burn the
+          # retry on a conflict that has nothing to do with a finalize failure. It is
+          # also what holds the invariant every consumer of this upload globs on:
+          # at most ONE live artifact ever matches `<name>*`.
+          overwrite: true
 
       # A finalize 403 comes from an intermediary having a moment, and the
       # retry runs about a second later — well inside the same window. Wait

--- a/.github/workflows/conformance-ci.yaml
+++ b/.github/workflows/conformance-ci.yaml
@@ -97,6 +97,12 @@ jobs:
         with:
           name: conformance-ci-sarif
           path: ci.sarif
+          # Overwrite on the FIRST attempt too. Artifacts survive across attempts of
+          # a run, so re-running a failed job would otherwise 409 here and burn the
+          # retry on a conflict that has nothing to do with a finalize failure. It is
+          # also what holds the invariant every consumer of this upload globs on:
+          # at most ONE live artifact ever matches `<name>*`.
+          overwrite: true
 
       # A finalize 403 comes from an intermediary having a moment, and the
       # retry runs about a second later — well inside the same window. Wait

--- a/.github/workflows/conformance-ci.yaml
+++ b/.github/workflows/conformance-ci.yaml
@@ -98,12 +98,24 @@ jobs:
           name: conformance-ci-sarif
           path: ci.sarif
 
+      # A finalize 403 comes from an intermediary having a moment, and the
+      # retry runs about a second later — well inside the same window. Wait
+      # it out, so the two attempts fail independently or not at all.
+      - name: Wait before the upload retry
+        if: steps.upload-sarif.outcome == 'failure'
+        run: sleep 20
+
       - name: "Upload SARIF artifact (retry)"
         if: steps.upload-sarif.outcome == 'failure'
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: conformance-ci-sarif
+          # A DISTINCT name, never the first attempt's: a FinalizeArtifact
+          # failure leaves an unfinalized record holding that name for the whole
+          # run. The list API cannot see it, so `overwrite` cannot clear it and
+          # CreateArtifact 409s — a same-named retry could never have worked.
+          # Consumers resolve this artifact by `<name>*` glob, not exact name.
+          name: conformance-ci-sarif-retry
           path: ci.sarif
           overwrite: true
 

--- a/.github/workflows/conformance-error-handling.yaml
+++ b/.github/workflows/conformance-error-handling.yaml
@@ -97,6 +97,12 @@ jobs:
         with:
           name: conformance-error-handling-sarif
           path: error-handling.sarif
+          # Overwrite on the FIRST attempt too. Artifacts survive across attempts of
+          # a run, so re-running a failed job would otherwise 409 here and burn the
+          # retry on a conflict that has nothing to do with a finalize failure. It is
+          # also what holds the invariant every consumer of this upload globs on:
+          # at most ONE live artifact ever matches `<name>*`.
+          overwrite: true
 
       # A finalize 403 comes from an intermediary having a moment, and the
       # retry runs about a second later — well inside the same window. Wait

--- a/.github/workflows/conformance-error-handling.yaml
+++ b/.github/workflows/conformance-error-handling.yaml
@@ -98,12 +98,24 @@ jobs:
           name: conformance-error-handling-sarif
           path: error-handling.sarif
 
+      # A finalize 403 comes from an intermediary having a moment, and the
+      # retry runs about a second later — well inside the same window. Wait
+      # it out, so the two attempts fail independently or not at all.
+      - name: Wait before the upload retry
+        if: steps.upload-sarif.outcome == 'failure'
+        run: sleep 20
+
       - name: "Upload SARIF artifact (retry)"
         if: steps.upload-sarif.outcome == 'failure'
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: conformance-error-handling-sarif
+          # A DISTINCT name, never the first attempt's: a FinalizeArtifact
+          # failure leaves an unfinalized record holding that name for the whole
+          # run. The list API cannot see it, so `overwrite` cannot clear it and
+          # CreateArtifact 409s — a same-named retry could never have worked.
+          # Consumers resolve this artifact by `<name>*` glob, not exact name.
+          name: conformance-error-handling-sarif-retry
           path: error-handling.sarif
           overwrite: true
 

--- a/.github/workflows/conformance-logging.yaml
+++ b/.github/workflows/conformance-logging.yaml
@@ -111,12 +111,24 @@ jobs:
           name: conformance-logging-sarif
           path: logging.sarif
 
+      # A finalize 403 comes from an intermediary having a moment, and the
+      # retry runs about a second later — well inside the same window. Wait
+      # it out, so the two attempts fail independently or not at all.
+      - name: Wait before the upload retry
+        if: steps.upload-sarif.outcome == 'failure'
+        run: sleep 20
+
       - name: "Upload SARIF artifact (retry)"
         if: steps.upload-sarif.outcome == 'failure'
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: conformance-logging-sarif
+          # A DISTINCT name, never the first attempt's: a FinalizeArtifact
+          # failure leaves an unfinalized record holding that name for the whole
+          # run. The list API cannot see it, so `overwrite` cannot clear it and
+          # CreateArtifact 409s — a same-named retry could never have worked.
+          # Consumers resolve this artifact by `<name>*` glob, not exact name.
+          name: conformance-logging-sarif-retry
           path: logging.sarif
           overwrite: true
 

--- a/.github/workflows/conformance-logging.yaml
+++ b/.github/workflows/conformance-logging.yaml
@@ -110,6 +110,12 @@ jobs:
         with:
           name: conformance-logging-sarif
           path: logging.sarif
+          # Overwrite on the FIRST attempt too. Artifacts survive across attempts of
+          # a run, so re-running a failed job would otherwise 409 here and burn the
+          # retry on a conflict that has nothing to do with a finalize failure. It is
+          # also what holds the invariant every consumer of this upload globs on:
+          # at most ONE live artifact ever matches `<name>*`.
+          overwrite: true
 
       # A finalize 403 comes from an intermediary having a moment, and the
       # retry runs about a second later — well inside the same window. Wait

--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -490,6 +490,12 @@ jobs:
         with:
           name: conformance-${{ matrix.slug }}-sarif
           path: ${{ matrix.slug }}.sarif
+          # Overwrite on the FIRST attempt too. Artifacts survive across attempts of
+          # a run, so re-running a failed job would otherwise 409 here and burn the
+          # retry on a conflict that has nothing to do with a finalize failure. It is
+          # also what holds the invariant every consumer of this upload globs on:
+          # at most ONE live artifact ever matches `<name>*`.
+          overwrite: true
 
       # A finalize 403 comes from an intermediary having a moment, and the
       # retry runs about a second later — well inside the same window. Wait

--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -491,12 +491,24 @@ jobs:
           name: conformance-${{ matrix.slug }}-sarif
           path: ${{ matrix.slug }}.sarif
 
+      # A finalize 403 comes from an intermediary having a moment, and the
+      # retry runs about a second later — well inside the same window. Wait
+      # it out, so the two attempts fail independently or not at all.
+      - name: Wait before the upload retry
+        if: steps.upload-sarif.outcome == 'failure'
+        run: sleep 20
+
       - name: "Upload SARIF artifact (retry)"
         if: steps.upload-sarif.outcome == 'failure'
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: conformance-${{ matrix.slug }}-sarif
+          # A DISTINCT name, never the first attempt's: a FinalizeArtifact
+          # failure leaves an unfinalized record holding that name for the whole
+          # run. The list API cannot see it, so `overwrite` cannot clear it and
+          # CreateArtifact 409s — a same-named retry could never have worked.
+          # Consumers resolve this artifact by `<name>*` glob, not exact name.
+          name: conformance-${{ matrix.slug }}-sarif-retry
           path: ${{ matrix.slug }}.sarif
           overwrite: true
 

--- a/.github/workflows/conformance-upload-sarif.yaml
+++ b/.github/workflows/conformance-upload-sarif.yaml
@@ -107,13 +107,23 @@ jobs:
         id: download
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: conformance-${{ matrix.slug }}-sarif
+          # Glob + merge-multiple, not the bare name: the suite's retry attempt
+          # uploads under `…-sarif-retry` (a same-named retry cannot work — see
+          # that step), and merge-multiple flattens whichever of the two landed
+          # into the working directory as `<slug>.sarif`, which is what the
+          # strip step below reads.
+          pattern: conformance-${{ matrix.slug }}-sarif*
+          merge-multiple: true
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
         continue-on-error: true  # absent when series had no relevant changes
 
+      # Gated on the FILE, not on `steps.download.outcome`: with `pattern:`
+      # (unlike `name:`) download-artifact treats "nothing matched" as success,
+      # so the outcome no longer distinguishes a series that uploaded SARIF
+      # from one that had no relevant changes. hashFiles does.
       - name: "Strip suppressed results"
-        if: steps.download.outcome == 'success'
+        if: hashFiles(format('{0}.sarif', matrix.slug)) != ''
         env:
           SARIF_SLUG: ${{ matrix.slug }}
         run: |
@@ -121,7 +131,7 @@ jobs:
             "$SARIF_SLUG.sarif" > "$SARIF_SLUG-upload.sarif"
 
       - name: "Upload SARIF to Security tab"
-        if: steps.download.outcome == 'success' && steps.probe.outputs.available == 'true'
+        if: hashFiles(format('{0}-upload.sarif', matrix.slug)) != '' && steps.probe.outputs.available == 'true'
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           sarif_file: ${{ matrix.slug }}-upload.sarif

--- a/.github/workflows/sdk-loop-phase.yml
+++ b/.github/workflows/sdk-loop-phase.yml
@@ -364,14 +364,28 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      # A finalize 403 comes from an intermediary having a moment, and the
+      # retry runs about a second later — well inside the same window. Wait
+      # it out, so the two attempts fail independently or not at all.
+      - name: Wait before the upload retry
+        if: always() && steps.transcript.outcome == 'failure'
+        run: sleep 20
+
       - name: Keep the agent transcript (retry)
         if: always() && steps.transcript.outcome == 'failure'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: sdk-loop-${{ inputs.phase }}-${{ inputs.round }}
+          # A DISTINCT name, never the first attempt's: a FinalizeArtifact
+          # failure leaves an unfinalized record holding that name for the whole
+          # run. The list API cannot see it, so `overwrite` cannot clear it and
+          # CreateArtifact 409s — a same-named retry could never have worked.
+          # Consumers resolve this artifact by `<name>*` glob, not exact name.
+          name: sdk-loop-${{ inputs.phase }}-${{ inputs.round }}-retry
           path: sdk-loop-*.log
           if-no-files-found: ignore
           retention-days: 14
-          # A finalize that failed can still leave the artifact behind, and
-          # without this the retry 409s on its own first attempt.
+          # For a re-run of a failed job, which keeps the run's existing
+          # artifacts. It does NOT rescue a same-named retry after a failed
+          # finalize — that record is invisible to the delete-by-name lookup,
+          # which is why the name above is distinct.
           overwrite: true

--- a/.github/workflows/sdk-loop-phase.yml
+++ b/.github/workflows/sdk-loop-phase.yml
@@ -363,6 +363,12 @@ jobs:
           path: sdk-loop-*.log
           if-no-files-found: ignore
           retention-days: 14
+          # Overwrite on the FIRST attempt too. Artifacts survive across attempts of
+          # a run, so re-running a failed job would otherwise 409 here and burn the
+          # retry on a conflict that has nothing to do with a finalize failure. It is
+          # also what holds the invariant every consumer of this upload globs on:
+          # at most ONE live artifact ever matches `<name>*`.
+          overwrite: true
 
       # A finalize 403 comes from an intermediary having a moment, and the
       # retry runs about a second later — well inside the same window. Wait

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -2774,6 +2774,12 @@ jobs:
           name: test-readiness-scorecard
           path: results/test-readiness.json
           retention-days: 14
+          # Overwrite on the FIRST attempt too. Artifacts survive across attempts of
+          # a run, so re-running a failed job would otherwise 409 here and burn the
+          # retry on a conflict that has nothing to do with a finalize failure. It is
+          # also what holds the invariant every consumer of this upload globs on:
+          # at most ONE live artifact ever matches `<name>*`.
+          overwrite: true
 
       # A finalize 403 comes from an intermediary having a moment, and the
       # retry runs about a second later — well inside the same window. Wait

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -2452,7 +2452,11 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         continue-on-error: true
         with:
-          pattern: sdr-integration-tests-${{ inputs.app-name }}*-results
+          # Trailing `*` as well as the middle one: a leg whose first upload
+          # attempt hit the artifact service's finalize 403 lands under
+          # `…-results-retry` (see the retry step in sdr-e2e), and a pattern
+          # anchored on `-results` would silently skip that leg.
+          pattern: sdr-integration-tests-${{ inputs.app-name }}*-results*
           merge-multiple: true
           path: connector-results
 
@@ -2633,14 +2637,20 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         continue-on-error: true
         with:
-          name: unit-test-coverage
+          # Glob + merge-multiple rather than the bare name: the tier's retry
+          # attempt uploads under `<name>-retry`, and merge-multiple keeps the
+          # single-artifact layout the CLI's globs expect.
+          pattern: unit-test-coverage*
+          merge-multiple: true
           path: unit-evidence
 
       - name: Download integration evidence
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         continue-on-error: true
         with:
-          name: integration-test-results
+          # Glob + merge-multiple, for the same reason as the unit tier above.
+          pattern: integration-test-results*
+          merge-multiple: true
           path: integration-evidence
 
       # `pattern:` with merge-multiple LEFT OFF, and that is the whole point:
@@ -2661,7 +2671,11 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         continue-on-error: true
         with:
-          pattern: sdr-integration-tests-${{ inputs.app-name }}*-results
+          # Trailing `*` as well as the middle one: a leg whose first upload
+          # attempt hit the artifact service's finalize 403 lands under
+          # `…-results-retry` (see the retry step in sdr-e2e), and a pattern
+          # anchored on `-results` would silently skip that leg.
+          pattern: sdr-integration-tests-${{ inputs.app-name }}*-results*
           path: e2e-evidence
 
       # ── What this repo is WIRED for, whether or not e2e ran (FND-34) ───────
@@ -2761,12 +2775,24 @@ jobs:
           path: results/test-readiness.json
           retention-days: 14
 
+      # A finalize 403 comes from an intermediary having a moment, and the
+      # retry runs about a second later — well inside the same window. Wait
+      # it out, so the two attempts fail independently or not at all.
+      - name: Wait before the upload retry
+        if: steps.upload-scorecard.outcome == 'failure'
+        run: sleep 20
+
       - name: Upload scorecard (retry)
         if: steps.upload-scorecard.outcome == 'failure'
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: test-readiness-scorecard
+          # A DISTINCT name, never the first attempt's: a FinalizeArtifact
+          # failure leaves an unfinalized record holding that name for the whole
+          # run. The list API cannot see it, so `overwrite` cannot clear it and
+          # CreateArtifact 409s — a same-named retry could never have worked.
+          # Consumers resolve this artifact by `<name>*` glob, not exact name.
+          name: test-readiness-scorecard-retry
           path: results/test-readiness.json
           retention-days: 14
           overwrite: true

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -653,15 +653,24 @@ jobs:
             --json databaseId,conclusion \
             --jq '[.[] | select(.conclusion=="success" or .conclusion=="failure")] | .[].databaseId')
 
+          # Matches the retry name too. When the scorecard upload's first
+          # attempt hits the artifact service's finalize 403, the retry has to
+          # upload under `test-readiness-scorecard-retry` (a same-named retry
+          # 409s — see that step), so a run whose scorecard landed on the
+          # second attempt is only discoverable under that name. The name that
+          # actually matched is carried forward, so the download stays a
+          # single-artifact one and keeps its flat directory layout.
           RUN_ID=""
+          ARTIFACT_NAME=""
           for candidate in ${CANDIDATES}; do
-            HAS_SCORECARD=$(gh api \
+            FOUND_NAME=$(gh api \
               "repos/${{ github.repository }}/actions/runs/${candidate}/artifacts" \
-              --jq '[.artifacts[] | select(.expired == false) | select(.name == "test-readiness-scorecard")] | length' \
-              2>/dev/null || echo 0)
-            if [ "${HAS_SCORECARD:-0}" -gt 0 ]; then
+              --jq 'first(.artifacts[] | select(.expired == false) | select(.name == "test-readiness-scorecard" or .name == "test-readiness-scorecard-retry") | .name) // ""' \
+              2>/dev/null || echo "")
+            if [ -n "${FOUND_NAME}" ]; then
               RUN_ID="${candidate}"
-              echo "Run ${candidate} has a live test-readiness-scorecard — using it"
+              ARTIFACT_NAME="${FOUND_NAME}"
+              echo "Run ${candidate} has a live ${FOUND_NAME} — using it"
               break
             fi
             echo "Run ${candidate} has no live scorecard — trying older"
@@ -671,12 +680,14 @@ jobs:
             echo "::warning::No Tests run with a live test-readiness-scorecard in the last 20 completed runs — skipping test-readiness dashboard update"
           fi
           echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Download test-readiness artifact
         if: steps.discover.outputs.run_id != ''
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ steps.discover.outputs.run_id }}
+          ARTIFACT_NAME: ${{ steps.discover.outputs.artifact_name }}
         run: |
           set -euo pipefail
           mkdir -p scorecard-dl
@@ -688,7 +699,7 @@ jobs:
           # upload into a green no-op.
           gh run download "$RUN_ID" \
             --repo "${{ github.repository }}" \
-            --name test-readiness-scorecard \
+            --name "$ARTIFACT_NAME" \
             --dir scorecard-dl
 
       - name: Build history entry

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -117,8 +117,18 @@ jobs:
             exit 0
           fi
 
-          echo "Downloading artifacts from run $RUN_ID"
-          gh run download "$RUN_ID" --name trivy-results --dir /tmp/scan-artifacts || echo "No trivy results"
+          # `trivy-results` or `trivy-results-retry`, newest match wins: the
+          # scan's upload retry cannot reuse the first attempt's artifact name
+          # (a failed FinalizeArtifact holds it for the whole run and
+          # CreateArtifact then 409s), so a run whose results landed on the
+          # second attempt is only reachable under the retry name. Same
+          # discovery as the test-readiness job below.
+          ARTIFACT_NAME=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts" \
+            --jq '[.artifacts[] | select(.expired == false) | select(.name == "trivy-results" or .name == "trivy-results-retry")] | sort_by(.created_at) | last | .name // ""')
+
+          echo "Downloading artifacts from run $RUN_ID (artifact: ${ARTIFACT_NAME:-none live})"
+          gh run download "$RUN_ID" --name "${ARTIFACT_NAME:-trivy-results}" --dir /tmp/scan-artifacts || echo "No trivy results"
 
           # If no scan results at all, skip dashboard update to avoid overwriting with zeros
           if [ ! -f /tmp/scan-artifacts/trivy_results.json ]; then
@@ -665,7 +675,7 @@ jobs:
           for candidate in ${CANDIDATES}; do
             FOUND_NAME=$(gh api \
               "repos/${{ github.repository }}/actions/runs/${candidate}/artifacts" \
-              --jq 'first(.artifacts[] | select(.expired == false) | select(.name == "test-readiness-scorecard" or .name == "test-readiness-scorecard-retry") | .name) // ""' \
+              --jq '[.artifacts[] | select(.expired == false) | select(.name == "test-readiness-scorecard" or .name == "test-readiness-scorecard-retry")] | sort_by(.created_at) | last | .name // ""' \
               2>/dev/null || echo "")
             if [ -n "${FOUND_NAME}" ]; then
               RUN_ID="${candidate}"

--- a/docs/standards/ci.md
+++ b/docs/standards/ci.md
@@ -58,6 +58,45 @@ failure mode. Because it now concludes on every PR, it can be added to branch
 protection directly, without the always-concluding-gate wrapper that
 path-filtered required checks need (see `sdk-gate.yaml` for that pattern).
 
+## An artifact upload retry must use a DIFFERENT artifact name
+
+`actions/upload-artifact` treats the artifact service's `FinalizeArtifact` 403
+as non-retryable and fails the step, so every upload on a gating path is paired
+with a retry (first attempt `continue-on-error: true`, companion step guarded on
+`steps.<id>.outcome == 'failure'`). Three rules the pairing has to follow:
+
+1. **The retry uploads under `<first attempt's name>-retry`.** A failed finalize
+   leaves an artifact record that holds the name for the rest of the run but
+   never becomes visible: it is absent from `GET /actions/runs/<id>/artifacts`,
+   and `overwrite: true` deletes by looking the name up in that same listing —
+   so it finds nothing, skips (on a `core.debug` line, invisible in the log),
+   and `CreateArtifact` then 409s on the record it could not see:
+
+   ```
+   Upload test results          FinalizeArtifact -> (403) Forbidden   [warning]
+   Upload test results (retry)  CreateArtifact   -> (409) Conflict:
+                                an artifact with this name already exists
+   ```
+
+   A same-named retry can therefore never absorb the one failure it exists for,
+   and on a fatal path it turns a warning into a red job after all the expensive
+   work has passed. `overwrite: true` stays on the retry for the case it does
+   handle: re-running a failed job inside a run that already holds the artifact.
+
+2. **A backoff step sits between the two attempts** (`run: sleep 20`, guarded on
+   the same outcome). The 403 comes from an intermediary having a moment; an
+   immediate retry lands in the same window and both attempts fail together.
+
+3. **Consumers resolve these artifacts by glob**, `pattern: <name>*` with
+   `merge-multiple: true`, not by exact `name:` — otherwise the retry's artifact
+   is invisible to them. Note that with `pattern:` (unlike `name:`)
+   `download-artifact` treats "nothing matched" as **success**, so any step
+   gated on `steps.<download>.outcome` has to move onto `hashFiles(...)`.
+
+`.github/scripts/tests/test_artifact_upload_retry.py` enforces all three over
+every workflow and composite action in this repo, and `EXEMPT` there carries the
+reason for each upload that does not need the hardening.
+
 ## Label gates must be event-aware
 
 **Rule:** if a workflow can receive a `labeled` event, every job gated on a

--- a/docs/standards/ci.md
+++ b/docs/standards/ci.md
@@ -87,15 +87,32 @@ with a retry (first attempt `continue-on-error: true`, companion step guarded on
    the same outcome). The 403 comes from an intermediary having a moment; an
    immediate retry lands in the same window and both attempts fail together.
 
-3. **Consumers resolve these artifacts by glob**, `pattern: <name>*` with
-   `merge-multiple: true`, not by exact `name:` — otherwise the retry's artifact
-   is invisible to them. Note that with `pattern:` (unlike `name:`)
-   `download-artifact` treats "nothing matched" as **success**, so any step
-   gated on `steps.<download>.outcome` has to move onto `hashFiles(...)`.
+3. **Both attempts set `overwrite: true`** — the first attempt is the
+   load-bearing one. Artifacts survive across attempts of a run, so without it
+   re-running a failed job 409s on the *first* attempt, hands the upload to the
+   retry, and leaves both `<name>` (from the earlier attempt) and
+   `<name>-retry` live. A `merge-multiple` consumer then flattens two files of
+   the same inner name in undefined order — for `docker-image` that means
+   scanning the previous attempt's image. Overwrite is what keeps **at most one
+   live artifact per name**, which is the invariant the globs below rest on.
 
-`.github/scripts/tests/test_artifact_upload_retry.py` enforces all three over
-every workflow and composite action in this repo, and `EXEMPT` there carries the
-reason for each upload that does not need the hardening.
+4. **Consumers accept the retry name.** Three shapes, pick per call site:
+   - same-run `download-artifact`: `pattern: <name>*` + `merge-multiple: true`,
+     never an exact `name:`;
+   - cross-run `gh run download`: resolve the name from the run's artifact
+     listing first (newest live match of `<name>` or `<name>-retry`) and pass
+     that — a hard-coded `--name <name>` silently no-ops on a retried upload;
+   - a jq/regex selector: match either name explicitly.
+
+   Note that with `pattern:` (unlike `name:`) `download-artifact` treats
+   "nothing matched" as **success**, so any step gated on
+   `steps.<download>.outcome` has to move onto `hashFiles(...)`.
+
+`.github/scripts/tests/test_artifact_upload_retry.py` enforces all four over
+every workflow, composite action and script in this repo — including a
+cross-file check that no consumer addresses a retried artifact by its base name
+alone — and `EXEMPT` there carries the reason for each upload that does not need
+the hardening.
 
 ## Label gates must be event-aware
 

--- a/packages/conformance/conformance/bootstrap/templates/conformance-upload-sarif.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/conformance-upload-sarif.yaml
@@ -95,13 +95,24 @@ jobs:
         id: download
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: conformance-${{ matrix.slug }}-sarif
+          # Glob + merge-multiple, not the bare name: the suite's upload retry
+          # cannot reuse the first attempt's artifact name (a failed
+          # FinalizeArtifact holds that name for the whole run and
+          # CreateArtifact then 409s), so it publishes `…-sarif-retry`.
+          # merge-multiple flattens whichever of the two landed into the working
+          # directory as `<slug>.sarif`, which is what the strip step reads.
+          pattern: conformance-${{ matrix.slug }}-sarif*
+          merge-multiple: true
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
         continue-on-error: true  # absent when series had no relevant changes
 
+      # Gated on the FILE, not on `steps.download.outcome`: with `pattern:`
+      # (unlike `name:`) download-artifact treats "nothing matched" as success,
+      # so the outcome no longer distinguishes a series that uploaded SARIF
+      # from one that had no relevant changes. hashFiles does.
       - name: "Strip suppressed results"
-        if: steps.download.outcome == 'success'
+        if: hashFiles(format('{0}.sarif', matrix.slug)) != ''
         env:
           SARIF_SLUG: ${{ matrix.slug }}
         run: |
@@ -109,7 +120,7 @@ jobs:
             "$SARIF_SLUG.sarif" > "$SARIF_SLUG-upload.sarif"
 
       - name: "Upload SARIF to Security tab"
-        if: steps.download.outcome == 'success' && steps.probe.outputs.available == 'true'
+        if: hashFiles(format('{0}-upload.sarif', matrix.slug)) != '' && steps.probe.outputs.available == 'true'
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           sarif_file: ${{ matrix.slug }}-upload.sarif

--- a/packages/conformance/tests/test_upload_sarif_probe_wiring.py
+++ b/packages/conformance/tests/test_upload_sarif_probe_wiring.py
@@ -167,6 +167,74 @@ def test_upload_is_gated_on_the_probe_output(label: str, source: str) -> None:
 
 
 @pytest.mark.parametrize("label,source", _COPIES, ids=lambda v: v)
+def test_sarif_download_globs_so_a_retried_upload_is_found(
+    label: str, source: str
+) -> None:
+    """The suite's upload retry publishes `conformance-<slug>-sarif-retry`.
+
+    It has to: a failed `FinalizeArtifact` holds the first attempt's name for
+    the rest of the run — invisible to the artifact listing, so `overwrite`
+    cannot clear it — and `CreateArtifact` then 409s. An exact `name:` here
+    therefore misses every series whose SARIF landed on the second attempt,
+    silently, on the same code path FND-1149 was about keeping green.
+
+    `merge-multiple` is what keeps the file at `<slug>.sarif` in the working
+    directory rather than under a per-artifact subdirectory, which is where
+    the strip step below reads it.
+    """
+    download = _step_by_id(_steps(source), "download")
+    with_ = download.get("with", {})
+    pattern = str(with_.get("pattern", ""))
+    assert pattern.startswith("conformance-") and pattern.endswith("-sarif*"), (
+        f"[{label}] the SARIF download's `pattern:` is {pattern!r}; it must glob "
+        f"`conformance-<slug>-sarif*` so the `-retry` artifact is in scope"
+    )
+    assert "name" not in with_, (
+        f"[{label}] the SARIF download still passes `name: {with_.get('name')!r}`, "
+        f"which reads only the first attempt's artifact"
+    )
+    assert with_.get("merge-multiple") is True, (
+        f"[{label}] `merge-multiple: true` is missing, so a matched artifact "
+        f"lands under its own directory and the strip step's `<slug>.sarif` is "
+        f"not there"
+    )
+
+
+@pytest.mark.parametrize("label,source", _COPIES, ids=lambda v: v)
+def test_the_empty_sarif_gate_reads_the_file_not_the_download_outcome(
+    label: str, source: str
+) -> None:
+    """With `pattern:` a download that matched NOTHING succeeds.
+
+    Confirmed in the pinned action: only the single-artifact `name:` path
+    throws when the artifact is absent. So `steps.download.outcome` no longer
+    separates "this series published SARIF" from "this series had no relevant
+    changes" — it is `success` either way, and a gate reading it would hand
+    `upload-sarif` a file that does not exist (or, before that, `jq` a missing
+    input) on every skipped series.
+    """
+    steps = _steps(source)
+    gated = [
+        step
+        for step in steps
+        if "codeql-action/upload-sarif" in str(step.get("uses", ""))
+        or "jq" in str(step.get("run", ""))
+    ]
+    assert gated, f"[{label}] neither the strip nor the upload step was found"
+    for step in gated:
+        condition = str(step.get("if", ""))
+        assert "steps.download.outcome" not in condition, (
+            f"[{label}] step {step.get('name')!r} gates on "
+            f"`steps.download.outcome`, which is `success` even when the "
+            f"pattern matched no artifact"
+        )
+        assert "hashFiles(" in condition, (
+            f"[{label}] step {step.get('name')!r} has `if: {condition!r}`, which "
+            f"does not test for the SARIF file's presence"
+        )
+
+
+@pytest.mark.parametrize("label,source", _COPIES, ids=lambda v: v)
 def test_probe_invokes_the_vendored_script(label: str, source: str) -> None:
     """The probe runs the script, and the script is one bootstrap vendors."""
     probe = _step_by_id(_steps(source), "probe")


### PR DESCRIPTION
## The flake

An e2e run that passed every test died on its very last step, after all the expensive work:

```
Upload test results          FinalizeArtifact -> (403) Forbidden   [warning]
Upload test results (retry)  CreateArtifact   -> (409) Conflict:
                             an artifact with this name already exists
```

Second sighting. FND-1825.

## Why the retry could never have worked

The hardening (first attempt `continue-on-error`, companion retry on its outcome, `overwrite: true`) assumed `overwrite` clears whatever the failed attempt left behind. It cannot.

A failed **FinalizeArtifact** leaves an artifact record that holds the name for the rest of the run but never becomes visible:

- the record is absent from `GET /actions/runs/<id>/artifacts` — verified on the failing run: the leg's artifact simply is not in the listing, while its sibling legs' are;
- `overwrite` deletes by looking the name up in that same listing, so it finds nothing and skips — on a `core.debug` line, which is why the retry's log shows no deletion at all;
- `CreateArtifact` then 409s on the record `overwrite` could not see.

The name is burnt for the whole run. So on a *non-fatal* pair the retry was a no-op, and on a **fatal** pair (e2e results, the image tar, parity output, loop transcripts) it converted a warning into a red job — the worst possible outcome for the one failure mode it exists to absorb.

All 13 upload/retry pairs in this repo had that shape.

## The fix

1. **Every retry uploads under `<first attempt's name>-retry`.** A fresh name can actually land. `overwrite: true` stays, for the case it does handle: re-running a failed job inside a run that already holds that artifact (its inline rationale is corrected accordingly).
2. **Every retry waits 20s first.** The 403 comes from an intermediary having a moment; the retry otherwise fires ~1s later, inside the same window, so both attempts fail together — the only remaining path to a red job.
3. **Consumers resolve by glob**, `pattern: <name>*` + `merge-multiple: true`, not exact `name:`: `tests-reusable.yaml` (unit, integration and both e2e evidence downloads), `build-and-scan.yaml` (image tar, Trivy results), `conformance-upload-sarif.yaml` (+ its bootstrap template, force-written fleet-wide), the `e2e-apps` composite's artifact lookup, and `fetch_conformance_sarif.py` (series discovery + a two-candidate download).
4. **The guard is inverted.** `test_artifact_upload_retry.py` used to *require* the same name; it now forbids it, requires the `-retry` name and the backoff step, and its docstring records the mechanism so this is not rediscovered a third time. Same rule written up in `docs/standards/ci.md`.

### One behavioural subtlety worth a reviewer's eye

With `pattern:` (unlike `name:`) `download-artifact` treats "nothing matched" as **success** — confirmed in the pinned action's source. So the SARIF workflow's two gates move off `steps.download.outcome` onto `hashFiles(...)`, which still distinguishes "series uploaded SARIF" from "series had no relevant changes". The scorecard dashboard keeps its flat single-artifact download by carrying the name its discovery actually matched forward to `gh run download`.

## Verification

- `pytest .github/scripts/tests` — 4250 passed (the guard's new assertions fail loudly against the old shape).
- `pytest packages/conformance/tests/test_bootstrap.py test_upload_sarif_probe_wiring.py` — 255 passed.
- `pre-commit run --files <all 21 changed files>` — passed (actionlint and check-yaml included).

## Known residue

Consumers **in other repos** that download these artifacts by exact name will not see a `-retry` artifact. Not a regression — today they get nothing at all in that case — but it moves where a retried upload surfaces. The in-repo consumers are all converted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZnscDJqDMZaD4BydjT4CQ
