### PR TITLE
fix(dapr): surface the Dapr error body in BindingError

### DIFF
--- a/application_sdk/infrastructure/_dapr/client.py
+++ b/application_sdk/infrastructure/_dapr/client.py
@@ -138,6 +138,42 @@ def is_dapr_transport_unavailable(exc: BaseException) -> bool:
     return isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code >= 500
 
 
+#: Upper bound on how much of a non-JSON Dapr error body is copied into a
+#: :class:`BindingError` message. Dapr's own bodies are one short JSON object;
+#: anything longer is an HTML error page from a proxy in front of the sidecar.
+_DAPR_ERROR_BODY_MAX_CHARS = 512
+
+
+def dapr_error_detail(exc: Exception) -> str | None:
+    """Best-effort extraction of the Dapr HTTP API's error body from *exc*.
+
+    Dapr answers a failed API call with a JSON body of the shape
+    ``{"errorCode": "ERR_INVOKE_OUTPUT_BINDING", "message": "error invoking
+    output binding eventstore: received status code 403"}`` — and logs that
+    same text only at *debug* level in the sidecar (``pkg/api/http/http.go``
+    in ``dapr/dapr``). The body is therefore the **only** place the real
+    cause of a binding failure is available at default log levels; httpx's
+    exception string carries just ``Server error '500 Internal Server Error'
+    for url ...``. Returns ``None`` when *exc* is not an
+    :class:`httpx.HTTPStatusError` or has an empty body; a non-JSON body is
+    returned verbatim, truncated to :data:`_DAPR_ERROR_BODY_MAX_CHARS`.
+    """
+    if not isinstance(exc, httpx.HTTPStatusError):
+        return None
+    text = exc.response.text
+    if not text:
+        return None
+    try:
+        body = orjson.loads(text)
+    except Exception:
+        body = None
+    if isinstance(body, dict) and (body.get("errorCode") or body.get("message")):
+        code = body.get("errorCode") or "unknown"
+        message = body.get("message") or ""
+        return f"dapr errorCode={code}: {message}".rstrip(": ")
+    return text[:_DAPR_ERROR_BODY_MAX_CHARS]
+
+
 #: Dapr secrets-API JSON error body ``errorCode`` values that unambiguously
 #: mean "not ready yet" — as opposed to :data:`_ERR_SECRET_GET`, which Dapr
 #: also returns for a *genuinely missing* key. Verified against a live Dapr
@@ -472,8 +508,15 @@ class DaprBinding:
             raise
         # conformance: ignore[E004] re-raises as typed BindingError with cause chain; traceback preserved
         except Exception as e:
+            # The Dapr error body is the only place the real cause lives at
+            # default sidecar log levels; without it a customer's log shows a
+            # bare 500 with no way to tell a rejected request from a blocked one.
+            detail = dapr_error_detail(e)
+            message = f"Failed to invoke binding: {e}"
+            if detail:
+                message = f"{message} ({detail})"
             raise BindingError(
-                f"Failed to invoke binding: {e}",
+                message,
                 binding_name=self._binding_name,
                 operation=operation,
                 cause=e,

--- a/tests/unit/infrastructure/test_dapr_wrappers.py
+++ b/tests/unit/infrastructure/test_dapr_wrappers.py
@@ -365,6 +365,57 @@ class TestDaprBinding:
         with pytest.raises(BindingError):
             await self.binding.invoke("get")
 
+    async def test_invoke_error_surfaces_dapr_error_body(self):
+        """A Dapr 500 carries the real cause only in its JSON body; the
+        BindingError message must carry it too, since the sidecar logs it
+        only at debug level."""
+        req = httpx.Request("POST", "http://localhost:3500/v1.0/bindings/eventstore")
+        resp = httpx.Response(
+            500,
+            request=req,
+            json={
+                "errorCode": "ERR_INVOKE_OUTPUT_BINDING",
+                "message": "error invoking output binding eventstore: "
+                "received status code 403",
+            },
+        )
+        self.client.invoke_binding.side_effect = httpx.HTTPStatusError(
+            "internal error", request=req, response=resp
+        )
+        with pytest.raises(BindingError) as exc:
+            await self.binding.invoke("create")
+        text = str(exc.value)
+        assert "ERR_INVOKE_OUTPUT_BINDING" in text
+        assert "received status code 403" in text
+        assert exc.value.binding_name == "s3"
+        assert exc.value.operation == "create"
+        assert isinstance(exc.value.cause, httpx.HTTPStatusError)
+
+    async def test_invoke_error_surfaces_non_json_body_truncated(self):
+        """A proxy in front of the sidecar may answer with HTML; keep a bounded
+        slice of it rather than dropping it."""
+        req = httpx.Request("POST", "http://localhost:3500/v1.0/bindings/eventstore")
+        resp = httpx.Response(502, request=req, text="<html>" + "x" * 2000)
+        self.client.invoke_binding.side_effect = httpx.HTTPStatusError(
+            "bad gateway", request=req, response=resp
+        )
+        with pytest.raises(BindingError) as exc:
+            await self.binding.invoke("create")
+        text = str(exc.value)
+        assert "<html>" in text
+        assert "x" * 600 not in text
+
+    async def test_invoke_error_without_body_keeps_plain_message(self):
+        req = httpx.Request("POST", "http://localhost:3500/v1.0/bindings/eventstore")
+        resp = httpx.Response(500, request=req)
+        self.client.invoke_binding.side_effect = httpx.HTTPStatusError(
+            "internal error", request=req, response=resp
+        )
+        with pytest.raises(BindingError) as exc:
+            await self.binding.invoke("create")
+        assert str(exc.value).count("Failed to invoke binding") == 1
+        assert "dapr errorCode" not in str(exc.value)
+
 
 # ---------------------------------------------------------------------------
 # DaprPubSub.subscribe / DaprSubscription


### PR DESCRIPTION
### Changelog
- `DaprBinding.invoke` now appends Dapr's JSON error body (`errorCode` + `message`) to the `BindingError` message when the sidecar answers a non-2xx. A non-JSON body (proxy HTML) is included as a bounded 512-char slice. Cause chain, `binding_name` and `operation` are unchanged.
- New helper `dapr_error_detail()` in `infrastructure/_dapr/client.py`.
- Three unit tests covering JSON body, non-JSON body truncation, and empty body.

### Additional context (e.g. screenshots, logs, links)
- Dapr's HTTP API (`pkg/api/http/http.go`, `onOutputBindingMessage`) returns the failure reason in the response body and logs it only at `log.Debug`. At the entrypoint's default `DAPR_LOG_LEVEL=warn` (or `info`) the sidecar log therefore shows nothing for a failed invoke, and the body is the only place the cause exists.
- Before this change the `eventstore binding unavailable — worker_start event not emitted` and `Failed to emit token_refresh event` warnings carried only `Server error '500 Internal Server Error' for url 'http://localhost:3500/v1.0/bindings/eventstore'`. In a recent SDR RCA that left no way to distinguish a gateway 403, an upstream 5xx, or a dial/TLS failure from the customer's log, and required the customer to redeploy with debug logging.
- After this change the same warning reads, for example:
  `[AAF-INF-003] Failed to invoke binding: Server error '500 Internal Server Error' for url '...' (dapr errorCode=ERR_INVOKE_OUTPUT_BINDING: error invoking output binding eventstore: received status code 403) | binding=eventstore | operation=create | caused_by=HTTPStatusError: ...`
- Linear: ARUN-1258

### Checklist
- [x] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated (no public API or docs change; helper lives in the private `_dapr` adapter)

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)? No.
- [ ] If yes, have you modified the code in the context of this project? N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
