### PR TITLE
fix(e2e): skip the teardown connection-delete when the run created nothing

### DIFF
--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -1077,6 +1077,11 @@ class BaseE2ETest:
         self._active_dag = None
         self.dag_outcomes = []
         self._connection_seeded = False
+        # Whether a DAG was ever submitted under this run's own connection.
+        # Together with ``_connection_seeded`` it is what tells teardown that
+        # the minted QN names something that can exist — see
+        # :meth:`_own_connection_may_exist`.
+        self._dag_submitted = False
         self._seeded_connection_qns: list[str] = []
         self._seeded_prefixes: list[str] = []
         self._validate_dag_runs()
@@ -1520,6 +1525,17 @@ class BaseE2ETest:
         worker that does not wake) and for when it should go.
         """
         conn_qn = getattr(self, "connection_qualified_name", "")
+        if conn_qn and not self._own_connection_may_exist():
+            logger.info(
+                "e2e cleanup: no cleanup needed for %s — this run seeded no "
+                "connection and submitted no DAG, so nothing was ever created "
+                "under that name",
+                conn_qn,
+            )
+            # Emptied rather than filtered out of the loop below, so the
+            # ordinals a seeding suite's teardown workflow names are built from
+            # do not shift when the run's own connection is skipped.
+            conn_qn = ""
         seeded = tuple(getattr(self, "_seeded_connection_qns", ()))
         for ordinal, target in enumerate((conn_qn, *seeded), start=1):
             if not target:
@@ -1529,6 +1545,38 @@ class BaseE2ETest:
                 continue
             self._warn_connection_delete_incomplete(target, report)
             await self._purge_connection_from_runner(target)
+
+    def _own_connection_may_exist(self) -> bool:
+        """Whether anything this run did could have created its own connection.
+
+        ``setup_method`` mints ``connection_qualified_name`` before the test
+        body runs, so by teardown it is always non-empty — non-emptiness is
+        therefore no evidence that a connection exists under it. Two things
+        create one, and nothing else does:
+
+        * :meth:`seed_connection`, which writes it to Atlas directly and sets
+          ``_connection_seeded``;
+        * a DAG submit, whose run mints the Connection on the tenant.
+
+        A run that did neither holds a freshly minted name under which, by
+        construction, nothing can exist — a suite that skipped in
+        :meth:`seed_prerequisites`, a leg where the source-availability tier
+        wired no AE client at all, or a test that errored before it submitted.
+        Deleting that name costs an AE workflow publish, a submit and a
+        minute of polling to reclaim nothing, on every leg of every push
+        (FND-1873).
+
+        The submit flag is set *before* the submit rather than after, because a
+        submit that times out is a run executing orphaned rather than one that
+        never happened — and that run creates the connection.
+
+        Returns:
+            Whether teardown has anything to reclaim under
+            ``self.connection_qualified_name``.
+        """
+        return bool(getattr(self, "_connection_seeded", False)) or bool(
+            getattr(self, "_dag_submitted", False)
+        )
 
     async def _delete_connection_via_app(
         self, qualified_name: str, *, ordinal: int
@@ -3652,6 +3700,11 @@ class BaseE2ETest:
             self.mode.value,
             self.connection_qualified_name,
         )
+        # Set before the submit, not after: a submit that times out is a run
+        # executing orphaned rather than one that never happened, and that run
+        # creates the connection teardown has to reclaim. See
+        # :meth:`_own_connection_may_exist`.
+        self._dag_submitted = True
         run_id = await self._submit(payload, slug=slug)
         logger.info("AE submit returned run_id=%s", run_id)
 

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -1076,11 +1076,18 @@ class BaseE2ETest:
         # single-DAG suite ever sees.
         self._active_dag = None
         self.dag_outcomes = []
+        # Whether the seed *completed* — the create landed AND the connection
+        # became searchable. This is the idempotency flag ``seed_connection``
+        # reads to reuse rather than re-create, and it is deliberately NOT what
+        # teardown gates on: it lands after the searchability poll, so a create
+        # that committed and then failed to become searchable would read as
+        # "nothing exists here". The two flags below are the existence ones.
         self._connection_seeded = False
-        # Whether a DAG was ever submitted under this run's own connection.
-        # Together with ``_connection_seeded`` it is what tells teardown that
-        # the minted QN names something that can exist — see
-        # :meth:`_own_connection_may_exist`.
+        # Whether anything has been sent that can bring this run's own
+        # connection into being: the create write, and a DAG submit. Both are
+        # set on the way *in* to the call, for the reason
+        # :meth:`_own_connection_may_exist` gives.
+        self._connection_create_attempted = False
         self._dag_submitted = False
         self._seeded_connection_qns: list[str] = []
         self._seeded_prefixes: list[str] = []
@@ -1551,30 +1558,45 @@ class BaseE2ETest:
 
         ``setup_method`` mints ``connection_qualified_name`` before the test
         body runs, so by teardown it is always non-empty — non-emptiness is
-        therefore no evidence that a connection exists under it. Two things
+        therefore no evidence that a connection exists under it. Two calls
         create one, and nothing else does:
 
-        * :meth:`seed_connection`, which writes it to Atlas directly and sets
-          ``_connection_seeded``;
+        * the Atlas create :meth:`seed_connection` issues;
         * a DAG submit, whose run mints the Connection on the tenant.
 
-        A run that did neither holds a freshly minted name under which, by
-        construction, nothing can exist — a suite that skipped in
+        A run that made neither call holds a freshly minted name under which,
+        by construction, nothing can exist — a suite that skipped in
         :meth:`seed_prerequisites`, a leg where the source-availability tier
         wired no AE client at all, or a test that errored before it submitted.
         Deleting that name costs an AE workflow publish, a submit and a
         minute of polling to reclaim nothing, on every leg of every push
         (FND-1873).
 
-        The submit flag is set *before* the submit rather than after, because a
-        submit that times out is a run executing orphaned rather than one that
-        never happened — and that run creates the connection.
+        **Both flags are set on the way in to the call, not on its way out**,
+        and each for the same reason: a call whose response never arrived is
+        not a call that did not happen. A submit that times out is a run
+        executing orphaned, and an Atlas create whose reply is lost may still
+        have committed. Recording success instead would turn each of those into
+        a connection nobody reclaims on a shared tenant. Over-deleting is the
+        harmless direction: the delete path already tolerates a connection that
+        is not there.
+
+        ``_connection_seeded`` is deliberately not consulted. It is
+        :meth:`seed_connection`'s *idempotency* flag and lands only after the
+        searchability poll, so a seed whose create committed and whose poll
+        then timed out (:class:`SeededConnectionNotSearchableError`) reads as
+        unseeded — which is precisely the half-set-up left-over teardown exists
+        for.
+
+        The one shape this cannot see is a suite that creates its connection
+        by hand rather than through :meth:`seed_connection`. Seed through the
+        hook and teardown follows; that is why the hook exists.
 
         Returns:
             Whether teardown has anything to reclaim under
             ``self.connection_qualified_name``.
         """
-        return bool(getattr(self, "_connection_seeded", False)) or bool(
+        return bool(getattr(self, "_connection_create_attempted", False)) or bool(
             getattr(self, "_dag_submitted", False)
         )
 
@@ -2039,6 +2061,10 @@ class BaseE2ETest:
                 await self._retry_seed_probe_async(probe)
             return qualified_name
         async with self._atlas_client() as client:
+            # Before the write, not after: a create whose reply never arrived
+            # may still have committed, and teardown must reclaim it. See
+            # :meth:`_own_connection_may_exist`.
+            self._connection_create_attempted = True
             await atlas.create_connection(
                 client,
                 qualified_name=qualified_name,

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -1531,12 +1531,18 @@ missing install. Drop it once neither is true.
 **A run that created nothing submits nothing.** `setup_method` mints
 `connection_qualified_name` before the test body runs, so it is non-empty by
 teardown whatever happened in between — non-emptiness is no evidence that a
-connection exists under it. Teardown therefore gates the run's own delete on
-what actually creates one: `seed_connection`, or a DAG submit (recorded *before*
-the POST, since a submit that times out is a run executing orphaned rather than
-one that never happened). A suite that skipped — no source provisioned, no
-subsystem wired, a `seed_prerequisites` that bailed — logs `no cleanup needed`
-at `INFO` and submits nothing. Before FND-1873 it published an AE workflow,
+connection exists under it. Teardown therefore gates the run's own delete on the
+two calls that actually create one: the Atlas create `seed_connection` issues,
+and a DAG submit. Both are recorded on the way **in** to the call rather than on
+its way out — a submit that times out is a run executing orphaned, and a create
+whose reply is lost may still have committed, so recording success instead would
+leave exactly those connections unreclaimed. (For the same reason the gate does
+*not* read `_connection_seeded`: that flag lands only after the searchability
+poll, so a seed that created its connection and then raised
+`SeededConnectionNotSearchableError` would read as having created nothing.) A
+suite that skipped — no source provisioned, no subsystem wired, a
+`seed_prerequisites` that bailed — logs `no cleanup needed` at `INFO` and
+submits nothing. Before FND-1873 it published an AE workflow,
 submitted it and waited ~60s to `PURGE` a name under which, by construction,
 nothing could exist, on every leg of every push. Connections `seed_assets` or a
 `DAGSpec` registered are unaffected: those exist because something published

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -1528,6 +1528,20 @@ tier (`source_available=false`) wires no AE client to submit a delete through at
 all, and a scale-to-zero worker that fails to wake is indistinguishable from a
 missing install. Drop it once neither is true.
 
+**A run that created nothing submits nothing.** `setup_method` mints
+`connection_qualified_name` before the test body runs, so it is non-empty by
+teardown whatever happened in between — non-emptiness is no evidence that a
+connection exists under it. Teardown therefore gates the run's own delete on
+what actually creates one: `seed_connection`, or a DAG submit (recorded *before*
+the POST, since a submit that times out is a run executing orphaned rather than
+one that never happened). A suite that skipped — no source provisioned, no
+subsystem wired, a `seed_prerequisites` that bailed — logs `no cleanup needed`
+at `INFO` and submits nothing. Before FND-1873 it published an AE workflow,
+submitted it and waited ~60s to `PURGE` a name under which, by construction,
+nothing could exist, on every leg of every push. Connections `seed_assets` or a
+`DAGSpec` registered are unaffected: those exist because something published
+them.
+
 **None of this can red a leg.** Teardown runs after the assertions have decided
 the verdict, so every step reports rather than raises — a missing app, an
 unreachable tenant and a store with no binding are all `WARNING` lines. Tenant

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -1740,6 +1740,10 @@ class TestTeardownFallsBackToTheHarnessPurge:
 
         harness = _ConcreteE2ETest()
         harness.connection_qualified_name = self._QN
+        # A run that got as far as submitting its DAG, so the connection it
+        # minted may exist — which is what teardown gates the reclaim on since
+        # FND-1873.
+        harness._dag_submitted = True
         monkeypatch.setattr(
             "application_sdk.testing.e2e.base.purge_connection", _record
         )
@@ -1774,6 +1778,7 @@ class TestTeardownFallsBackToTheHarnessPurge:
         """
         harness = _ConcreteE2ETest()
         harness.connection_qualified_name = self._QN
+        harness._dag_submitted = True
 
         def _unreachable(self: object) -> Any:
             raise RuntimeError("no tenant configured")

--- a/tests/unit/testing/e2e/test_multi_dag_runs.py
+++ b/tests/unit/testing/e2e/test_multi_dag_runs.py
@@ -281,6 +281,8 @@ def _wire(
     harness._auto_admin_users = ()  # type: ignore[attr-defined]
     harness._active_dag = None  # type: ignore[attr-defined]
     harness._connection_seeded = False  # type: ignore[attr-defined]
+    harness._connection_create_attempted = False  # type: ignore[attr-defined]
+    harness._dag_submitted = False  # type: ignore[attr-defined]
     harness._seed_version = None  # type: ignore[attr-defined]
     harness._node_dispatch = {}  # type: ignore[attr-defined]
     harness._expected_node_identities = {}  # type: ignore[attr-defined]
@@ -625,6 +627,51 @@ class TestDeclaredRuns:
         # graph is the one the harness published, which is FND-1775.
         assert len(ae.submitted_versions) == 1
         assert [s.entrypoint for s in ae.submits] == ["crawler", "miner"]
+
+    def test_a_submit_that_times_out_still_gets_its_connection_back(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FND-1873's gate is recorded on the way *in* to the submit.
+
+        A submit whose response never arrives is a run executing orphaned, not
+        a run that never happened — so the connection it mints is real and has
+        to be reclaimed. Recording the flag after the ``await`` instead would
+        leave this leg's connection on a shared tenant, and this is the only
+        test that would notice: it drives ``_run_full_dag_async`` for real
+        rather than presetting the flag.
+        """
+        harness = _Crawler()
+        ae = _FakeAE(_succeeded(CONNECTION_DELETE_NODE_ID))
+
+        async def _times_out(_payload: dict[str, Any], **_kwargs: Any) -> str:
+            raise TimeoutError("read timeout on submit")
+
+        monkeypatch.setattr(ae, "submit_workflow", _times_out)
+        calls = _wire(harness, ae, monkeypatch)
+
+        with pytest.raises(TimeoutError):
+            harness.run_full_dag()
+        harness.teardown_method(None)
+
+        teardowns = [name for name in ae.created_names if "-teardown-" in name]
+        assert len(teardowns) == 1
+        assert calls.purged == []
+
+    def test_a_run_that_never_submitted_reclaims_nothing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The other side of the same gate, through the same real wiring: a
+        suite that skipped before ``run_full_dag`` submits no teardown DAG and
+        does not fall back to the runner purge either."""
+        harness = _Crawler()
+        ae = _FakeAE(_succeeded(CONNECTION_DELETE_NODE_ID))
+        calls = _wire(harness, ae, monkeypatch)
+
+        harness.teardown_method(None)
+
+        assert ae.created_names == []
+        assert ae.submitted_versions == []
+        assert calls.purged == []
 
     def test_a_failing_run_stops_the_sequence(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/testing/e2e/test_non_publishing_entrypoint.py
+++ b/tests/unit/testing/e2e/test_non_publishing_entrypoint.py
@@ -612,3 +612,23 @@ class TestSeededConnectionIsTornDown:
             f"seeded connection {seeded_qn} was not purged — a surviving "
             "connection breaks run isolation"
         )
+
+    def test_a_seed_whose_searchability_poll_timed_out_is_still_purged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The half-set-up left-over this class exists for, exactly.
+
+        The create committed; only the searchability poll gave up, so
+        ``seed_connection`` raised and ``_connection_seeded`` was never set.
+        The connection is nonetheless real. FND-1873's teardown gate therefore
+        keys off the create *attempt* rather than off the seed completing — a
+        gate on ``_connection_seeded`` would skip precisely this run and leak
+        the connection onto the shared tenant.
+        """
+        harness, calls = _seeding_harness(monkeypatch, connection_found=False)
+
+        with pytest.raises(SeededConnectionNotSearchableError):
+            harness.seed_connection()
+        harness.teardown_method(None)
+
+        assert calls.purged == ["default/miner-source/minted"]

--- a/tests/unit/testing/e2e/test_seed_assets_registry.py
+++ b/tests/unit/testing/e2e/test_seed_assets_registry.py
@@ -139,6 +139,11 @@ def _harness(
     harness.run_id = 1787587123
     harness._ae = object()
     harness.connection_qualified_name = _RUN_QN
+    # A run that submitted its DAG, which is what every test here but
+    # ``TestTeardownSkipsAConnectionThatWasNeverCreated`` is about: the submit is
+    # what makes the run's own connection exist, and therefore what teardown
+    # keys its delete off (FND-1873).
+    harness._dag_submitted = True
     harness._seeded_connection_qns = []
     harness._seeded_prefixes = []
     harness._minter = SimpleNamespace(
@@ -454,6 +459,99 @@ class TestTeardownIncludesSeededConnections:
         )
         harness.teardown_method(method=None)
         assert harness.deleted_connections == [_RUN_QN, _SEED_QN]
+
+
+class TestTeardownSkipsAConnectionThatWasNeverCreated:
+    """FND-1873: a run that created nothing has nothing to reclaim.
+
+    ``setup_method`` mints ``connection_qualified_name`` before the test body
+    runs, so it is non-empty by teardown whatever happened in between — and
+    teardown used to read that non-emptiness as "there is a connection here".
+    A suite that skipped (no z/OS subsystem wired, no source provisioned) then
+    spent an AE workflow publish, a submit and a minute of polling PURGE-ing a
+    name under which, by construction, nothing exists — on every leg of every
+    push.
+
+    The gate is what actually creates one: :meth:`seed_connection`, or a DAG
+    submit. Both are pinned here, because a gate that also skipped those would
+    trade a wasted minute for a connection leaked onto a shared tenant.
+    """
+
+    def test_a_run_that_neither_seeded_nor_submitted_deletes_nothing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        harness, _seeded, purged, deleted = _harness(monkeypatch)
+        harness._dag_submitted = False
+        harness.teardown_method(method=None)
+        assert harness.deleted_connections == []
+        assert harness.recorded_delete_plans == []
+        # And no runner-side purge either: the fallback exists for a delete that
+        # did not complete, not for one that was never needed.
+        assert purged == []
+        assert deleted == []
+
+    def test_a_submitted_run_still_deletes_its_own_connection(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The submit is set *before* the POST, so a submit that timed out — a
+        run executing orphaned rather than one that never happened — still
+        gets reclaimed."""
+        harness, _seeded, _purged, _deleted = _harness(monkeypatch)
+        harness.teardown_method(method=None)
+        assert harness.deleted_connections == [_RUN_QN]
+
+    def test_a_seeded_connection_is_deleted_without_any_submit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A miner suite seeds the connection it enriches in
+        ``seed_prerequisites``; if the run then fails before submitting, that
+        connection is real and still has to go."""
+        harness, _seeded, _purged, _deleted = _harness(monkeypatch)
+        harness._dag_submitted = False
+        harness._connection_seeded = True
+        harness.teardown_method(method=None)
+        assert harness.deleted_connections == [_RUN_QN]
+
+    def test_a_seeded_lineage_parent_is_still_reclaimed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``seed_assets`` publishes a second connection through a real run, so
+        it exists whether or not the suite's own DAG was ever submitted — and
+        the ordinal its teardown workflow is named from does not shift when the
+        run's own connection is skipped."""
+        harness, _seeded, _purged, deleted = _harness(monkeypatch)
+        harness.seed_assets(_spec())
+        harness._dag_submitted = False
+        harness.teardown_method(method=None)
+        assert harness.deleted_connections == [_SEED_QN]
+        assert harness.recorded_delete_plans[0].ae_workflow_name.endswith("-teardown-2")
+        assert deleted == [_SEED_KEY]
+
+    def test_the_skipped_delete_is_logged_rather_than_silent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ "Nothing to clean up" and "cleanup did not run" look identical in a
+        CI log unless one of them says so.
+
+        The module's logger is substituted rather than captured with ``caplog``:
+        the SDK's adaptor is loguru-backed and does not propagate to stdlib
+        ``logging``, so ``caplog`` would assert against an empty record list and
+        read as "the code failed to log".
+        """
+        harness, _seeded, _purged, _deleted = _harness(monkeypatch)
+        harness._dag_submitted = False
+        messages: list[str] = []
+
+        def _record(message: str, *args: object, **_kwargs: object) -> None:
+            messages.append(message % args if args else message)
+
+        monkeypatch.setattr(
+            "application_sdk.testing.e2e.base.logger",
+            SimpleNamespace(info=_record, warning=_record, error=_record),
+        )
+        harness.teardown_method(method=None)
+        assert any(_RUN_QN in message for message in messages)
+        assert any("no cleanup needed" in message for message in messages)
 
 
 class TestPerRunConnection:

--- a/tests/unit/testing/e2e/test_seed_assets_registry.py
+++ b/tests/unit/testing/e2e/test_seed_assets_registry.py
@@ -472,9 +472,13 @@ class TestTeardownSkipsAConnectionThatWasNeverCreated:
     name under which, by construction, nothing exists — on every leg of every
     push.
 
-    The gate is what actually creates one: :meth:`seed_connection`, or a DAG
-    submit. Both are pinned here, because a gate that also skipped those would
-    trade a wasted minute for a connection leaked onto a shared tenant.
+    The gate is what actually creates one: the Atlas create ``seed_connection``
+    issues, or a DAG submit. Both are pinned here, because a gate that also
+    skipped those would trade a wasted minute for a connection leaked onto a
+    shared tenant — and both are recorded on the way *in* to the call, which is
+    pinned through the real paths in ``test_multi_dag_runs.py`` (a submit that
+    times out) and ``test_non_publishing_entrypoint.py`` (a create that
+    committed and then failed to become searchable).
     """
 
     def test_a_run_that_neither_seeded_nor_submitted_deletes_nothing(
@@ -493,22 +497,33 @@ class TestTeardownSkipsAConnectionThatWasNeverCreated:
     def test_a_submitted_run_still_deletes_its_own_connection(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The submit is set *before* the POST, so a submit that timed out — a
-        run executing orphaned rather than one that never happened — still
-        gets reclaimed."""
+        """The control for the two above, on the helper's own preset.
+
+        That the flag is set *before* the POST — so a submit that timed out,
+        which is a run executing orphaned rather than one that never happened,
+        is still reclaimed — cannot be shown here: this harness never reaches
+        ``_run_full_dag_async``. It is pinned through the real submit path in
+        ``test_multi_dag_runs.py``.
+        """
         harness, _seeded, _purged, _deleted = _harness(monkeypatch)
         harness.teardown_method(method=None)
         assert harness.deleted_connections == [_RUN_QN]
 
-    def test_a_seeded_connection_is_deleted_without_any_submit(
+    def test_an_attempted_create_is_deleted_without_any_submit(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A miner suite seeds the connection it enriches in
         ``seed_prerequisites``; if the run then fails before submitting, that
-        connection is real and still has to go."""
+        connection is real and still has to go.
+
+        The gate is the create *attempt*, not ``_connection_seeded`` — which
+        lands only after the searchability poll, and so is false on exactly the
+        half-set-up seed that most needs reclaiming. Driven through the real
+        seed path in ``test_non_publishing_entrypoint.py``.
+        """
         harness, _seeded, _purged, _deleted = _harness(monkeypatch)
         harness._dag_submitted = False
-        harness._connection_seeded = True
+        harness._connection_create_attempted = True
         harness.teardown_method(method=None)
         assert harness.deleted_connections == [_RUN_QN]
 


### PR DESCRIPTION
Closes FND-1873.

`setup_method` mints `connection_qualified_name` before the test body runs, so it is non-empty by teardown whatever happened in between — and `_delete_connections` read that non-emptiness as "there is a connection here". A run that skipped (no source provisioned, no subsystem wired, a `seed_prerequisites` that bailed) therefore published an AE workflow, submitted it, and waited ~60s to `PURGE` a name under which, by construction, nothing could exist. On the reporting connector that was ~17 minutes of runner time and three tenant mutations per push across the three cloud legs, for zero assertions and a green check.

## The gate

Two calls create the run's own connection, and nothing else does:

* the Atlas create `seed_connection()` issues — new `_connection_create_attempted`;
* a DAG submit, whose run mints the Connection on the tenant — new `_dag_submitted`.

Both sit behind `BaseE2ETest._own_connection_may_exist()`, which `_delete_connections` now consults for the run's own QN.

**Both flags are set on the way in to the call, not on its way out.** A submit that times out is a run executing orphaned, and an Atlas create whose reply is lost may still have committed. Recording success instead would turn each of those into a connection nobody reclaims on a shared tenant. Over-deleting is the harmless direction — the delete path already tolerates a connection that is not there.

### Why not `_connection_seeded`

The linked issue suggests gating on `_connection_seeded`. Two reasons that is the wrong flag, and both were worth writing tests for:

1. **It is never set on a crawler suite.** Only `seed_connection()` sets it, and a crawler suite never calls it — its connection is minted by the DAG run. Gating on it alone would leave every crawler leg's connection behind on a shared tenant. Strictly worse than the wasted minute.
2. **It lands too late even on a seeding suite.** It is set after `poll_for_connection` succeeds, while `create_connection` commits earlier. A seed whose create landed and whose searchability poll then timed out (`SeededConnectionNotSearchableError`) would reach teardown with every flag false — and that is exactly the half-set-up left-over teardown exists for.

`_connection_seeded` therefore stays what it always was: `seed_connection`'s *idempotency* flag, now documented as not being the existence flag.

## Scope

* Connections `seed_assets` or a `DAGSpec` registered are untouched: those exist because something published them, and the emptiness check on `_seeded_connection_qns` was already correct.
* The run's own QN is *emptied* rather than filtered out of the delete loop, so the ordinals a seeding suite's teardown AE workflow names are built from do not shift when it is skipped.
* A skipped teardown logs `e2e cleanup: no cleanup needed for <qn> — this run seeded no connection and submitted no DAG` at INFO, so "nothing to clean up" is distinguishable from "cleanup did not run".
* Side effect: the `source_available=false` tier wires no AE client, so its teardown used to fall through to the runner-side `pyatlan` purge and emit a `no AE client on this tier, so <qn> could not be deleted` WARNING on every worker-up-only run — for a connection that never existed. That line is gone too.

## Tests

Both creation edges are pinned through their **real** paths, not through a preset flag — each verified red before the fix:

* `test_non_publishing_entrypoint.py` — `seed_connection` with a searchability poll that never settles; the purge still runs. Red on a gate that reads `_connection_seeded`.
* `test_multi_dag_runs.py` — `_run_full_dag_async` with a submit that raises a timeout; the teardown DAG is still submitted. Red if the flag moves after the `await`. Plus the negative case (a suite that never submitted creates no AE workflow and does not fall back to the purge) through the same wiring.

Wiring-level cases in `test_seed_assets_registry.py::TestTeardownSkipsAConnectionThatWasNeverCreated`:

* a run that neither created nor submitted deletes nothing **and** does not fall back to the runner purge;
* an attempted create is deleted without any submit;
* a `seed_assets` lineage parent is still reclaimed, with its teardown ordinal intact;
* the skip is logged rather than silent (module logger substituted — the SDK's adaptor is loguru-backed and does not reach `caplog`).

Two existing teardown helpers now declare `_dag_submitted = True`, which is what they were always modelling.

`tests/unit/testing`: 2108 passed, 6 skipped. Pre-commit clean.

## Docs

New paragraph in `docs/standards/connector-ci-e2e.md` under "Teardown goes through the app that owns the artifacts".

## Security review

No security-relevant changes: no new inputs, no credential handling, no network destinations. The change strictly *reduces* the number of tenant mutations a CI leg performs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNoUHw4dYgfcnfEA8VHPzT
