### PR TITLE
fix(conformance): slot every tests-reusable input in the bootstrap template

### DIFF
--- a/packages/conformance/conformance/bootstrap/extract.py
+++ b/packages/conformance/conformance/bootstrap/extract.py
@@ -191,6 +191,83 @@ _BLOCK_SCALAR_RE = re.compile(
 # only decides whether a per-app value is a preserved choice or drift.
 SDK_UNIT_COVERAGE_FLOOR = 0
 
+# ``tests-reusable.yaml``'s ``install-app-to-tenant`` default. Copied here for
+# the same reason as the coverage floor above — this package ships standalone —
+# and pinned against the real input default by ``test_bootstrap``, which is what
+# makes the policy drop below safe: if the SDK ever flips this default, that test
+# fails in the monorepo instead of nine repos silently losing their install.
+SDK_INSTALL_APP_TO_TENANT_DEFAULT = "true"
+
+# A single-token value: no whitespace, no quote, no ``#``. The shape every
+# path/name/ref-valued input below is checked against before it is read back,
+# because the template re-emits these inside double quotes — a value carrying a
+# quote would render invalid YAML, and one carrying a ``#`` or a space would
+# either truncate or change meaning. A value this rejects reads as *absent*, so
+# it reaches ``unpreserved_declarations`` and refuses the resync rather than
+# being silently rewritten into something else.
+_PLAIN_VALUE_RE = re.compile(r"^[A-Za-z0-9_.,/:@+*=-]+$")
+
+# Every remaining input of ``tests-reusable.yaml`` that the canonical
+# ``tests.yaml`` now has a slot for, as ``(render param, input, value shape)``.
+#
+# FND-1143: an input with no slot is not merely unsupported, it *freezes* any
+# repo that passes it — ``--resync`` refuses the whole file rather than delete
+# the declaration (FND-604), so every structural update the template carries is
+# withheld too. That cost 25 of the fleet's 80 ``tests.yaml`` repos, across 13
+# inputs; ``install-app-to-tenant`` is handled by the policy drop below instead,
+# and ``test-paths`` / ``pytest-args`` by the block-scalar splice, because both
+# are written as folded scalars in the wild.
+#
+# The shape is what the value must parse as to be read back. Anything else is
+# left to the round-trip guard: a bare ``timeout-minutes: soon`` must refuse the
+# resync, not be re-rendered as a number nobody wrote.
+_TESTS_YAML_VALUE_INPUTS: tuple[tuple[str, str, str], ...] = (
+    ("timeout_minutes", "timeout-minutes", "int"),
+    ("apt_packages", "apt-packages", "apt"),
+    ("private_git_deps", "private-git-deps", "bool"),
+    ("git_lfs_skip_smudge", "git-lfs-skip-smudge", "bool"),
+    ("health_check_timeout_seconds", "health-check-timeout-seconds", "int"),
+    ("container_health_timeout_seconds", "container-health-timeout-seconds", "int"),
+    ("runtime_sdk_ref", "runtime-sdk-ref", "plain"),
+    ("harness_sdk_ref", "harness-sdk-ref", "plain"),
+    ("e2e_test_path", "e2e-test-path", "plain"),
+    ("source_available", "source-available", "bool"),
+    ("dataforge_datasource", "dataforge-datasource", "plain"),
+    ("dataforge_mode", "dataforge-mode", "plain"),
+    ("dataforge_env_tier", "dataforge-env-tier", "plain"),
+    ("dataforge_output_prefix", "dataforge-output-prefix", "plain"),
+    ("dataforge_hermetic_fallback", "dataforge-hermetic-fallback", "bool"),
+)
+
+# The two inputs whose real-world spelling is a ``>-`` folded scalar — a list of
+# pytest target paths, and an argument line — so they are spliced verbatim like
+# ``secrets_block`` rather than read as values. A value-shaped read of these
+# returns the scalar *header* (``>-``), which is the silent-corruption class
+# ``extract_field``'s single-quote arm was fixed for, one dimension over.
+_TESTS_YAML_BLOCK_INPUTS: tuple[tuple[str, str], ...] = (
+    ("test_paths_block", "test-paths"),
+    ("pytest_args_block", "pytest-args"),
+)
+
+
+def _reads_back(value: str, shape: str) -> bool:
+    """True when *value* parses as *shape*, so it can be re-rendered as written.
+
+    The gate on every value read by ``_TESTS_YAML_VALUE_INPUTS``. Returning
+    False means "treat the declaration as unreadable", which routes it to the
+    round-trip guard's refusal — the safe direction, and the one FND-604
+    established for an ``unit-coverage-fail-under: ninety``.
+    """
+    if not value:
+        return False
+    if shape == "bool":
+        return value in ("true", "false")
+    if shape == "int":
+        return value.isdigit()
+    if shape == "apt":
+        return all(APT_PACKAGE_RE.match(token) for token in value.split())
+    return bool(_PLAIN_VALUE_RE.match(value))
+
 
 def strip_action_pins(text: str) -> str:
     """Return *text* with every pinned action SHA normalised to ``@<pinned>``.
@@ -234,6 +311,22 @@ def extract_tests_yaml_params(text: str) -> dict[str, str]:
     removing the line so the app inherits the SDK floor again). A value equal
     to the floor is kept rather than flagged: it weakens nothing, and deleting
     a redundant-but-honest declaration is churn, not remediation.
+
+    FND-1143 added the rest of ``tests-reusable.yaml``'s inputs
+    (``_TESTS_YAML_VALUE_INPUTS`` and ``_TESTS_YAML_BLOCK_INPUTS``). Not because
+    each is individually load-bearing, but because an input with no slot
+    *freezes* the repo that passes it: since FND-604 ``--resync`` refuses the
+    whole file rather than delete a declaration it cannot carry, so one
+    unslotted line withholds every structural update the template carries. On
+    ``atlan-postgres-app`` that was ``merge_group:`` and the ``labeled`` trigger
+    type — and a required check that never dispatches for ``merge_group`` leaves
+    the merge-queue entry pending until it times out. 25 of the 80 connector
+    repos with a ``tests.yaml`` were in that state, across 13 inputs, when this
+    landed.
+
+    Each value is gated on ``_reads_back``: a declaration whose value the
+    template cannot re-emit faithfully reads as absent, which routes it to the
+    round-trip guard's refusal rather than re-rendering a value nobody wrote.
     """
     params: dict[str, str] = {}
     # Inputs of the reusable job, so read from its own `with:` block through the
@@ -260,6 +353,23 @@ def extract_tests_yaml_params(text: str) -> dict[str, str]:
         services_script = extract_field(with_block, "services-script")
         if services_script:
             params["services_script"] = services_script
+        # FND-1143's slots. Read through the same quote-tolerant `extract_field`
+        # for the same reason, and gated on `_reads_back` so a value the template
+        # cannot re-emit faithfully reads as absent and refuses the resync
+        # instead of being rewritten. A declaration written as a block scalar is
+        # skipped here for the same reason: `extract_field` would return the
+        # scalar's header (`>-`) as the value.
+        for param, field, shape in _TESTS_YAML_VALUE_INPUTS:
+            declaration = extract_with_declaration(text, field)
+            if not declaration or _BLOCK_SCALAR_RE.search(declaration.splitlines()[0]):
+                continue
+            value = extract_field(declaration, field)
+            if _reads_back(value, shape):
+                params[param] = value
+        for param, field in _TESTS_YAML_BLOCK_INPUTS:
+            declaration = extract_with_declaration(text, field)
+            if declaration:
+                params[param] = declaration
     declared = extract_declared_unit_coverage_fail_under(text)
     if declared and int(declared) >= SDK_UNIT_COVERAGE_FLOOR:
         params["unit_coverage_fail_under"] = declared
@@ -421,6 +531,82 @@ def reusable_job_with_block(text: str) -> str:
     while body_end < len(lines) and not _outdents(lines, body_end, key_indent + 1):
         body_end += 1
     return "\n".join(lines[with_at + 1 : body_end])
+
+
+def _reusable_with_key_line(text: str, key: str) -> tuple[list[str], int, int] | None:
+    """Find *key* among the *direct children* of the reusable job's ``with:``.
+
+    Returns ``(structural_lines, index, indent)`` for the first match, or
+    ``None``. The ``with:``-block counterpart of ``_reusable_job_key_line``,
+    which finds siblings of ``uses:``.
+
+    Direct children only, measured against the first child's own indentation: a
+    key nested *deeper* than the input level belongs to a value, not to the
+    inputs the job passes, and hoisting one into the rendered ``with:`` would
+    fabricate an input nobody declared — the same class
+    ``_reusable_job_scope``'s narrowing exists to prevent, one level down.
+    """
+    found = _reusable_job_key_line(text, "with")
+    if found is None:
+        return None
+    structural, with_at, key_indent = found
+    child_indent: int | None = None
+    for i in range(with_at + 1, len(structural)):
+        if _outdents(structural, i, key_indent + 1):
+            break
+        line = structural[i]
+        if not line.strip():
+            continue
+        m = _KEY_LINE_RE.match(line)
+        if m is None:
+            continue
+        indent = len(m.group("indent"))
+        if child_indent is None:
+            child_indent = indent
+        if indent != child_indent:
+            continue
+        if _yaml_key(m.group("key")) == key:
+            return structural, i, indent
+    return None
+
+
+def extract_with_declaration(text: str, key: str) -> str:
+    """Return the reusable job's ``with: <key>`` declaration verbatim, or ``""``.
+
+    *text* is a tests.yaml. The return value is the declaration exactly as
+    written — its key line plus, when that line opens a block scalar
+    (``key: >-``), every line of the scalar's body — with no trailing newline,
+    so it drops into the template's slot the way ``extract_secrets_block``'s
+    return value does.
+
+    Used for the two inputs whose real-world form is a folded scalar
+    (``test-paths``, ``pytest-args``), and by the value reads to *detect* that
+    form: a value-shaped read of a block scalar returns its header, so the
+    header check has to happen on the verbatim line.
+
+    Boundaries come off the structural view (so a key quoted inside another
+    input's scalar body is not mistaken for a declaration) while the returned
+    bytes come off the original, because a scalar body is blank in the
+    structural view by construction.
+    """
+    found = _reusable_with_key_line(text, key)
+    if found is None:
+        return ""
+    _, start, indent = found
+    lines = text.splitlines()
+    end = start + 1
+    if _BLOCK_SCALAR_RE.search(lines[start]):
+        while end < len(lines):
+            line = lines[end]
+            if line.strip() and len(line) - len(line.lstrip()) <= indent:
+                break
+            end += 1
+        # Trailing blank lines separate this declaration from the next; a
+        # folded scalar that swallowed them would re-render extra blank lines
+        # into the block on every resync.
+        while end > start + 1 and not lines[end - 1].strip():
+            end -= 1
+    return "\n".join(lines[start:end])
 
 
 def extract_force_external_runtime(text: str) -> str:
@@ -655,6 +841,10 @@ def unpreserved_tests_yaml_declarations(existing: str, rerendered: str) -> list[
     parse (``unit-coverage-fail-under: ninety``) is not a decision anyone made,
     so it still counts as unpreserved and still stops the resync.
 
+    ``install-app-to-tenant: true`` is the second such drop (FND-1143), on the
+    same value-conditioned terms — see ``redundant_install_app_to_tenant`` for
+    why that one input gets a policy drop where the rest got slots.
+
     ``secrets`` is added in the other direction, because for that key alone a
     shared name is *not* evidence of preservation: an inline mapping and the
     canonical ``inherit`` both spell the key ``secrets``, so the key-set
@@ -666,6 +856,8 @@ def unpreserved_tests_yaml_declarations(existing: str, rerendered: str) -> list[
     dropped = unpreserved_declarations(existing, rerendered)
     if rejected_unit_coverage_fail_under(existing):
         dropped = [key for key in dropped if key != "unit-coverage-fail-under"]
+    if redundant_install_app_to_tenant(existing):
+        dropped = [key for key in dropped if key != "install-app-to-tenant"]
     if unpreservable_secrets_form(existing) and "secrets" not in dropped:
         dropped.append("secrets")
     return dropped
@@ -702,6 +894,37 @@ def rejected_unit_coverage_fail_under(text: str) -> str:
     declared = extract_declared_unit_coverage_fail_under(text)
     if declared and int(declared) < SDK_UNIT_COVERAGE_FLOOR:
         return declared
+    return ""
+
+
+def redundant_install_app_to_tenant(text: str) -> str:
+    """Return *text*'s ``install-app-to-tenant`` when it merely restates the
+    reusable's own default, else ``""``.
+
+    The second declaration this module drops on purpose rather than preserves —
+    ``unit-coverage-fail-under`` below the floor being the first. Deliberately
+    *not* given a slot (FND-1143): all nine repos that declared it passed
+    ``true``, which is ``SDK_INSTALL_APP_TO_TENANT_DEFAULT``, so a slot would
+    bake a no-op line into nine canonical files forever while a refusal keeps
+    those repos frozen out of every structural update. Dropping it changes no
+    behaviour and un-freezes them in one resync.
+
+    Conditioned on the value, not the key: an explicit ``false`` is a real
+    opt-out with no slot to carry it, so it still reaches the refusal and the
+    repo keeps its declaration. Same for a value neither boolean — not a
+    decision anyone made, so not one to act on.
+
+    The safety of the drop rests on the copied default being right, which
+    ``test_bootstrap`` pins against ``tests-reusable.yaml``'s own input default
+    in the monorepo. If the SDK flips it to ``false``, that test fails there
+    rather than nine repos silently losing their pre-e2e install.
+    """
+    declaration = extract_with_declaration(text, "install-app-to-tenant")
+    if not declaration:
+        return ""
+    value = extract_field(declaration, "install-app-to-tenant")
+    if value == SDK_INSTALL_APP_TO_TENANT_DEFAULT:
+        return value
     return ""
 
 

--- a/packages/conformance/conformance/bootstrap/render.py
+++ b/packages/conformance/conformance/bootstrap/render.py
@@ -177,6 +177,23 @@ def render(
     use_ghcr_base: str = "",
     force_external_runtime: str = "",
     secrets_block: str = "",
+    test_paths_block: str = "",
+    pytest_args_block: str = "",
+    timeout_minutes: str = "",
+    apt_packages: str = "",
+    private_git_deps: str = "",
+    git_lfs_skip_smudge: str = "",
+    health_check_timeout_seconds: str = "",
+    container_health_timeout_seconds: str = "",
+    runtime_sdk_ref: str = "",
+    harness_sdk_ref: str = "",
+    e2e_test_path: str = "",
+    source_available: str = "",
+    dataforge_datasource: str = "",
+    dataforge_mode: str = "",
+    dataforge_env_tier: str = "",
+    dataforge_output_prefix: str = "",
+    dataforge_hermetic_fallback: str = "",
 ) -> str:
     """Render template *name* with the given substitution variables.
 
@@ -227,6 +244,40 @@ def render(
       FND-604 added, hugged onto their tags' lines for the same byte-identity
       reason.  ``secrets_block`` carries no trailing newline of its own — the
       template's line supplies it, so the no-override render is unchanged.
+
+      FND-1143 adds a slot for every remaining input of
+      ``tests-reusable.yaml``, in one ``<% endif %><% if … %>`` chain between
+      ``app-image-name`` and the ``enable-e2e`` block: ``test_paths_block``,
+      ``pytest_args_block``, ``timeout_minutes``, ``apt_packages``,
+      ``private_git_deps``, ``git_lfs_skip_smudge``,
+      ``health_check_timeout_seconds``,
+      ``container_health_timeout_seconds``, ``runtime_sdk_ref``,
+      ``harness_sdk_ref``, ``e2e_test_path``, ``source_available`` and the five
+      ``dataforge_*`` values.  All default ``""`` — no line, so the reusable's
+      own default applies — and the chain emits nothing at all when every one
+      of them is empty, which is what keeps the no-override render
+      byte-identical to the pre-FND-1143 one for the whole bootstrapped fleet.
+
+      Why the whole set rather than the five ``dataforge_*`` ones FND-1143 was
+      filed about: a slot is what makes a declaration *preservable*, so an
+      input with no slot freezes any repo that passes it — ``--resync`` refuses
+      the whole file rather than delete the line (FND-604), and every
+      structural update the template carries is withheld with it.  At the time
+      this landed that was 25 of the 80 connector repos with a ``tests.yaml``,
+      across 13 different inputs; the four nobody had declared yet
+      (``source-available``, ``container-health-timeout-seconds``,
+      ``runtime-sdk-ref``, ``harness-sdk-ref``) are slotted too so the next
+      repo to need one does not re-open the trap.
+
+      ``test_paths_block`` and ``pytest_args_block`` are verbatim splices
+      rather than values, for the reason ``secrets_block`` is: both inputs are
+      written as ``>-`` block scalars in the wild (a folded list of pytest
+      target paths, a folded argument line), and a value-shaped param would
+      read the scalar *header* back as the value.  Like ``secrets_block`` they
+      carry their own key and indentation and no trailing newline.  Every other
+      new param is a single value, quoted or bare in the spelling the fleet
+      hand-wrote it (bare for the numeric and boolean inputs, quoted for the
+      strings).
     - ``.gitignore``: static template, no substitution.
 
     All other keyword arguments are accepted but unused, so callers can pass
@@ -254,4 +305,21 @@ def render(
         use_ghcr_base=use_ghcr_base,
         force_external_runtime=force_external_runtime,
         secrets_block=secrets_block,
+        test_paths_block=test_paths_block,
+        pytest_args_block=pytest_args_block,
+        timeout_minutes=timeout_minutes,
+        apt_packages=apt_packages,
+        private_git_deps=private_git_deps,
+        git_lfs_skip_smudge=git_lfs_skip_smudge,
+        health_check_timeout_seconds=health_check_timeout_seconds,
+        container_health_timeout_seconds=container_health_timeout_seconds,
+        runtime_sdk_ref=runtime_sdk_ref,
+        harness_sdk_ref=harness_sdk_ref,
+        e2e_test_path=e2e_test_path,
+        source_available=source_available,
+        dataforge_datasource=dataforge_datasource,
+        dataforge_mode=dataforge_mode,
+        dataforge_env_tier=dataforge_env_tier,
+        dataforge_output_prefix=dataforge_output_prefix,
+        dataforge_hermetic_fallback=dataforge_hermetic_fallback,
     )

--- a/packages/conformance/conformance/bootstrap/templates/tests.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/tests.yaml
@@ -145,7 +145,24 @@ jobs:
 <% endif %><% if force_external_runtime %>      force-external-runtime: << force_external_runtime >>
 <% endif %>      app-name: "<< app_name >>"
       app-image-name: "<< app_image_name >>"
-<% if enable_e2e != 'true' %>
+<% if test_paths_block %><< test_paths_block >>
+<% endif %><% if pytest_args_block %><< pytest_args_block >>
+<% endif %><% if timeout_minutes %>      timeout-minutes: << timeout_minutes >>
+<% endif %><% if apt_packages %>      apt-packages: "<< apt_packages >>"
+<% endif %><% if private_git_deps %>      private-git-deps: << private_git_deps >>
+<% endif %><% if git_lfs_skip_smudge %>      git-lfs-skip-smudge: << git_lfs_skip_smudge >>
+<% endif %><% if health_check_timeout_seconds %>      health-check-timeout-seconds: "<< health_check_timeout_seconds >>"
+<% endif %><% if container_health_timeout_seconds %>      container-health-timeout-seconds: "<< container_health_timeout_seconds >>"
+<% endif %><% if runtime_sdk_ref %>      runtime-sdk-ref: "<< runtime_sdk_ref >>"
+<% endif %><% if harness_sdk_ref %>      harness-sdk-ref: "<< harness_sdk_ref >>"
+<% endif %><% if e2e_test_path %>      e2e-test-path: "<< e2e_test_path >>"
+<% endif %><% if source_available %>      source-available: << source_available >>
+<% endif %><% if dataforge_datasource %>      dataforge-datasource: "<< dataforge_datasource >>"
+<% endif %><% if dataforge_mode %>      dataforge-mode: "<< dataforge_mode >>"
+<% endif %><% if dataforge_env_tier %>      dataforge-env-tier: "<< dataforge_env_tier >>"
+<% endif %><% if dataforge_output_prefix %>      dataforge-output-prefix: "<< dataforge_output_prefix >>"
+<% endif %><% if dataforge_hermetic_fallback %>      dataforge-hermetic-fallback: "<< dataforge_hermetic_fallback >>"
+<% endif %><% if enable_e2e != 'true' %>
       enable-e2e: << enable_e2e >>
 <% endif %>
 <% if services_script %>

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -3099,3 +3099,208 @@ def test_sdk_unit_coverage_floor_matches_the_reusable_workflow_default() -> None
         "conformance/bootstrap/extract.py to match, or C002 will keep "
         "preserving per-app floors below the SDK's own."
     )
+
+
+# ---------------------------------------------------------------------------
+# FND-1143: the unslotted-input freeze, end to end through --resync
+# ---------------------------------------------------------------------------
+
+
+def _dataforge_tests_yaml() -> str:
+    """A tests.yaml wired to dataforge the way the connectors that use it are.
+
+    Hand-positioned, under its own explanatory comments, rather than rendered
+    from the template: these seven repos wrote these lines before any slot
+    existed, and a fixture rendered from the template would pass on a preserve
+    that only works for the exact bytes the template emits.
+    """
+    canonical = render("tests.yaml", app_name="app")
+    return canonical.replace(
+        '      app-image-name: "atlan-app-app"\n',
+        '      app-image-name: "atlan-app-app"\n'
+        "      # Source: the dataforge org-vault entry — no provisioned resource\n"
+        "      # for this family, so managed mode, looked up by datasource + tier.\n"
+        '      dataforge-datasource: "cosmosnosql"\n'
+        '      dataforge-mode: "managed"\n'
+        '      dataforge-env-tier: "dev"\n'
+        '      dataforge-output-prefix: "COSMOSNOSQL"\n'
+        "      # No hermetic Cosmos, so an unresolved source must fail fast:\n"
+        '      # the "true" default would let a dataforge miss turn the\n'
+        "      # INTEGRATION merge gate green against no source at all.\n"
+        '      dataforge-hermetic-fallback: "false"\n',
+    )
+
+
+def test_resync_keeps_the_dataforge_inputs(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The FND-1143 headline: seven connectors pass these, and until the
+    template had slots for them --resync refused their whole file.
+
+    ``dataforge-hermetic-fallback: "false"`` is the load-bearing one — it is
+    what makes an unresolved source FAIL the integration tier instead of
+    passing it green against no source at all.
+    """
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    wf = tmp_path / ".github" / "workflows" / "tests.yaml"
+    wf.write_text(_dataforge_tests_yaml())
+    _cmd_bootstrap(["--resync"])
+    after = wf.read_text()
+    assert 'dataforge-datasource: "cosmosnosql"' in after
+    assert 'dataforge-mode: "managed"' in after
+    assert 'dataforge-env-tier: "dev"' in after
+    assert 'dataforge-output-prefix: "COSMOSNOSQL"' in after
+    assert 'dataforge-hermetic-fallback: "false"' in after
+
+
+def test_resync_of_a_dataforge_file_lands_the_structural_catch_up(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The damage the refusal did was never the dataforge lines themselves.
+
+    A whole-file refusal withholds every structural update the template
+    carries. On atlan-postgres-app that was ``merge_group:`` and the
+    ``labeled`` trigger type — and a required check that never dispatches for
+    ``merge_group`` leaves the merge-queue entry pending until it times out.
+    """
+    from conformance.suite.checks.bootstrap_drift import scan_path
+
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    wf = tmp_path / ".github" / "workflows" / "tests.yaml"
+    stale = _dataforge_tests_yaml().replace("  merge_group:\n", "")
+    assert "merge_group" not in stale, "fixture is not actually stale"
+    wf.write_text(stale)
+    assert scan_path(wf, tmp_path), "fixture is not actually drifted"
+    _cmd_bootstrap(["--resync"])
+    assert "  merge_group:\n" in wf.read_text()
+    assert scan_path(wf, tmp_path) == []
+
+
+def test_resync_is_idempotent_on_a_dataforge_file(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second run must be a no-op, or the fleet churns a .bak on every run."""
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    wf = tmp_path / ".github" / "workflows" / "tests.yaml"
+    wf.write_text(_dataforge_tests_yaml())
+    _cmd_bootstrap(["--resync"])
+    once = wf.read_text()
+    (tmp_path / ".github" / "workflows" / "tests.yaml.bak").unlink()
+    _cmd_bootstrap(["--resync"])
+    assert wf.read_text() == once
+    assert not (tmp_path / ".github" / "workflows" / "tests.yaml.bak").exists()
+
+
+def test_resync_drops_a_redundant_install_app_to_tenant(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Nine repos declared ``install-app-to-tenant: true``, which is the
+    reusable's own default. The line goes; the install does not."""
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    wf = tmp_path / ".github" / "workflows" / "tests.yaml"
+    wf.write_text(
+        render("tests.yaml", app_name="app").replace(
+            '      app-image-name: "atlan-app-app"\n',
+            '      app-image-name: "atlan-app-app"\n'
+            "      # Install the PR-built image before the legs run (FND-128).\n"
+            "      install-app-to-tenant: true\n",
+        )
+    )
+    _cmd_bootstrap(["--resync"])
+    assert "install-app-to-tenant" not in wf.read_text()
+
+
+def test_resync_still_refuses_an_install_app_to_tenant_opt_out(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``false`` is a real opt-out with no slot to carry it, so the refusal
+    must keep the declaration rather than silently re-enabling the install."""
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    wf = tmp_path / ".github" / "workflows" / "tests.yaml"
+    customised = render("tests.yaml", app_name="app").replace(
+        '      app-image-name: "atlan-app-app"\n',
+        '      app-image-name: "atlan-app-app"\n      install-app-to-tenant: false\n',
+    )
+    wf.write_text(customised)
+    _cmd_bootstrap(["--resync"])
+    assert wf.read_text() == customised
+
+
+def test_sdk_install_app_to_tenant_default_matches_the_reusable_workflow() -> None:
+    """``SDK_INSTALL_APP_TO_TENANT_DEFAULT`` must equal the input's own default.
+
+    The whole safety argument for dropping ``install-app-to-tenant: true``
+    rather than slotting it is that the value restates the reusable's default,
+    so deleting it changes nothing. The constant is a copy — this package ships
+    standalone into consumer repos — so it is pinned against the real default
+    here, in the monorepo where both exist. If the SDK ever flips the default to
+    ``false``, this fails here instead of nine repos silently losing their
+    pre-e2e install. Skipped when the monorepo tree isn't checked out, matching
+    the coverage-floor pin above.
+    """
+    workflow = _MONOREPO_ROOT / ".github" / "workflows" / "tests-reusable.yaml"
+    if not workflow.exists():
+        pytest.skip(f"monorepo source not checked out: {workflow}")
+    block = workflow.read_text(encoding="utf-8").split("install-app-to-tenant:", 1)
+    assert len(block) == 2, "tests-reusable.yaml no longer declares the input"
+    m = re.search(r"default:\s*\"?(true|false)\"?", block[1])
+    assert m is not None, "the input no longer declares a boolean default"
+    assert m.group(1) == extract_mod.SDK_INSTALL_APP_TO_TENANT_DEFAULT, (
+        "tests-reusable.yaml's install-app-to-tenant default has moved to "
+        f"{m.group(1)} — update SDK_INSTALL_APP_TO_TENANT_DEFAULT in "
+        "conformance/bootstrap/extract.py, or --resync will keep deleting a "
+        "declaration that is no longer redundant."
+    )
+
+
+def test_every_reusable_input_has_a_slot_or_a_documented_reason() -> None:
+    """The trap FND-1143 closed, pinned so it cannot re-open silently.
+
+    An input the canonical template has no place for freezes any repo that
+    passes it: --resync refuses the whole file (FND-604) and every structural
+    update the template carries is withheld with it. So each of the reusable's
+    inputs must be reachable — through a render param, a dispatch passthrough
+    the template hardcodes, or the one deliberate policy drop. A new input added
+    to tests-reusable.yaml without one lands here, not in a connector's frozen
+    CI.
+    """
+    workflow = _MONOREPO_ROOT / ".github" / "workflows" / "tests-reusable.yaml"
+    if not workflow.exists():
+        pytest.skip(f"monorepo source not checked out: {workflow}")
+    text = workflow.read_text(encoding="utf-8")
+    inputs_block = text.split("    inputs:", 1)[1].split("\n    secrets:", 1)[0]
+    declared = set(re.findall(r"^      ([a-z0-9-]+):$", inputs_block, re.MULTILINE))
+    assert declared, "could not read the reusable's inputs block"
+    # Reachable through a per-repo value slot, verbatim splice, or policy drop.
+    slotted = {field for _, field, _ in extract_mod._TESTS_YAML_VALUE_INPUTS}
+    slotted |= {field for _, field in extract_mod._TESTS_YAML_BLOCK_INPUTS}
+    slotted |= {
+        "app-name",
+        "app-image-name",
+        "enable-e2e",
+        "services-script",
+        "unit-coverage-fail-under",
+        "force-external-runtime",
+        # Hardcoded by the template: forwarded from this workflow's own
+        # workflow_dispatch inputs, or pinned to the SDK posture (two-store).
+        "application-sdk-ref",
+        "distinct-id",
+        "run-e2e",
+        "base-image-ref",
+        "agent-name-override",
+        "e2e-clouds",
+        "two-store",
+        # Policy drop, not a slot — see redundant_install_app_to_tenant.
+        "install-app-to-tenant",
+    }
+    assert declared - slotted == set(), (
+        f"tests-reusable.yaml inputs with no slot in the bootstrap template: "
+        f"{sorted(declared - slotted)} — add one (render param + read-back in "
+        "extract_tests_yaml_params + template line), or any repo that passes "
+        "one is frozen out of every structural CI update."
+    )

--- a/packages/conformance/tests/test_bootstrap_extract.py
+++ b/packages/conformance/tests/test_bootstrap_extract.py
@@ -1120,3 +1120,265 @@ def test_tagged_and_indent_first_scalar_bodies_are_not_mined(header: str) -> Non
     )
     assert declared_keys(text) == ["jobs", "tests", "steps", "run"]
     assert extract_force_external_runtime(text) == ""
+
+
+# ---------------------------------------------------------------------------
+# FND-1143: a slot for every remaining tests-reusable.yaml input
+#
+# The point of these is not that any one input is precious. It is that an input
+# with NO slot freezes the repo that passes it: since FND-604 ``--resync``
+# refuses the whole file rather than delete a declaration it cannot carry, so
+# one unslotted line withholds every structural update the template carries. 25
+# of the fleet's 82 tests.yaml files were in that state, across 13 inputs.
+# ---------------------------------------------------------------------------
+
+
+_FND1143_VALUES: dict[str, tuple[str, str]] = {
+    # param: (the input line as an app hand-wrote it, expected read-back)
+    "timeout_minutes": ("      timeout-minutes: 150", "150"),
+    "apt_packages": (
+        '      apt-packages: "libkrb5-dev gcc python3-dev"',
+        "libkrb5-dev gcc python3-dev",
+    ),
+    "private_git_deps": ("      private-git-deps: true", "true"),
+    "git_lfs_skip_smudge": ("      git-lfs-skip-smudge: true", "true"),
+    "health_check_timeout_seconds": (
+        '      health-check-timeout-seconds: "180"',
+        "180",
+    ),
+    "container_health_timeout_seconds": (
+        '      container-health-timeout-seconds: "240"',
+        "240",
+    ),
+    "runtime_sdk_ref": ('      runtime-sdk-ref: "v3.1.0"', "v3.1.0"),
+    "harness_sdk_ref": ('      harness-sdk-ref: "main"', "main"),
+    "e2e_test_path": (
+        '      e2e-test-path: "tests/e2e/full_dag/"',
+        "tests/e2e/full_dag/",
+    ),
+    "source_available": ("      source-available: false", "false"),
+    "dataforge_datasource": (
+        '      dataforge-datasource: "cosmosnosql"',
+        "cosmosnosql",
+    ),
+    "dataforge_mode": ('      dataforge-mode: "managed"', "managed"),
+    "dataforge_env_tier": ('      dataforge-env-tier: "dev"', "dev"),
+    "dataforge_output_prefix": (
+        '      dataforge-output-prefix: "COSMOSNOSQL"',
+        "COSMOSNOSQL",
+    ),
+    "dataforge_hermetic_fallback": (
+        '      dataforge-hermetic-fallback: "false"',
+        "false",
+    ),
+}
+
+
+def _with_inputs(*lines: str) -> str:
+    """A minimal tests.yaml whose reusable job passes *lines* as its inputs."""
+    body = "".join(f"{line}\n" for line in lines)
+    return f"jobs:\n  tests:\n{_REUSABLE_USES}\n    with:\n{body}"
+
+
+@pytest.mark.parametrize("param", sorted(_FND1143_VALUES))
+def test_fnd1143_value_inputs_read_back(param: str) -> None:
+    """Each new slot's value survives the read the re-render feeds from.
+
+    Written the way an app wrote it — in the quoting the fleet used — rather
+    than by rendering the template back at itself: a fixture rendered from the
+    template would pass on a read-back that only works for the exact bytes it
+    emits, which is the FND-604 ``services-script`` trap.
+    """
+    line, expected = _FND1143_VALUES[param]
+    assert extract_tests_yaml_params(_with_inputs(line))[param] == expected
+
+
+@pytest.mark.parametrize("param", sorted(_FND1143_VALUES))
+def test_fnd1143_value_inputs_round_trip_through_render(param: str) -> None:
+    """Render → read → render must be a fixed point, or the fleet churns a
+    ``.bak`` on every resync."""
+    _, value = _FND1143_VALUES[param]
+    once = render("tests.yaml", app_name="widget", **{param: value})
+    params = extract_tests_yaml_params(once)
+    assert params[param] == value
+    assert render("tests.yaml", **params) == once
+    assert unpreserved_tests_yaml_declarations(once, once) == []
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        '      dataforge-datasource: "oracle"',
+        "      dataforge-datasource: oracle",
+        "      dataforge-datasource: 'oracle'",
+    ],
+    ids=["double", "bare", "single"],
+)
+def test_fnd1143_reads_quoted_and_bare(line: str) -> None:
+    """The fleet hand-wrote these before any slot existed, in whichever
+    spelling — and a read-back that knows one spelling deletes the others
+    (FND-604's third gotcha). The re-render normalises to the canonical
+    quoting: one-time C002 drift, against losing the value.
+    """
+    assert (
+        extract_tests_yaml_params(_with_inputs(line))["dataforge_datasource"]
+        == "oracle"
+    )
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "      timeout-minutes: soon",
+        "      private-git-deps: yes",
+        '      apt-packages: "libkrb5-dev && reboot"',
+        '      e2e-test-path: "tests/e2e/a b"',
+    ],
+    ids=["non-numeric", "non-boolean", "shell-operator", "space"],
+)
+def test_fnd1143_unreadable_values_refuse_rather_than_rewrite(line: str) -> None:
+    """A value the template cannot re-emit faithfully must read as ABSENT.
+
+    Absent routes the declaration to the round-trip guard, which refuses the
+    resync and names it — the safe direction FND-604 established for
+    ``unit-coverage-fail-under: ninety``. The unsafe direction is re-rendering
+    it as some other value: a shell operator carried into an interpolated
+    ``run:`` step, or a path truncated at the first space, neither of which
+    anybody wrote.
+    """
+    text = _with_inputs(line)
+    params = extract_tests_yaml_params(text)
+    key = line.strip().split(":", 1)[0]
+    assert key.replace("-", "_") not in params
+    assert key in unpreserved_tests_yaml_declarations(
+        text, render("tests.yaml", **params)
+    )
+
+
+def test_fnd1143_block_scalar_inputs_are_spliced_verbatim() -> None:
+    """``test-paths`` and ``pytest-args`` are folded scalars in the wild.
+
+    A value-shaped read of one returns the scalar HEADER (``>-``), so both are
+    spliced whole like ``secrets_block``. The folded form is not hypothetical:
+    it is how the repos that scope their integration run wrote it.
+    """
+    test_paths = (
+        "      test-paths: >-\n"
+        "        tests/integration\n"
+        "        tests/e2e/test_miner_extraction"
+    )
+    pytest_args = (
+        "      pytest-args: >-\n"
+        "        -n auto --dist=loadfile --tb=short -m integration"
+    )
+    text = (
+        f"jobs:\n  tests:\n{_REUSABLE_USES}\n    with:\n{test_paths}\n{pytest_args}\n"
+    )
+    params = extract_tests_yaml_params(text)
+    assert params["test_paths_block"] == test_paths
+    assert params["pytest_args_block"] == pytest_args
+    rendered = render("tests.yaml", **params)
+    assert test_paths in rendered
+    assert pytest_args in rendered
+    assert unpreserved_tests_yaml_declarations(text, rendered) == []
+
+
+def test_fnd1143_single_line_test_paths_is_spliced_too() -> None:
+    """One repo wrote the same input as a plain quoted scalar.
+
+    The splice is whole-declaration either way, so both forms are preservable
+    and neither is normalised into the other.
+    """
+    line = '      test-paths: "tests/unit"'
+    params = extract_tests_yaml_params(_with_inputs(line))
+    assert params["test_paths_block"] == line
+    assert line in render("tests.yaml", **params)
+
+
+def test_fnd1143_a_value_input_written_as_a_block_scalar_refuses() -> None:
+    """The header-as-value corruption, guarded on the inputs that are NOT
+    spliced: reading ``>-`` back as the value would render
+    ``apt-packages: ">-"``, which the job's own package-name allowlist then
+    fails on."""
+    text = _with_inputs("      apt-packages: >-", "        libkrb5-dev gcc")
+    params = extract_tests_yaml_params(text)
+    assert "apt_packages" not in params
+    assert "apt-packages" in unpreserved_tests_yaml_declarations(
+        text, render("tests.yaml", **params)
+    )
+
+
+def test_fnd1143_ignores_an_input_of_another_job() -> None:
+    """Same scoping as ``force-external-runtime``: hoisting a match from an
+    unrelated job into the rendered ``with:`` passes an input nobody declared —
+    here a dataforge fetch, and with it a VPN dial, on a repo that never asked
+    for one."""
+    text = (
+        "jobs:\n"
+        "  docs:\n"
+        "    uses: ./.github/workflows/docs.yaml\n"
+        "    with:\n"
+        '      dataforge-datasource: "oracle"\n'
+        f"  tests:\n{_REUSABLE_USES}\n"
+        "    with:\n"
+        '      app-name: "widget"\n'
+    )
+    assert "dataforge_datasource" not in extract_tests_yaml_params(text)
+
+
+def test_fnd1143_ignores_a_nested_key_of_the_same_name() -> None:
+    """Only DIRECT children of ``with:`` are inputs the job passes. A key
+    nested inside another input's value is part of that value."""
+    text = _with_inputs(
+        '      app-name: "widget"',
+        "      some-mapping:",
+        "        timeout-minutes: 999",
+    )
+    assert "timeout_minutes" not in extract_tests_yaml_params(text)
+
+
+def test_fnd1143_ignores_a_commented_input() -> None:
+    """A commented line is documentation. Reading it back activates an input
+    the repo deliberately left off — and for ``dataforge-datasource`` that
+    means dialling the VPN on every e2e leg."""
+    text = _with_inputs(
+        '      app-name: "widget"',
+        '      # dataforge-datasource: "oracle"',
+    )
+    assert "dataforge_datasource" not in extract_tests_yaml_params(text)
+
+
+# --- install-app-to-tenant: the one input that got a policy drop, not a slot -
+
+
+def test_redundant_install_app_to_tenant_is_dropped_not_refused() -> None:
+    """All nine repos that declared it passed ``true``, which is the reusable's
+    own default — so a slot would bake a no-op line into nine canonical files
+    while a refusal keeps them frozen out of every structural update. Dropping
+    it changes no behaviour and un-freezes them in one resync."""
+    text = _with_inputs('      app-name: "widget"', "      install-app-to-tenant: true")
+    assert extract_mod.redundant_install_app_to_tenant(text) == "true"
+    params = extract_tests_yaml_params(text)
+    rendered = render("tests.yaml", **params)
+    assert "install-app-to-tenant" not in rendered
+    assert unpreserved_tests_yaml_declarations(text, rendered) == []
+
+
+@pytest.mark.parametrize(
+    "value", ["false", "TRUE", "maybe"], ids=["opt-out", "shouting", "garbage"]
+)
+def test_non_default_install_app_to_tenant_still_refuses(value: str) -> None:
+    """The drop is conditioned on the VALUE, not the key.
+
+    An explicit ``false`` is a real opt-out with no slot to carry it, so it must
+    reach the refusal and keep its declaration; a value that is not a boolean at
+    all is not a decision anyone made.
+    """
+    text = _with_inputs(
+        '      app-name: "widget"', f"      install-app-to-tenant: {value}"
+    )
+    assert extract_mod.redundant_install_app_to_tenant(text) == ""
+    rendered = render("tests.yaml", **extract_tests_yaml_params(text))
+    assert "install-app-to-tenant" in unpreserved_tests_yaml_declarations(
+        text, rendered
+    )


### PR DESCRIPTION
Closes FND-1143.

## The problem

An input that the canonical `tests.yaml` template has no place for does not merely go unsupported — it **freezes the repo that passes it**. Since FND-604, `bootstrap --resync` refuses the whole file rather than delete a declaration it cannot carry, so one unslotted line withholds every structural update the template carries with it. On `atlan-postgres-app` that was `merge_group:` and the `labeled` trigger type, and a required check that never dispatches for `merge_group` leaves the merge-queue entry pending until it times out.

The refusal message reads as "these two lines were skipped". The actual cost is the whole file's catch-up.

## What the audit found

FND-1143 was filed about the five `dataforge-*` inputs. Reading every app repo's real `tests.yaml` showed the same trap open on **13 inputs**, freezing **25 of the 82** files — the per-repo roster is on the issue.

Two findings changed the plan:

- **Dataforge is not being retired for callers.** Every repo that sets `dataforge-hermetic-fallback` sets it `"false"`, which is what makes an unresolved source *fail* the integration tier instead of passing it green against no source at all. So: add slots (option 1 on the issue), don't deprecate.
- **`install-app-to-tenant` needed no slot**, confirming the issue's own read. Every declaration of it was `true`, which is the reusable's own default.

## What this does

**A slot for all 17 remaining inputs**, in one `<% endif %><% if … %>` chain between `app-image-name` and the `enable-e2e` block — including the four nobody has declared yet, so the next repo to need one does not re-open the trap. The chain emits nothing when every value is empty, so the no-override render stays **byte-identical** and no already-bootstrapped repo picks up C002 drift for this.

**`test-paths` and `pytest-args` are verbatim splices**, like `secrets_block`: both are written as `>-` folded scalars in the wild, and a value-shaped read of one returns the scalar *header*. Every other value is gated on a shape check — a value the template cannot re-emit faithfully reads as **absent**, which routes it to the round-trip guard's refusal rather than re-rendering something nobody wrote.

**`install-app-to-tenant` gets a policy drop**, the second after a sub-floor `unit-coverage-fail-under`. `--resync` now deletes the redundant line. The drop is conditioned on the *value* — an explicit `false` is a real opt-out and still refuses — and `SDK_INSTALL_APP_TO_TENANT_DEFAULT` is pinned against the reusable's own input default, so flipping that default fails a test here rather than costing nine repos their pre-e2e install.

**A regression test asserts every input `tests-reusable.yaml` declares is reachable** through a slot, a hardcoded passthrough, or the one policy drop. A new input added without one fails in this repo instead of silently freezing a connector's CI months later.

## Verification

- Replayed every app repo's real `tests.yaml` through extract → render → `unpreserved_tests_yaml_declarations`: **3 refusals, down from 25**. All three remaining carry whole hand-written extra jobs — a different, already-known refusal class, out of scope here.
- The no-override render is byte-identical to `main`'s, diffed against `git show main:` for the template.
- Full conformance suite green: 3521 passed, 1 xfailed. `pre-commit` clean.

## Reviewer notes

No behaviour change for a repo that declares none of these inputs — that render is byte-for-byte what it was. For a repo that does declare one, the first `--resync` will reposition the line to the canonical slot and normalise its quoting, and drop the surrounding hand-written comment into the `.bak`: one-time C002 drift, against a file that could never be resynced at all.

Nothing here touches a workflow, a permission, or a credential path; the template's `permissions:` block and the reusable itself are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TnnbVkjnhvryUF6Rhzusz
