### PR TITLE
fix(conformance): K018 resolves ambiguous contract names as a union

### DIFF
--- a/packages/conformance/conformance/suite/checks/manifest_contract/_input_fields.py
+++ b/packages/conformance/conformance/suite/checks/manifest_contract/_input_fields.py
@@ -199,6 +199,7 @@ def _is_known_sdk_contract(name: str) -> bool:
 def _walk_chain(
     rec: ClassRecord,
     by_name: dict[str, ClassRecord],
+    by_name_all: dict[str, list[ClassRecord]] | None = None,
 ) -> tuple[list[ast.ClassDef], bool]:
     """Return (in-repo ClassDefs across the chain, whether it fully resolved).
 
@@ -208,6 +209,18 @@ def _walk_chain(
     incomplete, and the caller must then skip rather than guess. That matches
     K006's stated preference for a false negative over a false positive on a
     repo shape the check does not understand.
+
+    *by_name_all* is the same opt-in multimap
+    :func:`resolve_contract_fields` takes: when a base-class NAME is declared
+    more than once in the scanned repo, ``by_name`` keeps only whichever
+    declaration the filesystem walk reached first, and the chain silently
+    becomes that one's. Passing the multimap walks EVERY declaration of an
+    ambiguous name instead, so both the ``extra="allow"`` scan and the
+    resolvability verdict see the union — either of which, on this check's
+    stated false-negative-over-false-positive preference, is the safe
+    direction: an ambiguous name that any declaration leaves unresolved, or
+    that any declaration opens with ``extra="allow"``, silences the manifest
+    rather than guessing which one the runtime import picked.
     """
     nodes: list[ast.ClassDef] = []
     fully_resolved = True
@@ -219,11 +232,15 @@ def _walk_chain(
             return  # cycle — mirrors resolve_contract_fields' guard
         visiting.add(name)
 
-        ancestor = by_name.get(name)
-        if ancestor is not None:
-            nodes.append(ancestor.node)
-            for base_name in ancestor.bases:
-                walk(base_name)
+        ancestors = (by_name_all or {}).get(name)
+        if not ancestors:
+            sole = by_name.get(name)
+            ancestors = [sole] if sole is not None else []
+        if ancestors:
+            for ancestor in ancestors:
+                nodes.append(ancestor.node)
+                for base_name in ancestor.bases:
+                    walk(base_name)
         elif not _is_known_sdk_contract(name):
             fully_resolved = False
 
@@ -297,6 +314,16 @@ def _sole_extraction_input(
     unreferenced class cannot be the live one, so candidates with no mention
     anywhere are dropped before the uniqueness test. Still ambiguous after that
     (two live descendants, or none) means skip rather than guess.
+
+    Deliberately reads first-wins ``by_name`` rather than the ambiguity-aware
+    multimap the field resolution uses. This fallback runs only in
+    single-entrypoint mode (its one caller guards on ``mode == "single"``), and
+    the bare-name collision that motivates the multimap is a bundle-app shape:
+    one ``AppInputContract`` per entrypoint, all emitted by ``pkl eval``. With
+    one entrypoint there is one generated contract, and any remaining collision
+    is between hand-written classes the app can simply rename. Widening here
+    would instead turn one candidate into two and skip the check outright —
+    a false negative on the very family this fallback exists to cover.
     """
     candidates = [
         rec
@@ -314,9 +341,37 @@ def _resolved_field_names(
     rec: ClassRecord,
     file_aliases: dict[str, dict[str, str]],
     by_name: dict[str, ClassRecord],
+    by_name_all: dict[str, list[ClassRecord]] | None = None,
 ) -> set[str]:
-    aliases = file_aliases.get(rec.file, {})
-    return {f.name for f in resolve_contract_fields(rec.node, aliases, by_name)}
+    """Every field name *rec* can receive, across its resolved base chain.
+
+    Class registries are keyed by BARE class name, and the contract-toolkit
+    names every entrypoint's generated Input contract ``AppInputContract`` —
+    so every bundle app declares that one name once per entrypoint. ``by_name``
+    keeps only the first the filesystem walk reached, and an inherited field
+    that lives on any of the others silently reads as undeclared.
+
+    Passing *by_name_all* resolves ambiguous ancestors to the UNION of their
+    declarations, and widens *rec* itself the same way when its own name is
+    ambiguous (the shape where two entrypoints bind the generated contract
+    directly, so the pairing in :func:`_pair_manifests_with_contracts` can only
+    reach the first). Presence ONLY, as B005 does in
+    ``deprecation/_contract_compat.py``: this widens what counts as
+    *declared*, it does not change which contract a manifest is paired with.
+    Omitting the multimap keeps the first-wins behaviour, and with it there is
+    no behaviour change on a repo where no class name is declared twice.
+    """
+    records = (by_name_all or {}).get(rec.name) or [rec]
+    names: set[str] = set()
+    for candidate in records:
+        aliases = file_aliases.get(candidate.file, {})
+        names.update(
+            f.name
+            for f in resolve_contract_fields(
+                candidate.node, aliases, by_name, by_name_all=by_name_all
+            )
+        )
+    return names
 
 
 def _pair_manifests_with_contracts(
@@ -383,6 +438,11 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
     file_directives: dict[str, dict[int, _IgnoreDirective]] = {}
     file_aliases: dict[str, dict[str, str]] = {}
     by_name: dict[str, ClassRecord] = {}
+    # Every declaration per class name, not just the first. Both registries are
+    # keyed by BARE class name, and `pkl eval` emits one `AppInputContract` per
+    # entrypoint, so on any bundle app that name is ambiguous — see
+    # _resolved_field_names.
+    by_name_all: dict[str, list[ClassRecord]] = {}
 
     for path in paths:
         try:
@@ -404,6 +464,7 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
         file_aliases[rel] = aliases
         for rec in collect_classes(tree, rel, aliases):
             by_name.setdefault(rec.name, rec)
+            by_name_all.setdefault(rec.name, []).append(rec)
 
     code = CodeContractScan()
     app_cache: dict[str, bool | None] = {}
@@ -422,13 +483,15 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
     findings: list[Finding] = []
 
     for manifest, input_rec in pairs:
-        chain_nodes, fully_resolved = _walk_chain(input_rec, by_name)
+        chain_nodes, fully_resolved = _walk_chain(input_rec, by_name, by_name_all)
         if not fully_resolved:
             continue  # incomplete picture — stay silent rather than guess.
         if any(_class_allows_extra(node) for node in chain_nodes):
             continue  # real Pydantic extra="allow" keeps undeclared keys.
 
-        declared = _resolved_field_names(input_rec, file_aliases, by_name)
+        declared = _resolved_field_names(
+            input_rec, file_aliases, by_name, by_name_all
+        )
         directives = file_directives.get(input_rec.file, {})
 
         findings.extend(

--- a/packages/conformance/conformance/suite/checks/manifest_contract/_input_fields.py
+++ b/packages/conformance/conformance/suite/checks/manifest_contract/_input_fields.py
@@ -221,6 +221,16 @@ def _walk_chain(
     direction: an ambiguous name that any declaration leaves unresolved, or
     that any declaration opens with ``extra="allow"``, silences the manifest
     rather than guessing which one the runtime import picked.
+
+    The walk starts at *rec*'s own NAME rather than seeding its node directly,
+    so that union covers the root record too. *rec* reaches this function from
+    a first-wins ``by_name`` lookup in :func:`_pair_manifests_with_contracts`,
+    and when two entrypoints bind their generated ``AppInputContract``
+    *directly* — no app-side subclass to give it a distinct name — the root IS
+    the ambiguous record. Seeding its node would then read ``extra="allow"``
+    and base resolvability off whichever declaration the pairing happened to
+    pick, which is the same first-wins hazard one level up. Ambiguity is a
+    property of a name, so it is handled in exactly one place: ``walk``.
     """
     nodes: list[ast.ClassDef] = []
     fully_resolved = True
@@ -244,9 +254,7 @@ def _walk_chain(
         elif not _is_known_sdk_contract(name):
             fully_resolved = False
 
-    nodes.append(rec.node)
-    for base in rec.bases:
-        walk(base)
+    walk(rec.name)
     return nodes, fully_resolved
 
 
@@ -489,9 +497,7 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
         if any(_class_allows_extra(node) for node in chain_nodes):
             continue  # real Pydantic extra="allow" keeps undeclared keys.
 
-        declared = _resolved_field_names(
-            input_rec, file_aliases, by_name, by_name_all
-        )
+        declared = _resolved_field_names(input_rec, file_aliases, by_name, by_name_all)
         directives = file_directives.get(input_rec.file, {})
 
         findings.extend(

--- a/packages/conformance/tests/test_manifest_contract_config_keys.py
+++ b/packages/conformance/tests/test_manifest_contract_config_keys.py
@@ -492,6 +492,72 @@ def test_k018_silent_when_the_losing_declaration_sets_extra_allow(
     assert _only(scan_all(paths, tmp_path), "K018") == []
 
 
+_DIRECT_BIND_APP_SRC = """\
+from application_sdk.app import App, entrypoint
+
+from app.generated.crawler._input import AppInputContract as CrawlerInput
+from app.generated.miner._input import AppInputContract as MinerInput
+
+
+class CrawlOutput:
+    status: str
+
+
+class MineOutput:
+    status: str
+
+
+class MyApp(App):
+    @entrypoint(name="crawler")
+    async def crawl(self, input: CrawlerInput) -> CrawlOutput:
+        pass
+
+    @entrypoint(name="miner")
+    async def mine(self, input: MinerInput) -> MineOutput:
+        pass
+"""
+
+
+def test_k018_silent_when_a_directly_bound_contract_sibling_sets_extra_allow(
+    tmp_path: Path,
+) -> None:
+    """Both entrypoints bind the generated contract itself — the root is ambiguous.
+
+    With no app-side subclass to give it a distinct name, the record
+    `_pair_manifests_with_contracts` hands to `_walk_chain` *is* the ambiguous
+    one, and its first-wins lookup can only ever reach the crawler's. Seeding
+    that node directly would read `extra="allow"` off the wrong declaration;
+    starting the walk at the name unions both. Same hazard as the base-chain
+    case above, one level up.
+    """
+    paths = _write_py(
+        tmp_path,
+        {
+            "app/generated/crawler/_input.py": _generated_input(
+                "    output_dir: str = ''\n"
+            ),
+            "app/generated/miner/_input.py": (
+                "from pydantic import ConfigDict\n"
+                "from application_sdk.templates.contracts.sql_metadata import "
+                "ExtractionInput\n"
+                "\n"
+                "class AppInputContract(ExtractionInput):\n"
+                "    model_config = ConfigDict(extra='allow')\n"
+            ),
+            "app/connector.py": _DIRECT_BIND_APP_SRC,
+        },
+    )
+    _write_manifest(
+        tmp_path / "app" / "generated" / "crawler" / "manifest.json",
+        {"extract": _extract_node({})},
+    )
+    _write_manifest(
+        tmp_path / "app" / "generated" / "miner" / "manifest.json",
+        {"extract": _extract_node({"anything_at_all": "{{anything-at-all}}"})},
+    )
+    assert _only(scan_all(paths, tmp_path), "K018") == []
+
+
 # ---------------------------------------------------------------------------
 # K018 — arg-shape handling
 # ---------------------------------------------------------------------------

--- a/packages/conformance/tests/test_manifest_contract_config_keys.py
+++ b/packages/conformance/tests/test_manifest_contract_config_keys.py
@@ -336,6 +336,163 @@ def test_k018_ignores_platform_injected_credential_arg(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# K018 — bundle apps: one `AppInputContract` per entrypoint (FND-1791)
+# ---------------------------------------------------------------------------
+#
+# `pkl eval` names every entrypoint's generated Input contract
+# `AppInputContract`, so a bundle app declares that one name once per
+# entrypoint. Both class registries are keyed by bare name, so the first
+# declaration the filesystem walk reaches wins — and every field that lives
+# only on one of the others reads as undeclared. Observed live: 5 K018 findings
+# on a two-entrypoint app, all five present in `model_fields` at runtime, and
+# all five exactly the fields missing from the *other* entrypoint's same-named
+# contract. B005 already carries the fix (`by_name_all`); these pin it for K018.
+
+
+def _generated_input(fields: str) -> str:
+    """One entrypoint's `pkl eval` output — always the name `AppInputContract`."""
+    return (
+        "from application_sdk.templates.contracts.sql_metadata import "
+        "ExtractionInput\n"
+        "\n"
+        "class AppInputContract(ExtractionInput):\n"
+        f"{fields}"
+    )
+
+
+_BUNDLE_APP_SRC = """\
+from application_sdk.app import App, entrypoint
+
+from app.generated.crawler._input import AppInputContract as CrawlerInput
+from app.generated.miner._input import AppInputContract as MinerInput
+
+
+class CrawlOutput:
+    status: str
+
+
+class MineOutput:
+    status: str
+
+
+class QueryExtractionInput(MinerInput):
+    chunk_size: int = 10000
+
+
+class MyApp(App):
+    @entrypoint(name="crawler")
+    async def crawl(self, input: CrawlerInput) -> CrawlOutput:
+        pass
+
+    @entrypoint(name="miner")
+    async def mine(self, input: QueryExtractionInput) -> MineOutput:
+        pass
+"""
+
+
+def _write_bundle(tmp_path: Path, *, miner_args: dict) -> list[Path]:
+    """A two-entrypoint app, both entrypoints' contracts named the same."""
+    paths = _write_py(
+        tmp_path,
+        {
+            "app/generated/crawler/_input.py": _generated_input(
+                "    preflight_check: bool = True\n    output_dir: str = ''\n"
+            ),
+            "app/generated/miner/_input.py": _generated_input(
+                "    preflight_check: bool = True\n"
+                "    miner_start_time_epoch: int = 0\n"
+                "    advanced_config: dict = {}\n"
+            ),
+            "app/connector.py": _BUNDLE_APP_SRC,
+        },
+    )
+    _write_manifest(
+        tmp_path / "app" / "generated" / "crawler" / "manifest.json",
+        {"extract": _extract_node({"output_dir": "{{output-dir}}"})},
+    )
+    _write_manifest(
+        tmp_path / "app" / "generated" / "miner" / "manifest.json",
+        {"extract": _extract_node(miner_args)},
+    )
+    return paths
+
+
+def test_k018_silent_for_fields_on_the_bound_entrypoints_own_contract(
+    tmp_path: Path,
+) -> None:
+    """The miner's fields are declared — on the miner's `AppInputContract`.
+
+    Before the fix the crawler's same-named declaration won the registry and
+    every miner-only field was reported as undeclared. `preflight_check` was
+    never reported, because it happens to exist on both — the tell that the
+    resolution, not the app, was wrong.
+    """
+    paths = _write_bundle(
+        tmp_path,
+        miner_args={
+            "preflight_check": "{{preflight-check}}",
+            "miner_start_time_epoch": "{{miner-start-time-epoch}}",
+            "advanced_config": "{{advanced-config}}",
+        },
+    )
+    assert _only(scan_all(paths, tmp_path), "K018") == []
+
+
+def test_k018_still_fires_on_a_bundle_app_for_a_genuinely_undeclared_arg(
+    tmp_path: Path,
+) -> None:
+    """Widening is presence-only: a key on neither declaration still reports."""
+    paths = _write_bundle(
+        tmp_path,
+        miner_args={
+            "advanced_config": "{{advanced-config}}",
+            "not_on_either_contract": "{{nope}}",
+        },
+    )
+    assert _flagged(scan_all(paths, tmp_path), "K018") == {"not_on_either_contract"}
+
+
+def test_k018_silent_when_the_losing_declaration_sets_extra_allow(
+    tmp_path: Path,
+) -> None:
+    """`extra="allow"` on the *losing* declaration must still silence the check.
+
+    `_walk_chain` reads the same bare-name registry, so which declaration
+    supplies the `extra="allow"` verdict was walk-order luck too. Here the
+    crawler is parsed first and the open one is the miner's — the declaration
+    the runtime import actually resolves to, and the one the old registry threw
+    away. An ambiguous name that any declaration opens is treated as open: the
+    false-negative direction this check already prefers over guessing.
+    """
+    paths = _write_py(
+        tmp_path,
+        {
+            "app/generated/crawler/_input.py": _generated_input(
+                "    output_dir: str = ''\n"
+            ),
+            "app/generated/miner/_input.py": (
+                "from pydantic import ConfigDict\n"
+                "from application_sdk.templates.contracts.sql_metadata import "
+                "ExtractionInput\n"
+                "\n"
+                "class AppInputContract(ExtractionInput):\n"
+                "    model_config = ConfigDict(extra='allow')\n"
+            ),
+            "app/connector.py": _BUNDLE_APP_SRC,
+        },
+    )
+    _write_manifest(
+        tmp_path / "app" / "generated" / "crawler" / "manifest.json",
+        {"extract": _extract_node({})},
+    )
+    _write_manifest(
+        tmp_path / "app" / "generated" / "miner" / "manifest.json",
+        {"extract": _extract_node({"anything_at_all": "{{anything-at-all}}"})},
+    )
+    assert _only(scan_all(paths, tmp_path), "K018") == []
+
+
+# ---------------------------------------------------------------------------
 # K018 — arg-shape handling
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes [FND-1791](https://linear.app/atlan-epd/issue/FND-1791/k018-false-positives-on-bundle-apps-inherited-fields-resolved-through).

## Problem

K018 (`ManifestArgsUndeclaredOnInput`) resolved a contract's inherited fields through a **bare-class-name, first-wins** registry. `pkl eval` names every entrypoint's generated Input contract `AppInputContract`, so any app with more than one entrypoint declares that one name once per entrypoint. `by_name` keeps only whichever declaration the filesystem walk reached first, and every field living only on one of the others reads as undeclared.

The finding is WARN-tier so it gates nothing, but it is actively misleading: the remedy it prints is to declare a field that is already declared, and its alternative suggestion — mix in `ExtractionInput` — is already in the MRO. Apps cannot work around it either: both classes are toolkit template output, so an app cannot rename its way out the way a hand-written collision can.

B005 hit exactly this and was already fixed — the `by_name_all` union in `deprecation/_contract_compat.py`. K018 never got the same treatment.

## Change

`packages/conformance/conformance/suite/checks/manifest_contract/_input_fields.py`

1. **`scan_all`** builds `by_name_all` alongside `by_name`, as `_contract_compat.py` does.
2. **`_resolved_field_names`** takes the multimap and threads it into `resolve_contract_fields`, so an ambiguous ancestor contributes the **union** of its declarations. It also widens *`rec` itself* the same way when its own name is ambiguous — the shape where two entrypoints bind the generated `AppInputContract` directly, so `_pair_manifests_with_contracts`'s `by_name.get(...)` can only ever reach the first. Presence only: this widens what counts as *declared*, it does not change which contract a manifest is paired with.
3. **`_walk_chain`** takes it too. It reads the same first-wins registry, so both things it decides — the `extra="allow"` scan and the resolvability verdict — were walk-order luck on an ambiguous name. It now walks every declaration: a name that *any* declaration leaves unresolved, or that *any* declaration opens with `extra="allow"`, silences the manifest. Both are the false-negative direction this check already states it prefers over guessing.

On a repo where no class name is declared twice, the union is the single declaration — behaviour is unchanged.

### `_sole_extraction_input` — reviewed, deliberately left first-wins

The ticket flagged it for review. Its one caller guards on `mode == "single"`, and the collision that motivates the multimap is a bundle-app shape: one `AppInputContract` per entrypoint, all `pkl eval` output. With one entrypoint there is one generated contract, and any remaining same-name collision is between hand-written classes an app can rename. Widening there would turn one candidate into two, fail the uniqueness test, and skip the check outright — a false negative on precisely the SQL-connector family the fallback exists to cover. The rationale is in the docstring.

## Tests

Three new tests in `packages/conformance/tests/test_manifest_contract_config_keys.py`, on a two-entrypoint fixture whose contracts are both named `AppInputContract`. **All three fail at `main` and pass with the fix:**

| Test | Pins |
|---|---|
| `..._silent_for_fields_on_the_bound_entrypoints_own_contract` | fields on the bound entrypoint's own declaration are no longer reported |
| `..._still_fires_on_a_bundle_app_for_a_genuinely_undeclared_arg` | widening stays presence-only — a key on *neither* declaration still reports |
| `..._silent_when_the_losing_declaration_sets_extra_allow` | `extra="allow"` on the declaration the walk discarded now silences, where before it was parse-order luck |

## Verification

- Full conformance suite: **3447 passed**, 1 xfailed.
- `detect` on the reported repro repo at its current `main`: **5 K018 findings before, 0 after**. The other 96 findings in the report are byte-identical — the removal is exactly the five reported, nothing else moved.
- `pre-commit` clean on both files.

No version bump: conformance releases land as their own `chore(conformance): release vX` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkKmtDWLcpWnkbtebL1b8D
