### PR TITLE
feat(conformance): resolve source-available and compose-overlay per e2e suite

### DIFF
--- a/.github/actions/discover-e2e-suites/action.yaml
+++ b/.github/actions/discover-e2e-suites/action.yaml
@@ -10,6 +10,13 @@ description: |
   suite runs once per CSP tenant. Leaving it empty keeps the single-tenant
   shape, which is what a caller without the tenant-matrix secret wants.
 
+  `source-available` / `source-available-overrides` / `compose-overlay` make
+  the two per-suite dimensions the legs need (FND-1865): each leg carries its
+  own source-availability tier and its own compose overlay, so a connector
+  whose entrypoints are not equally testable can say so. Resolution runs
+  against the caller's checked-out tree, which is what lets the overlay be a
+  convention (`<dir>/<suite>-docker-compose.yaml`) rather than an input.
+
 inputs:
   test-dir:
     description: Directory to glob for test_*.py e2e suites.
@@ -54,10 +61,59 @@ inputs:
       per suite (e2e-full-reusable.yaml). `test-dir` is unused in that mode.
     required: false
     default: "false"
+  source-available:
+    description: |
+      The repo-wide source-availability default every discovered suite takes
+      unless `source-available-overrides` names it. Emitted per leg as the
+      matrix's `source-available`, which the caller forwards to the sdr-e2e
+      action (and thence to the harness's E2E_SOURCE_AVAILABLE). "true" runs
+      the full DAG; "false" degrades every leg to a worker-up-only check.
+    required: false
+    default: "true"
+  source-available-overrides:
+    description: |
+      Per-suite overrides of `source-available` (FND-1865), as comma-separated
+      `<suite>=true|false` — keyed off the DISCOVERED suite name
+      (`test_db2zos_e2e.py` -> `db2zos-e2e`), the same key `artifact-suffix`
+      and the derived ATLAN_DEPLOYMENT_NAME already use.
+
+      For a multi-entrypoint connector whose entrypoints are not equally
+      testable: db2's LUW flavour has a community container, its z/OS flavour
+      cannot have one at all (container images are architecture AND OS
+      specific), so one repo-wide boolean could only be wrong for one of them.
+
+      An override that names an undiscovered suite FAILS discovery rather than
+      being ignored — an inert override leaves the leg on the repo-wide
+      default, which is the silent full-DAG-on-a-sourceless-leg this input
+      exists to prevent. Empty (the default) means no overrides.
+    required: false
+    default: ""
+  compose-overlay:
+    description: |
+      The repo-wide compose overlay each leg falls back to. When set, each
+      leg's overlay is resolved PER SUITE — `<dir>/<suite>-docker-compose.yaml`
+      when that file exists in the caller's checked-out tree, else this path —
+      and emitted as the matrix's `compose-overlay` for the caller to forward
+      to the sdr-e2e action.
+
+      The convention is what makes a per-suite source container possible: with
+      one pinned path, a multi-entrypoint connector started every container on
+      every leg, and the worker's `depends_on: service_healthy` made the legs
+      that cannot use one wait for it.
+
+      Empty (the default) omits the matrix key entirely: there is no sane
+      default overlay path to derive the convention from (the SDR and full-DAG
+      pipelines use different ones), and forwarding an empty value would send
+      the sdr-e2e action to its own SDR convention on the full-DAG pipeline.
+    required: false
+    default: ""
 
 outputs:
   matrix:
-    description: JSON include-list for strategy.matrix; each entry has file and name (plus suite and cloud when `clouds` is set).
+    description: |
+      JSON include-list for strategy.matrix; each entry has file and name (plus
+      suite and cloud when `clouds` is set, source-available always in suite
+      mode, and compose-overlay when `compose-overlay` is set).
     value: ${{ steps.discover.outputs.matrix }}
   count:
     description: Number of discovered suites (0 means the e2e job should skip). Independent of the cloud fan-out.
@@ -89,6 +145,9 @@ runs:
         TEST_DIR: ${{ inputs.test-dir }}
         CLOUDS: ${{ inputs.clouds }}
         AVAILABLE_CLOUDS: ${{ inputs.available-clouds }}
+        SOURCE_AVAILABLE: ${{ inputs.source-available }}
+        SOURCE_AVAILABLE_OVERRIDES: ${{ inputs.source-available-overrides }}
+        COMPOSE_OVERLAY: ${{ inputs.compose-overlay }}
         CLOUDS_ONLY_FLAG: ${{ inputs.clouds-only == 'true' && '--clouds-only' || '' }}
       run: |
         set -euo pipefail
@@ -96,4 +155,7 @@ runs:
           --test-dir "$TEST_DIR" \
           --clouds "$CLOUDS" \
           --available-clouds "$AVAILABLE_CLOUDS" \
+          --source-available "$SOURCE_AVAILABLE" \
+          --source-available-overrides "$SOURCE_AVAILABLE_OVERRIDES" \
+          --compose-overlay "$COMPOSE_OVERLAY" \
           ${CLOUDS_ONLY_FLAG} >> "$GITHUB_OUTPUT"

--- a/.github/actions/discover-e2e-suites/discover_e2e_suites.py
+++ b/.github/actions/discover-e2e-suites/discover_e2e_suites.py
@@ -75,6 +75,32 @@ deliberate edit here.
 callers that target a whole directory rather than fanning out per file
 (``e2e-full-reusable.yaml``).
 
+Per-suite dimensions (FND-1865)
+-------------------------------
+Two of the values a leg runs with used to be resolved once for the whole repo
+while the legs were already per suite: ``source-available`` and the compose
+overlay. A connector whose entrypoints differ in source provisioning could not
+express that — db2's LUW flavour has a community container, its z/OS flavour
+cannot have one at all (container images are architecture *and* OS specific) —
+and no app-side workaround exists: the harness's class attribute loses to
+``E2E_SOURCE_AVAILABLE`` on every CI run, and a module-level ``pytest.skip``
+exits 5, which the composite propagates verbatim, so the leg reds rather than
+skipping.
+
+Both are resolved here, keyed off the discovered suite, and carried in the
+matrix the same way the artifact suffix and the derived deployment name already
+are — see :class:`PerSuiteOptions`:
+
+* ``--source-available`` is the repo-wide default; ``--source-available-overrides``
+  is ``<suite>=true|false``, comma-separated, and overrides in both directions.
+  An override naming an undiscovered suite is a hard failure, not a no-op: an
+  inert override leaves the leg on the repo-wide default, and the run greens
+  having tried to extract from a source that cannot exist.
+* ``--compose-overlay`` is the repo-wide FALLBACK; the per-suite overlay is a
+  convention resolved against the caller's tree
+  (``<dir>/<suite>-docker-compose.yaml``), which is possible here precisely
+  because this driver runs after the caller's checkout.
+
 Co-located with the composite action — NOT under ``.github/scripts/`` — so it
 is checked out alongside the action when consumed from another repo (mirrors
 build_compose_chain.py). It scans the *caller's* checked-out working tree, so
@@ -87,7 +113,8 @@ import argparse
 import json
 import re
 import sys
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
 from pathlib import Path
 
 _SANITIZE_RE = re.compile(r"[^a-z0-9]+")
@@ -102,9 +129,30 @@ DEFAULT_CLOUDS = ("aws", "azure", "gcp")
 # every un-customised run is the failure this sentinel exists to prevent.
 NO_CLOUDS = "none"
 
+# The per-suite compose-overlay convention (FND-1865). The matrix fans out one
+# leg per suite, but the overlay used to be a single repo-wide path pinned by
+# the caller, so a multi-entrypoint connector started EVERY source container on
+# EVERY leg — and the worker's `depends_on: service_healthy` made the legs that
+# cannot use one wait for it. A file named for the discovered suite wins over
+# the repo-wide fallback; no such file means "nothing suite-specific here",
+# which is what every single-flavour connector already has, so their behaviour
+# stays byte-identical.
+SUITE_COMPOSE_OVERLAY = "{suite}-docker-compose.yaml"
+
+# The only two spellings a source-availability value may take here. The harness
+# itself is lenient (``1``/``yes`` count as true) because it reads an env var
+# several things write; this reads a hand-written workflow input, where
+# rejecting a ``zos=0`` costs one loud discovery failure and accepting it
+# silently decides whether a leg extracts anything at all.
+_BOOLS = {"true": True, "false": False}
+
 
 class CloudSelectionError(ValueError):
     """The requested cloud fan-out cannot be satisfied."""
+
+
+class SuiteOptionError(ValueError):
+    """A per-suite option is malformed, or names a suite that was not found."""
 
 
 def _leg_name(path: Path) -> str:
@@ -202,7 +250,146 @@ def parse_clouds(raw: str, available: Iterable[str] | None = None) -> list[str]:
     return _split_clouds(raw)
 
 
-def discover(test_dir: str, clouds: list[str] | None = None) -> list[dict[str, str]]:
+def _parse_bool(raw: str, what: str) -> bool:
+    """Return the boolean *raw* spells, or raise naming *what* and the value."""
+    value = raw.strip().lower()
+    if value not in _BOOLS:
+        raise SuiteOptionError(
+            f"{what} must be 'true' or 'false', not {raw.strip()!r}. Rejected "
+            "rather than coerced: this value decides whether a leg runs the "
+            "full DAG or degrades to a worker-up-only check, and a typo that "
+            "read as false would green a leg that extracted nothing."
+        )
+    return _BOOLS[value]
+
+
+def parse_source_available_overrides(raw: str) -> dict[str, bool]:
+    """Parse the per-suite source-availability overrides (FND-1865).
+
+    Accepts the comma-separated ``<suite>=true|false`` form the workflow input
+    carries — ``"db2zos-e2e=false"`` — keyed off the DISCOVERED suite name (the
+    matrix's ``suite``/``name``, i.e. ``test_db2zos_e2e.py`` -> ``db2zos-e2e``),
+    which is the same key ``artifact-suffix`` and the derived
+    ``ATLAN_DEPLOYMENT_NAME`` already use. ``""`` (an untouched input) yields no
+    overrides, so every suite takes the repo-wide default.
+
+    Overrides key on the SUITE, never on the leg: source availability is a
+    property of the entrypoint, not of the CSP tenant the leg runs against, so
+    an override applies to that suite on every cloud.
+
+    Malformed tokens raise rather than being skipped — a dropped override is
+    exactly the silent full-DAG-on-a-sourceless-leg the input exists to prevent.
+    A suite named twice raises too, even with the same value: one of the two
+    lines is not what its author meant.
+    """
+    overrides: dict[str, bool] = {}
+    for token in raw.split(","):
+        item = token.strip()
+        if not item:
+            continue
+        suite, sep, value = item.partition("=")
+        suite = suite.strip()
+        if not sep or not suite:
+            raise SuiteOptionError(
+                f"source-available override {item!r} is not '<suite>=true|false'. "
+                "The suite is the discovered suite name (test_db2zos_e2e.py -> "
+                "db2zos-e2e), e.g. 'db2zos-e2e=false'."
+            )
+        if suite in overrides:
+            raise SuiteOptionError(
+                f"suite {suite!r} appears twice in the source-available "
+                "overrides; one of the two is not what it meant to say."
+            )
+        overrides[suite] = _parse_bool(value, f"source-available override {suite!r}")
+    return overrides
+
+
+def resolve_compose_overlay(suite: str, fallback: str) -> str:
+    """Return *suite*'s compose overlay: its own file if it exists, else *fallback*.
+
+    The convention is ``<fallback's dir>/<suite>-docker-compose.yaml``, resolved
+    against the CALLER's checked-out tree (this driver runs after the caller's
+    checkout, which is what lets a per-suite file be a convention rather than an
+    input). *fallback* is the single repo-wide overlay the caller used to pin for
+    every leg, so a connector with no per-suite file is unaffected.
+
+    Note the asymmetry with the source-availability default: a missing per-suite
+    file falls back, it does not mean "no overlay". Expressing "this suite must
+    layer nothing" is the app's job — it moves the shared overlay's contents
+    into the per-suite files that want them and stops shipping the shared path.
+    """
+    candidate = Path(fallback).parent / SUITE_COMPOSE_OVERLAY.format(suite=suite)
+    return candidate.as_posix() if candidate.is_file() else fallback
+
+
+@dataclass(frozen=True)
+class PerSuiteOptions:
+    """The per-suite dimensions a matrix leg carries beyond file/name/cloud.
+
+    Both existed as ONE repo-wide value per run while the legs were already
+    per-suite (FND-1865): a multi-entrypoint connector whose entrypoints differ
+    in source provisioning — db2's containerisable LUW flavour beside z/OS,
+    which no container can serve — could not express that, and had no app-side
+    workaround (a class attribute loses to the env var; a module-level
+    ``pytest.skip`` exits 5 and reds the leg).
+
+    ``compose_overlay`` is the repo-wide FALLBACK path, not the resolved one:
+    resolution is per suite, against the caller's tree, in
+    :func:`resolve_compose_overlay`.
+    """
+
+    source_available: bool = True
+    source_available_overrides: Mapping[str, bool] = field(default_factory=dict)
+    compose_overlay: str = ""
+
+    def source_available_for(self, suite: str) -> bool:
+        """Whether *suite* has a source: its override if it has one, else the default."""
+        return self.source_available_overrides.get(suite, self.source_available)
+
+    def keys_for(self, suite: str) -> dict[str, str]:
+        """The extra matrix keys for *suite*, as the strings a leg forwards.
+
+        ``source-available`` is always emitted — it always has a value, and a
+        leg that forwarded an empty one would fall back to the harness's class
+        default (true), which is the wrong direction to fail in for a connector
+        that set it false. ``compose-overlay`` is emitted only when a fallback
+        was supplied, because there is no sane default overlay path to derive a
+        convention from (the SDR and full-DAG pipelines use different ones), and
+        an empty value would send the sdr-e2e action to its OWN convention —
+        the SDR overlay — on the full-DAG pipeline.
+        """
+        keys = {"source-available": str(self.source_available_for(suite)).lower()}
+        if self.compose_overlay:
+            keys["compose-overlay"] = resolve_compose_overlay(
+                suite, self.compose_overlay
+            )
+        return keys
+
+    def require_known_suites(self, suites: Iterable[str]) -> None:
+        """Raise when an override names a suite discovery did not find.
+
+        A typo'd or renamed suite name would otherwise be a no-op: the override
+        matches nothing, the leg keeps the repo-wide default, and the run reports
+        green having tried to extract from a source that does not exist. Failing
+        in the discovery job costs seconds and names the suites that do exist.
+        """
+        known = list(suites)
+        unknown = [s for s in self.source_available_overrides if s not in known]
+        if unknown:
+            raise SuiteOptionError(
+                "source-available override(s) name suite(s) that were not "
+                f"discovered: {', '.join(sorted(unknown))}. Discovered suites: "
+                f"{', '.join(known) or 'none'}. An override that matches no "
+                "suite is silently inert — the leg would keep the repo-wide "
+                "default — so this fails instead."
+            )
+
+
+def discover(
+    test_dir: str,
+    clouds: list[str] | None = None,
+    options: PerSuiteOptions | None = None,
+) -> list[dict[str, str]]:
     """Return the ordered matrix ``include`` entries for *test_dir*.
 
     One entry per ``test_*.py`` directly under *test_dir*, crossed with *clouds*
@@ -218,6 +405,11 @@ def discover(test_dir: str, clouds: list[str] | None = None) -> list[dict[str, s
     With no *clouds* the entries keep the pre-FND-6 ``{file, name}`` shape
     exactly: no ``suite``/``cloud`` keys are added, so ``matrix.cloud`` is empty
     in the caller and the tenant resolver takes its single-tenant fallback path.
+
+    *options* adds the per-suite dimensions (FND-1865) — ``source-available``,
+    and ``compose-overlay`` when a fallback path was given. Omitted (the
+    default) it adds nothing, so a caller that does not pass the new inputs gets
+    the pre-FND-1865 entry shape unchanged.
     """
     root = Path(test_dir)
     files = sorted(p for p in root.glob("test_*.py") if p.is_file())
@@ -233,8 +425,14 @@ def discover(test_dir: str, clouds: list[str] | None = None) -> list[dict[str, s
             seen[name] = 1
         suites.append((path, name))
 
+    def extra(suite: str) -> dict[str, str]:
+        return options.keys_for(suite) if options else {}
+
     if not clouds:
-        return [{"file": path.as_posix(), "name": name} for path, name in suites]
+        return [
+            {"file": path.as_posix(), "name": name, **extra(name)}
+            for path, name in suites
+        ]
 
     return [
         {
@@ -242,6 +440,7 @@ def discover(test_dir: str, clouds: list[str] | None = None) -> list[dict[str, s
             "suite": name,
             "cloud": cloud,
             "name": f"{name}-{cloud}",
+            **extra(name),
         }
         for path, name in suites
         for cloud in clouds
@@ -296,6 +495,39 @@ def main(argv: list[str] | None = None) -> int:
             "suite. --test-dir is not read in this mode."
         ),
     )
+    parser.add_argument(
+        "--source-available",
+        default="true",
+        help=(
+            "The repo-wide source-availability default every discovered suite "
+            "takes unless --source-available-overrides names it. 'true' (the "
+            "default) runs the full DAG; 'false' degrades every leg to a "
+            "worker-up-only check."
+        ),
+    )
+    parser.add_argument(
+        "--source-available-overrides",
+        default="",
+        help=(
+            "Comma-separated <suite>=true|false overrides of the repo-wide "
+            "default, keyed off the discovered suite name (test_db2zos_e2e.py "
+            "-> db2zos-e2e), e.g. 'db2zos-e2e=false'. For a multi-entrypoint "
+            "connector whose entrypoints are not equally testable. Empty = no "
+            "overrides. An override naming an undiscovered suite is an error, "
+            "not a no-op."
+        ),
+    )
+    parser.add_argument(
+        "--compose-overlay",
+        default="",
+        help=(
+            "The repo-wide compose overlay each leg falls back to. When set, "
+            "every leg's overlay is resolved per suite as "
+            f"<dir>/{SUITE_COMPOSE_OVERLAY.format(suite='<suite>')} when that "
+            "file exists in the caller's tree, else this path. Empty (the "
+            "default) omits the compose-overlay matrix key entirely."
+        ),
+    )
     args = parser.parse_args(sys.argv[1:] if argv is None else argv)
 
     try:
@@ -304,7 +536,35 @@ def main(argv: list[str] | None = None) -> int:
         print(f"::error::{exc}", file=sys.stderr)
         return 1
 
+    # Parsed before the matrix is built, and nothing is written to stdout on the
+    # failing path: a caller that read a matrix from an errored run would fan out
+    # legs whose per-suite dimensions were never resolved.
+    try:
+        options = PerSuiteOptions(
+            source_available=_parse_bool(args.source_available, "--source-available"),
+            source_available_overrides=parse_source_available_overrides(
+                args.source_available_overrides
+            ),
+            compose_overlay=args.compose_overlay.strip(),
+        )
+    except SuiteOptionError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
     if args.clouds_only:
+        # The cloud-only mode has no suite dimension, so a per-suite option
+        # passed here would be silently inert — which is the failure class the
+        # whole of FND-1865 is about. Say so instead.
+        if options.source_available_overrides or options.compose_overlay:
+            print(
+                "::error::--source-available-overrides / --compose-overlay have "
+                "no meaning with --clouds-only: that mode emits no suite "
+                "dimension, so a per-suite value could not reach any leg. Drop "
+                "them, or drop --clouds-only.",
+                file=sys.stderr,
+            )
+            return 1
+
         # No suites to count in this mode: the caller runs one pytest target per
         # cloud, so the suite count IS the cloud count and a zero there means
         # "no clouds configured" — which the caller's guard should still catch.
@@ -321,7 +581,12 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     suites = discover(args.test_dir)
-    entries = discover(args.test_dir, clouds)
+    try:
+        options.require_known_suites(e["name"] for e in suites)
+    except SuiteOptionError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+    entries = discover(args.test_dir, clouds, options)
 
     nested = _nested_only(args.test_dir)
     if nested:
@@ -344,8 +609,16 @@ def main(argv: list[str] | None = None) -> int:
         f"= {len(entries)} leg(s)",
         file=sys.stderr,
     )
+    # Per-leg, not per-run: "source-available: false" printed once for the run
+    # is what this driver used to be able to say, and it is exactly the sentence
+    # that was wrong for a connector with one testable flavour and one not.
     for e in entries:
-        print(f"  - {e['name']}: {e['file']}", file=sys.stderr)
+        dims = "".join(
+            f" {key}={e[key]}"
+            for key in ("source-available", "compose-overlay")
+            if key in e
+        )
+        print(f"  - {e['name']}: {e['file']}{dims}", file=sys.stderr)
     print(f"matrix={matrix}")
     print(f"count={len(suites)}")
     print(f"leg-count={len(entries)}")

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -180,6 +180,12 @@ inputs:
       (e.g. mysql-app's `.github/e2e/e2e-full-docker-compose.yaml`
       which propagates AWS_* env vars to the worker and sets a unique
       agent-name so the worker registers on its own Temporal queue).
+
+      tests-reusable.yaml passes a PER-LEG value here (FND-1865): its
+      discovery job resolves `.github/e2e/<suite>-docker-compose.yaml`
+      when the caller's tree has one and falls back to the repo-wide
+      path otherwise, so a multi-entrypoint connector no longer starts
+      every source container on every leg.
     required: false
     default: ""
   git-token:
@@ -227,6 +233,12 @@ inputs:
       BaseE2ETest.setup_method via the E2E_SOURCE_AVAILABLE env var). Apps
       with no free container / no wired credentials set this false until they
       provision a source.
+
+      tests-reusable.yaml passes a PER-LEG value here (FND-1865): the env var
+      is resolved per run and therefore per leg, so a connector whose
+      entrypoints are not equally testable narrows the repo-wide input with
+      `source-available-overrides` and only the sourceless suite's legs
+      degrade to the worker-up tier.
     required: false
     default: "true"
   full-dag:

--- a/.github/scripts/tests/test_discover_e2e_suites.py
+++ b/.github/scripts/tests/test_discover_e2e_suites.py
@@ -20,9 +20,13 @@ sys.path.insert(
 from discover_e2e_suites import (  # noqa: E402
     DEFAULT_CLOUDS,
     CloudSelectionError,
+    PerSuiteOptions,
+    SuiteOptionError,
     discover,
     main,
     parse_clouds,
+    parse_source_available_overrides,
+    resolve_compose_overlay,
 )
 
 
@@ -421,3 +425,291 @@ def test_clouds_only_narrows_the_same_way(capsys, tmp_path: Path) -> None:
     assert rc == 0
     assert [e["cloud"] for e in _matrix(out)["include"]] == ["aws", "gcp"]
     assert "count=2" in out.splitlines()
+
+
+# ── Per-suite source-availability and compose overlay (FND-1865) ─────────────
+#
+# The legs were per-suite and these two values were per-repo, which a connector
+# whose entrypoints are not equally testable cannot express: db2's LUW flavour
+# has a community container, its z/OS flavour cannot have one at all. The tests
+# below pin the three properties that make the pair usable — an override
+# reaches only its own suite, an undiscovered suite name is a hard failure
+# rather than an inert line, and a suite with no overlay file of its own keeps
+# the repo-wide path byte-identically.
+
+
+def test_overrides_parse_to_the_named_suites_only() -> None:
+    assert parse_source_available_overrides("db2zos-e2e=false") == {"db2zos-e2e": False}
+    assert parse_source_available_overrides(" a=false , b=true ,") == {
+        "a": False,
+        "b": True,
+    }
+
+
+def test_no_overrides_is_an_empty_map_not_an_error() -> None:
+    # An untouched GitHub input arrives as "". Every suite then takes the
+    # repo-wide default, which is the pre-FND-1865 behaviour.
+    assert parse_source_available_overrides("") == {}
+    assert parse_source_available_overrides("  ,  ") == {}
+
+
+@pytest.mark.parametrize("raw", ["db2zos-e2e", "=false", "db2zos-e2e=", "a=0", "a=no"])
+def test_a_malformed_override_raises_rather_than_being_skipped(raw: str) -> None:
+    # Skipping the token would leave the leg on the repo-wide default — the
+    # silent full-DAG-on-a-sourceless-leg the input exists to prevent. Note
+    # `a=0`/`a=no`: the HARNESS accepts those spellings from its env var, and
+    # this input deliberately does not, because here a rejected value costs one
+    # loud discovery failure and an accepted one decides a leg's whole tier.
+    with pytest.raises(SuiteOptionError):
+        parse_source_available_overrides(raw)
+
+
+def test_a_suite_named_twice_raises() -> None:
+    # Even with the same value on both lines: one of the two is not what its
+    # author meant, and picking either silently is a coin toss.
+    with pytest.raises(SuiteOptionError):
+        parse_source_available_overrides("a=false,a=false")
+
+
+def test_an_override_applies_to_its_suite_and_nothing_else(tmp_path: Path) -> None:
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_db2luw_e2e.py", "test_db2zos_e2e.py")
+    options = PerSuiteOptions(
+        source_available=True,
+        source_available_overrides={"db2zos-e2e": False},
+    )
+    resolved = {
+        e["name"]: e["source-available"] for e in discover(str(e2e), [], options)
+    }
+    assert resolved == {"db2luw-e2e": "true", "db2zos-e2e": "false"}
+
+
+def test_an_override_survives_the_cloud_cross_product(tmp_path: Path) -> None:
+    # Source availability is a property of the ENTRYPOINT, not of the CSP tenant
+    # the leg runs against, so the override has to reach that suite on every
+    # cloud — otherwise two of three legs would still try to extract.
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_db2luw_e2e.py", "test_db2zos_e2e.py")
+    options = PerSuiteOptions(source_available_overrides={"db2zos-e2e": False})
+    entries = discover(str(e2e), ["aws", "azure", "gcp"], options)
+    zos = [e for e in entries if e["suite"] == "db2zos-e2e"]
+    luw = [e for e in entries if e["suite"] == "db2luw-e2e"]
+    assert len(zos) == len(luw) == 3
+    assert {e["source-available"] for e in zos} == {"false"}
+    assert {e["source-available"] for e in luw} == {"true"}
+
+
+def test_the_repo_wide_default_can_be_false_with_one_suite_opted_in(
+    tmp_path: Path,
+) -> None:
+    # The inverse direction, which a "suites with no source" list could not
+    # express: most flavours unsourced, one containerisable.
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_a.py", "test_b.py")
+    options = PerSuiteOptions(
+        source_available=False, source_available_overrides={"b": True}
+    )
+    resolved = {
+        e["name"]: e["source-available"] for e in discover(str(e2e), [], options)
+    }
+    assert resolved == {"a": "false", "b": "true"}
+
+
+def test_source_available_is_emitted_even_when_nothing_is_overridden(
+    tmp_path: Path,
+) -> None:
+    # Always present, never blank: a leg forwarding "" would fall back to the
+    # harness's class default (true), so a connector that set the repo-wide
+    # input false would silently run the full DAG.
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_a.py")
+    (entry,) = discover(str(e2e), [], PerSuiteOptions(source_available=False))
+    assert entry["source-available"] == "false"
+
+
+def test_without_options_the_entry_shape_is_unchanged(tmp_path: Path) -> None:
+    # A caller that has not adopted the new inputs must get the pre-FND-1865
+    # matrix, key for key.
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_a.py")
+    (entry,) = discover(str(e2e))
+    assert set(entry) == {"file", "name"}
+
+
+def test_an_undiscovered_suite_in_the_overrides_raises(tmp_path: Path) -> None:
+    # The failure this guards is a no-op, not a crash: a renamed or misspelt
+    # suite name matches nothing, the leg keeps the repo-wide default, and the
+    # run reports green having tried to extract from a source that cannot exist.
+    options = PerSuiteOptions(source_available_overrides={"db2zos-e2e": False})
+    with pytest.raises(SuiteOptionError) as excinfo:
+        options.require_known_suites(["db2luw-e2e"])
+    message = str(excinfo.value)
+    assert "db2zos-e2e" in message
+    assert "db2luw-e2e" in message, "the discovered suites must be named too"
+
+
+def test_a_matching_suite_name_passes_the_check() -> None:
+    options = PerSuiteOptions(source_available_overrides={"a": False})
+    options.require_known_suites(["a", "b"])
+
+
+def test_the_per_suite_overlay_wins_when_the_file_exists(tmp_path: Path) -> None:
+    overlays = tmp_path / ".github" / "e2e"
+    _mk(overlays, "db2luw-e2e-docker-compose.yaml", "e2e-full-docker-compose.yaml")
+    fallback = (overlays / "e2e-full-docker-compose.yaml").as_posix()
+    assert resolve_compose_overlay("db2luw-e2e", fallback) == (
+        (overlays / "db2luw-e2e-docker-compose.yaml").as_posix()
+    )
+
+
+def test_a_suite_without_its_own_overlay_keeps_the_repo_wide_path(
+    tmp_path: Path,
+) -> None:
+    overlays = tmp_path / ".github" / "e2e"
+    _mk(overlays, "e2e-full-docker-compose.yaml")
+    fallback = (overlays / "e2e-full-docker-compose.yaml").as_posix()
+    assert resolve_compose_overlay("db2zos-e2e", fallback) == fallback
+
+
+def test_the_fallback_is_returned_even_when_it_does_not_exist(tmp_path: Path) -> None:
+    # The sdr-e2e action skips a missing overlay silently, which is how a
+    # connector with no overlay at all already runs. Discovery must not start
+    # failing those repos.
+    fallback = (
+        tmp_path / ".github" / "e2e" / "e2e-full-docker-compose.yaml"
+    ).as_posix()
+    assert resolve_compose_overlay("a", fallback) == fallback
+
+
+def test_the_overlay_key_is_omitted_without_a_fallback(tmp_path: Path) -> None:
+    # There is no sane default overlay path to derive the convention from — the
+    # SDR and full-DAG pipelines use different ones — and forwarding "" would
+    # send the sdr-e2e action to its OWN convention (the SDR overlay) on the
+    # full-DAG pipeline.
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_a.py")
+    (entry,) = discover(str(e2e), [], PerSuiteOptions())
+    assert "compose-overlay" not in entry
+
+
+def test_the_overlay_is_resolved_per_leg_in_the_matrix(tmp_path: Path) -> None:
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_db2luw_e2e.py", "test_db2zos_e2e.py")
+    overlays = tmp_path / ".github" / "e2e"
+    _mk(overlays, "db2luw-e2e-docker-compose.yaml", "e2e-full-docker-compose.yaml")
+    fallback = (overlays / "e2e-full-docker-compose.yaml").as_posix()
+    entries = discover(str(e2e), [], PerSuiteOptions(compose_overlay=fallback))
+    assert {e["name"]: e["compose-overlay"] for e in entries} == {
+        "db2luw-e2e": (overlays / "db2luw-e2e-docker-compose.yaml").as_posix(),
+        "db2zos-e2e": fallback,
+    }
+
+
+# ── main(): the CLI surface the composite action drives ──────────────────────
+
+
+def test_main_carries_the_per_suite_dimensions_into_the_matrix(
+    capsys, tmp_path: Path
+) -> None:
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_db2luw_e2e.py", "test_db2zos_e2e.py")
+    overlays = tmp_path / ".github" / "e2e"
+    _mk(overlays, "db2luw-e2e-docker-compose.yaml", "e2e-full-docker-compose.yaml")
+    fallback = (overlays / "e2e-full-docker-compose.yaml").as_posix()
+
+    rc = main(
+        [
+            "--test-dir",
+            str(e2e),
+            "--clouds",
+            "none",
+            "--source-available",
+            "true",
+            "--source-available-overrides",
+            "db2zos-e2e=false",
+            "--compose-overlay",
+            fallback,
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0
+    legs = {e["name"]: e for e in _matrix(captured.out)["include"]}
+    assert legs["db2zos-e2e"]["source-available"] == "false"
+    assert legs["db2zos-e2e"]["compose-overlay"] == fallback
+    assert legs["db2luw-e2e"]["source-available"] == "true"
+    assert legs["db2luw-e2e"]["compose-overlay"] == (
+        (overlays / "db2luw-e2e-docker-compose.yaml").as_posix()
+    )
+    # Per leg, not per run: one "source-available: false" line for the whole run
+    # is exactly the sentence that was wrong for this connector.
+    assert "db2zos-e2e: " in captured.err
+    assert "source-available=false" in captured.err
+    assert "source-available=true" in captured.err
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--source-available", "yes"],
+        ["--source-available", ""],
+        ["--source-available-overrides", "nope"],
+    ],
+)
+def test_main_refuses_a_malformed_per_suite_option(
+    capsys, tmp_path: Path, argv: list[str]
+) -> None:
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_a.py")
+    rc = main(["--test-dir", str(e2e), "--clouds", "none", *argv])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "::error::" in captured.err
+    # Same discipline as the cloud-narrowing failure: nothing on stdout, or the
+    # caller reads a matrix out of a run that errored.
+    assert captured.out == ""
+
+
+def test_main_refuses_an_override_for_an_undiscovered_suite(
+    capsys, tmp_path: Path
+) -> None:
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_db2luw_e2e.py")
+    rc = main(
+        [
+            "--test-dir",
+            str(e2e),
+            "--clouds",
+            "none",
+            "--source-available-overrides",
+            "db2zos-e2e=false",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "db2zos-e2e" in captured.err
+    assert captured.out == ""
+
+
+def test_main_refuses_per_suite_options_in_clouds_only_mode(capsys) -> None:
+    # That mode emits no suite dimension, so a per-suite value could not reach
+    # any leg — inert, which is the failure class this whole change is about.
+    rc = main(
+        ["--clouds", "aws", "--clouds-only", "--source-available-overrides", "a=false"]
+    )
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "::error::" in captured.err
+    assert captured.out == ""
+
+
+def test_clouds_only_still_works_with_the_defaulted_per_suite_options(
+    capsys,
+) -> None:
+    # The composite passes --source-available on every call, so the cloud-only
+    # caller (e2e-full-reusable's plan-clouds) must be unaffected by it.
+    rc = main(["--clouds", "aws,gcp", "--clouds-only", "--source-available", "true"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert _matrix(out) == {
+        "include": [{"cloud": "aws", "name": "aws"}, {"cloud": "gcp", "name": "gcp"}]
+    }

--- a/.github/scripts/tests/test_e2e_per_suite_wiring.py
+++ b/.github/scripts/tests/test_e2e_per_suite_wiring.py
@@ -1,0 +1,159 @@
+"""Guards for the FND-1865 per-suite wiring in tests-reusable.yaml.
+
+The e2e job has fanned out one leg per suite since FND-6, but two of the values
+each leg runs with were resolved once for the whole repo: `source-available` and
+the compose overlay. A multi-entrypoint connector whose entrypoints are not
+equally testable cannot express that with one value each — db2's LUW flavour has
+a community container, its z/OS flavour cannot have one at all — and the app-side
+workarounds do not work (the harness's class attribute loses to
+`E2E_SOURCE_AVAILABLE` on every CI run; a module-level `pytest.skip` exits 5,
+which the composite propagates verbatim, so the leg reds instead of skipping).
+
+Both are now resolved per suite in the discovery job and carried in the matrix.
+The failure mode of losing that wiring is NOT a red build:
+
+* an e2e leg that forwards `inputs.source-available` again silently puts every
+  suite back on one boolean, and the sourceless leg goes back to burning the
+  tenant-resolution phase before failing (or skipping from inside the suite);
+* an e2e leg that pins the overlay path again silently starts every source
+  container on every leg, and the worker's `depends_on: service_healthy` makes
+  the legs that cannot use one wait for it;
+* a discovery step that stops passing `compose-overlay` emits no
+  `compose-overlay` key at all, so the leg forwards "" and the sdr-e2e action
+  falls back to its OWN convention — the SDR overlay — on the full-DAG pipeline.
+
+Deliberately YAML-shape assertions: the wiring is GitHub Actions' own (job
+outputs, matrix contexts, action inputs) and cannot be exercised without a
+runner. The resolution *logic* is unit-tested in test_discover_e2e_suites.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_WORKFLOW = _REPO_ROOT / ".github/workflows/tests-reusable.yaml"
+_ACTION = _REPO_ROOT / ".github/actions/discover-e2e-suites/action.yaml"
+
+_DISCOVER_ACTION = "atlanhq/application-sdk/.github/actions/discover-e2e-suites@main"
+_SDR_E2E_ACTION = "atlanhq/application-sdk/.github/actions/sdr-e2e@main"
+
+#: The overlay path the fleet's connectors actually carry, and the value the e2e
+#: job used to pin at its sdr-e2e step. It now appears once, at the discovery
+#: step, as the fallback the per-suite convention is derived from.
+_REPO_WIDE_OVERLAY = ".github/e2e/e2e-full-docker-compose.yaml"
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, Any]:
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def action() -> dict[str, Any]:
+    return yaml.safe_load(_ACTION.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def discover_step(workflow: dict[str, Any]) -> dict[str, Any]:
+    steps = workflow["jobs"]["discover-e2e"]["steps"]
+    matching = [
+        s
+        for s in steps
+        if s.get("uses") == _DISCOVER_ACTION
+        and s.get("with", {}).get("clouds-only") != "true"
+    ]
+    assert len(matching) == 1, (
+        "expected exactly one suite-mode discovery step; the cloud-only call is "
+        "prepare-tenant's and carries no suite dimension to key these off"
+    )
+    return matching[0]
+
+
+@pytest.fixture(scope="module")
+def e2e_step(workflow: dict[str, Any]) -> dict[str, Any]:
+    steps = workflow["jobs"]["e2e"]["steps"]
+    matching = [s for s in steps if s.get("uses") == _SDR_E2E_ACTION]
+    assert len(matching) == 1, "the e2e job must invoke the sdr-e2e composite once"
+    return matching[0]
+
+
+def test_the_e2e_matrix_is_the_discovery_job_s(workflow: dict[str, Any]) -> None:
+    # Everything below rests on this: the per-suite values are resolved in
+    # discovery, so the legs must be expanded from the matrix it emitted.
+    matrix = workflow["jobs"]["e2e"]["strategy"]["matrix"]
+    assert "needs.discover-e2e.outputs.matrix" in matrix
+
+
+def test_discovery_is_given_both_per_suite_dimensions(
+    discover_step: dict[str, Any],
+) -> None:
+    with_ = discover_step["with"]
+    assert with_["source-available"] == "${{ inputs.source-available }}"
+    assert (
+        with_["source-available-overrides"]
+        == "${{ inputs.source-available-overrides }}"
+    ), (
+        "the caller's per-suite overrides have to reach discovery; nothing else "
+        "in the run can see the suite names they key off"
+    )
+    assert with_["compose-overlay"] == _REPO_WIDE_OVERLAY, (
+        "discovery needs the repo-wide overlay as the fallback AND as the "
+        "directory the per-suite convention is derived from; without it no "
+        "compose-overlay key is emitted and the leg forwards an empty path"
+    )
+
+
+def test_the_leg_forwards_what_discovery_resolved(e2e_step: dict[str, Any]) -> None:
+    with_ = e2e_step["with"]
+    assert with_["source-available"] == "${{ matrix.source-available }}", (
+        "forwarding inputs.source-available again puts every suite back on one "
+        "repo-wide boolean, silently"
+    )
+    assert with_["compose-overlay"] == "${{ matrix.compose-overlay }}", (
+        "pinning the path again silently starts every source container on " "every leg"
+    )
+
+
+def test_the_overlay_path_is_written_once(workflow: dict[str, Any]) -> None:
+    # Two spellings of the fallback would drift: discovery would key the
+    # convention off one directory while the legs fell back to a file in
+    # another. The fallback belongs at the resolution site.
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    occurrences = [line for line in text.splitlines() if _REPO_WIDE_OVERLAY in line]
+    assert len(occurrences) == 1, (
+        f"{_REPO_WIDE_OVERLAY} appears {len(occurrences)} times; it is the "
+        "discovery step's fallback input and nothing else's: "
+        f"{occurrences}"
+    )
+    assert workflow["jobs"]["discover-e2e"], "sanity: the discovery job still exists"
+
+
+def test_the_caller_input_exists_and_is_optional(workflow: dict[str, Any]) -> None:
+    # Optional and empty-by-default: every existing caller keeps the repo-wide
+    # behaviour without an edit.
+    spec = workflow[True]["workflow_call"]["inputs"]["source-available-overrides"]
+    assert spec["required"] is False
+    assert spec["type"] == "string"
+    assert spec["default"] == ""
+
+
+def test_the_action_declares_the_inputs_the_workflow_passes(
+    action: dict[str, Any], discover_step: dict[str, Any]
+) -> None:
+    # An input the action does not declare is a warning on the run and nothing
+    # else: the value is dropped and every leg quietly keeps the default.
+    declared = action["inputs"]
+    for name in ("source-available", "source-available-overrides", "compose-overlay"):
+        assert name in declared, f"the discovery action must declare `{name}`"
+        assert declared[name]["required"] is False
+    assert declared["source-available"]["default"] == "true"
+    assert declared["source-available-overrides"]["default"] == ""
+    assert declared["compose-overlay"]["default"] == ""
+    assert set(discover_step["with"]) <= set(
+        declared
+    ), "the discovery step passes an input the action does not declare"

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -250,13 +250,44 @@ on:
         default: true
         description: |
           Whether an extraction source is provisioned for this connector in
-          CI — forwarded to the sdr-e2e action's `source-available` input.
+          CI — resolved per suite by discovery and forwarded from the matrix to
+          the sdr-e2e action's `source-available` input.
           Sourcing is the app owner's responsibility. Default true: the
           full-DAG e2e runs unchanged. Set false for apps with no free
           container / no wired credentials — the e2e then degrades to a
           worker-up-only check (assert the worker deploys + serves
           /server/health) and skips extraction/publish/Atlas assertions,
           until the owner provisions a source.
+
+          Repo-WIDE: the default every discovered suite takes. A connector whose
+          entrypoints differ in source provisioning overrides the odd one out
+          with `source-available-overrides` below.
+      source-available-overrides:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Per-suite overrides of `source-available` (FND-1865), as
+          comma-separated `<suite>=true|false` keyed off the discovered suite
+          name (`tests/e2e/test_db2zos_e2e.py` -> `db2zos-e2e`) — the same key
+          `artifact-suffix` and the derived ATLAN_DEPLOYMENT_NAME already use.
+
+          The e2e job has fanned out one leg per suite since FND-6, but
+          `source-available` was one value for the whole repo, and a
+          multi-entrypoint connector whose entrypoints are not equally testable
+          cannot say so with one boolean: db2's LUW flavour has a community
+          container, its z/OS flavour cannot have one at all (container images
+          are architecture AND OS specific — z/OS needs a real subsystem). The
+          app-side workarounds do not work either: the harness's class attribute
+          loses to E2E_SOURCE_AVAILABLE on every CI run, and a module-level
+          `pytest.skip` exits 5, which the composite propagates verbatim, so the
+          leg reds instead of skipping.
+
+          An override naming a suite discovery did not find FAILS the discovery
+          job rather than being ignored — an inert override leaves the leg on
+          the repo-wide default, which is the silent full-DAG-on-a-sourceless-leg
+          the input exists to prevent. Empty (the default) means every suite
+          takes `source-available`, so existing callers are unaffected.
       dataforge-datasource:
         required: false
         type: string
@@ -1180,6 +1211,21 @@ jobs:
           # into "none" and quietly disables the matrix on every un-customised
           # caller. The negated form never evaluates the input for truthiness.
           clouds: ${{ secrets.E2E_TENANT_MATRIX_JSON == '' && 'none' || inputs.e2e-clouds }}
+          # ── The per-suite dimensions (FND-1865) ─────────────────────────────
+          # Resolved here, once, and carried in the matrix — so a leg's source
+          # availability and compose overlay arrive the same way its artifact
+          # suffix and ATLAN_DEPLOYMENT_NAME already do. This job checks out the
+          # CALLER's tree, which is what lets the overlay be a convention
+          # (`.github/e2e/<suite>-docker-compose.yaml`) rather than an input:
+          # discovery can see whether the file exists.
+          source-available: ${{ inputs.source-available }}
+          source-available-overrides: ${{ inputs.source-available-overrides }}
+          # The repo-wide FALLBACK every leg without its own file keeps using,
+          # and the directory the per-suite convention is derived from. Pinned
+          # here rather than at the e2e job's sdr-e2e step (where it used to
+          # live) so the path is written once: the e2e job forwards whatever
+          # discovery resolved for that leg.
+          compose-overlay: .github/e2e/e2e-full-docker-compose.yaml
 
       # The same fan-out, cloud dimension only, for prepare-tenant. A second
       # invocation rather than deriving the unique clouds out of the matrix above:
@@ -2230,7 +2276,14 @@ jobs:
           # falls back to the SDR component/compose set (wrong stack).
           secrets-script: .github/e2e/make-secrets-e2e-full.py
           components-dir: .github/e2e/e2e-full-components
-          compose-overlay: .github/e2e/e2e-full-docker-compose.yaml
+          # Per-suite (FND-1865), resolved by discovery against the caller's
+          # tree: `.github/e2e/<suite>-docker-compose.yaml` when that file
+          # exists, else the repo-wide path discovery was given. One pinned
+          # overlay for every leg meant a multi-entrypoint connector started
+          # EVERY source container on EVERY leg — and the worker's
+          # `depends_on: service_healthy` made the legs that cannot use one wait
+          # for it before failing.
+          compose-overlay: ${{ matrix.compose-overlay }}
           # Force the full-DAG config dir even when the repo also has a
           # .github/sdr-e2e/ (testcontainer) setup, which the action would
           # otherwise prefer — see the action's `config-dir` input.
@@ -2263,7 +2316,12 @@ jobs:
           harness-sdk-ref: ${{ inputs.harness-sdk-ref }}
           base-image-ref: ${{ inputs.base-image-ref }}
           enable-two-store: ${{ inputs.two-store }}
-          source-available: ${{ inputs.source-available }}
+          # Per-suite (FND-1865): the repo-wide input narrowed by
+          # `source-available-overrides` for this leg's suite, resolved in
+          # discovery. Reaches the harness as E2E_SOURCE_AVAILABLE, which is
+          # per-run and therefore per-leg — which is why this had to move into
+          # the matrix rather than be expressible in the suite itself.
+          source-available: ${{ matrix.source-available }}
           # Push the test image with the org PAT (same identity build-and-publish
           # uses) so it can write PAT-published connector packages — a plain
           # GITHUB_TOKEN 403s on those (e.g. atlan-redshift-app). Available here

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -1175,6 +1175,79 @@ entrypoint's `pipeline` — `expect_connection`, `require_nonempty_assets`,
 `expect_lineage`, `required_dag_nodes`. A miner therefore is not graded against
 crawler-shaped assertions: with no `publish` step its pass criterion is its DAG.
 
+### When the entrypoints are not equally testable (FND-1865)
+
+One leg per suite, but for a long time two of the values a leg ran with were
+resolved **once for the whole repo**: `source-available`, and the compose
+overlay the worker's stack is layered from. A connector whose entrypoints differ
+in source provisioning could not say so, and had no app-side workaround.
+
+`atlan-db2-app` is the case that surfaced it. `luw` (Db2 LUW) is containerisable
+today — `icr.io/db2_community/db2`, port 50000, seeded sibling container, full
+DAG. `zos` (Db2 for z/OS) **cannot be**: container images are architecture *and*
+OS specific, and IBM's own `IBM-Z-zOS` guidance is explicit that multi-arch
+emulation is not available for the `zos/s390x` platform (the community image's
+`s390x` tag is Linux on IBM Z, not z/OS). It needs a real subsystem — Wazi as a
+Service, or zD&T. AS/400 is already anticipated as a third flavour.
+
+Both values are now resolved **per suite**, in the discovery job, and carried in
+the matrix — the same way `artifact-suffix` and the derived
+`ATLAN_DEPLOYMENT_NAME` already are:
+
+```yaml
+# .github/workflows/tests.yaml
+with:
+  source-available: true                       # the repo-wide default
+  source-available-overrides: "db2zos-e2e=false"
+```
+
+```
+.github/e2e/db2luw-e2e-docker-compose.yaml   → layered on the db2luw-e2e legs only
+.github/e2e/e2e-full-docker-compose.yaml     → the fallback for every other suite
+```
+
+* **`source-available-overrides`** is `<suite>=true|false`, comma-separated,
+  keyed off the discovered suite name (`tests/e2e/test_db2zos_e2e.py` →
+  `db2zos-e2e`). It overrides in **both** directions, so "most flavours
+  unsourced, one containerisable" is expressible too. It keys on the *suite*,
+  not the leg: source availability is a property of the entrypoint, not of the
+  CSP tenant, so an override applies on every cloud. An override naming a suite
+  discovery did not find **fails the discovery job** — an inert override would
+  leave that leg on the repo-wide default and green a run that tried to extract
+  from a source which cannot exist.
+* **The overlay is a convention**, not an input:
+  `.github/e2e/<suite>-docker-compose.yaml` wins when the file exists, and the
+  repo-wide `.github/e2e/e2e-full-docker-compose.yaml` is the fallback for every
+  suite that ships none — so a single-flavour connector is untouched. To keep a
+  container off the legs that cannot use it, move the shared overlay's contents
+  into the per-suite files that want them and stop shipping the shared path;
+  absence of a per-suite file means "nothing suite-specific here", never "layer
+  nothing".
+
+This matters beyond tidiness, in both directions. With one pinned overlay the
+LUW container also started on the three `db2zos-e2e` legs, and the worker's
+`depends_on: service_healthy` made those legs *wait* for it. With one repo-wide
+boolean, setting it `true` for `luw` also told the `zos` suite a source existed.
+
+**None of the app-side workarounds work**, which is why this had to move into the
+matrix:
+
+| Workaround | What happens |
+| -- | -- |
+| `source_available = False` class attribute | Overridden by `E2E_SOURCE_AVAILABLE` on every CI run — `BaseE2ETest` resolves it per run, and the env value wins whenever it is set. |
+| Module-level `pytest.skip` in the sourceless suite | pytest exits **5** ("no tests collected"), which the composite propagates verbatim (`exit "${TEST_EXIT_CODE}"`), so the leg goes **red**, not skipped. |
+| In-test skip from `seed_prerequisites()` | Works (exit 0, reports skipped) but costs the worker-up assertion, and the suite still burns the read-only tenant-resolution phase before reaching the hook. |
+
+With the per-leg value, the sourceless leg keeps the tier it should have: the
+worker-up-only check (assert the worker deploys and serves `/server/health`,
+skip extraction/publish/Atlas), and `setup_method` returns before the AE/tenant
+wiring it does not need.
+
+`e2e-full-reusable.yaml` still takes a single `compose-overlay` and a single
+`source-available`: it targets a whole directory rather than fanning out per
+suite (`--clouds-only` discovery), so there is no suite dimension to key either
+off.
+
 ### Seeding state a dependent entrypoint consumes
 
 A miner enriches a connection it does **not** create. The harness mints an
@@ -1547,7 +1620,7 @@ Three `ClassVar`s tune it, and the defaults suit every connector:
 
 1. **Action manifest**: `app.yaml` at repo root (3 lines).
 2. **Unified workflow**: copy `.github/workflows/tests.yaml` from mysql-app; swap connector references. This single file covers unit + integration tests (always) and full-DAG e2e (on the `e2e` label or `run_e2e=true` dispatch input).
-3. **Config dir**: create `.github/sdr-e2e/` (new) or `.github/e2e/` (legacy). Files: `docker-compose.ci.yml`, `e2e-full-docker-compose.yaml`, `e2e-full-components/`, `seed.sql`, `make-secrets.py`, `make-secrets-e2e-full.py`.
+3. **Config dir**: create `.github/sdr-e2e/` (new) or `.github/e2e/` (legacy). Files: `docker-compose.ci.yml`, `e2e-full-docker-compose.yaml`, `e2e-full-components/`, `seed.sql`, `make-secrets.py`, `make-secrets-e2e-full.py`. On a bundle app whose entrypoints need different source containers, name the overlay per suite instead — `.github/e2e/<suite>-docker-compose.yaml`, see [When the entrypoints are not equally testable](#when-the-entrypoints-are-not-equally-testable-fnd-1865).
 4. **Tests**: unit + integration tests under `tests/unit/` and `tests/integration/`; full-DAG e2e under `tests/e2e/` (`SQLAppE2ETest` subclass for SQL connectors, otherwise the generated `BaseE2ETest` subclass — see [Which harness](#which-harness)). On a bundle app, one `tests/e2e/test_*.py` **per entrypoint** — see [Multi-entrypoint (bundle) apps](#multi-entrypoint-bundle-apps-one-suite-per-entrypoint).
 5. **Repo secrets**: set the 7 entries from the table above.
 6. **SDK matrix**: add `<connector>-app` to the `DEFAULT_MATRIX` in apps-sdk's `matrix-builder` job (`pull_request.yaml`) so `connector-tests` fans out to your connector automatically.

--- a/packages/conformance/conformance/bootstrap/extract.py
+++ b/packages/conformance/conformance/bootstrap/extract.py
@@ -232,6 +232,7 @@ _TESTS_YAML_VALUE_INPUTS: tuple[tuple[str, str, str], ...] = (
     ("harness_sdk_ref", "harness-sdk-ref", "plain"),
     ("e2e_test_path", "e2e-test-path", "plain"),
     ("source_available", "source-available", "bool"),
+    ("source_available_overrides", "source-available-overrides", "plain"),
     ("dataforge_datasource", "dataforge-datasource", "plain"),
     ("dataforge_mode", "dataforge-mode", "plain"),
     ("dataforge_env_tier", "dataforge-env-tier", "plain"),

--- a/packages/conformance/conformance/bootstrap/render.py
+++ b/packages/conformance/conformance/bootstrap/render.py
@@ -189,6 +189,7 @@ def render(
     harness_sdk_ref: str = "",
     e2e_test_path: str = "",
     source_available: str = "",
+    source_available_overrides: str = "",
     dataforge_datasource: str = "",
     dataforge_mode: str = "",
     dataforge_env_tier: str = "",
@@ -252,8 +253,10 @@ def render(
       ``private_git_deps``, ``git_lfs_skip_smudge``,
       ``health_check_timeout_seconds``,
       ``container_health_timeout_seconds``, ``runtime_sdk_ref``,
-      ``harness_sdk_ref``, ``e2e_test_path``, ``source_available`` and the five
-      ``dataforge_*`` values.  All default ``""`` — no line, so the reusable's
+      ``harness_sdk_ref``, ``e2e_test_path``, ``source_available``,
+      ``source_available_overrides`` (FND-1865 — the per-suite overrides of
+      the repo-wide ``source-available``) and the five ``dataforge_*``
+      values.  All default ``""`` — no line, so the reusable's
       own default applies — and the chain emits nothing at all when every one
       of them is empty, which is what keeps the no-override render
       byte-identical to the pre-FND-1143 one for the whole bootstrapped fleet.
@@ -317,6 +320,7 @@ def render(
         harness_sdk_ref=harness_sdk_ref,
         e2e_test_path=e2e_test_path,
         source_available=source_available,
+        source_available_overrides=source_available_overrides,
         dataforge_datasource=dataforge_datasource,
         dataforge_mode=dataforge_mode,
         dataforge_env_tier=dataforge_env_tier,

--- a/packages/conformance/conformance/bootstrap/templates/tests.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/tests.yaml
@@ -157,6 +157,7 @@ jobs:
 <% endif %><% if harness_sdk_ref %>      harness-sdk-ref: "<< harness_sdk_ref >>"
 <% endif %><% if e2e_test_path %>      e2e-test-path: "<< e2e_test_path >>"
 <% endif %><% if source_available %>      source-available: << source_available >>
+<% endif %><% if source_available_overrides %>      source-available-overrides: "<< source_available_overrides >>"
 <% endif %><% if dataforge_datasource %>      dataforge-datasource: "<< dataforge_datasource >>"
 <% endif %><% if dataforge_mode %>      dataforge-mode: "<< dataforge_mode >>"
 <% endif %><% if dataforge_env_tier %>      dataforge-env-tier: "<< dataforge_env_tier >>"

--- a/packages/conformance/tests/test_bootstrap_extract.py
+++ b/packages/conformance/tests/test_bootstrap_extract.py
@@ -1157,6 +1157,10 @@ _FND1143_VALUES: dict[str, tuple[str, str]] = {
         "tests/e2e/full_dag/",
     ),
     "source_available": ("      source-available: false", "false"),
+    "source_available_overrides": (
+        '      source-available-overrides: "db2zos-e2e=false"',
+        "db2zos-e2e=false",
+    ),
     "dataforge_datasource": (
         '      dataforge-datasource: "cosmosnosql"',
         "cosmosnosql",


### PR DESCRIPTION
Closes FND-1865.

The e2e job has fanned out **one leg per suite** since FND-6, but two of the values each leg ran with were resolved **once for the whole repo**: `source-available`, and the compose overlay the worker's stack is layered from. A multi-entrypoint connector whose entrypoints are not equally testable could not express that, and had no app-side workaround:

| Workaround | What actually happens |
| -- | -- |
| `source_available = False` class attribute | Overridden by `E2E_SOURCE_AVAILABLE` on every CI run — `BaseE2ETest` resolves it per run and the env value wins whenever it is set. |
| Module-level `pytest.skip` in the sourceless suite | pytest exits **5** ("no tests collected"), which the composite propagates verbatim (`exit "${TEST_EXIT_CODE}"`), so the leg goes **red**, not skipped. |
| In-test skip from `seed_prerequisites()` | Works, but costs the worker-up assertion and still burns the read-only tenant-resolution phase before reaching the hook. |

## What this does

Both dimensions are resolved in the **discovery job**, keyed off the discovered suite, and carried in the matrix — the same key `artifact-suffix` and the derived `ATLAN_DEPLOYMENT_NAME` already use.

```yaml
# an app's tests.yaml
with:
  source-available: true                        # the repo-wide default
  source-available-overrides: "db2zos-e2e=false"   # new, optional
```

```
.github/e2e/db2luw-e2e-docker-compose.yaml   → layered on the db2luw-e2e legs only
.github/e2e/e2e-full-docker-compose.yaml     → the fallback for every other suite
```

* **`source-available-overrides`** is comma-separated `<suite>=true|false`, keyed off the discovered suite name (`tests/e2e/test_db2zos_e2e.py` → `db2zos-e2e`). It overrides in **both** directions, so "most flavours unsourced, one containerisable" is expressible too, and it keys on the *suite* rather than the leg: source availability is a property of the entrypoint, not of the CSP tenant, so an override applies on every cloud.
* **The overlay is a convention, not an input** — `.github/e2e/<suite>-docker-compose.yaml` wins when the caller's tree has one, else the repo-wide path. Resolvable in discovery precisely because that job runs after the caller's checkout. The repo-wide path is now written **once**, at the discovery step, and the e2e leg forwards `matrix.compose-overlay`.

Why that second one matters beyond tidiness: with one pinned overlay, every source container started on **every** leg, and the worker's `depends_on: service_healthy` made the legs that cannot use one *wait* for it.

## Fails loudly, in the cheapest job

All three cost seconds in `discover-e2e`, before any image build:

* an override naming a suite discovery did not find — an inert override would leave that leg on the repo-wide default and green a run that tried to extract from a source which cannot exist. The error names the suites that do exist.
* a malformed token, or a `zos=0` — rejected rather than coerced. The harness's env var is deliberately lenient (`1`/`yes` count as true) because several things write it; a hand-written workflow input that decides a leg's whole tier is not.
* a per-suite option passed with `--clouds-only`, where there is no suite dimension for it to reach.

## Scope

* **No harness change.** `E2E_SOURCE_AVAILABLE` is already resolved per run, so a per-leg input reaches it correctly — and a sourceless leg now keeps the worker-up assertion while `setup_method` returns before the AE/tenant wiring it does not need.
* **`e2e-full-reusable.yaml` unchanged.** It targets a whole directory (`--clouds-only` discovery), so it has no suite dimension to key either value off.
* **Existing callers unaffected.** The new input is optional and empty by default; `discover()` without the new options emits the pre-FND-1865 entry shape key for key (pinned by a test).
* **Bootstrap slot included** — render param, template line, and read-back in `_TESTS_YAML_VALUE_INPUTS`. Per FND-1143 an unslotted input *freezes* every repo that declares it out of all structural CI updates; `test_every_reusable_input_has_a_slot_or_a_documented_reason` caught exactly that mid-change.

## Tests

* 22 new driver unit tests in `test_discover_e2e_suites.py` (override direction and cloud-crossing, strict parsing, unknown-suite refusal, overlay resolution and fallback, `main`'s stdout discipline on the failing paths).
* New `test_e2e_per_suite_wiring.py` — YAML-shape guards, because the failure mode of losing this wiring is **not** a red build: a leg that forwards `inputs.source-available` again silently puts every suite back on one boolean, and one that pins the overlay path again silently starts every container on every leg. It also pins that the repo-wide path appears exactly once in the workflow.
* `4369` `.github/scripts/tests` and `406` conformance bootstrap tests pass locally; pre-commit clean on every touched file.

## Docs

`docs/standards/connector-ci-e2e.md` gains **"When the entrypoints are not equally testable (FND-1865)"** under the multi-entrypoint section: the two per-suite dimensions, the overlay convention, the table of workarounds above, and why a missing per-suite file falls back rather than meaning "layer nothing".

## Follow-up (separate, app-side)

`atlan-db2-app`: set `source-available-overrides` for its z/OS suite, rename the LUW overlay to the per-suite name, and drop the in-test skip from `seed_prerequisites()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2nBdsGDiNaa6zXVw5RnhC
