### PR TITLE
chore(security): allowlist x/mod, quinn-proto, regexp2 residual HIGHs (SLA 30d)

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,11 +1,65 @@
 {
   "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Auto-maintained by the vuln-triage rover; CODEOWNERS: SDK/security team + @atlan-ci (auto-merge of allowlist-only PRs).",
   "_base_image": "app-runtime-base:3",
-  "_updated": "2026-09-07",
+  "_updated": "2026-09-09",
   "_renewal_note": "Expiry dates are the remediation SLA per severity, measured from first detection. CRITICAL: 7 days. HIGH: 30 days. MEDIUM/LOW are NOT allowlisted (tracked on Linear tickets only). The gate (check_allowlist.py) passes while an entry is unexpired and fails once it expires. Enforced by .github/scripts/validate_allowlist.py via _expiry_policy below.",
   "_expiry_policy": {
     "CRITICAL": 7,
     "HIGH": 30
   },
-  "_entry_schema": "Each non-underscore key is a CVE/advisory ID. Required: package, severity (CRITICAL|HIGH only), reason, expires, added_by, case (1-4), ticket. Optional: fix_pr. Keep entries minimal but descriptive."
+  "_entry_schema": "Each non-underscore key is a CVE/advisory ID. Required: package, severity (CRITICAL|HIGH only), reason, expires, added_by, case (1-4), ticket. Optional: fix_pr. Keep entries minimal but descriptive.",
+  "CVE-2026-56865": {
+    "package": "dapr-daprd-1.18",
+    "severity": "HIGH",
+    "reason": "Case 4: base-image CVE — golang.org/x/mod v0.38.0 linked into Chainguard dapr-daprd-1.18 1.18.3-r8 (app-runtime-base:3), not a uv.lock dependency; fix is x/mod v0.40.0 (upstream Dapr carries it only from 1.18.4, still rc). Not exploitable: the shipped daprd has 0 references to golang.org/x/mod/sumdb and never verifies Go modules at runtime. Clears on a base rebuild onto a dapr-daprd build with x/mod >= 0.40.0.",
+    "expires": "2026-10-09",
+    "added_by": "@vaibhavatlan",
+    "case": 4,
+    "ticket": "FND-12",
+    "re_evaluation_trigger": "fix_released",
+    "fix_available_date": "2026-08-13"
+  },
+  "CVE-2026-56864": {
+    "package": "dapr-daprd-1.18",
+    "severity": "HIGH",
+    "reason": "Case 4: base-image CVE — golang.org/x/mod v0.38.0 linked into Chainguard dapr-daprd-1.18 1.18.3-r8 (app-runtime-base:3), not a uv.lock dependency; fix is x/mod v0.40.0 (upstream Dapr carries it only from 1.18.4, still rc). Not exploitable: the shipped daprd has 0 references to golang.org/x/mod/sumdb and never verifies Go modules at runtime. Clears on a base rebuild onto a dapr-daprd build with x/mod >= 0.40.0.",
+    "expires": "2026-10-09",
+    "added_by": "@vaibhavatlan",
+    "case": 4,
+    "ticket": "FND-12",
+    "re_evaluation_trigger": "fix_released",
+    "fix_available_date": "2026-08-13"
+  },
+  "GHSA-qfwj-vfxf-92j2": {
+    "package": "uv",
+    "severity": "HIGH",
+    "reason": "Case 4: base-image advisory — quinn-proto 0.11.15 compiled into Chainguard uv 0.12.10-r0 (app-runtime-base:3), not a uv.lock dependency; fix is quinn-proto 0.11.17 (2026-08-17), not yet in any uv release (<= 0.12.11) nor in the Wolfi uv recipe bump list. Not exploitable: the container only runs `uv run --no-sync` with UV_NO_CACHE=1 (no network at runtime) and uv's reqwest is built without http3, so the QUIC stack is never exercised. Clears when Chainguard's uv build bumps quinn-proto >= 0.11.17.",
+    "expires": "2026-10-09",
+    "added_by": "@vaibhavatlan",
+    "case": 4,
+    "ticket": "FND-12",
+    "re_evaluation_trigger": "fix_released",
+    "fix_available_date": "2026-08-17"
+  },
+  "GHSA-2hv7-gw8g-gpq5": {
+    "package": "uv",
+    "severity": "HIGH",
+    "reason": "Case 4: base-image advisory — quinn-proto 0.11.15 compiled into Chainguard uv 0.12.10-r0 (app-runtime-base:3), not a uv.lock dependency; fix is quinn-proto 0.11.17 (2026-08-17), not yet in any uv release (<= 0.12.11) nor in the Wolfi uv recipe bump list. Not exploitable: the container only runs `uv run --no-sync` with UV_NO_CACHE=1 (no network at runtime) and uv's reqwest is built without http3, so the QUIC stack is never exercised. Clears when Chainguard's uv build bumps quinn-proto >= 0.11.17.",
+    "expires": "2026-10-09",
+    "added_by": "@vaibhavatlan",
+    "case": 4,
+    "ticket": "FND-12",
+    "re_evaluation_trigger": "fix_released",
+    "fix_available_date": "2026-08-17"
+  },
+  "XRAY-1032976": {
+    "package": "dapr-daprd-1.18",
+    "severity": "HIGH",
+    "reason": "Case 4: base-image advisory (JFrog Xray id; GHSA-wq9v-j77v-qr26 is withdrawn and OSV reports the version clean) — github.com/dlclark/regexp2 v1.11.5 in Chainguard dapr-daprd-1.18 1.18.3-r8. No reachable fix: the stated fix 2.3.0 lives at the /v2 module path, so the v1 module can never publish it; only a migration by the importing library resolves it. Not exploitable: requires attacker-controlled regex patterns, and the shipped binary contains no regexp2 code paths. Re-evaluate quarterly.",
+    "expires": "2026-10-09",
+    "added_by": "@vaibhavatlan",
+    "case": 4,
+    "ticket": "FND-12",
+    "re_evaluation_trigger": "quarterly"
+  }
 }


### PR DESCRIPTION
## Why

A customer-side JFrog Xray scan of the hive SDR image (FND-12) reported 28 rows, all inside `/usr/bin/daprd` and `/usr/bin/uv` — binaries inherited from the Chainguard golden layer through `app-runtime-base:3`. No connector repo can move them (Case 4).

The current base (3.33.2, 2026-09-08, `dapr-daprd-1.18` 1.18.3-r8, `uv` 0.12.10-r0) already clears 14 rows including all 3 Criticals: the r8 daprd links amqp091-go 1.13.0, x/crypto 0.56.0 and grpc 1.83.1 (read from the binary's Go buildinfo). The 5 remaining HIGH rows have no fix in any build we consume today. This PR records them in the central compensating-controls registry with the exposure analysis, so the 30-day SLA clock starts and downstream customer responses can cite one source.

Touches only `.security/base-allowlist.json`.

## Entries (all HIGH, Case 4, ticket FND-12, expires 2026-10-09)

| Key | Package in base | Vulnerable | Fixed in | Why not in our base yet |
|---|---|---|---|---|
| CVE-2026-56865 (8.4) | `dapr-daprd-1.18` 1.18.3-r8 | golang.org/x/mod 0.38.0 | 0.40.0 (2026-08-13) | Upstream Dapr carries 0.40.0 only from 1.18.4, still at rc.4 |
| CVE-2026-56864 (7.5) | same | same | same | same |
| GHSA-qfwj-vfxf-92j2 (7.5) | `uv` 0.12.10-r0 | quinn-proto 0.11.15 | 0.11.17 (2026-08-17) | No uv release through 0.12.11 has bumped it; the Wolfi `uv.yaml` bump list pins only `quinn-proto@0.11.14` |
| GHSA-2hv7-gw8g-gpq5 | same | same | same | same |
| XRAY-1032976 | `dapr-daprd-1.18` 1.18.3-r8 | github.com/dlclark/regexp2 1.11.5 | none reachable | The "2.3.0" fix lives at the `/v2` module path; v1 can never publish it. GHSA-wq9v-j77v-qr26 is withdrawn; OSV reports 1.11.5 clean |

## Exposure analysis (why none is exploitable in a shipped connector)

- **x/mod (sumdb tile/lookup verification):** the live daprd binary has 0 references to `golang.org/x/mod/sumdb` (18 to `/semver` only). daprd never resolves or verifies Go modules at runtime; this is a `go` toolchain/proxy-client flaw.
- **quinn-proto (QUIC memory exhaustion):** the runtime entrypoint runs `uv run --no-sync` with `UV_NO_CACHE=1`, so uv opens no network connections in the container. uv's reqwest is built with `http2` but not `http3`, so the QUIC stack is linked yet never exercised. Exploitation requires uv to talk to a malicious QUIC peer.
- **regexp2 (`{m}` quantifier amplification):** requires attacker-controlled regex patterns; the binary lists the module in buildinfo but contains no regexp2 code paths.

## What actually removes them

- Chainguard (Custom Assembly): bump `dapr-daprd-1.18` to x/mod 0.40.0 (also amqp091-go 1.14.0 and grpc 1.83.2 for the next scan's rows) and `uv` to quinn-proto 0.11.17 / h2 0.4.16. Fastest lever for uv is a PR to the public `wolfi-dev/os` `uv.yaml` bump list.
- Dapr 1.18.4 GA reaching the golden image (x/mod).
- regexp2 stays a documented residual until the importing library migrates to `/v2`.

## Validation

`python3 .github/scripts/validate_allowlist.py` → all entries within policy (HIGH ≤ 30d). pre-commit run on the file.

Full row-by-row classification of the scan is on FND-12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
