### PR TITLE
feat(worker): hold a restarted worker back, and only when something is coming

### DIFF
--- a/application_sdk/common/restart_marker.py
+++ b/application_sdk/common/restart_marker.py
@@ -24,11 +24,12 @@ absent one is reported rather than worked around: on a container filesystem the
 marker would be discarded with every restart, so nothing would ever be detected
 and nothing would say why.
 
-Detection always runs and always logs. Waiting happens only when
-``ATLAN_DIRTY_RESTART_IDLE_MAX_SECONDS`` is a positive number, so a fleet can be
-observed before its behaviour changes. Every failure path falls through to a
-normal start: an absent or unreadable directory, a corrupt marker, anything
-raised while setting up the wait.
+The volume is the switch. Without it nothing is detected and nothing waits, so
+the behaviour arrives with the deployment that mounts it rather than with an
+upgrade of this package. ``ATLAN_DIRTY_RESTART_IDLE_MAX_SECONDS`` sizes the wait
+and ``0`` turns it off where the volume is mounted. Every failure path falls
+through to a normal start: an absent or unreadable directory, a corrupt marker,
+anything raised while setting up the wait.
 """
 
 from __future__ import annotations
@@ -39,7 +40,7 @@ import os
 import time
 from pathlib import Path
 
-from application_sdk.common._env import env_int
+from application_sdk.constants import DIRTY_RESTART_IDLE_MAX_SECONDS
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -52,9 +53,6 @@ MARKER_NAME = "worker.json"
 #: Creating this file ends a wait early, for an operator who knows the pod is
 #: not going to be replaced.
 RELEASE_NAME = "resume"
-
-#: How long a restarted worker waits before polling anyway. 0 disables waiting.
-MAX_WAIT_SECONDS_ENV = "ATLAN_DIRTY_RESTART_IDLE_MAX_SECONDS"
 
 #: One row a minute while waiting, so a waiting pod is visible in logs without
 #: the wait itself becoming log volume.
@@ -173,12 +171,13 @@ async def wait_if_pod_restarted(shutdown_event: asyncio.Event) -> None:
         restarted_count + 1,
     )
 
-    budget = max(0, env_int(MAX_WAIT_SECONDS_ENV, 0))
+    budget = DIRTY_RESTART_IDLE_MAX_SECONDS
     if budget <= 0:
         # A zero budget would fall straight through the wait below, but silently
-        # and after announcing a wait of 0s. Say which knob is unset instead.
+        # and after announcing a wait of 0s. Say it is switched off instead.
         logger.warning(
-            "%s is not set, so this worker starts polling anyway", MAX_WAIT_SECONDS_ENV
+            "waiting is switched off (ATLAN_DIRTY_RESTART_IDLE_MAX_SECONDS=0), so this "
+            "worker starts polling anyway"
         )
         return
 

--- a/application_sdk/common/restart_marker.py
+++ b/application_sdk/common/restart_marker.py
@@ -94,10 +94,18 @@ def check_and_update_the_marker() -> int:
 
     path = directory / MARKER_NAME
     restarted_count = 0
+    raw = ""
     try:
         raw = path.read_text()
     except FileNotFoundError:
-        raw = ""  # a fresh pod, not an error - and it still needs its marker
+        pass  # a fresh pod, not an error - and it still needs its marker
+    except UnicodeDecodeError:
+        # The read reached the file, so a marker is there; only its bytes are
+        # unusable. Presence is the signal, so this is a restart. Falling through
+        # also replaces the file, which an early return would leave in place for
+        # every later start to trip over.
+        logger.warning("%s is not valid UTF-8; treating it as one start", path)
+        restarted_count = 1
     except OSError:
         logger.warning(
             "could not read %s, so this start is treated as clean", path, exc_info=True

--- a/application_sdk/common/restart_marker.py
+++ b/application_sdk/common/restart_marker.py
@@ -94,18 +94,20 @@ def check_and_update_the_marker() -> int:
 
     path = directory / MARKER_NAME
     restarted_count = 0
-    raw = ""
     try:
         raw = path.read_text()
     except FileNotFoundError:
-        pass  # a fresh pod, not an error - and it still needs its marker
+        raw = ""  # a fresh pod, not an error - and it still needs its marker
     except UnicodeDecodeError:
         # The read reached the file, so a marker is there; only its bytes are
         # unusable. Presence is the signal, so this is a restart. Falling through
         # also replaces the file, which an early return would leave in place for
         # every later start to trip over.
-        logger.warning("%s is not valid UTF-8; treating it as one start", path)
+        raw = ""
         restarted_count = 1
+        logger.warning(
+            "%s is not valid UTF-8; treating it as one start", path, exc_info=True
+        )
     except OSError:
         logger.warning(
             "could not read %s, so this start is treated as clean", path, exc_info=True
@@ -119,7 +121,9 @@ def check_and_update_the_marker() -> int:
             # Truncated or hand-edited. The file existing is the signal; only the
             # count is lost, and one is the answer that changes behaviour.
             logger.warning(
-                "%s is not readable as a marker; treating it as one start", path
+                "%s is not readable as a marker; treating it as one start",
+                path,
+                exc_info=True,
             )
             restarted_count = 1
 
@@ -146,7 +150,7 @@ def clear() -> None:
     try:
         path.unlink()
     except FileNotFoundError:
-        pass  # the worker may return before ever writing one
+        logger.debug("no marker at %s to remove; nothing wrote one", path)
     except OSError:
         logger.warning(
             "could not remove %s, so the next container start in this pod will be "
@@ -228,8 +232,8 @@ async def wait_for_pod_to_get_replaced(
             await asyncio.wait_for(
                 shutdown_event.wait(), timeout=min(RECHECK_SECONDS, remaining)
             )
-        except TimeoutError:
-            pass  # nobody asked us to stop; keep waiting
+        except TimeoutError:  # conformance: ignore[E002] the timeout is the sleep expiring, not a failure: it fires every RECHECK_SECONDS for the whole wait and means nobody asked us to stop
+            pass
         else:
             logger.info(
                 "shutdown requested while waiting, which is this pod being replaced"

--- a/application_sdk/common/restart_marker.py
+++ b/application_sdk/common/restart_marker.py
@@ -1,0 +1,232 @@
+"""Pod-scoped record of whether this container start is a restart.
+
+Written by the worker on its first start in a pod and removed when it returns
+cleanly, so an abnormal exit is what leaves it behind. A later container start in
+the same pod finds it there and knows it is a restart.
+
+A container that exceeds its memory limit is killed by the kernel and restarted
+by the kubelet *inside the same pod*, and a pod's resource spec is immutable for
+its lifetime - so the container comes back on the limit that just killed it.
+Something outside has to replace the pod before the memory can change. Until it
+does, a restarted worker that resumes polling takes work straight back onto a
+pod that cannot hold it, and the retries cannot succeed. So a restarted worker
+waits instead of polling, for a bounded time, and resumes either way.
+
+Written at birth, not at death: under cgroup v2 ``memory.oom.group=1`` the kernel
+kills every process in the container's cgroup, PID 1 included, so no handler
+runs. Recording the start and clearing it on a clean return inverts that into
+something always observable.
+
+The marker lives on a small memory-backed ``emptyDir``, whose lifetime is the
+pod's: contents survive every container restart and vanish with the pod. Nothing
+here creates that directory - it exists only if the volume is mounted, and an
+absent one is reported rather than worked around: on a container filesystem the
+marker would be discarded with every restart, so nothing would ever be detected
+and nothing would say why.
+
+Detection always runs and always logs. Waiting happens only when
+``ATLAN_DIRTY_RESTART_IDLE_MAX_SECONDS`` is a positive number, so a fleet can be
+observed before its behaviour changes. Every failure path falls through to a
+normal start: an absent or unreadable directory, a corrupt marker, anything
+raised while setting up the wait.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+
+from application_sdk.common._env import env_int
+from application_sdk.observability.logger_adaptor import get_logger
+
+logger = get_logger(__name__)
+
+#: Directory holding the marker. A memory-backed ``emptyDir`` in the chart.
+MARKER_DIR_ENV = "ATLAN_RESTART_MARKER_DIR"
+DEFAULT_MARKER_DIR = "/run/atlan"
+MARKER_NAME = "worker.json"
+
+#: Creating this file ends a wait early, for an operator who knows the pod is
+#: not going to be replaced.
+RELEASE_NAME = "resume"
+
+#: How long a restarted worker waits before polling anyway. 0 disables waiting.
+IDLE_MAX_SECONDS_ENV = "ATLAN_DIRTY_RESTART_IDLE_MAX_SECONDS"
+
+#: One row a minute while waiting, so a waiting pod is visible in logs without
+#: the wait itself becoming log volume.
+IDLE_HEARTBEAT_SECONDS = 60
+
+#: How often the wait re-checks the release file.
+_IDLE_POLL_SECONDS = 5
+
+
+def marker_dir() -> Path:
+    return Path(os.getenv(MARKER_DIR_ENV) or DEFAULT_MARKER_DIR)
+
+
+def idle_max_seconds() -> int:
+    """Seconds a restarted worker waits before polling anyway. 0 disables it."""
+    return max(0, env_int(IDLE_MAX_SECONDS_ENV, 0))
+
+
+def begin() -> int:
+    """Record this container start; return how many started before it in this pod.
+
+    0 means a clean pod, or that detection is inert. Anything above 0 means an
+    earlier container here started and did not return cleanly.
+    """
+    directory = marker_dir()
+    if not directory.is_dir():
+        # Saying so is the whole point of this branch: without the volume the
+        # writes below fail anyway and detection is inert either way, but
+        # silently. This is the only thing that says why.
+        logger.warning(
+            "%s is not a directory, so a restarted worker cannot be told apart from a "
+            "fresh one and this worker will always poll immediately. Mount a small "
+            "memory-backed emptyDir there to enable it.",
+            directory,
+        )
+        return 0
+
+    path = directory / MARKER_NAME
+    starts = 0
+    try:
+        raw = path.read_text()
+    except FileNotFoundError:
+        raw = ""
+    except OSError:
+        logger.warning(
+            "could not read %s, so this start is treated as clean", path, exc_info=True
+        )
+        return 0
+
+    if raw:
+        try:
+            starts = max(0, int(json.loads(raw).get("starts", 0)))
+        except (ValueError, TypeError, AttributeError):
+            # Truncated or hand-edited. Its existence is the signal; only the
+            # count is lost, and one is the answer that changes behaviour.
+            logger.warning(
+                "%s is not readable as a marker; treating it as one start", path
+            )
+            starts = 1
+
+    try:
+        path.write_text(
+            json.dumps(
+                {
+                    "pod": os.getenv("K8S_POD_NAME", ""),
+                    "starts": starts + 1,
+                    "started_at": time.time(),
+                }
+            )
+        )
+    except OSError:
+        # The count is already known; losing the write costs the next start's
+        # count, not this decision.
+        logger.warning("could not write %s", path, exc_info=True)
+
+    return starts
+
+
+def end() -> None:
+    """Clear the marker after a clean return, so the next start is not a restart."""
+    path = marker_dir() / MARKER_NAME
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        logger.warning(
+            "could not remove %s, so the next container start in this pod will be "
+            "treated as a restart",
+            path,
+            exc_info=True,
+        )
+
+
+async def wait_if_restarted(shutdown_event: asyncio.Event) -> None:
+    """Hold a restarted worker back before it starts polling.
+
+    Call this after the health server is serving and signal handlers are
+    installed, and before anything builds a worker: the process is up and
+    answering probes while it waits, but it has no pollers.
+
+    Returns when the worker should proceed. A shutdown requested while waiting
+    also returns; the caller sees it on ``shutdown_event`` as it would anywhere
+    else.
+    """
+    starts = begin()
+    if starts == 0:
+        logger.debug("clean container start in this pod")
+        return
+
+    logger.warning(
+        "this is container start %d in this pod - an earlier one did not return cleanly. "
+        "A container killed for memory restarts here on the same limit, so polling now "
+        "would take work back onto a pod that cannot hold it.",
+        starts + 1,
+    )
+
+    budget = idle_max_seconds()
+    if budget <= 0:
+        # A zero budget would fall straight through the wait below, but silently
+        # and after announcing a wait of 0s. Say which knob is unset instead.
+        logger.warning(
+            "%s is not set, so this worker starts polling anyway", IDLE_MAX_SECONDS_ENV
+        )
+        return
+
+    try:
+        await _wait(shutdown_event, budget)
+    except Exception:
+        logger.exception("could not hold this worker back; starting it normally")
+
+
+async def _wait(shutdown_event: asyncio.Event, budget: int) -> None:
+    """The bounded wait. Three exits: released, shutdown, or the budget spent."""
+    release = marker_dir() / RELEASE_NAME
+    deadline = time.monotonic() + budget
+    last_beat = time.monotonic()
+    logger.warning(
+        "not polling for up to %ds, waiting to be replaced by a pod that can hold this "
+        "work. Create %s to end the wait early.",
+        budget,
+        release,
+    )
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            logger.warning(
+                "waited %ds and nothing replaced this pod; starting the worker on the "
+                "limit that already failed",
+                budget,
+            )
+            return
+        if release.exists():
+            logger.warning("released by %s; starting the worker", release)
+            return
+        try:
+            await asyncio.wait_for(
+                shutdown_event.wait(), timeout=min(_IDLE_POLL_SECONDS, remaining)
+            )
+        except TimeoutError:
+            pass
+        else:
+            logger.info(
+                "shutdown requested while waiting, which is this pod being replaced"
+            )
+            return
+        now = time.monotonic()
+        if now - last_beat >= IDLE_HEARTBEAT_SECONDS:
+            last_beat = now
+            # conformance: ignore[L006] one row a minute, not a tight loop: this is
+            # the only signal that a pod is deliberately idle rather than wedged,
+            # and it has to be visible for the whole wait.
+            logger.info(
+                "still not polling, %ds of %ds left", int(deadline - now), budget
+            )

--- a/application_sdk/common/restart_marker.py
+++ b/application_sdk/common/restart_marker.py
@@ -70,7 +70,7 @@ def marker_dir() -> Path:
 
 def check_and_update_the_marker() -> int:
     """Read the marker left by earlier containers in this pod, then leave one for
-    this start. Returns how many started before this one.
+    this start. Returns how many times a container has already restarted here.
 
     0 means a fresh pod, or that the volume is missing and this cannot be known.
     Anything above 0 means an earlier container here started and did not return
@@ -95,7 +95,7 @@ def check_and_update_the_marker() -> int:
         return 0
 
     path = directory / MARKER_NAME
-    previous = 0
+    restarted_count = 0
     try:
         raw = path.read_text()
     except FileNotFoundError:
@@ -108,21 +108,21 @@ def check_and_update_the_marker() -> int:
 
     if raw:
         try:
-            previous = max(0, int(json.loads(raw).get("starts", 0)))
+            restarted_count = max(0, int(json.loads(raw).get("starts", 0)))
         except (ValueError, TypeError, AttributeError):
             # Truncated or hand-edited. The file existing is the signal; only the
             # count is lost, and one is the answer that changes behaviour.
             logger.warning(
                 "%s is not readable as a marker; treating it as one start", path
             )
-            previous = 1
+            restarted_count = 1
 
     try:
         path.write_text(
             json.dumps(
                 {
                     "pod": os.getenv("K8S_POD_NAME", ""),
-                    "starts": previous + 1,
+                    "starts": restarted_count + 1,
                     "started_at": time.time(),
                 }
             )
@@ -131,7 +131,7 @@ def check_and_update_the_marker() -> int:
         # Only the next start's count is lost, not any decision taken here.
         logger.warning("could not write %s", path, exc_info=True)
 
-    return previous
+    return restarted_count
 
 
 def clear() -> None:
@@ -161,8 +161,8 @@ async def wait_if_pod_restarted(shutdown_event: asyncio.Event) -> None:
     also returns; the caller sees it on ``shutdown_event`` as it would anywhere
     else.
     """
-    previous = check_and_update_the_marker()
-    if previous == 0:
+    restarted_count = check_and_update_the_marker()
+    if restarted_count == 0:
         logger.debug("clean container start in this pod")
         return
 
@@ -170,7 +170,7 @@ async def wait_if_pod_restarted(shutdown_event: asyncio.Event) -> None:
         "this is container start %d in this pod - an earlier one did not return cleanly. "
         "A container killed for memory restarts here on the same limit, so polling now "
         "would take work back onto a pod that cannot hold it.",
-        previous + 1,
+        restarted_count + 1,
     )
 
     budget = max(0, env_int(MAX_WAIT_SECONDS_ENV, 0))

--- a/application_sdk/common/restart_marker.py
+++ b/application_sdk/common/restart_marker.py
@@ -54,36 +54,38 @@ MARKER_NAME = "worker.json"
 RELEASE_NAME = "resume"
 
 #: How long a restarted worker waits before polling anyway. 0 disables waiting.
-IDLE_MAX_SECONDS_ENV = "ATLAN_DIRTY_RESTART_IDLE_MAX_SECONDS"
+MAX_WAIT_SECONDS_ENV = "ATLAN_DIRTY_RESTART_IDLE_MAX_SECONDS"
 
 #: One row a minute while waiting, so a waiting pod is visible in logs without
 #: the wait itself becoming log volume.
-IDLE_HEARTBEAT_SECONDS = 60
+HEARTBEAT_SECONDS = 60
 
 #: How often the wait re-checks the release file.
-_IDLE_POLL_SECONDS = 5
+RECHECK_SECONDS = 5
 
 
 def marker_dir() -> Path:
     return Path(os.getenv(MARKER_DIR_ENV) or DEFAULT_MARKER_DIR)
 
 
-def idle_max_seconds() -> int:
-    """Seconds a restarted worker waits before polling anyway. 0 disables it."""
-    return max(0, env_int(IDLE_MAX_SECONDS_ENV, 0))
+def check_and_update_the_marker() -> int:
+    """Read the marker left by earlier containers in this pod, then leave one for
+    this start. Returns how many started before this one.
 
+    0 means a fresh pod, or that the volume is missing and this cannot be known.
+    Anything above 0 means an earlier container here started and did not return
+    cleanly, because a clean return removes the marker.
 
-def begin() -> int:
-    """Record this container start; return how many started before it in this pod.
-
-    0 means a clean pod, or that detection is inert. Anything above 0 means an
-    earlier container here started and did not return cleanly.
+    Reading and writing are one operation on purpose: the read has to happen
+    first, and doing them separately makes it possible to write first, after
+    which every start looks clean - silently, and forever.
     """
     directory = marker_dir()
     if not directory.is_dir():
-        # Saying so is the whole point of this branch: without the volume the
-        # writes below fail anyway and detection is inert either way, but
-        # silently. This is the only thing that says why.
+        # Nothing here creates it. Its absence means the volume is not mounted,
+        # and a marker on the container filesystem would be discarded with every
+        # restart - detecting nothing, forever. The writes below would fail
+        # anyway; this is the only thing that says why.
         logger.warning(
             "%s is not a directory, so a restarted worker cannot be told apart from a "
             "fresh one and this worker will always poll immediately. Mount a small "
@@ -93,11 +95,11 @@ def begin() -> int:
         return 0
 
     path = directory / MARKER_NAME
-    starts = 0
+    previous = 0
     try:
         raw = path.read_text()
     except FileNotFoundError:
-        raw = ""
+        raw = ""  # a fresh pod, not an error - and it still needs its marker
     except OSError:
         logger.warning(
             "could not read %s, so this start is treated as clean", path, exc_info=True
@@ -106,40 +108,39 @@ def begin() -> int:
 
     if raw:
         try:
-            starts = max(0, int(json.loads(raw).get("starts", 0)))
+            previous = max(0, int(json.loads(raw).get("starts", 0)))
         except (ValueError, TypeError, AttributeError):
-            # Truncated or hand-edited. Its existence is the signal; only the
+            # Truncated or hand-edited. The file existing is the signal; only the
             # count is lost, and one is the answer that changes behaviour.
             logger.warning(
                 "%s is not readable as a marker; treating it as one start", path
             )
-            starts = 1
+            previous = 1
 
     try:
         path.write_text(
             json.dumps(
                 {
                     "pod": os.getenv("K8S_POD_NAME", ""),
-                    "starts": starts + 1,
+                    "starts": previous + 1,
                     "started_at": time.time(),
                 }
             )
         )
     except OSError:
-        # The count is already known; losing the write costs the next start's
-        # count, not this decision.
+        # Only the next start's count is lost, not any decision taken here.
         logger.warning("could not write %s", path, exc_info=True)
 
-    return starts
+    return previous
 
 
-def end() -> None:
-    """Clear the marker after a clean return, so the next start is not a restart."""
+def clear() -> None:
+    """Remove the marker after a clean return, so the next start is not a restart."""
     path = marker_dir() / MARKER_NAME
     try:
         path.unlink()
     except FileNotFoundError:
-        pass
+        pass  # the worker may return before ever writing one
     except OSError:
         logger.warning(
             "could not remove %s, so the next container start in this pod will be "
@@ -149,8 +150,8 @@ def end() -> None:
         )
 
 
-async def wait_if_restarted(shutdown_event: asyncio.Event) -> None:
-    """Hold a restarted worker back before it starts polling.
+async def wait_if_pod_restarted(shutdown_event: asyncio.Event) -> None:
+    """Wait before polling if an earlier container already ran in this pod.
 
     Call this after the health server is serving and signal handlers are
     installed, and before anything builds a worker: the process is up and
@@ -160,8 +161,8 @@ async def wait_if_restarted(shutdown_event: asyncio.Event) -> None:
     also returns; the caller sees it on ``shutdown_event`` as it would anywhere
     else.
     """
-    starts = begin()
-    if starts == 0:
+    previous = check_and_update_the_marker()
+    if previous == 0:
         logger.debug("clean container start in this pod")
         return
 
@@ -169,25 +170,29 @@ async def wait_if_restarted(shutdown_event: asyncio.Event) -> None:
         "this is container start %d in this pod - an earlier one did not return cleanly. "
         "A container killed for memory restarts here on the same limit, so polling now "
         "would take work back onto a pod that cannot hold it.",
-        starts + 1,
+        previous + 1,
     )
 
-    budget = idle_max_seconds()
+    budget = max(0, env_int(MAX_WAIT_SECONDS_ENV, 0))
     if budget <= 0:
         # A zero budget would fall straight through the wait below, but silently
         # and after announcing a wait of 0s. Say which knob is unset instead.
         logger.warning(
-            "%s is not set, so this worker starts polling anyway", IDLE_MAX_SECONDS_ENV
+            "%s is not set, so this worker starts polling anyway", MAX_WAIT_SECONDS_ENV
         )
         return
 
     try:
-        await _wait(shutdown_event, budget)
+        await wait_for_pod_to_get_replaced(shutdown_event, budget)
     except Exception:
+        # The worst outcome of this whole feature has to be a worker that starts
+        # normally, so nothing raised in here reaches the caller.
         logger.exception("could not hold this worker back; starting it normally")
 
 
-async def _wait(shutdown_event: asyncio.Event, budget: int) -> None:
+async def wait_for_pod_to_get_replaced(
+    shutdown_event: asyncio.Event, budget: int
+) -> None:
     """The bounded wait. Three exits: released, shutdown, or the budget spent."""
     release = marker_dir() / RELEASE_NAME
     deadline = time.monotonic() + budget
@@ -211,18 +216,20 @@ async def _wait(shutdown_event: asyncio.Event, budget: int) -> None:
             logger.warning("released by %s; starting the worker", release)
             return
         try:
+            # One await does three jobs: it is the sleep, it is the shutdown
+            # listener, and the min() lands the last pass exactly on the deadline.
             await asyncio.wait_for(
-                shutdown_event.wait(), timeout=min(_IDLE_POLL_SECONDS, remaining)
+                shutdown_event.wait(), timeout=min(RECHECK_SECONDS, remaining)
             )
         except TimeoutError:
-            pass
+            pass  # nobody asked us to stop; keep waiting
         else:
             logger.info(
                 "shutdown requested while waiting, which is this pod being replaced"
             )
             return
         now = time.monotonic()
-        if now - last_beat >= IDLE_HEARTBEAT_SECONDS:
+        if now - last_beat >= HEARTBEAT_SECONDS:
             last_beat = now
             # conformance: ignore[L006] one row a minute, not a tight loop: this is
             # the only signal that a pod is deliberately idle rather than wedged,

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -506,27 +506,17 @@ WORKER_EVICTION_MAX_RETRIES = _load_worker_eviction_max_retries()
 #: Malformed or non-finite values (e.g. ``"abc"``, ``"inf"``, ``"nan"``) fall
 #: back to 0.
 #: How long a worker whose pod already restarted waits before it starts polling.
+#: The mechanism is in ``application_sdk.common.restart_marker``.
 #:
-#: A container killed for exceeding its memory limit restarts inside the same
-#: pod, whose resource spec cannot change, so it returns on the limit that just
-#: killed it. Waiting gives whatever replaces the pod time to do so before the
-#: worker takes work it cannot finish.
+#: This sizes the wait, it does not enable it: the marker's volume does that, so
+#: with no volume mounted the value is never read. ``0`` is the kill switch for a
+#: deployment that mounts the volume and wants the old behaviour.
 #:
-#: This only sizes the wait; it does not enable the behaviour. The marker's
-#: volume does that, and without it nothing is ever detected and nothing waits
-#: (see ``application_sdk.common.restart_marker``). ``0`` disables waiting even
-#: where the volume is mounted, which is the kill switch. Malformed values fall
-#: back to the default rather than failing startup, because a typo in a
-#: deployment must not stop a worker from running at all.
-#:
-#: The default has to exceed however long the slowest thing that replaces a pod
-#: takes to do it. Waiting too long costs bounded wall-clock on a pod that was
-#: going to be replaced anyway; waiting too little is worse than not waiting,
-#: because the worker resumes on the limit that already failed, takes work, and
-#: dies - moments before it would have been rescued. Nothing is charged to the
-#: activity meanwhile: the attempt that was running when the container died has
-#: already timed out, and a queued retry neither heartbeats nor expires
-#: (schedule-to-start defaults to infinity, and does not retry even when set).
+#: The default has to outlast whatever replaces the pod. Over-waiting only costs
+#: wall-clock on a pod that was going to be replaced anyway; under-waiting is
+#: worse than not waiting, because the worker resumes on the limit that already
+#: failed moments before it would have been rescued. An unparsable value (an
+#: unset Helm value renders as "") falls back rather than failing every worker.
 def _load_dirty_restart_max_wait_seconds() -> int:
     raw = os.getenv("ATLAN_DIRTY_RESTART_IDLE_MAX_SECONDS", "600")
     try:

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -505,6 +505,33 @@ WORKER_EVICTION_MAX_RETRIES = _load_worker_eviction_max_retries()
 #: activity is recorded and a positive window would kill a healthy worker.
 #: Malformed or non-finite values (e.g. ``"abc"``, ``"inf"``, ``"nan"``) fall
 #: back to 0.
+def _load_worker_liveness_max_idle_seconds() -> float:
+    raw = os.getenv("ATLAN_WORKER_LIVENESS_MAX_IDLE_SECONDS", "0")
+    try:
+        value = float(raw)
+    except ValueError:
+        warnings.warn(
+            f"ATLAN_WORKER_LIVENESS_MAX_IDLE_SECONDS={raw!r} is not a valid number; "
+            "falling back to 0 (disabled)",
+            stacklevel=2,
+        )
+        return 0.0
+    # Reject inf/nan: an ``inf`` window is set but can never trip (``idle > inf``
+    # is always False), and ``nan`` comparisons are always False too — both are
+    # silently useless. Fall back to 0 (disabled) with a warning instead.
+    if not math.isfinite(value):
+        warnings.warn(
+            f"ATLAN_WORKER_LIVENESS_MAX_IDLE_SECONDS={raw!r} is not finite; "
+            "falling back to 0 (disabled)",
+            stacklevel=2,
+        )
+        return 0.0
+    return max(0.0, value)
+
+
+WORKER_LIVENESS_MAX_IDLE_SECONDS = _load_worker_liveness_max_idle_seconds()
+
+
 #: How long a worker whose pod already restarted waits before it starts polling.
 #: The mechanism is in ``application_sdk.common.restart_marker``.
 #:
@@ -531,33 +558,6 @@ def _load_dirty_restart_max_wait_seconds() -> int:
 
 
 DIRTY_RESTART_IDLE_MAX_SECONDS = _load_dirty_restart_max_wait_seconds()
-
-
-def _load_worker_liveness_max_idle_seconds() -> float:
-    raw = os.getenv("ATLAN_WORKER_LIVENESS_MAX_IDLE_SECONDS", "0")
-    try:
-        value = float(raw)
-    except ValueError:
-        warnings.warn(
-            f"ATLAN_WORKER_LIVENESS_MAX_IDLE_SECONDS={raw!r} is not a valid number; "
-            "falling back to 0 (disabled)",
-            stacklevel=2,
-        )
-        return 0.0
-    # Reject inf/nan: an ``inf`` window is set but can never trip (``idle > inf``
-    # is always False), and ``nan`` comparisons are always False too — both are
-    # silently useless. Fall back to 0 (disabled) with a warning instead.
-    if not math.isfinite(value):
-        warnings.warn(
-            f"ATLAN_WORKER_LIVENESS_MAX_IDLE_SECONDS={raw!r} is not finite; "
-            "falling back to 0 (disabled)",
-            stacklevel=2,
-        )
-        return 0.0
-    return max(0.0, value)
-
-
-WORKER_LIVENESS_MAX_IDLE_SECONDS = _load_worker_liveness_max_idle_seconds()
 
 # SQL Client Constants
 #: Whether to use server-side cursors for SQL operations.

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -505,6 +505,44 @@ WORKER_EVICTION_MAX_RETRIES = _load_worker_eviction_max_retries()
 #: activity is recorded and a positive window would kill a healthy worker.
 #: Malformed or non-finite values (e.g. ``"abc"``, ``"inf"``, ``"nan"``) fall
 #: back to 0.
+#: How long a worker whose pod already restarted waits before it starts polling.
+#:
+#: A container killed for exceeding its memory limit restarts inside the same
+#: pod, whose resource spec cannot change, so it returns on the limit that just
+#: killed it. Waiting gives whatever replaces the pod time to do so before the
+#: worker takes work it cannot finish.
+#:
+#: This only sizes the wait; it does not enable the behaviour. The marker's
+#: volume does that, and without it nothing is ever detected and nothing waits
+#: (see ``application_sdk.common.restart_marker``). ``0`` disables waiting even
+#: where the volume is mounted, which is the kill switch. Malformed values fall
+#: back to the default rather than failing startup, because a typo in a
+#: deployment must not stop a worker from running at all.
+#:
+#: The default has to exceed however long the slowest thing that replaces a pod
+#: takes to do it. Waiting too long costs bounded wall-clock on a pod that was
+#: going to be replaced anyway; waiting too little is worse than not waiting,
+#: because the worker resumes on the limit that already failed, takes work, and
+#: dies - moments before it would have been rescued. Nothing is charged to the
+#: activity meanwhile: the attempt that was running when the container died has
+#: already timed out, and a queued retry neither heartbeats nor expires
+#: (schedule-to-start defaults to infinity, and does not retry even when set).
+def _load_dirty_restart_max_wait_seconds() -> int:
+    raw = os.getenv("ATLAN_DIRTY_RESTART_IDLE_MAX_SECONDS", "600")
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        warnings.warn(
+            f"ATLAN_DIRTY_RESTART_IDLE_MAX_SECONDS={raw!r} is not a valid integer; "
+            "falling back to 600",
+            stacklevel=2,
+        )
+        return 600
+
+
+DIRTY_RESTART_IDLE_MAX_SECONDS = _load_dirty_restart_max_wait_seconds()
+
+
 def _load_worker_liveness_max_idle_seconds() -> float:
     raw = os.getenv("ATLAN_WORKER_LIVENESS_MAX_IDLE_SECONDS", "0")
     try:

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -40,6 +40,12 @@ from typing import TYPE_CHECKING, Any, NoReturn
 import orjson
 
 from application_sdk.common._env import env_int as _env_int
+from application_sdk.common.restart_marker import (
+    end as _end_restart_marker,
+)
+from application_sdk.common.restart_marker import (
+    wait_if_restarted as _wait_if_restarted,
+)
 from application_sdk.common.task_queue import task_queue_from_env
 from application_sdk.discovery import (
     load_app_class,
@@ -1462,6 +1468,12 @@ async def run_worker_mode(config: AppConfig) -> None:
     # health_server stays up across worker restarts so the runtime keeps
     # answering health checks while the supervisor rebuilds a crashed worker.
     async with health_server:
+        # A container that restarted in place after running out of memory comes
+        # back on the limit that killed it, so polling now would take the work
+        # straight back onto a pod that cannot hold it. This has to run before
+        # anything builds a worker, which is why it is here and not in the
+        # supervisor.
+        await _wait_if_restarted(shutdown_event)
         await _run_worker_with_restart(
             build_worker=_build_worker,
             shutdown_event=shutdown_event,
@@ -1470,6 +1482,9 @@ async def run_worker_mode(config: AppConfig) -> None:
             health_server=health_server,
             reconnect=_reconnect,
         )
+        # Reached only when the worker drained on request. Anything that escapes
+        # leaves the marker in place, which is what makes the next start a restart.
+        _end_restart_marker()
 
     from application_sdk.infrastructure.context import (  # noqa: PLC0415 — cold path: only when infrastructure init is needed
         close_infrastructure,

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -39,13 +39,8 @@ from typing import TYPE_CHECKING, Any, NoReturn
 
 import orjson
 
+from application_sdk.common import restart_marker
 from application_sdk.common._env import env_int as _env_int
-from application_sdk.common.restart_marker import (
-    end as _end_restart_marker,
-)
-from application_sdk.common.restart_marker import (
-    wait_if_restarted as _wait_if_restarted,
-)
 from application_sdk.common.task_queue import task_queue_from_env
 from application_sdk.discovery import (
     load_app_class,
@@ -1473,7 +1468,7 @@ async def run_worker_mode(config: AppConfig) -> None:
         # straight back onto a pod that cannot hold it. This has to run before
         # anything builds a worker, which is why it is here and not in the
         # supervisor.
-        await _wait_if_restarted(shutdown_event)
+        await restart_marker.wait_if_pod_restarted(shutdown_event)
         await _run_worker_with_restart(
             build_worker=_build_worker,
             shutdown_event=shutdown_event,
@@ -1484,7 +1479,7 @@ async def run_worker_mode(config: AppConfig) -> None:
         )
         # Reached only when the worker drained on request. Anything that escapes
         # leaves the marker in place, which is what makes the next start a restart.
-        _end_restart_marker()
+        restart_marker.clear()
 
     from application_sdk.infrastructure.context import (  # noqa: PLC0415 — cold path: only when infrastructure init is needed
         close_infrastructure,

--- a/tests/unit/common/test_restart_marker.py
+++ b/tests/unit/common/test_restart_marker.py
@@ -82,9 +82,9 @@ def test_no_volume_means_detection_is_inert(monkeypatch, tmp_path, logs):
     missing = tmp_path / "not-mounted"
     monkeypatch.setenv(rm.MARKER_DIR_ENV, str(missing))
     assert rm.check_and_update_the_marker() == 0
-    assert not missing.exists(), (
-        "check_and_update_the_marker() must not create the directory"
-    )
+    assert (
+        not missing.exists()
+    ), "check_and_update_the_marker() must not create the directory"
     assert logs.says("warning", str(missing), "emptyDir"), (
         "an absent volume must be reported, or it is indistinguishable from a "
         f"pod that never restarted: {logs.rows}"
@@ -123,12 +123,12 @@ async def test_a_clean_start_does_not_wait(marker_dir, monkeypatch):
 async def test_a_restart_does_not_wait_while_waiting_is_switched_off(marker_dir, logs):
     rm.check_and_update_the_marker()
     await asyncio.wait_for(rm.wait_if_pod_restarted(asyncio.Event()), timeout=1)
-    assert logs.says("warning", "ATLAN_DIRTY_RESTART_IDLE_MAX_SECONDS=0"), (
-        f"must say it is switched off rather than announce a 0s wait: {logs.rows}"
-    )
-    assert not logs.says("warning", "not polling for up to"), (
-        f"must not announce a wait it is not doing: {logs.rows}"
-    )
+    assert logs.says(
+        "warning", "ATLAN_DIRTY_RESTART_IDLE_MAX_SECONDS=0"
+    ), f"must say it is switched off rather than announce a 0s wait: {logs.rows}"
+    assert not logs.says(
+        "warning", "not polling for up to"
+    ), f"must not announce a wait it is not doing: {logs.rows}"
 
 
 async def test_a_restart_waits_out_the_budget_then_proceeds(

--- a/tests/unit/common/test_restart_marker.py
+++ b/tests/unit/common/test_restart_marker.py
@@ -101,6 +101,17 @@ def test_an_unparsable_start_count_still_counts_as_a_restart(marker_dir):
     assert rm.check_and_update_the_marker() == 1
 
 
+def test_a_non_utf8_marker_counts_as_a_restart_and_is_replaced(marker_dir):
+    """A marker that cannot be decoded must not reach the caller: it is read
+    before the wait's own error handling, so raising here would stop the worker
+    from starting at all."""
+    path = marker_dir / rm.MARKER_NAME
+    path.write_bytes(b"\xff\xfe not utf-8")
+    assert rm.check_and_update_the_marker() == 1
+    # replaced, so the next start reads a usable marker rather than tripping again
+    assert json.loads(path.read_text())["starts"] == 2
+
+
 # ---------------------------------------------------------------- the wait
 
 
@@ -142,6 +153,8 @@ async def test_the_wait_holds_until_something_ends_it(
     await asyncio.sleep(0.1)
     assert not task.done(), "the wait returned without being released"
     task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
 
 async def test_the_release_file_ends_the_wait_early(

--- a/tests/unit/common/test_restart_marker.py
+++ b/tests/unit/common/test_restart_marker.py
@@ -12,7 +12,8 @@ from application_sdk.common import restart_marker as rm
 def marker_dir(tmp_path, monkeypatch):
     """Point the marker at a real directory, as the mounted volume would be."""
     monkeypatch.setenv(rm.MARKER_DIR_ENV, str(tmp_path))
-    monkeypatch.delenv(rm.MAX_WAIT_SECONDS_ENV, raising=False)
+    # The shipped default is a positive number; switch it off unless a test asks.
+    monkeypatch.setattr(rm, "DIRTY_RESTART_IDLE_MAX_SECONDS", 0)
     return tmp_path
 
 
@@ -104,15 +105,15 @@ def test_an_unparsable_start_count_still_counts_as_a_restart(marker_dir):
 
 
 async def test_a_clean_start_does_not_wait(marker_dir, monkeypatch):
-    monkeypatch.setenv(rm.MAX_WAIT_SECONDS_ENV, "300")
+    monkeypatch.setattr(rm, "DIRTY_RESTART_IDLE_MAX_SECONDS", 300)
     await asyncio.wait_for(rm.wait_if_pod_restarted(asyncio.Event()), timeout=1)
 
 
-async def test_a_restart_does_not_wait_while_the_budget_is_unset(marker_dir, logs):
+async def test_a_restart_does_not_wait_while_waiting_is_switched_off(marker_dir, logs):
     rm.check_and_update_the_marker()
     await asyncio.wait_for(rm.wait_if_pod_restarted(asyncio.Event()), timeout=1)
-    assert logs.says("warning", rm.MAX_WAIT_SECONDS_ENV), (
-        f"must name the unset knob rather than announce a 0s wait: {logs.rows}"
+    assert logs.says("warning", "ATLAN_DIRTY_RESTART_IDLE_MAX_SECONDS=0"), (
+        f"must say it is switched off rather than announce a 0s wait: {logs.rows}"
     )
     assert not logs.says("warning", "not polling for up to"), (
         f"must not announce a wait it is not doing: {logs.rows}"
@@ -123,7 +124,7 @@ async def test_a_restart_waits_out_the_budget_then_proceeds(
     marker_dir, monkeypatch, prompt_polling
 ):
     rm.check_and_update_the_marker()
-    monkeypatch.setenv(rm.MAX_WAIT_SECONDS_ENV, "1")
+    monkeypatch.setattr(rm, "DIRTY_RESTART_IDLE_MAX_SECONDS", 1)
     loop = asyncio.get_running_loop()
     started = loop.time()
     await asyncio.wait_for(rm.wait_if_pod_restarted(asyncio.Event()), timeout=5)
@@ -136,7 +137,7 @@ async def test_the_wait_holds_until_something_ends_it(
     """The point of the wait: with a long budget and nothing to release it, the
     worker is still not polling."""
     rm.check_and_update_the_marker()
-    monkeypatch.setenv(rm.MAX_WAIT_SECONDS_ENV, "300")
+    monkeypatch.setattr(rm, "DIRTY_RESTART_IDLE_MAX_SECONDS", 300)
     task = asyncio.ensure_future(rm.wait_if_pod_restarted(asyncio.Event()))
     await asyncio.sleep(0.1)
     assert not task.done(), "the wait returned without being released"
@@ -147,7 +148,7 @@ async def test_the_release_file_ends_the_wait_early(
     marker_dir, monkeypatch, prompt_polling
 ):
     rm.check_and_update_the_marker()
-    monkeypatch.setenv(rm.MAX_WAIT_SECONDS_ENV, "300")
+    monkeypatch.setattr(rm, "DIRTY_RESTART_IDLE_MAX_SECONDS", 300)
     task = asyncio.ensure_future(rm.wait_if_pod_restarted(asyncio.Event()))
     await asyncio.sleep(0.05)
     assert not task.done()
@@ -157,7 +158,7 @@ async def test_the_release_file_ends_the_wait_early(
 
 async def test_shutdown_ends_the_wait(marker_dir, monkeypatch, prompt_polling):
     rm.check_and_update_the_marker()
-    monkeypatch.setenv(rm.MAX_WAIT_SECONDS_ENV, "300")
+    monkeypatch.setattr(rm, "DIRTY_RESTART_IDLE_MAX_SECONDS", 300)
     shutdown = asyncio.Event()
     task = asyncio.ensure_future(rm.wait_if_pod_restarted(shutdown))
     await asyncio.sleep(0.05)
@@ -170,7 +171,7 @@ async def test_a_failure_setting_up_the_wait_starts_the_worker_anyway(
     marker_dir, monkeypatch
 ):
     rm.check_and_update_the_marker()
-    monkeypatch.setenv(rm.MAX_WAIT_SECONDS_ENV, "300")
+    monkeypatch.setattr(rm, "DIRTY_RESTART_IDLE_MAX_SECONDS", 300)
 
     async def boom(*_args, **_kwargs):
         raise RuntimeError("no clock")

--- a/tests/unit/common/test_restart_marker.py
+++ b/tests/unit/common/test_restart_marker.py
@@ -1,0 +1,177 @@
+"""The restart marker and the bounded wait it gates."""
+
+import asyncio
+import json
+
+import pytest
+
+from application_sdk.common import restart_marker as rm
+
+
+@pytest.fixture(autouse=True)
+def marker_dir(tmp_path, monkeypatch):
+    """Point the marker at a real directory, as the mounted volume would be."""
+    monkeypatch.setenv(rm.MARKER_DIR_ENV, str(tmp_path))
+    monkeypatch.delenv(rm.IDLE_MAX_SECONDS_ENV, raising=False)
+    return tmp_path
+
+
+class _RecordingLogger:
+    """Captures what the module logged, since several guards exist only to say
+    something an operator needs and are otherwise behaviour-neutral."""
+
+    def __init__(self):
+        self.rows: list[tuple[str, str]] = []
+
+    def _record(self, level):
+        def log(msg, *args, **_kwargs):
+            self.rows.append((level, msg % args if args else msg))
+
+        return log
+
+    def __getattr__(self, level):
+        return self._record(level)
+
+    def says(self, level, *fragments) -> bool:
+        return any(
+            lvl == level and all(f in text for f in fragments)
+            for lvl, text in self.rows
+        )
+
+
+@pytest.fixture
+def logs(monkeypatch):
+    recorder = _RecordingLogger()
+    monkeypatch.setattr(rm, "logger", recorder)
+    return recorder
+
+
+@pytest.fixture
+def prompt_polling(monkeypatch):
+    """Shrink the release-file poll so the wait's exits are testable in real time."""
+    monkeypatch.setattr(rm, "_IDLE_POLL_SECONDS", 0.02)
+
+
+def test_first_start_in_a_pod_is_clean_and_leaves_a_marker(marker_dir):
+    assert rm.begin() == 0
+    assert json.loads((marker_dir / rm.MARKER_NAME).read_text())["starts"] == 1
+
+
+def test_a_second_start_in_the_same_pod_is_a_restart(marker_dir):
+    rm.begin()
+    assert rm.begin() == 1
+    assert rm.begin() == 2
+
+
+def test_a_clean_return_makes_the_next_start_clean_again(marker_dir):
+    rm.begin()
+    rm.end()
+    assert not (marker_dir / rm.MARKER_NAME).exists()
+    assert rm.begin() == 0
+
+
+def test_end_is_quiet_when_there_is_no_marker(marker_dir):
+    rm.end()  # the worker may return before ever writing one
+
+
+def test_no_volume_means_detection_is_inert(monkeypatch, tmp_path, logs):
+    """Without the volume a marker cannot survive a restart. Detection is inert
+    either way, so the only thing that distinguishes an unmounted volume from a
+    healthy fleet is that it says so."""
+    missing = tmp_path / "not-mounted"
+    monkeypatch.setenv(rm.MARKER_DIR_ENV, str(missing))
+    assert rm.begin() == 0
+    assert not missing.exists(), "begin() must not create the directory"
+    assert logs.says("warning", str(missing), "emptyDir"), (
+        "an absent volume must be reported, or it is indistinguishable from a "
+        f"pod that never restarted: {logs.rows}"
+    )
+
+
+def test_a_corrupt_marker_still_counts_as_a_restart(marker_dir):
+    (marker_dir / rm.MARKER_NAME).write_text("{ truncated")
+    assert rm.begin() == 1
+
+
+def test_an_unparsable_start_count_still_counts_as_a_restart(marker_dir):
+    (marker_dir / rm.MARKER_NAME).write_text(json.dumps({"starts": "many"}))
+    assert rm.begin() == 1
+
+
+# ---------------------------------------------------------------- the wait
+
+
+async def test_a_clean_start_does_not_wait(marker_dir, monkeypatch):
+    monkeypatch.setenv(rm.IDLE_MAX_SECONDS_ENV, "300")
+    await asyncio.wait_for(rm.wait_if_restarted(asyncio.Event()), timeout=1)
+
+
+async def test_a_restart_does_not_wait_while_the_budget_is_unset(marker_dir, logs):
+    rm.begin()
+    await asyncio.wait_for(rm.wait_if_restarted(asyncio.Event()), timeout=1)
+    assert logs.says("warning", rm.IDLE_MAX_SECONDS_ENV), (
+        f"must name the unset knob rather than announce a 0s wait: {logs.rows}"
+    )
+    assert not logs.says("warning", "not polling for up to"), (
+        f"must not announce a wait it is not doing: {logs.rows}"
+    )
+
+
+async def test_a_restart_waits_out_the_budget_then_proceeds(
+    marker_dir, monkeypatch, prompt_polling
+):
+    rm.begin()
+    monkeypatch.setenv(rm.IDLE_MAX_SECONDS_ENV, "1")
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    await asyncio.wait_for(rm.wait_if_restarted(asyncio.Event()), timeout=5)
+    assert loop.time() - started >= 1, "returned before the budget was spent"
+
+
+async def test_the_wait_holds_until_something_ends_it(
+    marker_dir, monkeypatch, prompt_polling
+):
+    """The point of the wait: with a long budget and nothing to release it, the
+    worker is still not polling."""
+    rm.begin()
+    monkeypatch.setenv(rm.IDLE_MAX_SECONDS_ENV, "300")
+    task = asyncio.ensure_future(rm.wait_if_restarted(asyncio.Event()))
+    await asyncio.sleep(0.1)
+    assert not task.done(), "the wait returned without being released"
+    task.cancel()
+
+
+async def test_the_release_file_ends_the_wait_early(
+    marker_dir, monkeypatch, prompt_polling
+):
+    rm.begin()
+    monkeypatch.setenv(rm.IDLE_MAX_SECONDS_ENV, "300")
+    task = asyncio.ensure_future(rm.wait_if_restarted(asyncio.Event()))
+    await asyncio.sleep(0.05)
+    assert not task.done()
+    (marker_dir / rm.RELEASE_NAME).write_text("")
+    await asyncio.wait_for(task, timeout=5)
+
+
+async def test_shutdown_ends_the_wait(marker_dir, monkeypatch, prompt_polling):
+    rm.begin()
+    monkeypatch.setenv(rm.IDLE_MAX_SECONDS_ENV, "300")
+    shutdown = asyncio.Event()
+    task = asyncio.ensure_future(rm.wait_if_restarted(shutdown))
+    await asyncio.sleep(0.05)
+    assert not task.done()
+    shutdown.set()
+    await asyncio.wait_for(task, timeout=5)
+
+
+async def test_a_failure_setting_up_the_wait_starts_the_worker_anyway(
+    marker_dir, monkeypatch
+):
+    rm.begin()
+    monkeypatch.setenv(rm.IDLE_MAX_SECONDS_ENV, "300")
+
+    async def boom(*_args, **_kwargs):
+        raise RuntimeError("no clock")
+
+    monkeypatch.setattr(rm, "_wait", boom)
+    await asyncio.wait_for(rm.wait_if_restarted(asyncio.Event()), timeout=1)

--- a/tests/unit/common/test_restart_marker.py
+++ b/tests/unit/common/test_restart_marker.py
@@ -12,7 +12,7 @@ from application_sdk.common import restart_marker as rm
 def marker_dir(tmp_path, monkeypatch):
     """Point the marker at a real directory, as the mounted volume would be."""
     monkeypatch.setenv(rm.MARKER_DIR_ENV, str(tmp_path))
-    monkeypatch.delenv(rm.IDLE_MAX_SECONDS_ENV, raising=False)
+    monkeypatch.delenv(rm.MAX_WAIT_SECONDS_ENV, raising=False)
     return tmp_path
 
 
@@ -49,29 +49,29 @@ def logs(monkeypatch):
 @pytest.fixture
 def prompt_polling(monkeypatch):
     """Shrink the release-file poll so the wait's exits are testable in real time."""
-    monkeypatch.setattr(rm, "_IDLE_POLL_SECONDS", 0.02)
+    monkeypatch.setattr(rm, "RECHECK_SECONDS", 0.02)
 
 
 def test_first_start_in_a_pod_is_clean_and_leaves_a_marker(marker_dir):
-    assert rm.begin() == 0
+    assert rm.check_and_update_the_marker() == 0
     assert json.loads((marker_dir / rm.MARKER_NAME).read_text())["starts"] == 1
 
 
 def test_a_second_start_in_the_same_pod_is_a_restart(marker_dir):
-    rm.begin()
-    assert rm.begin() == 1
-    assert rm.begin() == 2
+    rm.check_and_update_the_marker()
+    assert rm.check_and_update_the_marker() == 1
+    assert rm.check_and_update_the_marker() == 2
 
 
 def test_a_clean_return_makes_the_next_start_clean_again(marker_dir):
-    rm.begin()
-    rm.end()
+    rm.check_and_update_the_marker()
+    rm.clear()
     assert not (marker_dir / rm.MARKER_NAME).exists()
-    assert rm.begin() == 0
+    assert rm.check_and_update_the_marker() == 0
 
 
-def test_end_is_quiet_when_there_is_no_marker(marker_dir):
-    rm.end()  # the worker may return before ever writing one
+def test_clearing_is_quiet_when_there_is_no_marker(marker_dir):
+    rm.clear()  # the worker may return before ever writing one
 
 
 def test_no_volume_means_detection_is_inert(monkeypatch, tmp_path, logs):
@@ -80,7 +80,7 @@ def test_no_volume_means_detection_is_inert(monkeypatch, tmp_path, logs):
     healthy fleet is that it says so."""
     missing = tmp_path / "not-mounted"
     monkeypatch.setenv(rm.MARKER_DIR_ENV, str(missing))
-    assert rm.begin() == 0
+    assert rm.check_and_update_the_marker() == 0
     assert not missing.exists(), "begin() must not create the directory"
     assert logs.says("warning", str(missing), "emptyDir"), (
         "an absent volume must be reported, or it is indistinguishable from a "
@@ -90,26 +90,26 @@ def test_no_volume_means_detection_is_inert(monkeypatch, tmp_path, logs):
 
 def test_a_corrupt_marker_still_counts_as_a_restart(marker_dir):
     (marker_dir / rm.MARKER_NAME).write_text("{ truncated")
-    assert rm.begin() == 1
+    assert rm.check_and_update_the_marker() == 1
 
 
 def test_an_unparsable_start_count_still_counts_as_a_restart(marker_dir):
     (marker_dir / rm.MARKER_NAME).write_text(json.dumps({"starts": "many"}))
-    assert rm.begin() == 1
+    assert rm.check_and_update_the_marker() == 1
 
 
 # ---------------------------------------------------------------- the wait
 
 
 async def test_a_clean_start_does_not_wait(marker_dir, monkeypatch):
-    monkeypatch.setenv(rm.IDLE_MAX_SECONDS_ENV, "300")
-    await asyncio.wait_for(rm.wait_if_restarted(asyncio.Event()), timeout=1)
+    monkeypatch.setenv(rm.MAX_WAIT_SECONDS_ENV, "300")
+    await asyncio.wait_for(rm.wait_if_pod_restarted(asyncio.Event()), timeout=1)
 
 
 async def test_a_restart_does_not_wait_while_the_budget_is_unset(marker_dir, logs):
-    rm.begin()
-    await asyncio.wait_for(rm.wait_if_restarted(asyncio.Event()), timeout=1)
-    assert logs.says("warning", rm.IDLE_MAX_SECONDS_ENV), (
+    rm.check_and_update_the_marker()
+    await asyncio.wait_for(rm.wait_if_pod_restarted(asyncio.Event()), timeout=1)
+    assert logs.says("warning", rm.MAX_WAIT_SECONDS_ENV), (
         f"must name the unset knob rather than announce a 0s wait: {logs.rows}"
     )
     assert not logs.says("warning", "not polling for up to"), (
@@ -120,11 +120,11 @@ async def test_a_restart_does_not_wait_while_the_budget_is_unset(marker_dir, log
 async def test_a_restart_waits_out_the_budget_then_proceeds(
     marker_dir, monkeypatch, prompt_polling
 ):
-    rm.begin()
-    monkeypatch.setenv(rm.IDLE_MAX_SECONDS_ENV, "1")
+    rm.check_and_update_the_marker()
+    monkeypatch.setenv(rm.MAX_WAIT_SECONDS_ENV, "1")
     loop = asyncio.get_running_loop()
     started = loop.time()
-    await asyncio.wait_for(rm.wait_if_restarted(asyncio.Event()), timeout=5)
+    await asyncio.wait_for(rm.wait_if_pod_restarted(asyncio.Event()), timeout=5)
     assert loop.time() - started >= 1, "returned before the budget was spent"
 
 
@@ -133,9 +133,9 @@ async def test_the_wait_holds_until_something_ends_it(
 ):
     """The point of the wait: with a long budget and nothing to release it, the
     worker is still not polling."""
-    rm.begin()
-    monkeypatch.setenv(rm.IDLE_MAX_SECONDS_ENV, "300")
-    task = asyncio.ensure_future(rm.wait_if_restarted(asyncio.Event()))
+    rm.check_and_update_the_marker()
+    monkeypatch.setenv(rm.MAX_WAIT_SECONDS_ENV, "300")
+    task = asyncio.ensure_future(rm.wait_if_pod_restarted(asyncio.Event()))
     await asyncio.sleep(0.1)
     assert not task.done(), "the wait returned without being released"
     task.cancel()
@@ -144,9 +144,9 @@ async def test_the_wait_holds_until_something_ends_it(
 async def test_the_release_file_ends_the_wait_early(
     marker_dir, monkeypatch, prompt_polling
 ):
-    rm.begin()
-    monkeypatch.setenv(rm.IDLE_MAX_SECONDS_ENV, "300")
-    task = asyncio.ensure_future(rm.wait_if_restarted(asyncio.Event()))
+    rm.check_and_update_the_marker()
+    monkeypatch.setenv(rm.MAX_WAIT_SECONDS_ENV, "300")
+    task = asyncio.ensure_future(rm.wait_if_pod_restarted(asyncio.Event()))
     await asyncio.sleep(0.05)
     assert not task.done()
     (marker_dir / rm.RELEASE_NAME).write_text("")
@@ -154,10 +154,10 @@ async def test_the_release_file_ends_the_wait_early(
 
 
 async def test_shutdown_ends_the_wait(marker_dir, monkeypatch, prompt_polling):
-    rm.begin()
-    monkeypatch.setenv(rm.IDLE_MAX_SECONDS_ENV, "300")
+    rm.check_and_update_the_marker()
+    monkeypatch.setenv(rm.MAX_WAIT_SECONDS_ENV, "300")
     shutdown = asyncio.Event()
-    task = asyncio.ensure_future(rm.wait_if_restarted(shutdown))
+    task = asyncio.ensure_future(rm.wait_if_pod_restarted(shutdown))
     await asyncio.sleep(0.05)
     assert not task.done()
     shutdown.set()
@@ -167,11 +167,11 @@ async def test_shutdown_ends_the_wait(marker_dir, monkeypatch, prompt_polling):
 async def test_a_failure_setting_up_the_wait_starts_the_worker_anyway(
     marker_dir, monkeypatch
 ):
-    rm.begin()
-    monkeypatch.setenv(rm.IDLE_MAX_SECONDS_ENV, "300")
+    rm.check_and_update_the_marker()
+    monkeypatch.setenv(rm.MAX_WAIT_SECONDS_ENV, "300")
 
     async def boom(*_args, **_kwargs):
         raise RuntimeError("no clock")
 
-    monkeypatch.setattr(rm, "_wait", boom)
-    await asyncio.wait_for(rm.wait_if_restarted(asyncio.Event()), timeout=1)
+    monkeypatch.setattr(rm, "wait_for_pod_to_get_replaced", boom)
+    await asyncio.wait_for(rm.wait_if_pod_restarted(asyncio.Event()), timeout=1)

--- a/tests/unit/common/test_restart_marker.py
+++ b/tests/unit/common/test_restart_marker.py
@@ -81,7 +81,9 @@ def test_no_volume_means_detection_is_inert(monkeypatch, tmp_path, logs):
     missing = tmp_path / "not-mounted"
     monkeypatch.setenv(rm.MARKER_DIR_ENV, str(missing))
     assert rm.check_and_update_the_marker() == 0
-    assert not missing.exists(), "begin() must not create the directory"
+    assert not missing.exists(), (
+        "check_and_update_the_marker() must not create the directory"
+    )
     assert logs.says("warning", str(missing), "emptyDir"), (
         "an absent volume must be reported, or it is indistinguishable from a "
         f"pod that never restarted: {logs.rows}"

--- a/tests/unit/test_constants.py
+++ b/tests/unit/test_constants.py
@@ -5,7 +5,10 @@ import importlib
 import pytest
 
 import application_sdk.constants as constants
-from application_sdk.constants import _load_worker_liveness_max_idle_seconds
+from application_sdk.constants import (
+    _load_dirty_restart_max_wait_seconds,
+    _load_worker_liveness_max_idle_seconds,
+)
 
 
 class TestLoadWorkerLivenessMaxIdleSeconds:
@@ -215,3 +218,33 @@ class TestStorageLockWaitProgressSeconds:
     async def _hold_briefly(registry, path: str) -> None:
         async with registry.guard(path):
             pass
+
+
+class TestLoadDirtyRestartMaxWaitSeconds:
+    """Cover the ``ATLAN_DIRTY_RESTART_IDLE_MAX_SECONDS`` loader."""
+
+    ENV = "ATLAN_DIRTY_RESTART_IDLE_MAX_SECONDS"
+
+    def test_default_when_unset(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv(self.ENV, raising=False)
+        assert _load_dirty_restart_max_wait_seconds() == 600
+
+    def test_valid_positive_value(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(self.ENV, "900")
+        assert _load_dirty_restart_max_wait_seconds() == 900
+
+    def test_zero_is_the_kill_switch(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(self.ENV, "0")
+        assert _load_dirty_restart_max_wait_seconds() == 0
+
+    def test_negative_clamped_to_zero(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(self.ENV, "-30")
+        assert _load_dirty_restart_max_wait_seconds() == 0
+
+    def test_non_numeric_falls_back_to_the_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A typo in a deployment must not stop a worker from running at all."""
+        monkeypatch.setenv(self.ENV, "abc")
+        with pytest.warns(UserWarning, match="not a valid integer"):
+            assert _load_dirty_restart_max_wait_seconds() == 600


### PR DESCRIPTION
### Scope

The SDK owns marker write, marker clear, one question asked of the rerouter, and one bounded passive wait. No pod deletion, no resize, no apiserver access, no RBAC, no concurrency changes, no tier routing in SDK code.

### Changelog

- A worker that finds a restart marker in its pod waits, for a bounded time, before it starts polling. A container killed for exceeding its memory limit is restarted by the kubelet *inside the same pod*, on the limit that just killed it. Kubernetes 1.33 made a running pod's resources mutable through `pods/resize`, so the spec is not immutable in general — but on the vcluster platform this deploys to a resize is accepted and never actuated, so replacing the pod stays the only thing that changes its memory, so it comes back on the limit that just killed it. Polling again takes work straight back onto a pod that cannot hold it, and the retries cannot succeed — measured on a cluster, an activity with a 60s heartbeat timeout and three attempts spent two of them that way.
- New leaf module `application_sdk/common/restart_marker.py`, seven functions: `check_and_update_the_marker()` reads the marker left by earlier containers in this pod and leaves one for this start, returning how many came before; `clear()` removes it on a clean return; `wait_if_pod_restarted()` is the entry point and reads as the sentence it implements; `wait_for_pod_to_get_replaced()` is the bounded wait; `act_on_restart()` and `ask_what_this_restart_earns()` are the question put to the rerouter; `_record_park()` counts a finished park. Standard library, the logger, the SDK's metrics adapter, and `httpx` for the one question it asks.
- Reading and writing the marker are deliberately one call. The read has to happen first, and separating them makes it possible to write first — after which every start looks clean, silently and forever.
- The wait budget is `DIRTY_RESTART_IDLE_MAX_SECONDS` in `constants.py`, from `ATLAN_DIRTY_RESTART_IDLE_MAX_SECONDS`, **defaulting to 150**, sized to the eviction it waits on (settleDelay 90s plus the replacement's admission). It cannot use `env_int` — `common/_env.py` imports the logger adaptor, which imports `constants` — so it is a private loader over `os.getenv` that warns and falls back rather than failing every worker on a bad value (an unset Helm value renders as `""`).
- **A restarted worker asks whether waiting is worth it**, rather than waiting on every dirty restart. One `GET` to the activity rerouter's `/restart-advice`, naming this pod; `wait: true` means an eviction is scheduled for it. A container that merely crashed comes back on a limit that was never the problem, asks, is not queued, and polls immediately — so a crash loop no longer pays the wait on every loop.
- Both questions are answered where the answers live. The rerouter sees the OOMKill through its pod informer and owns the eviction, so *was this memory* and *is a replacement coming* are the same question there: a pod is only in its queue because it was OOMKilled, and only still in it because the eviction is still to come. That is what keeps this module free of Kubernetes — no pod read, no status parsing, no grant.
- `ATLAN_OOM_RESTART_CHECK` = `none` (default) | `api` decides whether to ask; `ATLAN_RESTART_ADVICE_URL` says where. Both off by default, so nothing changes for a deployment that does not set them.
- The wait is `min(waitSeconds, ATLAN_DIRTY_RESTART_IDLE_MAX_SECONDS)`. The rerouter returns time-remaining-to-eviction plus an admission grace, so the wait tracks the actual eviction and the budget is only a ceiling.
- **A worker parks once per pod.** If the wait on the previous start did not get the pod replaced, the thing it waits for is not coming; one bounded penalty per pod rather than one per restart.
- Three lines of substance in `main.py`. The wait sits in `run_worker_mode` after the health server is serving and before anything builds a worker, so the process answers probes throughout and is simply pollerless while it waits. `clear()` runs after the supervisor returns, so anything that escapes leaves the marker in place — which is what makes the next start a restart.

### Blast radius

**Two gates, both off by default.** Detection and logging always run. Waiting needs the marker directory to exist, and nothing here creates it; asking needs `ATLAN_OOM_RESTART_CHECK=api` and a URL. Without the chart mounting a memory-backed `emptyDir` at `/run/atlan`, `check_and_update_the_marker()` reports the absent directory and returns a clean start, so the module is inert on every workload that has not opted in. Setting the budget to `0` disables waiting explicitly and says so in the log.

That is the real switch: a fleet is observed by deploying this without the volume, and changes behaviour per app by adding it and pointing it at the rerouter.

**Everything fails toward polling.** Holding a worker back is only worth the activity's retry budget while something is genuinely on its way, so every way of not getting a clear yes resumes polling: check switched off, no URL, `K8S_POD_NAME` or `K8S_CONTAINER_NAME` unset, a 2s timeout, a refusal, an unparseable body, or `wait: false`. `wait_if_pod_restarted` also swallows anything raised inside it — the worst outcome of this feature has to be a worker that starts normally.

### Additional context

**Why the marker is written at birth, not at death.** Under cgroup v2 `memory.oom.group=1` the kernel kills every process in the container's cgroup, PID 1 included, so nothing runs on the way down. Recording the start and clearing it on a clean return inverts that into something always observable: the marker's presence means an earlier container in this pod started and did not finish.

**Why nothing outside the pod writes it.** Anything sent from outside — a label, a projected file, a patch — has to arrive before the kubelet restarts the container, which happens within seconds of the kill. The previous container instance already left the record, so nothing has to win that race.

**Why a memory-backed `emptyDir`.** Its lifetime is the pod's: contents survive every container restart and vanish with the pod, which is exactly the boundary this needs. Nothing here creates the directory — it exists only if the volume is mounted, and an absent one is reported rather than worked around, because on a container filesystem the marker would be discarded with every restart and nothing would ever be detected.

**Why the wait is here and not in the supervisor.** `_supervise_worker` rebuilds a crashed worker inside the same process and never touches the marker. Only a *new process* — a container restart — parks. An ordinary worker crash (auth blip, fatal gRPC error) rebuilds and polls at once, because the pod is the right size in that case. Putting the wait in the supervisor would park for the budget on every such crash.

**Two exits from the wait**, so a pod can never sit indefinitely: the budget is spent, or a shutdown is requested — which is this pod being taken away, the thing it was waiting for. There is no operator escape hatch, deliberately: the budget is already the bound, and a second way out would be one more thing to be wrong at 3am. Every failure path falls through to a normal start — absent or unreadable directory, corrupt marker, anything raised while setting up the wait.

**Where to look hardest.** Two of the guards are behaviour-neutral and exist only to say something an operator needs: the missing-directory branch and the unset-budget branch. Removing either leaves the observable outcome unchanged, so both are covered by asserting the message rather than the result.

### Verified on a tenant

Run in-cluster on an internal tenant against a fixture pinned to this branch's commit, worker VPA in `updateMode: Initial`.

| # | Check | Result |
|---|---|---|
| 1 | Marker survives a container restart, dies with the pod | ✅ count **1 → 2 → 3** across in-place restarts on one pod |
| 2 | A restarted worker does not poll | ✅ activity sat **SCHEDULED, 112s undispatched**, while the restarted container was up and `Ready` |
| 3 | Budget exit | ✅ resumed and polled on the old limit when the budget expired |
| 4 | Shutdown exit | ✅ observed as the pod being replaced |
| 5 | A replacement pod starts clean | ✅ fresh tmpfs, no marker, polls immediately |

**The marker alone does not save a workflow.** With nothing replacing the pod, it parked the worker correctly three times and the workflow still failed — all three attempts ran on the same limit. The asking half is what makes the wait conditional, and the eviction lane is what makes it pay off.

Full loop, run against the shipped rerouter Service rather than a test rig:

| | |
|---|---|
| kill | OOMKilled at a 362Mi limit |
| ask | marker found, told `eviction-scheduled`, held off polling for 114s |
| replace | VPA 362Mi → 728Mi, evicted at kill+89s, replacement admitted at 728Mi |
| result | **one** OOM, workflow completed on attempt **2 of 3** |

The same scenario with the worker polling instead of parking took a second OOM and finished on attempt 3 of 3, so the spare attempt is what parking buys. The budget must exceed the lane's `settleDelay` (90s) or the worker resumes before the replacement arrives.

Pairs with [temporal-activity-rerouter#16](https://github.com/atlanhq/temporal-activity-rerouter/pull/16), which serves the endpoint and performs the eviction, and the chart PRs [atlan#14930](https://github.com/atlanhq/atlan/pull/14930) / [#14931](https://github.com/atlanhq/atlan/pull/14931) / [#14932](https://github.com/atlanhq/atlan/pull/14932), which publish the advice port on the rerouter's Service. Without those the endpoint is reachable only inside the rerouter's own pod and every worker polls.

Full worksheet: [ARUN-1226](https://linear.app/atlan-epd/issue/ARUN-1226).

### The race, decided

A worker asks once. If its container restarts and reaches the endpoint before the rerouter's informer has delivered the OOM, it is told `no-eviction-scheduled`, polls, and no eviction follows.

Since [rerouter#17](https://github.com/atlanhq/temporal-activity-rerouter/pull/17) that costs more than it used to. The eviction is now gated on a worker having asked, so losing the race means no promise and therefore no eviction at all — where before the kill still produced a bigger replacement for the next attempt. **A worker will re-ask once mid-wait**, in a follow-up on this branch, so the mechanism already reviewed here does not move again. One GET on a worker that is otherwise idle.

### How a park is visible

Every finished park emits `worker_restart_park{outcome}` and `worker_restart_park_seconds{outcome}`, on two outcomes:

- `replaced` — something took the pod away while the worker was holding its work back, which is the mechanism working
- `spent` — the worker sat out its whole budget and resumed on the limit that killed it, having bought nothing

`spent` climbing is the signal that the lane has quietly stopped helping, and nothing outside the pod can produce it. The rerouter counts *evictions*, and an eviction that lands after the budget looks there exactly like one that arrived in time. The elapsed seconds are a value rather than a label, so the two metrics stay at one series per outcome.

Alongside it, the rerouter's `rerouter_oom_restarts_total{namespace, owner, outcome, reason}` says what happened to the kill, since rerouter#17 made the eviction require a park: `outcome="evict"` is a park that got its replacement, and `reason="no-worker-waiting"` is a kill nobody parked for. That reason covers both a worker that never asked and one that asked and was turned away — a label split on the rerouter side separates them. There is no alert on either yet; that is a separate PR in `atlan-alerts`.

### The at-ceiling trade

#16 declined to evict a pod already at its VPA cap, which meant a worker could park for an eviction that was then refused. The sizing check is gone — [rerouter#18](https://github.com/atlanhq/temporal-activity-rerouter/pull/18) made **an answer of `wait` oblige the eviction to happen**, with three reasons allowed to break it, each a fact that was not knowable when the worker asked.

What replaced it is a different cost: an at-ceiling workload is now evicted, to a pod the same size. The park is honoured, so the worker loses nothing it would not have lost anyway; what is spent is an eviction and one of that owner's three hourly allowances on a replacement that will OOM again. That is the better side of the trade — a worker never holds work back for a rescue nobody was going to perform — but it is a trade, not a free fix.

### Checklist

- [x] Additional tests added — **35 new**: all 26 of `tests/unit/common/test_restart_marker.py`, which is new, and 9 added to `tests/unit/test_constants.py` (44 collected there in total, the rest already existed). Includes a stand-in advice server covering each answer and each failure mode, and the park metric on both outcomes
- [x] All CI checks passed — locally: those two files, 70 together, `main.py`'s existing 157, ruff clean on the changed files (`main.py`'s 12 findings are unchanged from `main`), 3464 conformance tests pass with 3 failures confirmed pre-existing on an unmodified tree
- [ ] Relevant documentation updated — held back deliberately; the deployment side lands separately and the prose is better written against it

Each of the ten guards was removed in turn to confirm the test covering it goes red. That caught two tests of mine that still passed with the guard gone, for the reason described above. The park metric went through the same check: dropping either emit, mislabelling one, or moving the elapsed seconds back into the labels each turns a test red.

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)? — No




