### PR TITLE
ci(renovate): allow contract_schema.lock.json through the Renovate approval gate

### DIFF
--- a/.github/scripts/renovate_approval_conditions.py
+++ b/.github/scripts/renovate_approval_conditions.py
@@ -102,6 +102,18 @@ DOT_GITHUB_PREFIX = ".github/"
 #: at the repo root, so an unrelated app.yaml/atlan.yaml elsewhere in a consumer
 #: tree must NOT ride this gate. They are otherwise a deterministic function of
 #: the contract and the (already auto-merged) toolkit version.
+#:
+#: contract_schema.lock.json is here on that same argument, and is ROOT-ONLY for
+#: the same reason: renovate-contract-ledger resolves it as ``repo / NAME`` and
+#: writes nowhere else. The conformance lane regenerates it in-branch (FND-607)
+#: so a release that adds a contract-base field cannot red B006 on the very PR
+#: adopting that release. Without this entry the lane's own self-healing step is
+#: what disqualifies it: the PR reads as non-dependency-only, the atlan-ci
+#: approval is withheld, and the one lane whose job is to propagate fleet policy
+#: is the one that needs a human. It carries no reviewable content of its own —
+#: content is a function of the version this PR locks, the generator is the
+#: SDK's own pinned driver, and the append-only invariant is enforced
+#: independently by B005, so a removal cannot be laundered through this gate.
 DEP_FILE_RE = (
     r"(.*/)?uv\.lock"
     r"|(.*/)?package-lock\.json"
@@ -112,6 +124,7 @@ DEP_FILE_RE = (
     r"|app/generated/.*"
     r"|atlan\.yaml"
     r"|app\.yaml"
+    r"|contract_schema\.lock\.json"
 )
 
 APPROVAL_BODY = (

--- a/.github/scripts/tests/test_renovate_approval_conditions.py
+++ b/.github/scripts/tests/test_renovate_approval_conditions.py
@@ -274,6 +274,7 @@ class TestDepFileAllowlist:
             "app/generated/nested/deep.pkl",
             "atlan.yaml",
             "app.yaml",
+            "contract_schema.lock.json",
         ],
     )
     def test_dependency_paths_are_allowed(self, path):
@@ -299,13 +300,27 @@ class TestDepFileAllowlist:
         assert gate.non_dep_files([path]) == [path]
 
     @pytest.mark.parametrize(
-        "path", ["sub/atlan.yaml", "sub/app.yaml", "x/app/generated/a.pkl"]
+        "path",
+        [
+            "sub/atlan.yaml",
+            "sub/app.yaml",
+            "x/app/generated/a.pkl",
+            "sub/contract_schema.lock.json",
+        ],
     )
     def test_generated_artifacts_are_root_only(self, path):
-        # renovate-pkl-sync only ever writes these at the repo root. An
-        # unrelated app.yaml/atlan.yaml elsewhere in a consumer tree is ordinary
-        # source and must not ride this gate.
+        # renovate-pkl-sync and renovate-contract-ledger only ever write these
+        # at the repo root. An unrelated app.yaml/atlan.yaml/ledger elsewhere in
+        # a consumer tree is ordinary source and must not ride this gate.
         assert gate.non_dep_files([path]) == [path]
+
+    def test_conformance_lane_diff_is_dep_only(self):
+        # The exact shape the conformance-package lane produces: the lock plus
+        # the ledger its own postUpgradeTask regenerates (FND-607). Before
+        # contract_schema.lock.json joined the allowlist this read as
+        # non-dependency-only, so the lane never earned its atlan-ci approval.
+        files = ["uv.lock", "contract_schema.lock.json"]
+        assert gate.non_dep_files(files) == []
 
     def test_one_bad_file_among_many_good_ones_is_reported(self):
         files = ["uv.lock", "pyproject.toml", "application_sdk/foo.py"]


### PR DESCRIPTION
## What

Adds `contract_schema.lock.json` to `DEP_FILE_RE` in `.github/scripts/renovate_approval_conditions.py`, so the conformance-package Renovate lane can earn its atlan-ci code-owner approval.

## Why

Found while investigating why a conformance bump on a fleet repo was sitting unmerged. The approval gate skipped it outright:

```
--- Evaluating PR #117 ---
PR #117: contains non-dependency files:
  contract_schema.lock.json
Skipping.
```

The conformance lane regenerates `contract_schema.lock.json` in-branch via the `renovate-contract-ledger` postUpgradeTask (FND-607), precisely so a conformance release that adds a contract-base field cannot red B006 on the very PR adopting that release. But the file was absent from the gate's dependency-only allowlist, so the PR read as non-dependency-only and the approval was withheld — the lane's own self-healing step was what disqualified it, leaving the one lane whose job is to propagate fleet policy needing a human in every repo.

## Notes on the entry

- **Root-only**, no `(.*/)?` prefix — mirroring the `atlan.yaml` / `app.yaml` reasoning already documented there. `renovate-contract-ledger` resolves the path as `repo / LEDGER_NAME` and writes nowhere else, so an unrelated ledger elsewhere in a consumer tree must not ride the gate.
- It carries no reviewable content of its own: content is a function of the conformance version the PR locks, the generator is the SDK's own pinned driver, and the append-only invariant is enforced independently by B005 — so a removal cannot be laundered through this gate.

## Not in scope

Auto-merge on the PR that surfaced this is *proximately* blocked by something else, which this change does not address: a duplicate `conventional-commits / Validate PR title` check run with conclusion `cancelled` on the head SHA, left behind when Renovate's reopen plus two force-pushes tripped that workflow's `cancel-in-progress` concurrency group 5s apart on the same SHA. GitHub ignores it (not a required context; `mergeStateStatus` is `CLEAN`) but Renovate scans every check run and maps `cancelled` to yellow, so it logs `PR is not ready for merge (branch status is yellow)`. Tracked in FND-1870.

## Testing

```
uv run pytest .github/scripts/tests/test_renovate_approval_conditions.py -q   # 131 passed
uv run pre-commit run --files <both changed files>                            # all passed, pyright included
```

Three test additions: the path in `test_dependency_paths_are_allowed`, `sub/contract_schema.lock.json` in `test_generated_artifacts_are_root_only`, and a new `test_conformance_lane_diff_is_dep_only` pinning the exact lane diff shape (`uv.lock` + the ledger) that used to fail.

Closes FND-1870

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFeanM9HmSZjYDpgd4LRK4
