### PR TITLE
ci: stop transient infra failures from failing the Security Gate

### DIFF
--- a/.github/actions/build-app-image/action.yaml
+++ b/.github/actions/build-app-image/action.yaml
@@ -358,12 +358,15 @@ runs:
         # compose file as a pull target). --load would conflict with
         # --push under the standard buildx driver, and we don't need
         # the image in the local daemon since compose handles the pull.
+        #
+        # `ignore-error=true` on the cache export: see build-and-scan.yaml — a
+        # cache-service hiccup must not fail a build.
         docker buildx build \
           --tag "${IMAGE}" \
           --push \
           "${BUILD_ARGS[@]}" \
           --cache-from "type=gha,scope=sdr-${{ inputs.app-name }}${{ inputs.tag-suffix }}" \
-          --cache-to "type=gha,mode=max,scope=sdr-${{ inputs.app-name }}${{ inputs.tag-suffix }}" \
+          --cache-to "type=gha,mode=max,scope=sdr-${{ inputs.app-name }}${{ inputs.tag-suffix }},ignore-error=true" \
           .
         echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
         echo "image_base=${IMAGE_BASE}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/secure-build-push-apps/action.yaml
+++ b/.github/actions/secure-build-push-apps/action.yaml
@@ -43,7 +43,8 @@ inputs:
   cache-to:
     description: 'List of cache export destinations.'
     required: false
-    default: 'type=gha,mode=min'
+    # `ignore-error=true`: see build-and-scan.yaml — a cache-service hiccup must not fail a build.
+    default: 'type=gha,mode=min,ignore-error=true'
   cgroup-parent:
     description: 'Optional parent cgroup for the container.'
     required: false

--- a/.github/actions/trivy-container/action.yaml
+++ b/.github/actions/trivy-container/action.yaml
@@ -62,7 +62,8 @@ runs:
         load: true
         tags: trivy-scan-target:latest
         cache-from: type=gha
-        cache-to: type=gha,mode=max
+        # `ignore-error=true`: see build-and-scan.yaml — a cache-service hiccup must not fail a build.
+        cache-to: type=gha,mode=max,ignore-error=true
         secrets: |
           "PRIVATE_REPO_ACCESS_TOKEN=${{ inputs.github-token }}"
 

--- a/.github/scripts/check_allowlist.py
+++ b/.github/scripts/check_allowlist.py
@@ -6,6 +6,9 @@ Usage:
 
 Environment:
     FAIL_ON_FINDINGS  "true" (default) to exit 1 on blockers; "false" for warning only.
+    BUILD_RESULT      Result of the upstream image-build job, for diagnosing a
+                      missing results file. Optional.
+    SCAN_RESULT       Result of the upstream scan job, same purpose. Optional.
 """
 
 import argparse
@@ -13,6 +16,35 @@ import json
 import os
 import sys
 from datetime import datetime
+
+
+def missing_results_reason(build_result: str, scan_result: str) -> str:
+    """Name the upstream job that actually caused a missing results file.
+
+    This gate is the required check, so its log is where anyone debugging a red
+    PR lands first — and on its own it can only report that the file is absent,
+    which reads as a scanner problem no matter what really broke. Three
+    different transient failures (a build-cache write, a deleted PR merge ref,
+    an artifact-service 403) have all surfaced here as the same line. So the
+    upstream outcomes are passed in, and the cause is named.
+    """
+    if not build_result and not scan_result:
+        return "Cause: unknown — no upstream job results were passed to this check."
+    if build_result not in ("", "success", "skipped"):
+        return (
+            f"Cause: the image build did not succeed (result: {build_result}), so "
+            "nothing was ever scanned. Read that job's log, not this one."
+        )
+    if scan_result not in ("", "success"):
+        return (
+            f"Cause: the scan job did not succeed (result: {scan_result}). Read "
+            "that job's log, not this one."
+        )
+    return (
+        "Cause: every upstream job succeeded, so the results were produced and "
+        "the download of them failed twice. That is the artifact service, not "
+        "this change — re-run this job."
+    )
 
 
 def main() -> None:
@@ -67,8 +99,12 @@ def main() -> None:
                     }
                     trivy_count += 1
     except FileNotFoundError:
+        print(f"Error: Trivy results not found at {args.trivy_results}")
         print(
-            f"Error: Trivy results not found at {args.trivy_results} — scan may have failed"
+            missing_results_reason(
+                os.environ.get("BUILD_RESULT", ""),
+                os.environ.get("SCAN_RESULT", ""),
+            )
         )
         sys.exit(1)
     except json.JSONDecodeError as e:

--- a/.github/scripts/tests/test_artifact_download_retry.py
+++ b/.github/scripts/tests/test_artifact_download_retry.py
@@ -1,0 +1,443 @@
+"""Cross-file guard: artifact downloads on gating paths must retry.
+
+The sibling guard for uploads covers the artifact service failing to *finalize*.
+This one covers the other end of the same wire: `download-artifact` asking the
+service for the run's artifacts and getting
+
+    Failed to ListArtifacts: Received non-retryable error:
+    Failed request: (403) Forbidden: Error from intermediary
+
+The bytes are intact and the artifact is listed in the run — the step even
+prints its id, size and digest immediately before failing. `download-artifact`
+classifies the 403 as non-retryable and gives up on the first occurrence, so a
+gating job dies on a flake that a second attempt absorbs. Observed on an app
+repo's Security Gate, a required check, where it stalled an otherwise
+auto-mergeable PR until someone re-ran the job by hand.
+
+This guard reads the workflow and composite-action YAML directly rather than
+trusting a checked-in list, so a newly added download step fails here instead of
+silently reintroducing the flake.
+
+What counts as a retry
+----------------------
+Structure, never the step's name. A retry is an `actions/download-artifact` step
+whose `if:` is guarded on `steps.<id>.outcome == 'failure'` where `<id>` is
+another download step **in the same job or composite**, and which fetches the
+same artifact selector into the same path. A companion that guards on the right
+outcome but fetches something else, or is not a download at all, does not
+satisfy the pairing.
+
+Where this differs from the upload guard
+----------------------------------------
+A retried *upload* must take a DISTINCT name: a failed finalize leaves an
+invisible record holding the name for the rest of the run, so a same-named
+retry 409s. Nothing equivalent happens on a download — a failed read burns
+nothing — so the retry here reuses the first attempt's selector, and reusing it
+is what this guard requires. The two rules look contradictory side by side and
+are not; they are about opposite ends of the same call.
+
+The backoff is shared, though: the 403 comes from an intermediary having a
+moment, and a retry firing a second later lands inside the same window.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+DOWNLOAD_ACTION = "actions/download-artifact"
+
+# `steps.<id>.outcome == 'failure'` — the only shape that makes a step a retry.
+OUTCOME_GUARD_RE = re.compile(r"steps\.([A-Za-z0-9_-]+)\.outcome\s*==\s*'failure'")
+
+# Workflow/action YAML this guard cannot parse. Must shrink, never grow.
+UNPARSEABLE: set[str] = set()
+
+# Downloads that do NOT need retry hardening, each with the reason it is exempt.
+# Keyed by (path suffix, artifact selector) so an exemption cannot silently
+# widen to other downloads added to the same file later.
+EXEMPT = {
+    (
+        "workflows/tests-reusable.yaml",
+        "sdr-integration-tests-${{ inputs.app-name }}*-results*",
+    ): "evidence for a report, not a gate; the job already tolerates a miss",
+    (
+        "workflows/tests-reusable.yaml",
+        "unit-test-coverage*",
+    ): "scorecard evidence; a miss degrades the report and gates nothing",
+    (
+        "workflows/tests-reusable.yaml",
+        "integration-test-results*",
+    ): "scorecard evidence; a miss degrades the report and gates nothing",
+    (
+        "workflows/conformance-upload-sarif.yaml",
+        "conformance-${{ matrix.slug }}-sarif*",
+    ): "workflow_run consumer; nothing gates on it and there is no queue entry to eject",
+}
+
+
+def _yaml_files() -> list[Path]:
+    files = sorted((ROOT / "workflows").glob("*.y*ml"))
+    files += sorted((ROOT / "actions").glob("*/action.y*ml"))
+    return files
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(ROOT))
+
+
+def _unparseable() -> set[str]:
+    broken = set()
+    for path in _yaml_files():
+        try:
+            yaml.safe_load(path.read_text())
+        except yaml.YAMLError:
+            broken.add(_rel(path))
+    return broken
+
+
+def _scopes_from_doc(rel: str, doc: dict) -> list[tuple[str, str, list[dict]]]:
+    """(file, scope, steps) per job and per composite `runs` block.
+
+    Scoping matters: `steps.<id>` only resolves within one job, so a retry in a
+    *different* job of the same file must not satisfy another job's pairing.
+    """
+    scopes: list[tuple[str, str, list[dict]]] = []
+    for job_id, job in (doc.get("jobs") or {}).items():
+        if isinstance(job, dict):
+            steps = [s for s in (job.get("steps") or []) if isinstance(s, dict)]
+            if steps:
+                scopes.append((rel, f"job {job_id}", steps))
+    runs = doc.get("runs") or {}
+    if isinstance(runs, dict):
+        steps = [s for s in (runs.get("steps") or []) if isinstance(s, dict)]
+        if steps:
+            scopes.append((rel, "composite runs", steps))
+    return scopes
+
+
+def _scopes() -> list[tuple[str, str, list[dict]]]:
+    scopes: list[tuple[str, str, list[dict]]] = []
+    for path in _yaml_files():
+        rel = _rel(path)
+        if rel in UNPARSEABLE:
+            continue
+        try:
+            doc = yaml.safe_load(path.read_text())
+        except yaml.YAMLError as exc:
+            pytest.fail(
+                f"{rel} is not valid YAML ({exc.__class__.__name__}) and is not "
+                f"in UNPARSEABLE: {exc}"
+            )
+        if not isinstance(doc, dict):
+            continue
+        scopes.extend(_scopes_from_doc(rel, doc))
+    return scopes
+
+
+def _is_download(step: dict) -> bool:
+    return DOWNLOAD_ACTION in str(step.get("uses", ""))
+
+
+def _with(step: dict) -> dict:
+    value = step.get("with")
+    return value if isinstance(value, dict) else {}
+
+
+def _selector(step: dict) -> str:
+    """What the step asks the service for: a `pattern` glob or a bare `name`."""
+    inputs = _with(step)
+    return str(inputs.get("pattern") or inputs.get("name") or "")
+
+
+def _target_path(step: dict) -> str:
+    return str(_with(step).get("path", ""))
+
+
+def _retry_target(step: dict) -> str | None:
+    """The step id this download claims to retry, or None if it guards on nothing."""
+    match = OUTCOME_GUARD_RE.search(str(step.get("if", "")))
+    return match.group(1) if match else None
+
+
+def _classify(steps: list[dict]) -> tuple[list[dict], dict[str, list[dict]]]:
+    """Split a scope's downloads into (first_attempts, retries_by_target_id).
+
+    A retry must guard on the outcome of another *download* step in this same
+    scope. A download guarded on some non-download step's outcome is treated as
+    a first attempt, so it still has to prove it has a retry of its own.
+    """
+    downloads = [s for s in steps if _is_download(s)]
+    download_ids = {s.get("id") for s in downloads if s.get("id")}
+
+    retries: dict[str, list[dict]] = {}
+    first_attempts: list[dict] = []
+    for step in downloads:
+        target = _retry_target(step)
+        if target and target in download_ids:
+            retries.setdefault(target, []).append(step)
+        else:
+            first_attempts.append(step)
+    return first_attempts, retries
+
+
+def _live_first_attempts() -> list[tuple[str, str, dict, dict[str, list[dict]]]]:
+    """Every non-exempt first-attempt download, with its scope's retry index."""
+    live = []
+    for rel, scope, steps in _scopes():
+        first_attempts, retries = _classify(steps)
+        for step in first_attempts:
+            if (rel, _selector(step)) in EXEMPT:
+                continue
+            live.append((rel, scope, step, retries))
+    return live
+
+
+def _label(rel: str, scope: str, step: dict) -> str:
+    return f"{rel} [{scope}] '{step.get('name') or step.get('uses')}'"
+
+
+def _guards_on(step: dict, step_id: str) -> bool:
+    return step_id in OUTCOME_GUARD_RE.findall(str(step.get("if", "")))
+
+
+def test_no_new_unparseable_workflow_yaml():
+    """Quarantine must shrink, never grow. An unparseable workflow is invisible
+    to this guard — and GitHub cannot run it either."""
+    broken = _unparseable()
+    assert broken <= UNPARSEABLE, (
+        "New unparseable workflow/action YAML (GitHub will fail these runs and no "
+        f"guard can inspect them): {sorted(broken - UNPARSEABLE)}"
+    )
+    fixed = sorted(UNPARSEABLE - broken)
+    assert not fixed, (
+        f"{fixed} now parses — remove it from UNPARSEABLE so its steps start "
+        f"being guarded."
+    )
+
+
+def test_the_guard_actually_finds_downloads_and_retries():
+    """A scan that silently matched nothing would pass every assertion below.
+
+    Asserts on both halves: if retry classification broke, `retries` would empty
+    out while `first_attempts` grew, and the pairing test would then be
+    asserting over the wrong set.
+    """
+    scopes = _scopes()
+    assert len(scopes) > 50, "scope discovery collapsed"
+
+    total_first, total_retries = 0, 0
+    for _, _, steps in scopes:
+        first_attempts, retries = _classify(steps)
+        total_first += len(first_attempts)
+        total_retries += sum(len(v) for v in retries.values())
+    assert total_first >= 7, f"only {total_first} first-attempt downloads found"
+    assert total_retries >= 3, f"only {total_retries} retry downloads found"
+
+
+def test_every_gating_download_has_a_matching_retry_download():
+    """The retry must be a real download of the same artifact, in the same scope."""
+    problems = []
+    for rel, scope, step, retries in _live_first_attempts():
+        where = _label(rel, scope, step)
+        step_id = step.get("id")
+        if not step_id:
+            problems.append(f"{where}: no `id`, so nothing can guard a retry on it")
+            continue
+
+        companions = retries.get(step_id, [])
+        if not companions:
+            problems.append(
+                f"{where}: no `{DOWNLOAD_ACTION}` step in this scope is guarded on "
+                f"steps.{step_id}.outcome == 'failure'"
+            )
+            continue
+
+        for companion in companions:
+            if companion is step:
+                problems.append(f"{where}: a step cannot be its own retry")
+                continue
+            if _selector(companion) != _selector(step):
+                problems.append(
+                    f"{where}: its retry fetches '{_selector(companion)}', not "
+                    f"'{_selector(step)}' — so it is not a retry of this download"
+                )
+            if _target_path(companion) != _target_path(step):
+                problems.append(
+                    f"{where}: its retry unpacks to a different path "
+                    f"({_target_path(companion)!r} != {_target_path(step)!r})"
+                )
+
+    assert not problems, (
+        "Every artifact download on a gating path needs a companion "
+        f"`{DOWNLOAD_ACTION}` step, in the same job/composite, guarded on the "
+        "first attempt's outcome and fetching the same selector into the same "
+        "path (see build-and-scan.yaml for the pattern) — or an EXEMPT entry "
+        "with a reason:\n  " + "\n  ".join(problems)
+    )
+
+
+def test_first_attempt_never_fails_the_job_before_the_retry_runs():
+    """Without continue-on-error the job dies and the retry never executes."""
+    bad = [
+        _label(rel, scope, step)
+        for rel, scope, step, _ in _live_first_attempts()
+        if step.get("continue-on-error") is not True
+    ]
+    assert not bad, (
+        "The first download attempt must set `continue-on-error: true`, otherwise "
+        "the job fails before its retry can run:\n  " + "\n  ".join(bad)
+    )
+
+
+def test_every_retry_waits_before_it_runs():
+    """The 403 comes from an intermediary having a moment. A retry firing a
+    second after the first attempt lands in the same window and both fail
+    together — which is the one case that still reddens the job."""
+    problems = []
+    for rel, scope, steps in _scopes():
+        _, retries = _classify(steps)
+        for target_id, companions in retries.items():
+            waits = [
+                s
+                for s in steps
+                if "run" in s
+                and "sleep" in str(s.get("run", ""))
+                and _guards_on(s, target_id)
+            ]
+            if not waits:
+                for companion in companions:
+                    problems.append(
+                        f"{_label(rel, scope, companion)}: no `run: sleep …` step "
+                        f"guarded on steps.{target_id}.outcome == 'failure'"
+                    )
+    assert not problems, (
+        "Each retry needs a backoff step ahead of it, guarded on the same "
+        "outcome as the retry itself:\n  " + "\n  ".join(problems)
+    )
+
+
+def test_a_retry_is_not_identified_by_its_name():
+    """Regression: naming a step '(retry)' must not exempt it from validation.
+
+    Synthesised rather than read off disk, because the point is what the
+    classifier does with a shape the repo should never contain.
+    """
+    steps = [
+        {
+            "name": "Download something (retry)",
+            "uses": f"{DOWNLOAD_ACTION}@v8",
+            "with": {"pattern": "thing*", "path": "/tmp"},
+        }
+    ]
+    first_attempts, retries = _classify(steps)
+    assert not retries, "a name substring must not make a step a retry"
+    assert len(first_attempts) == 1, (
+        "a step named '(retry)' with no outcome guard is an unretried first "
+        "attempt and must still be validated"
+    )
+
+
+def test_a_companion_guarded_on_a_non_download_step_is_not_a_retry():
+    """Regression: the guard must require the retry to be a download of its own."""
+    steps = [
+        {"id": "prep", "name": "Prep", "run": "make"},
+        {
+            "id": "download",
+            "name": "Download",
+            "continue-on-error": True,
+            "uses": f"{DOWNLOAD_ACTION}@v8",
+            "with": {"pattern": "thing*", "path": "/tmp"},
+        },
+        {
+            # Guards on the right outcome but is not a download at all.
+            "name": "Tell someone it failed",
+            "if": "steps.download.outcome == 'failure'",
+            "run": "echo oh no",
+        },
+    ]
+    first_attempts, retries = _classify(steps)
+    assert [s["id"] for s in first_attempts] == ["download"]
+    assert not retries, "a non-download step must not count as the retry"
+
+
+def test_a_companion_fetching_a_different_artifact_is_not_a_retry():
+    """The pairing is on the artifact, not merely on the outcome guard.
+
+    Two unrelated downloads in one job, the second guarded on the first's
+    failure, would otherwise read as a retry and leave the first unhardened.
+    """
+    steps = [
+        {
+            "id": "download",
+            "name": "Download the image",
+            "continue-on-error": True,
+            "uses": f"{DOWNLOAD_ACTION}@v8",
+            "with": {"pattern": "docker-image*", "path": "/tmp"},
+        },
+        {
+            "name": "Download the fallback bundle",
+            "if": "steps.download.outcome == 'failure'",
+            "uses": f"{DOWNLOAD_ACTION}@v8",
+            "with": {"pattern": "something-else*", "path": "/tmp"},
+        },
+    ]
+    first_attempts, retries = _classify(steps)
+    companion = retries["download"][0]
+    assert _selector(companion) != _selector(
+        first_attempts[0]
+    ), "the fixture must differ in selector, or it proves nothing"
+
+
+def test_a_retry_in_another_job_does_not_satisfy_the_pairing():
+    """`steps.<id>` only resolves within one job, so a retry in a sibling job is
+    not a retry at all — it would reference an id that does not exist there."""
+    doc = {
+        "jobs": {
+            "scanner": {
+                "steps": [
+                    {
+                        "id": "download",
+                        "name": "Download",
+                        "continue-on-error": True,
+                        "uses": f"{DOWNLOAD_ACTION}@v8",
+                        "with": {"pattern": "thing*", "path": "/tmp"},
+                    }
+                ]
+            },
+            "elsewhere": {
+                "steps": [
+                    {
+                        "name": "Download (retry)",
+                        "if": "steps.download.outcome == 'failure'",
+                        "uses": f"{DOWNLOAD_ACTION}@v8",
+                        "with": {"pattern": "thing*", "path": "/tmp"},
+                    }
+                ]
+            },
+        }
+    }
+    scopes = _scopes_from_doc("synthetic.yaml", doc)
+    assert len(scopes) == 2, "jobs must be separate scopes"
+
+    by_scope = {scope: _classify(steps) for _, scope, steps in scopes}
+    scanner_first, scanner_retries = by_scope["job scanner"]
+    assert [s["id"] for s in scanner_first] == ["download"]
+    assert not scanner_retries
+    other_first, other_retries = by_scope["job elsewhere"]
+    assert len(other_first) == 1
+    assert not other_retries
+
+
+def test_exemptions_still_point_at_real_downloads():
+    """A stale exemption would silently excuse a file that no longer downloads."""
+    live = set()
+    for rel, _, steps in _scopes():
+        first_attempts, _ = _classify(steps)
+        live.update((rel, _selector(s)) for s in first_attempts)
+    stale = sorted(set(EXEMPT) - live)
+    assert not stale, f"EXEMPT entries no longer match any download step: {stale}"

--- a/.github/scripts/tests/test_build_app_image_action.py
+++ b/.github/scripts/tests/test_build_app_image_action.py
@@ -411,9 +411,12 @@ def test_pkl_is_downloaded_for_the_runners_architecture() -> None:
 
 def test_buildx_cache_scope_is_unchanged() -> None:
     text = _BUILD_ACTION.read_text(encoding="utf-8")
-    # `[^"]` rather than `\S`: the scope interpolates `${{ inputs.app-name }}`,
-    # which contains spaces.
-    scopes = set(re.findall(r"scope=([^\"]+)\"", text))
+    # `[^",]` rather than `\S`: the scope interpolates `${{ inputs.app-name }}`,
+    # which contains spaces — but it must still stop at the comma, because the
+    # cache spec is a CSV of attributes and `scope` is only one of them. Reading
+    # to the closing quote instead swept a later attribute into the "scope" and
+    # reported a change the build never made.
+    scopes = set(re.findall(r"scope=([^\",]+)", text))
     expected = "sdr-${{ inputs.app-name }}${{ inputs.tag-suffix }}"
     assert scopes == {expected}, (
         f"buildx cache scope changed to {scopes}. The scope was `sdr-<app-name>` "
@@ -437,9 +440,12 @@ def test_buildx_cache_scope_is_unchanged() -> None:
         "every run, a ~2 minute regression per leg that no assertion would "
         "otherwise catch."
     )
-    assert f'--cache-to "type=gha,mode=max,scope={expected}"' in text, (
-        "the `--cache-to` line was removed (or `mode=max` was dropped). Builds "
-        "would never write the cache, so every leg goes cold on the next run."
+    assert (
+        f'--cache-to "type=gha,mode=max,scope={expected},ignore-error=true"' in text
+    ), (
+        "the `--cache-to` line was removed, or `mode=max` or `ignore-error=true` "
+        "was dropped. Without the first two every leg goes cold on the next run; "
+        "without the third a cache-service write failure fails the build itself."
     )
 
 

--- a/.github/scripts/tests/test_check_allowlist.py
+++ b/.github/scripts/tests/test_check_allowlist.py
@@ -10,6 +10,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -259,7 +260,12 @@ class TestMissingResultsReason:
 
     def test_two_green_upstream_jobs_point_at_the_artifact_service(self) -> None:
         """Both jobs green and no results means the download failed twice —
-        the one case where re-running this job alone is the right move."""
+        the one case where re-running this job alone is the right move.
+
+        Load-bearing premise: a green upstream job proves the artifact was
+        published. That holds only while neither upload can fail silently, which
+        `TestUpstreamResultsAreTruthful` below pins in the workflow itself.
+        """
         reason = check_allowlist.missing_results_reason("success", "success")
         assert "artifact service" in reason
         assert "re-run" in reason
@@ -293,3 +299,57 @@ class TestMissingResultsReason:
                 check_allowlist.main()
         assert exc.value.code != 0
         assert "image build" in capsys.readouterr().out
+
+
+class TestUpstreamResultsAreTruthful:
+    """Cross-file: the workflow must not hand this script a lying job result.
+
+    `missing_results_reason` reads a green upstream job as proof that job
+    published its artifact, and says so — "the results were produced and the
+    download of them failed twice … re-run this job." An upload retry marked
+    `continue-on-error` breaks that: a double finalize-403 leaves the producing
+    job green with nothing published, and the gate then blames the download and
+    advises re-running itself, which can never find an artifact the run never
+    created. A fourth transient failure, wearing a confidently wrong name, in
+    the function written to stop exactly that.
+
+    `trivy-scan` shipped that way, on the reasoning that the gate downloads with
+    `continue-on-error` so nothing needed to fail at the upload. The gate fails
+    regardless when the results are absent; all the tolerance bought was the
+    wrong diagnosis.
+    """
+
+    GATING_JOBS = ("build", "trivy-scan")
+
+    def _upload_retries(self, job_id: str) -> list[dict[str, Any]]:
+        workflow = (
+            Path(__file__).resolve().parents[2] / "workflows" / "build-and-scan.yaml"
+        )
+        job = yaml.safe_load(workflow.read_text())["jobs"][job_id]
+        return [
+            step
+            for step in job["steps"]
+            if "actions/upload-artifact" in str(step.get("uses", ""))
+            and "outcome" in str(step.get("if", ""))
+        ]
+
+    @pytest.mark.parametrize("job_id", GATING_JOBS)
+    def test_the_guard_finds_the_retry_it_is_meant_to_check(self, job_id: str) -> None:
+        assert self._upload_retries(job_id), (
+            f"no upload retry found in `{job_id}` — the discovery below matched "
+            "nothing and would pass vacuously"
+        )
+
+    @pytest.mark.parametrize("job_id", GATING_JOBS)
+    def test_no_gating_upload_retry_swallows_its_own_failure(self, job_id: str) -> None:
+        swallowed = [
+            step.get("name")
+            for step in self._upload_retries(job_id)
+            if step.get("continue-on-error") is True
+        ]
+        assert not swallowed, (
+            f"`{job_id}` would stay green with no artifact published: {swallowed}. "
+            "Its result is read as proof the artifact exists — either drop "
+            "`continue-on-error`, or stop `missing_results_reason` treating this "
+            "job's success as publication."
+        )

--- a/.github/scripts/tests/test_check_allowlist.py
+++ b/.github/scripts/tests/test_check_allowlist.py
@@ -233,3 +233,63 @@ class TestGateEdgeCases:
                 check_allowlist.main()
             except SystemExit:
                 pass  # exit code behaviour with LOW is acceptable either way
+
+
+class TestMissingResultsReason:
+    """The gate is the required check, so its log is where anyone debugging a
+    red PR lands. Three unrelated transient failures — a build-cache write, a
+    deleted PR merge ref, an artifact-service 403 — all surface here as the same
+    absent file, so the message has to name which upstream job caused it."""
+
+    def test_a_failed_build_is_named_rather_than_the_scanner(self) -> None:
+        reason = check_allowlist.missing_results_reason("failure", "skipped")
+        assert "image build" in reason
+        assert "failure" in reason
+
+    def test_a_skipped_build_is_not_treated_as_the_cause(self) -> None:
+        """`build` is skipped whenever a prebuilt image is supplied. That is the
+        normal path, not a failure, so it must not shadow the real cause."""
+        reason = check_allowlist.missing_results_reason("skipped", "failure")
+        assert "scan job" in reason
+        assert "image build" not in reason
+
+    def test_a_failed_scan_is_named_when_the_build_succeeded(self) -> None:
+        reason = check_allowlist.missing_results_reason("success", "failure")
+        assert "scan job" in reason
+
+    def test_two_green_upstream_jobs_point_at_the_artifact_service(self) -> None:
+        """Both jobs green and no results means the download failed twice —
+        the one case where re-running this job alone is the right move."""
+        reason = check_allowlist.missing_results_reason("success", "success")
+        assert "artifact service" in reason
+        assert "re-run" in reason
+
+    def test_absent_env_does_not_claim_the_upstream_was_green(self) -> None:
+        """Run outside CI the outcomes are unset, and guessing 'everything
+        succeeded' would send the reader to the artifact service for a cause
+        this check cannot see."""
+        reason = check_allowlist.missing_results_reason("", "")
+        assert "unknown" in reason
+        assert "artifact service" not in reason
+
+    def test_the_reason_is_printed_when_results_are_missing(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """End to end: the env the workflow sets reaches the printed message."""
+        sdk_sec = tmp_path / "_sdk" / ".security"
+        sdk_sec.mkdir(parents=True)
+        (sdk_sec / "base-allowlist.json").write_text(json.dumps({}))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("BUILD_RESULT", "failure")
+        monkeypatch.setenv("SCAN_RESULT", "skipped")
+        with patch(
+            "sys.argv",
+            ["check_allowlist.py", "--trivy-results", str(tmp_path / "missing.json")],
+        ):
+            with pytest.raises(SystemExit) as exc:
+                check_allowlist.main()
+        assert exc.value.code != 0
+        assert "image build" in capsys.readouterr().out

--- a/.github/scripts/tests/test_endor_scan_prep.py
+++ b/.github/scripts/tests/test_endor_scan_prep.py
@@ -261,28 +261,29 @@ def test_caller_ref_travels_through_env():
 
 def test_endor_scan_consumes_the_retry_artifact_like_trivy_does():
     """The CI finding: the build job's first upload is continue-on-error and its
-    retry lands as `docker-image-retry`. A bare `name:` misses it silently."""
+    retry lands as `docker-image-retry`. A bare `name:` misses it silently.
+
+    Asserted over EVERY download attempt in both jobs, not just the first: the
+    download is itself retried now, and a retry that reverted to a bare `name:`
+    would reintroduce the miss in precisely the case the retry exists for.
+    """
     downloads = {
         job_id: [
             s
             for s in _steps(_job(BUILD_AND_SCAN, job_id))
             if "actions/download-artifact" in str(s.get("uses", ""))
-            and "docker-image" in str((s.get("with") or {}).get("pattern", ""))
         ]
         for job_id in ("trivy-scan", "endor-scan")
     }
-    assert len(downloads["endor-scan"]) == 1, "endor-scan must download the image"
-    endor = downloads["endor-scan"][0]["with"]
-    assert endor.get("pattern") == "docker-image*"
-    assert endor.get("merge-multiple") is True
-    assert "name" not in endor
-    # Same shape as Trivy so the two consumers cannot drift apart.
+    assert downloads["endor-scan"], "endor-scan must download the image"
     assert downloads["trivy-scan"], "reference Trivy download disappeared"
-    trivy = downloads["trivy-scan"][0]["with"]
-    assert (trivy["pattern"], trivy["merge-multiple"]) == (
-        endor["pattern"],
-        endor["merge-multiple"],
-    )
+    # Same shape in both, so the two consumers cannot drift apart.
+    for job_id, steps in downloads.items():
+        for step in steps:
+            with_block = step.get("with") or {}
+            assert with_block.get("pattern") == "docker-image*", job_id
+            assert with_block.get("merge-multiple") is True, job_id
+            assert "name" not in with_block, job_id
 
 
 def test_endor_scan_script_checkout_is_provenance_pinned():

--- a/.github/scripts/tests/test_gha_cache_export_ignores_errors.py
+++ b/.github/scripts/tests/test_gha_cache_export_ignores_errors.py
@@ -1,0 +1,130 @@
+"""Cross-file guard: a GitHub Actions cache export must never fail a build.
+
+BuildKit's `type=gha` cache exporter writes layer blobs to the Actions cache
+service at the end of a build. That service intermittently refuses the write:
+
+    #15 ERROR: error writing layer blob: failed to reserve cache
+    ERROR: failed to build: failed to solve: error writing layer blob:
+           failed to reserve cache
+
+By default buildx treats that as a build failure, so a transient on a *cache
+write* — after the image has already been built — reddens whatever check the
+build feeds. On `build-and-scan.yaml` that check is the Security Gate, which is
+required on every baselined app repo, so the flake parks an otherwise
+auto-mergeable PR until a human re-runs the job.
+
+`ignore-error=true` on the export is the whole fix: the cache is an
+optimisation, and losing an entry costs a slower build, never a red one. It has
+no effect on `cache-from` — a read miss is already non-fatal — so this guard
+deliberately covers exports only.
+
+Discovery is textual rather than YAML-structural because the exports are not all
+in the same shape: most are a `cache-to:` key on `docker/build-push-action`, one
+is a `--cache-to` flag inside a `run:` block, and one is the `default:` of a
+composite action's `cache-to` input. A structural walk would miss the last two.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+GHA_CACHE = "type=gha"
+IGNORE_ERROR = "ignore-error=true"
+
+
+def _yaml_files() -> list[Path]:
+    files = sorted((ROOT / "workflows").glob("*.y*ml"))
+    files += sorted((ROOT / "actions").glob("*/action.y*ml"))
+    return files
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(ROOT))
+
+
+def is_cache_export(line: str) -> bool:
+    """Is this line configuring a gha cache EXPORT (as opposed to an import)?
+
+    Two independent signals, either of which is enough:
+
+    * the line names `cache-to` — the explicit form, whether as a YAML key or a
+      `--cache-to` flag; or
+    * the line carries `mode=`, which only an export accepts. This is what
+      catches the shape with no `cache-to` on it at all: a composite action's
+      `default: 'type=gha,mode=min'`, which is an export destination named
+      several lines above the value.
+
+    Neither fires on an import: `cache-from: type=gha,scope=x` has no `mode=`
+    and does not say `cache-to`.
+
+    Comment lines are prose about the exporter, not the exporter — and the
+    surrounding files explain this setting at length, so matching them would
+    make the guard fail on its own rationale.
+    """
+    if GHA_CACHE not in line:
+        return False
+    if line.lstrip().startswith("#"):
+        return False
+    return "cache-to" in line or "mode=" in line
+
+
+def _exports() -> list[tuple[str, int, str]]:
+    found = []
+    for path in _yaml_files():
+        for number, line in enumerate(path.read_text().splitlines(), start=1):
+            if is_cache_export(line):
+                found.append((_rel(path), number, line.strip()))
+    return found
+
+
+def test_the_guard_actually_finds_cache_exports():
+    """A scan that silently matched nothing would pass the assertion below."""
+    exports = _exports()
+    assert (
+        len(exports) >= 8
+    ), f"cache-export discovery collapsed — found only {len(exports)}: {exports}"
+
+
+def test_every_gha_cache_export_ignores_errors():
+    bad = [
+        f"{rel}:{number}  {line}"
+        for rel, number, line in _exports()
+        if IGNORE_ERROR not in line
+    ]
+    assert not bad, (
+        f"Every `{GHA_CACHE}` cache export must carry `{IGNORE_ERROR}`, so a "
+        "cache-service write failure degrades the build instead of failing "
+        "it:\n  " + "\n  ".join(bad)
+    )
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "          cache-to: type=gha,mode=max,scope=scan,ignore-error=true",
+        '          --cache-to "type=gha,mode=max,scope=sdr-app,ignore-error=true" \\',
+        "    default: 'type=gha,mode=min,ignore-error=true'",
+    ],
+)
+def test_the_matcher_recognises_an_export(line: str):
+    assert is_cache_export(line)
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "          cache-from: type=gha,scope=${{ matrix.platform }}",
+        "          cache-from: type=gha",
+        '          --cache-from "type=gha,scope=sdr-app" \\',
+        "    default: 'type=gha'",
+        "          cache-to: ${{ inputs.cache-to }}",  # indirection, not a gha value
+        "        cache-to: type=registry,ref=example.com/cache",  # not the gha exporter
+        "        # `cache-from/cache-to: type=gha` plugs buildx into the cache",
+        "          # cache-to: type=gha,mode=max  (disabled for now)",
+    ],
+)
+def test_the_matcher_ignores_a_non_gha_export_or_an_import(line: str):
+    assert not is_cache_export(line)

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -1273,7 +1273,8 @@ jobs:
           build-contexts: ${{ needs.prepare.outputs.base_build_contexts }}
           tags: ${{ needs.prepare.outputs.ghcr_base }}:${{ needs.prepare.outputs.branch }}-${{ needs.prepare.outputs.image_tag }}-${{ matrix.arch }}
           cache-from: type=gha,scope=${{ matrix.platform }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          # `ignore-error=true`: see build-and-scan.yaml — a cache-service hiccup must not fail a build.
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }},ignore-error=true
           provenance: false
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}

--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -324,8 +324,16 @@ jobs:
       # non-retryable and fails on the first occurrence, even though the bytes
       # already landed and the next attempt normally succeeds. That failed the
       # job, which failed the aggregate gate, which ejected the merge-queue
-      # entry. So: retry once, and never fail the gate on it:
-      # the consumer already downloads this with continue-on-error.
+      # entry. So: retry once.
+      #
+      # The retry is NOT continue-on-error, matching the build job above. It was,
+      # on the reasoning that the gate downloads with continue-on-error so
+      # nothing needed to fail here. But the gate fails anyway when the results
+      # are absent, and a green `trivy-scan` then told it the artifact HAD been
+      # published — so it blamed the download and advised re-running itself,
+      # which could never find an artifact this run never created. This job's
+      # result has to be a truthful proxy for "the results exist", because
+      # `check_allowlist.py` reads it as exactly that.
       - name: Upload Trivy results
         id: upload-trivy
         continue-on-error: true
@@ -350,7 +358,6 @@ jobs:
 
       - name: Upload Trivy results (retry)
         if: steps.upload-trivy.outcome == 'failure'
-        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           # A DISTINCT name, never the first attempt's: a FinalizeArtifact

--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -94,7 +94,28 @@ jobs:
     outputs:
       scan_image: ${{ steps.meta.outputs.scan_image }}
     steps:
+      # On a pull_request `github.ref` is `refs/pull/N/merge`, a ref GitHub
+      # DELETES and recreates every time it recomputes mergeability — which the
+      # base branch merely moving is enough to trigger. Checkout's own three
+      # attempts span about 30s and can sit entirely inside that window, so the
+      # job dies with `couldn't find remote ref refs/pull/N/merge`, and the gate
+      # then reports a missing scan rather than the checkout that caused it.
+      # Every observed instance has been on a Renovate branch, where the base
+      # moves constantly. So: absorb one recompute.
       - name: Checkout
+        id: checkout
+        continue-on-error: true
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          lfs: ${{ inputs.lfs }}
+
+      - name: Wait before the checkout retry
+        if: steps.checkout.outcome == 'failure'
+        run: sleep 20
+
+      - name: Checkout (retry)
+        if: steps.checkout.outcome == 'failure'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -131,7 +152,11 @@ jobs:
           tags: ${{ steps.meta.outputs.scan_image }}
           outputs: type=docker,dest=/tmp/image.tar
           cache-from: type=gha,scope=scan
-          cache-to: type=gha,mode=max,scope=scan
+          # `ignore-error=true` because the cache is an optimisation and this
+          # is a gate. Without it a transient `failed to reserve cache` from the
+          # Actions cache service fails the export, fails the build, and fails
+          # the required check on a change that never touched the image.
+          cache-to: type=gha,mode=max,scope=scan,ignore-error=true
           provenance: false
           # The org PAT reaches the build ONLY as a BuildKit secret, never as a
           # build arg. Build args are recorded in image config and are readable
@@ -201,7 +226,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # Retried for the same reason the uploads are, one layer down: the
+      # artifact service answers `ListArtifacts` with a 403 from an intermediary
+      # often enough to matter, `download-artifact` classifies that as
+      # non-retryable and gives up on the first occurrence, and the bytes are
+      # sitting there intact the whole time. Unlike an upload retry this one can
+      # reuse the first attempt's pattern — a failed download burns no name.
       - name: Download image artifact
+        id: download-image
+        continue-on-error: true
         if: inputs.image == ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -215,6 +248,20 @@ jobs:
           # there, publish `docker-image-retry`, and leave two live image.tars
           # for merge-multiple to flatten in undefined order — Trivy could then
           # scan the previous attempt's image.
+          pattern: docker-image*
+          merge-multiple: true
+          path: /tmp
+
+      - name: Wait before the download retry
+        if: steps.download-image.outcome == 'failure'
+        run: sleep 20
+
+      # No continue-on-error: if the image cannot be fetched twice there is
+      # nothing to scan, and failing here says exactly that.
+      - name: Download image artifact (retry)
+        if: steps.download-image.outcome == 'failure'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
           pattern: docker-image*
           merge-multiple: true
           path: /tmp
@@ -376,7 +423,21 @@ jobs:
       # retry left this job with no tarball -- and, being continue-on-error
       # itself, it failed silently: Trivy still gated, Endor just never reported.
       - name: Download image artifact
+        id: download-image
+        continue-on-error: true
         if: steps.creds.outputs.configured == 'true' && inputs.image == ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: docker-image*
+          merge-multiple: true
+          path: /tmp
+
+      - name: Wait before the download retry
+        if: steps.download-image.outcome == 'failure'
+        run: sleep 20
+
+      - name: Download image artifact (retry)
+        if: steps.download-image.outcome == 'failure'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: docker-image*
@@ -474,7 +535,10 @@ jobs:
   # ── Security Gate — check Trivy results against allowlist ───────────────────
   security-gate:
     name: Security Gate
-    needs: [trivy-scan]
+    # `build` is in `needs` only so the gate can name which upstream job failed
+    # when there are no results to gate on. It is skipped when `image` is
+    # supplied, which the `always()` below tolerates.
+    needs: [build, trivy-scan]
     if: always() && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -500,7 +564,12 @@ jobs:
           path: _sdk
           token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
 
+      # Both attempts stay continue-on-error: this job is the required check, so
+      # a raw `Unable to download artifact(s)` here would be the whole story a
+      # reader gets. Let the allowlist check below fail instead — it is handed
+      # the upstream outcomes and can say which job actually broke.
       - name: Download Trivy results
+        id: download-trivy
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         continue-on-error: true
         with:
@@ -511,9 +580,30 @@ jobs:
           merge-multiple: true
           path: /tmp
 
+      # Also gated on the scan having succeeded. Absent results are the NORMAL
+      # outcome when it did not, and there the first attempt has already told
+      # the truth — retrying would only add 20s of sleep to every genuinely
+      # broken run before the gate gets to say what broke.
+      - name: Wait before the download retry
+        if: steps.download-trivy.outcome == 'failure' && needs['trivy-scan'].result == 'success'
+        run: sleep 20
+
+      - name: Download Trivy results (retry)
+        if: steps.download-trivy.outcome == 'failure' && needs['trivy-scan'].result == 'success'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        continue-on-error: true
+        with:
+          pattern: trivy-results*
+          merge-multiple: true
+          path: /tmp
+
       - name: Check against allowlist
         env:
           FAIL_ON_FINDINGS: ${{ inputs.fail_on_findings }}
+          # So a missing results file can name the job that caused it instead of
+          # sending every reader to the scanner.
+          BUILD_RESULT: ${{ needs.build.result }}
+          SCAN_RESULT: ${{ needs['trivy-scan'].result }}
         run: python3 _sdk/.github/scripts/check_allowlist.py --trivy-results /tmp/trivy_results.json --write-comment
 
       - name: Comment on PR

--- a/.github/workflows/build-apps-image.yaml
+++ b/.github/workflows/build-apps-image.yaml
@@ -208,7 +208,8 @@ jobs:
           tags: ${{ needs.prepare.outputs.ghcr_base }}:${{ needs.prepare.outputs.branch }}-${{ needs.prepare.outputs.image_tag }}-${{ matrix.arch }}
           # Scoped cache — prevents amd64 and arm64 from overwriting each other's cache entries
           cache-from: type=gha,scope=${{ matrix.platform }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          # `ignore-error=true`: see build-and-scan.yaml — a cache-service hiccup must not fail a build.
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }},ignore-error=true
           provenance: false  # skip SLSA provenance attestation — reduces push time per arch
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -120,7 +120,8 @@ jobs:
           # action's own default: this change is about where the build runs, not
           # about how much of it is cached.
           cache-from: type=gha,scope=${{ matrix.platform }}
-          cache-to: type=gha,mode=min,scope=${{ matrix.platform }}
+          # `ignore-error=true`: see build-and-scan.yaml — a cache-service hiccup must not fail a build.
+          cache-to: type=gha,mode=min,scope=${{ matrix.platform }},ignore-error=true
           # Arch-suffixed — merged into the real tag by merge-ghcr below.
           tags: |
             ghcr.io/atlanhq/app-runtime-base-${{ needs.prepare.outputs.lowercase_branch }}:sha-${{ needs.prepare.outputs.sha }}-${{ matrix.arch }}

--- a/.github/workflows/harbor-release.yaml
+++ b/.github/workflows/harbor-release.yaml
@@ -153,7 +153,8 @@ jobs:
           # time. `mode=min` matches the action's own default: this change is
           # about where the build runs, not about how much of it is cached.
           cache-from: type=gha,scope=${{ matrix.platform }}
-          cache-to: type=gha,mode=min,scope=${{ matrix.platform }}
+          # `ignore-error=true`: see build-and-scan.yaml — a cache-service hiccup must not fail a build.
+          cache-to: type=gha,mode=min,scope=${{ matrix.platform }},ignore-error=true
           tags: ${{ needs.prepare.outputs.staging_base }}:sha-${{ needs.prepare.outputs.sha }}-${{ matrix.arch }}
           github-token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
         env:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -335,7 +335,8 @@ jobs:
           # legs just go cold forever. Same trap tag-suffix closes for the app
           # image build.
           cache-from: type=gha,scope=sdk-base-${{ matrix.arch }}
-          cache-to: type=gha,mode=min,scope=sdk-base-${{ matrix.arch }}
+          # `ignore-error=true`: see build-and-scan.yaml — a cache-service hiccup must not fail a build.
+          cache-to: type=gha,mode=min,scope=sdk-base-${{ matrix.arch }},ignore-error=true
           github-token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
         env:
           DOCKER_CLIENT_TIMEOUT: 600


### PR DESCRIPTION
Closes FND-1869.

The `Security Gate` job is a required check on every baselined app repo. It has been going red on infrastructure noise, and because a re-run always clears it, each occurrence parks an otherwise auto-mergeable PR until a human notices and clicks the button.

## What was actually happening

Three failures in one app repo inside 48 hours — every one a different transient cause, and every one reported identically as `Trivy results not found`:

| Real cause | Where |
|---|---|
| `buildx`: `error writing layer blob: failed to reserve cache` | Actions cache service |
| `actions/checkout`: `couldn't find remote ref refs/pull/N/merge` | merge ref recomputed under a moving base |
| `download-artifact`: `Failed to ListArtifacts: (403) Forbidden: Error from intermediary` | artifact service |

All three on Renovate branches, where the base moves constantly. #3711 hardened the artifact **upload** against the finalize 403; none of these are that failure.

## Changes

**1. Cache exports no longer fail builds.** `ignore-error=true` on all eight `type=gha` cache exports — three shapes: a `cache-to:` key on `build-push-action`, a `--cache-to` flag inside a `run:` block, and the `default:` of a composite action's `cache-to` input. The Security Gate is where this was noticed, but `pull_request.yaml`'s sdk-base build had the same exposure on the same PR path.

**2. Artifact downloads retry.** Three sites in `build-and-scan.yaml` (`trivy-scan` → image, `endor-scan` → image, `security-gate` → results). Same `id` / `continue-on-error` / `sleep 20` / second-attempt shape as the upload retry.

The download retry reuses the first attempt's selector, where an upload retry must **not** reuse its name. That is not an inconsistency: a failed *finalize* leaves an invisible record holding the artifact name for the rest of the run, so a same-named upload retry 409s; a failed *read* burns nothing. Both rules are spelled out in the guards so the next reader doesn't collapse one into the other.

**3. Checkout absorbs one merge-ref recompute.** `github.ref` on a `pull_request` is `refs/pull/N/merge`, which GitHub deletes and recreates whenever it recomputes mergeability — the base branch moving is enough. Checkout's own three attempts span ~30s and can sit entirely inside that window.

**4. The gate names the real cause.** `security-gate` takes `build` into `needs` purely to hand `check_allowlist.py` the upstream outcomes, so a red gate says which job actually broke instead of sending every reader to the scanner.

## What this deliberately does not do

Make `security-gate` skippable when there are no results. It is a required context, and one that never reports stalls a PR harder than a red one does. Fail-closed stays; the work is removing the causes and making the message honest.

## Tests

- `test_artifact_download_retry.py` (new, 10 tests) — sibling to the upload guard. Discovers every `download-artifact` step in the repo; each on a gating path must be retry-paired in its own scope with a backoff, or carry an `EXEMPT` entry with a reason. Four report-only downloads are exempted.
- `test_gha_cache_export_ignores_errors.py` (new, 13 tests) — every `type=gha` export must carry `ignore-error=true`. Matches textually, because a structural YAML walk sees only one of the three shapes.
- Six tests on the new `missing_results_reason`, including that an unset environment does not claim the upstream was green.
- `test_endor_scan_prep.py`'s download-shape guard rewritten from "exactly one download step" to "every download attempt globs" — stronger, and it survives the retry.

## Blast radius

Callers pin this reusable at `@main`, so merging makes the fix live across the fleet with no per-repo change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XvX5TANmUvmrogx7T45m8
