### PR TITLE
fix(contract): make the pkl pin one readable value so a local eval predicts CI

### DIFF
--- a/.agents/skills/make-contract/SKILL.md
+++ b/.agents/skills/make-contract/SKILL.md
@@ -129,7 +129,22 @@ tree drifts.
 
 This repo guarantees the `pkl` toolchain — there is no dependency on an external
 CLI. Run every command from the **app repo root** (not from inside `contract/`).
-Prereq: `pkl >= 0.25.1` (`brew install pkl`).
+
+**Prereq: the pinned pkl, not a floor.** pkl is a language, so a version other
+than CI's can reject a contract CI accepts, or accept one CI rejects — a clean
+local render on the wrong version is not evidence the freshness gate will pass
+(FND-1864). The pin lives in `application_sdk/pkl_version.py` and the SDK hands
+you that exact build:
+
+```bash
+python -m application_sdk.dev.pkl print-version   # what CI renders with
+python -m application_sdk.dev.pkl check           # has your PATH pkl drifted?
+PKL="$(python -m application_sdk.dev.pkl path)"   # download + cache that build
+```
+
+Substitute `"$PKL"` for `pkl` in the commands below, or prefix them with
+`python -m application_sdk.dev.pkl run --`. `brew install pkl` is fine for
+exploring, but do not trust it to predict CI.
 
 ```bash
 # Resolve / refresh the dependency lock (writes contract/PklProject.deps.json):

--- a/.claude/skills/capability-manifest/references/subpackage-purposes.yaml
+++ b/.claude/skills/capability-manifest/references/subpackage-purposes.yaml
@@ -14,6 +14,7 @@ handler: HTTP handler framework — Handler ABC, DefaultHandler, preflight, auth
 infrastructure: Protocol-based infrastructure (StateStore, SecretStore, PubSub, Bindings, CapacityPool)
 observability: Logging context — ExecutionContext, CorrelationContext, request/correlation helpers
 outputs: Output collectors and record models for Automation Engine
+pkl_version: The Pkl toolchain pin — the one version CI renders contracts with, readable by an app's own tooling so a local render predicts the freshness gate
 main: Dev entry point — run_dev_combined() and AppConfig for local execution and container startup
 server: FastAPI server, MCP integration, middleware, health endpoint
 storage: Object-store abstraction — factory, formats, batch, transfer, cloud bindings

--- a/.claude/skills/make-contract/SKILL.md
+++ b/.claude/skills/make-contract/SKILL.md
@@ -129,7 +129,22 @@ tree drifts.
 
 This repo guarantees the `pkl` toolchain — there is no dependency on an external
 CLI. Run every command from the **app repo root** (not from inside `contract/`).
-Prereq: `pkl >= 0.25.1` (`brew install pkl`).
+
+**Prereq: the pinned pkl, not a floor.** pkl is a language, so a version other
+than CI's can reject a contract CI accepts, or accept one CI rejects — a clean
+local render on the wrong version is not evidence the freshness gate will pass
+(FND-1864). The pin lives in `application_sdk/pkl_version.py` and the SDK hands
+you that exact build:
+
+```bash
+python -m application_sdk.dev.pkl print-version   # what CI renders with
+python -m application_sdk.dev.pkl check           # has your PATH pkl drifted?
+PKL="$(python -m application_sdk.dev.pkl path)"   # download + cache that build
+```
+
+Substitute `"$PKL"` for `pkl` in the commands below, or prefix them with
+`python -m application_sdk.dev.pkl run --`. `brew install pkl` is fine for
+exploring, but do not trust it to predict CI.
 
 ```bash
 # Resolve / refresh the dependency lock (writes contract/PklProject.deps.json):

--- a/.github/actions/install-pkl/action.yaml
+++ b/.github/actions/install-pkl/action.yaml
@@ -1,6 +1,6 @@
 name: Install pkl
 description: |
-  Install the pkl runtime onto the runner, retrying the download.
+  Install the pinned pkl runtime onto the runner, retrying the download.
 
   pkl ships as a GitHub release asset, so every `curl` for it is a live
   dependency on github.com's release CDN at job time. That CDN returns 503s in
@@ -9,12 +9,18 @@ description: |
   burst took out the Connector Tests Gate and ejected a PR from the merge
   queue. This action is the one place that download lives now.
 
-  Two things it gets right that the hand-rolled copies did not:
+  Three things it gets right that the hand-rolled copies did not:
     - retry, via .github/scripts/with-retry.sh (reachable here through
       github.action_path regardless of what the caller checked out);
     - architecture, via runner.arch — pkl publishes a separate aarch64 asset,
       and naming the x86 one on an arm64 runner fails as `cannot execute
-      binary file` several steps later, nowhere near anything about arch.
+      binary file` several steps later, nowhere near anything about arch;
+    - the VERSION, resolved from the single source of truth in
+      application_sdk/pkl_version.py rather than restated here. Six workflows
+      and actions each carried their own "0.27.2" literal, free to drift apart
+      and — worse — invisible to the apps whose contracts they render. pkl is a
+      language, so a contract can evaluate cleanly on a developer's 0.32.x and
+      be structurally incapable of evaluating on CI's pin (FND-1864).
 
   Reusable workflows must reference this as
   `atlanhq/application-sdk/.github/actions/install-pkl@main`, not `./…` — a
@@ -25,26 +31,75 @@ description: |
 inputs:
   version:
     required: false
-    default: "0.27.2"
+    default: ""
     description: |
-      pkl runtime version to install. The default is the fleet-wide pin shared
-      by the contract-toolkit workflows and the regenerate-contract action;
-      pass an explicit value only when a caller must diverge.
+      pkl runtime version to install. EMPTY (the default) means the SDK pin in
+      application_sdk/pkl_version.py — pass an explicit value only when a caller
+      must deliberately diverge from the fleet, and say why at the call site.
+
+outputs:
+  version:
+    description: |
+      The pkl version actually installed — the resolved pin unless the caller
+      overrode it. Callers surface this to contributors (the freshness gate
+      quotes it in its sticky comment) so "align your local pkl" names a
+      version instead of pointing at a job log.
+    value: ${{ steps.resolve.outputs.version }}
 
 runs:
   using: composite
   steps:
+    # The "empty input means the pin" decision is conditional logic, so it lives
+    # in the tested driver rather than in this shell (docs/standards/ci.md). The
+    # driver reads the SoT out of the ACTION's own checkout — the SDK repo at
+    # the referenced ref — never the caller's workspace, which for a consumer
+    # repo has no application_sdk/ at all. Hence the explicit --sot: the
+    # script's own repo-root inference is right in this repo but would resolve
+    # against _actions/… identically only by coincidence, and naming it makes
+    # the dependency legible.
+    - name: Resolve pkl version
+      id: resolve
+      shell: bash
+      env:
+        REQUESTED: ${{ inputs.version }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+        version="$(python3 "${ACTION_PATH}/../../scripts/pkl_version.py" \
+          --sot "${ACTION_PATH}/../../../application_sdk/pkl_version.py" \
+          resolve --requested "$REQUESTED")"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "Installing pkl $version"
+
     - name: Install pkl
       shell: bash
       env:
-        PKL_VERSION: ${{ inputs.version }}
+        PKL_VERSION: ${{ steps.resolve.outputs.version }}
+        ACTION_PATH: ${{ github.action_path }}
         # Chosen in the expression layer rather than from `uname -m` in the
         # shell, so there is no inlined conditional shell (docs/standards/ci.md).
         PKL_ASSET: pkl-linux-${{ runner.arch == 'ARM64' && 'aarch64' || 'amd64' }}
       run: |
         set -euo pipefail
-        "${{ github.action_path }}/../../scripts/with-retry.sh" \
+        "${ACTION_PATH}/../../scripts/with-retry.sh" \
           curl -fsSL -o /tmp/pkl "https://github.com/apple/pkl/releases/download/${PKL_VERSION}/${PKL_ASSET}"
         chmod +x /tmp/pkl
         sudo mv /tmp/pkl /usr/local/bin/pkl
         pkl --version
+
+    # Assert that `pkl` on PATH is the version we just resolved. Downloading
+    # the right asset is not the same as *running* it: a runner image (or an
+    # earlier step) can leave another pkl ahead of /usr/local/bin on PATH, and
+    # the whole point of the pin is that every render uses one version. Strict,
+    # because a silent mismatch here reintroduces exactly the skew FND-1864
+    # removed — and would be invisible until a contract failed to eval.
+    - name: Verify the installed pkl is the resolved one
+      shell: bash
+      env:
+        EXPECTED: ${{ steps.resolve.outputs.version }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+        python3 "${ACTION_PATH}/../../scripts/pkl_version.py" \
+          --sot "${ACTION_PATH}/../../../application_sdk/pkl_version.py" \
+          check-runtime --strict --expected "$EXPECTED" --actual "$(pkl --version)"

--- a/.github/actions/regenerate-contract/action.yaml
+++ b/.github/actions/regenerate-contract/action.yaml
@@ -49,8 +49,12 @@ inputs:
       the configmaps and the root YAMLs. See FND-1777.
   pkl-version:
     required: false
-    default: "0.27.2"
-    description: pkl runtime version to download. Matches the contract-toolkit-* workflows.
+    default: ""
+    description: |
+      pkl runtime version to download. EMPTY (the default) means the SDK pin in
+      application_sdk/pkl_version.py, which is also what the contract-toolkit-*
+      workflows, the freshness gate and an app's own `poe generate` use. Pass an
+      explicit value only to diverge deliberately.
   working-directory:
     required: false
     default: "."
@@ -73,11 +77,30 @@ runs:
       shell: bash
       run: echo "present=${{ hashFiles(format('{0}/{1}/app.pkl', inputs.working-directory, inputs.contract-dir)) != '' }}" >> "$GITHUB_OUTPUT"
 
+    # "Empty input means the SDK pin" is conditional logic, so it lives in the
+    # tested driver rather than in the install shell below
+    # (docs/standards/ci.md). The driver reads the SoT out of THIS action's
+    # checkout — the SDK repo — not the caller's workspace, which is the
+    # connector repo and has no application_sdk/.
+    - name: Resolve pkl version
+      id: pkl
+      if: steps.guard.outputs.present == 'true'
+      shell: bash
+      env:
+        REQUESTED: ${{ inputs.pkl-version }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+        version="$(python3 "${ACTION_PATH}/../../scripts/pkl_version.py" \
+          --sot "${ACTION_PATH}/../../../application_sdk/pkl_version.py" \
+          resolve --requested "$REQUESTED")"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
     - name: Install pkl
       if: steps.guard.outputs.present == 'true'
       shell: bash
       env:
-        PKL_VERSION: ${{ inputs.pkl-version }}
+        PKL_VERSION: ${{ steps.pkl.outputs.version }}
         # Chosen from `runner.arch` in the expression layer rather than from
         # `uname -m` in the shell, so there is no inlined conditional
         # (docs/standards/ci.md) — same shape as the token fallbacks elsewhere.

--- a/.github/actions/regenerate-contract/action.yaml
+++ b/.github/actions/regenerate-contract/action.yaml
@@ -123,6 +123,32 @@ runs:
         sudo mv /tmp/pkl /usr/local/bin/pkl
         pkl --version
 
+    # Assert that `pkl` on PATH is the version resolved above — the same guard
+    # install-pkl runs, for the same reason: downloading the right asset is not
+    # the same as *running* it, since a runner image or an earlier step can
+    # leave another pkl ahead of /usr/local/bin. The `pkl --version` echo in the
+    # step above is logging, not verification; regenerate_contract.py then
+    # invokes bare `pkl`, so an unnoticed mismatch here reintroduces the
+    # FND-1864 skew on the connector regeneration path specifically.
+    #
+    # A copy rather than `uses:` install-pkl: a nested relative composite
+    # resolves against the CALLER's workspace, which for this action is the
+    # connector repo and has no copy of the SDK's actions. Folding both
+    # downloads into one action is the real fix and wants its own change —
+    # until then the guard test in .github/scripts/tests/test_pkl_version.py is
+    # what keeps the two copies from drifting on the version itself.
+    - name: Verify the installed pkl is the resolved one
+      if: steps.guard.outputs.present == 'true'
+      shell: bash
+      env:
+        EXPECTED: ${{ steps.pkl.outputs.version }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+        python3 "${ACTION_PATH}/../../scripts/pkl_version.py" \
+          --sot "${ACTION_PATH}/../../../application_sdk/pkl_version.py" \
+          check-runtime --strict --expected "$EXPECTED" --actual "$(pkl --version)"
+
     # SDK-level only: fetch just the toolkit source at the dispatched ref. A
     # sparse, blobless clone keeps this to a few hundred KB rather than the full
     # SDK history. The script overrides the connector's @app-contract-toolkit

--- a/.github/scripts/check_generated_freshness.py
+++ b/.github/scripts/check_generated_freshness.py
@@ -52,6 +52,23 @@ sys.path.insert(0, str(Path(__file__).parent))
 from renovate_pkl_sync import OUTPUT_PATHS, eval_roots, regenerate  # noqa: E402
 
 
+def _pkl_runtime_label() -> str:
+    """A human-readable label for the pkl that just ran, for the error message.
+
+    Best-effort by design: this is called only on the failure path, to say which
+    pkl produced the failure, and an unreadable banner must not replace the real
+    eval error with an error about reading a version.
+    """
+    try:
+        result = subprocess.run(["pkl", "--version"], text=True, capture_output=True)
+    except OSError:
+        return "an unidentifiable pkl (could not run 'pkl --version')"
+    if result.returncode != 0:
+        return "an unidentifiable pkl ('pkl --version' failed)"
+    banner = result.stdout.strip().splitlines()
+    return banner[0] if banner else "an unidentifiable pkl (empty version banner)"
+
+
 def _changed_output_paths() -> list[str] | None:
     """Return generated-output paths that regeneration changed or created.
 
@@ -174,12 +191,25 @@ def main(argv: list[str] | None = None) -> int:
     status, changed = check_freshness(args.contract_dir)
 
     if status == "eval_failed":
+        # Name BOTH causes, and name the pkl version. The message used to assert
+        # a single one ("almost certainly stale — a toolkit bump merged without
+        # regenerating"), which misdirected the FND-1864 report outright: the
+        # contract was fine and freshly generated, and the eval failed only
+        # because this runner's pkl was four minor versions behind the
+        # contributor's and rejected syntax theirs accepted. A gate whose value
+        # is that a local run predicts it must say which pkl it ran.
         print(
-            "::error::the contract has an evaluable pkl root but 'pkl eval' failed — the "
-            "committed generated artifacts cannot be verified and are almost "
-            "certainly stale (a toolkit bump merged without regenerating). Fix "
-            "the contract so 'pkl eval -m . contract/app.pkl' (or "
-            "'uv run poe generate') succeeds, then commit the refreshed output."
+            f"::error::the contract has an evaluable pkl root but 'pkl eval' failed "
+            f"with {_pkl_runtime_label()}, so the committed generated artifacts "
+            f"cannot be verified. Two causes, both worth checking: (1) VERSION SKEW "
+            f"— pkl is a language, and syntax your local pkl accepts can be "
+            f"rejected here (backslash line-continuations inside a multi-line "
+            f"string are valid from 0.28 on and an 'Invalid character escape "
+            f"sequence' before it); render with this exact version via "
+            f"'python -m application_sdk.dev.pkl run -- eval --project-dir contract "
+            f"-m . contract/app.pkl'. (2) A STALE CONTRACT — a toolkit bump merged "
+            f"without regenerating. The eval error itself is logged above; fix it, "
+            f"then commit the refreshed output."
         )
         return 1
 

--- a/.github/scripts/pkl_version.py
+++ b/.github/scripts/pkl_version.py
@@ -120,7 +120,9 @@ def _cmd_check_runtime(args: argparse.Namespace) -> int:
         return 1 if args.strict else 0
     if actual != expected:
         level = "error" if args.strict else "warning"
-        source = "requested" if args.expected.strip() else f"the SDK pin ({SOT_RELPATH})"
+        source = (
+            "requested" if args.expected.strip() else f"the SDK pin ({SOT_RELPATH})"
+        )
         print(
             f"::{level}::pkl version skew — this runner has {actual}, {source} is "
             f"{expected}. pkl is a language, not just a renderer: a contract that "

--- a/.github/scripts/pkl_version.py
+++ b/.github/scripts/pkl_version.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Resolve the Pkl toolchain pin for CI, and check a runtime against it.
+
+The pin's single source of truth is ``application_sdk/pkl_version.py``
+(``PKL_VERSION``). This script is how *CI* reads it — textually, without
+importing the SDK, because the jobs and composite actions that install pkl run
+long before (or entirely without) a Python environment that has
+``atlan-application-sdk`` in it, and several of them run in **consumer** repos
+where the SDK repo is only present as the checked-out action.
+
+Same shape and same reason as ``container_python_version.py``: one declared
+value, everything else derives from it, and the comparisons are conditional
+logic that ``docs/standards/ci.md`` requires live in a tested script rather than
+inline YAML.
+
+Subcommands:
+
+- ``print-version``  print the pin.
+- ``resolve``        print ``--requested`` when non-empty, else the pin. This is
+                     what lets every workflow and action default its
+                     ``pkl-version`` input to the empty string instead of
+                     carrying its own copy of the literal — the copies were the
+                     bug (six of them, free to drift apart).
+- ``check-runtime``  compare the ``--actual`` output of a ``pkl --version``
+                     invocation against the pin. Warns by default and fails with
+                     ``--strict``; a mismatch is reported as *version skew*,
+                     because pkl is a language and a contract that renders under
+                     one release can be rejected outright by another (FND-1864).
+
+Exit codes: 0 unless ``check-runtime --strict`` sees a mismatch (1), or the pin
+cannot be read (2 — a loud failure, since silently falling back to a guessed
+version is exactly the drift this file exists to remove).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Matches the SoT assignment. Anchored at column 0 on the exact constant name so
+# a mention of it in a docstring or comment cannot be picked up instead.
+_PIN_RE = re.compile(r'^PKL_VERSION\s*:\s*str\s*=\s*"([^"]+)"', re.MULTILINE)
+
+# Accepts pkl's `--version` banner ("Pkl 0.32.1 (macOS 26.4, native)") or a bare
+# version, with an optional pre-release suffix.
+_VERSION_RE = re.compile(r"(?:Pkl\s+)?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)")
+
+SOT_RELPATH = "application_sdk/pkl_version.py"
+
+
+def _repo_root() -> Path:
+    # <repo>/.github/scripts/pkl_version.py -> <repo>
+    return Path(__file__).resolve().parents[2]
+
+
+def parse_pin(source: Path) -> str:
+    """Return the ``PKL_VERSION`` literal declared in *source*.
+
+    Raises ``ValueError`` when the assignment is absent or reshaped. Loud on
+    purpose: a pin CI cannot read must fail the job, not degrade to a default
+    that reintroduces the skew.
+    """
+    text = source.read_text(encoding="utf-8")
+    matches = _PIN_RE.findall(text)
+    if not matches:
+        raise ValueError(
+            f"no 'PKL_VERSION: str = \"<version>\"' assignment found in {source}"
+        )
+    unique = set(matches)
+    if len(unique) > 1:
+        raise ValueError(f"conflicting PKL_VERSION values {sorted(unique)} in {source}")
+    return matches[0]
+
+
+def read_pin(sot: Path | None = None) -> str:
+    """The pin, read from the SoT (or *sot* when given)."""
+    return parse_pin(sot if sot is not None else _repo_root() / SOT_RELPATH)
+
+
+def normalize(version: str) -> str:
+    """Reduce any accepted spelling of a pkl version to the bare version."""
+    match = _VERSION_RE.search(version.strip())
+    if not match:
+        raise ValueError(f"could not parse a pkl version from {version!r}")
+    return match.group(1)
+
+
+def _cmd_print_version(args: argparse.Namespace) -> int:
+    print(read_pin(Path(args.sot) if args.sot else None))
+    return 0
+
+
+def _cmd_resolve(args: argparse.Namespace) -> int:
+    requested = args.requested.strip()
+    if requested:
+        print(requested)
+        return 0
+    print(read_pin(Path(args.sot) if args.sot else None))
+    return 0
+
+
+def _cmd_check_runtime(args: argparse.Namespace) -> int:
+    # --expected overrides the pin so a caller that DELIBERATELY diverged (an
+    # explicit `version:` on install-pkl) is checked against what it asked for,
+    # not against the fleet pin it chose not to use. Without this the guard
+    # would fail the one call site that is allowed to differ.
+    expected = (
+        normalize(args.expected)
+        if args.expected.strip()
+        else read_pin(Path(args.sot) if args.sot else None)
+    )
+    try:
+        actual = normalize(args.actual)
+    except ValueError as exc:
+        # An unreadable banner is not evidence of skew — pkl may simply be
+        # absent on this runner. Say so and move on unless asked to be strict.
+        print(f"::warning::{exc}", file=sys.stderr)
+        return 1 if args.strict else 0
+    if actual != expected:
+        level = "error" if args.strict else "warning"
+        source = "requested" if args.expected.strip() else f"the SDK pin ({SOT_RELPATH})"
+        print(
+            f"::{level}::pkl version skew — this runner has {actual}, {source} is "
+            f"{expected}. pkl is a language, not just a renderer: a contract that "
+            f"renders under one release can be rejected outright by another, so a "
+            f"render performed here does not predict the pinned one.",
+            file=sys.stderr,
+        )
+        return 1 if args.strict else 0
+    print(f"pkl {actual} matches the SDK pin.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sot",
+        default="",
+        help=f"override the source-of-truth path (default: <repo>/{SOT_RELPATH}).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_print = sub.add_parser("print-version", help="print the pinned pkl version")
+    p_print.set_defaults(func=_cmd_print_version)
+
+    p_resolve = sub.add_parser(
+        "resolve", help="print --requested if non-empty, else the pin"
+    )
+    p_resolve.add_argument(
+        "--requested",
+        default="",
+        help="a caller-supplied version; empty means 'use the pin'.",
+    )
+    p_resolve.set_defaults(func=_cmd_resolve)
+
+    p_check = sub.add_parser(
+        "check-runtime", help="compare a `pkl --version` output against the pin"
+    )
+    p_check.add_argument(
+        "--actual", required=True, help="output of `pkl --version` on this runner"
+    )
+    p_check.add_argument(
+        "--expected",
+        default="",
+        help="version to compare against; empty (default) means the pin.",
+    )
+    p_check.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 1 (and annotate ::error::) on skew instead of warning.",
+    )
+    p_check.set_defaults(func=_cmd_check_runtime)
+
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except (OSError, ValueError) as exc:
+        print(f"::error::cannot read the pkl pin: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_pkl_version.py
+++ b/.github/scripts/tests/test_pkl_version.py
@@ -297,6 +297,10 @@ def _ci_files() -> list[Path]:
 _PKL_ASSET_LITERAL = re.compile(
     r"releases/download/(\d+\.\d+\.\d+)/pkl-",
 )
+# The pkl release URL, however the asset name is spelled. Anchors the
+# "downloads pkl" test below, which must not depend on the asset literal.
+_PKL_RELEASE_URL = "apple/pkl/releases/download/"
+
 # A `PKL_VERSION: "x.y.z"` env or `default: "x.y.z"` on a pkl-version input.
 _PKL_ENV_LITERAL = re.compile(r"PKL_VERSION\s*:\s*[\"'](\d+\.\d+\.\d+)[\"']")
 
@@ -355,6 +359,47 @@ def test_no_install_pkl_call_site_pins_a_version() -> None:
     assert not offenders, (
         "these install-pkl call sites pin a pkl version instead of taking the "
         f"SoT default ({pv.SOT_RELPATH}): {sorted(set(offenders))}"
+    )
+
+
+def test_every_pkl_download_also_verifies_the_runtime() -> None:
+    """Anything that installs pkl must assert that PATH's pkl IS that version.
+
+    Downloading the right asset is not the same as running it: a runner image
+    or an earlier step can leave another pkl ahead of ``/usr/local/bin``, and
+    the drivers that follow invoke bare ``pkl``. So a download without a
+    ``check-runtime --strict`` reintroduces the FND-1864 skew on whichever path
+    it sits on — which is exactly what happened: the verify was added to
+    ``install-pkl`` and not to ``regenerate-contract``, whose download is a
+    separate copy. Echoing ``pkl --version`` is logging, not verification, so
+    this looks for the assertion specifically.
+
+    The right long-term fix is one download for the whole repo; this guard is
+    what makes the interim two-copy state safe, and it will simply keep passing
+    once they are folded together.
+    """
+    # Anchor on the release path, NOT on a `/pkl-<asset>` fragment: both
+    # downloads name the asset through `${PKL_ASSET}` (chosen from runner.arch
+    # in the expression layer), so a pattern wanting the literal asset name
+    # matches zero files and the guard silently passes forever. Caught by
+    # stripping the verify step and watching this stay green.
+    downloads = [
+        p for p in _ci_files() if _PKL_RELEASE_URL in p.read_text(encoding="utf-8")
+    ]
+    assert downloads, (
+        "no pkl download found in any CI file — this guard is only meaningful "
+        f"if it matches something; has the URL {_PKL_RELEASE_URL!r} changed?"
+    )
+    offenders = [
+        p.relative_to(REPO_ROOT).as_posix()
+        for p in downloads
+        if "check-runtime" not in p.read_text(encoding="utf-8")
+    ]
+    assert not offenders, (
+        "these files download pkl but never assert the pkl on PATH is the "
+        f"version they resolved: {sorted(offenders)}. Add a "
+        "`check-runtime --strict --expected <resolved>` step after the "
+        "download (see .github/actions/install-pkl/action.yaml)."
     )
 
 

--- a/.github/scripts/tests/test_pkl_version.py
+++ b/.github/scripts/tests/test_pkl_version.py
@@ -1,0 +1,384 @@
+"""Tests for ``.github/scripts/pkl_version.py`` — plus the cross-file guards
+that keep the pkl pin a *single* source of truth.
+
+The unit cases below cover the driver. The repo-wide guards at the bottom are
+the load-bearing half: FND-1864 was not caused by the pin being wrong, it was
+caused by the pin being **six literals in six files** that nothing kept in
+agreement and no app could read. Deleting the copies fixes it once; these
+guards are what stop the seventh from appearing.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import pkl_version as pv
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _sot(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "pkl_version.py"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# parse_pin
+# ---------------------------------------------------------------------------
+
+
+def test_parses_the_pin(tmp_path: Path) -> None:
+    sot = _sot(tmp_path, 'PKL_VERSION: str = "0.32.1"\n')
+    assert pv.parse_pin(sot) == "0.32.1"
+
+
+def test_ignores_mentions_in_prose(tmp_path: Path) -> None:
+    # The real SoT's docstring names other versions (0.27, 0.28) while
+    # explaining the skew. Anchoring at column 0 on the assignment is what keeps
+    # those out.
+    sot = _sot(
+        tmp_path,
+        '"""Valid on 0.28+, rejected on PKL_VERSION: str = "0.27.2" style prose."""\n'
+        "# see PKL_VERSION below\n"
+        'PKL_VERSION: str = "0.32.1"\n',
+    )
+    assert pv.parse_pin(sot) == "0.32.1"
+
+
+def test_missing_assignment_raises(tmp_path: Path) -> None:
+    sot = _sot(tmp_path, "PKL = '0.32.1'\n")
+    with pytest.raises(ValueError, match="no 'PKL_VERSION"):
+        pv.parse_pin(sot)
+
+
+def test_conflicting_assignments_raise(tmp_path: Path) -> None:
+    sot = _sot(tmp_path, 'PKL_VERSION: str = "0.32.1"\nPKL_VERSION: str = "0.27.2"\n')
+    with pytest.raises(ValueError, match="conflicting PKL_VERSION values"):
+        pv.parse_pin(sot)
+
+
+# ---------------------------------------------------------------------------
+# normalize
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Pkl 0.32.1 (macOS 26.4, native)", "0.32.1"),
+        ("Pkl 0.27.2 (Linux 6.8, native)", "0.27.2"),
+        ("0.32.1", "0.32.1"),
+        ("  0.32.1\n", "0.32.1"),
+        ("Pkl 0.33.0-rc.1 (Linux, native)", "0.33.0-rc.1"),
+    ],
+)
+def test_normalize_accepted_spellings(raw: str, expected: str) -> None:
+    assert pv.normalize(raw) == expected
+
+
+def test_normalize_rejects_unparseable() -> None:
+    with pytest.raises(ValueError, match="could not parse a pkl version"):
+        pv.normalize("command not found: pkl")
+
+
+# ---------------------------------------------------------------------------
+# resolve — the reason every call site can now omit the version
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_empty_requested_yields_the_pin(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    sot = _sot(tmp_path, 'PKL_VERSION: str = "0.32.1"\n')
+    assert pv.main(["--sot", str(sot), "resolve", "--requested", ""]) == 0
+    assert capsys.readouterr().out.strip() == "0.32.1"
+
+
+def test_resolve_whitespace_requested_yields_the_pin(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # An unset workflow input arrives as "", but a caller passing a quoted
+    # expression that resolved to nothing can arrive as whitespace.
+    sot = _sot(tmp_path, 'PKL_VERSION: str = "0.32.1"\n')
+    assert pv.main(["--sot", str(sot), "resolve", "--requested", "   "]) == 0
+    assert capsys.readouterr().out.strip() == "0.32.1"
+
+
+def test_resolve_explicit_override_wins(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    sot = _sot(tmp_path, 'PKL_VERSION: str = "0.32.1"\n')
+    assert pv.main(["--sot", str(sot), "resolve", "--requested", "0.28.2"]) == 0
+    assert capsys.readouterr().out.strip() == "0.28.2"
+
+
+def test_unreadable_sot_exits_2(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Loud, not defaulted: a pin CI cannot read must fail the job rather than
+    # fall back to a guess and quietly reintroduce the skew.
+    assert pv.main(["--sot", str(tmp_path / "nope.py"), "resolve"]) == 2
+    assert "cannot read the pkl pin" in capsys.readouterr().err
+
+
+def test_print_version(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    sot = _sot(tmp_path, 'PKL_VERSION: str = "0.32.1"\n')
+    assert pv.main(["--sot", str(sot), "print-version"]) == 0
+    assert capsys.readouterr().out.strip() == "0.32.1"
+
+
+# ---------------------------------------------------------------------------
+# check-runtime
+# ---------------------------------------------------------------------------
+
+
+def test_check_runtime_match(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    sot = _sot(tmp_path, 'PKL_VERSION: str = "0.32.1"\n')
+    code = pv.main(
+        [
+            "--sot",
+            str(sot),
+            "check-runtime",
+            "--actual",
+            "Pkl 0.32.1 (macOS 26.4, native)",
+        ]
+    )
+    assert code == 0
+    assert "matches the SDK pin" in capsys.readouterr().out
+
+
+def test_check_runtime_skew_warns_by_default(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    sot = _sot(tmp_path, 'PKL_VERSION: str = "0.32.1"\n')
+    code = pv.main(
+        ["--sot", str(sot), "check-runtime", "--actual", "Pkl 0.27.2 (Linux, native)"]
+    )
+    assert code == 0
+    err = capsys.readouterr().err
+    assert "::warning::pkl version skew" in err
+    assert "0.27.2" in err and "0.32.1" in err
+
+
+def test_check_runtime_skew_fails_under_strict(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    sot = _sot(tmp_path, 'PKL_VERSION: str = "0.32.1"\n')
+    code = pv.main(
+        [
+            "--sot",
+            str(sot),
+            "check-runtime",
+            "--actual",
+            "Pkl 0.27.2 (Linux, native)",
+            "--strict",
+        ]
+    )
+    assert code == 1
+    assert "::error::pkl version skew" in capsys.readouterr().err
+
+
+def test_check_runtime_expected_overrides_the_pin(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A deliberate override is checked against what it asked for.
+
+    ``install-pkl`` verifies that the pkl on PATH is the version it resolved —
+    which for a caller that passed an explicit ``version:`` is NOT the pin. Read
+    the pin instead and the one call site allowed to differ would be the one
+    that fails.
+    """
+    sot = _sot(tmp_path, 'PKL_VERSION: str = "0.32.1"\n')
+    code = pv.main(
+        [
+            "--sot",
+            str(sot),
+            "check-runtime",
+            "--strict",
+            "--expected",
+            "0.28.2",
+            "--actual",
+            "Pkl 0.28.2 (Linux, native)",
+        ]
+    )
+    assert code == 0
+    assert "matches the SDK pin" in capsys.readouterr().out
+
+
+def test_check_runtime_expected_mismatch_names_the_request_not_the_pin(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    sot = _sot(tmp_path, 'PKL_VERSION: str = "0.32.1"\n')
+    code = pv.main(
+        [
+            "--sot",
+            str(sot),
+            "check-runtime",
+            "--strict",
+            "--expected",
+            "0.28.2",
+            "--actual",
+            "Pkl 0.32.1 (Linux, native)",
+        ]
+    )
+    assert code == 1
+    err = capsys.readouterr().err
+    assert "requested is 0.28.2" in err
+    # The pin is irrelevant to this comparison and must not be blamed for it.
+    assert "SDK pin" not in err
+
+
+def test_check_runtime_unparseable_is_not_reported_as_skew(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # pkl absent from the runner is an infra gap, not evidence the contract is
+    # rendered by the wrong version.
+    sot = _sot(tmp_path, 'PKL_VERSION: str = "0.32.1"\n')
+    code = pv.main(
+        ["--sot", str(sot), "check-runtime", "--actual", "pkl: command not found"]
+    )
+    assert code == 0
+    err = capsys.readouterr().err
+    assert "could not parse a pkl version" in err
+    assert "skew" not in err
+
+
+# ---------------------------------------------------------------------------
+# Cross-file guards: the pin is declared exactly once
+# ---------------------------------------------------------------------------
+
+
+def test_the_real_sot_parses() -> None:
+    """The committed SoT must be readable by the parser CI depends on."""
+    version = pv.read_pin()
+    assert re.fullmatch(r"\d+\.\d+\.\d+", version), version
+
+
+def test_sot_agrees_with_the_python_constant() -> None:
+    """The textual read and the import must agree.
+
+    CI reads the pin as text (it has no SDK install); apps read it by import.
+    Two readers of one line is the whole design, so a reshaping that breaks
+    either one has to fail here.
+    """
+    sys.path.insert(0, str(REPO_ROOT))
+    from application_sdk.pkl_version import PKL_VERSION  # noqa: PLC0415
+
+    assert pv.read_pin() == PKL_VERSION
+
+
+def _ci_files() -> list[Path]:
+    """Every workflow, composite action and CI script in the repo."""
+    files: list[Path] = []
+    for pattern in (
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml",
+        ".github/actions/**/*.yml",
+        ".github/actions/**/*.yaml",
+        ".github/scripts/*.py",
+        ".github/scripts/*.sh",
+    ):
+        files.extend(sorted(REPO_ROOT.glob(pattern)))
+    return files
+
+
+# A pkl release asset URL with the version spelled out inline — the shape every
+# hand-rolled copy took before install-pkl existed.
+_PKL_ASSET_LITERAL = re.compile(
+    r"releases/download/(\d+\.\d+\.\d+)/pkl-",
+)
+# A `PKL_VERSION: "x.y.z"` env or `default: "x.y.z"` on a pkl-version input.
+_PKL_ENV_LITERAL = re.compile(r"PKL_VERSION\s*:\s*[\"'](\d+\.\d+\.\d+)[\"']")
+
+# Files allowed to spell a pkl version out, mapped to the reason. Empty on
+# purpose: after FND-1864 there is nowhere in CI the SoT cannot reach — both
+# downloads interpolate a resolved version rather than a literal. The mechanism
+# stays so a genuine future exception is recorded with its reason instead of
+# quietly weakening the regexes (same idiom as test_artifact_upload_retry.py).
+_EXEMPT: dict[str, str] = {}
+
+
+@pytest.mark.parametrize("path", _ci_files(), ids=lambda p: str(p))
+def test_no_ci_file_hardcodes_a_pkl_version(path: Path) -> None:
+    rel = path.relative_to(REPO_ROOT).as_posix()
+    text = path.read_text(encoding="utf-8")
+
+    hits = sorted(
+        set(_PKL_ASSET_LITERAL.findall(text) + _PKL_ENV_LITERAL.findall(text))
+    )
+    if not hits:
+        return
+    assert rel in _EXEMPT, (
+        f"{rel} spells a pkl version out ({hits}). The pin is declared once, in "
+        f"{pv.SOT_RELPATH}; install-pkl resolves it and every call site omits "
+        f"`version:`. A second literal is how FND-1864 happened — six of them, "
+        f"free to drift apart, and none of them readable by the apps whose "
+        f"contracts they render. If this file genuinely cannot reach the SoT, add "
+        f"it to _EXEMPT here with the reason."
+    )
+
+
+def test_no_install_pkl_call_site_pins_a_version() -> None:
+    """Every ``install-pkl`` use omits ``version:``.
+
+    A call site that passes one is not necessarily wrong — the input exists for
+    deliberate divergence — but it is exactly how the fleet drifted, so it has
+    to be an explicit, reviewed exception rather than the shape a copied step
+    happens to have.
+    """
+    offenders: list[str] = []
+    for path in _ci_files():
+        if path.suffix not in (".yml", ".yaml"):
+            continue
+        text = path.read_text(encoding="utf-8")
+        for match in re.finditer(
+            r"uses:\s*\S*install-pkl\S*\n(.*?)(?=\n\s*-\s|\Z)", text, re.S
+        ):
+            block = match.group(1)
+            # Stop at the next step; only look at this step's `with:`.
+            if re.search(r"^\s+version:\s*\S", block, re.M):
+                # The freshness gate forwards its own workflow_call input, which
+                # is itself empty by default — that is the pass-through, not a pin.
+                if "inputs.pkl-version" in block:
+                    continue
+                offenders.append(path.relative_to(REPO_ROOT).as_posix())
+    assert not offenders, (
+        "these install-pkl call sites pin a pkl version instead of taking the "
+        f"SoT default ({pv.SOT_RELPATH}): {sorted(set(offenders))}"
+    )
+
+
+def test_pin_file_is_in_the_toolkit_path_filter() -> None:
+    """A pin bump must run the toolkit generate-and-diff suite.
+
+    ``contract-toolkit-reusable.yaml``'s "Verify generated output" job
+    regenerates every ``contract-toolkit/examples/`` tree and fails on any diff
+    — the only check that can prove a pkl bump changes no generated artifact.
+    ``sdk-gate.yaml`` gates that whole reusable on its ``toolkit`` path filter,
+    so if the pin file is not listed there, a bump is a one-line Python change
+    that matches no filter and merges unverified.
+    """
+    gate = yaml.safe_load(
+        (REPO_ROOT / ".github/workflows/sdk-gate.yaml").read_text(encoding="utf-8")
+    )
+    filters = None
+    for job in gate["jobs"].values():
+        for step in job.get("steps", []) or []:
+            if "paths-filter" in str(step.get("uses", "")):
+                filters = yaml.safe_load(step["with"]["filters"])
+    assert filters is not None, "no dorny/paths-filter step found in sdk-gate.yaml"
+    assert pv.SOT_RELPATH in filters["toolkit"], (
+        f"{pv.SOT_RELPATH} is missing from sdk-gate.yaml's `toolkit` filter, so a "
+        f"pkl pin bump would not run contract-toolkit-reusable.yaml — the job that "
+        f"proves the bump regenerates every example byte-identically."
+    )

--- a/.github/workflows/contract-toolkit-publish.yml
+++ b/.github/workflows/contract-toolkit-publish.yml
@@ -31,7 +31,6 @@ permissions:
 
 env:
   PKG_NAME: app-contract-toolkit
-  PKL_VERSION: "0.27.2"
   PUBLISH_DIR: contracts
 
 jobs:
@@ -48,9 +47,9 @@ jobs:
           ref: main
           fetch-depth: 0
 
+      # No version: — install-pkl resolves the SDK pin from
+      # application_sdk/pkl_version.py, the one place it is declared.
       - uses: ./.github/actions/install-pkl
-        with:
-          version: ${{ env.PKL_VERSION }}
 
       - name: Read release version
         id: meta

--- a/.github/workflows/contract-toolkit-release.yml
+++ b/.github/workflows/contract-toolkit-release.yml
@@ -23,7 +23,6 @@ permissions:
 
 env:
   PKG_NAME: app-contract-toolkit
-  PKL_VERSION: "0.27.2"
   RELEASE_LABEL: "release:contract-toolkit"
   BUMP_BRANCH: "bump-version-contract-toolkit"
 
@@ -56,9 +55,9 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
+      # No version: — install-pkl resolves the SDK pin from
+      # application_sdk/pkl_version.py, the one place it is declared.
       - uses: ./.github/actions/install-pkl
-        with:
-          version: ${{ env.PKL_VERSION }}
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/.github/workflows/contract-toolkit-reusable.yaml
+++ b/.github/workflows/contract-toolkit-reusable.yaml
@@ -23,9 +23,6 @@ on:
 permissions:
   contents: read
 
-env:
-  PKL_VERSION: "0.27.2"
-
 jobs:
   generated-output:
     name: Verify generated output
@@ -37,9 +34,9 @@ jobs:
         with:
           version: "0.12.11"
 
+      # No version: — install-pkl resolves the SDK pin from
+      # application_sdk/pkl_version.py, the one place it is declared.
       - uses: ./.github/actions/install-pkl
-        with:
-          version: ${{ env.PKL_VERSION }}
 
       - name: Regenerate all examples
         run: contract-toolkit/scripts/regenerate-all.sh
@@ -76,9 +73,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # No version: — install-pkl resolves the SDK pin from
+      # application_sdk/pkl_version.py, the one place it is declared.
       - uses: ./.github/actions/install-pkl
-        with:
-          version: ${{ env.PKL_VERSION }}
 
       - name: Check generated output invariants
         run: contract-toolkit/scripts/check-invariants.sh

--- a/.github/workflows/generated-freshness.yaml
+++ b/.github/workflows/generated-freshness.yaml
@@ -38,9 +38,14 @@ on:
   workflow_call:
     inputs:
       pkl-version:
-        description: Pkl toolchain version to use.
+        description: >
+          Pkl toolchain version to render with. Empty (the default) means the
+          SDK pin in application_sdk/pkl_version.py — the same version an app's
+          `python -m application_sdk.dev.pkl path` hands its `poe generate`, so
+          a local render predicts this gate. Overriding it here reintroduces
+          exactly the skew FND-1864 removed; do it only deliberately.
         required: false
-        default: "0.27.2"
+        default: ""
         type: string
       check-freshness:
         description: >
@@ -93,7 +98,8 @@ jobs:
       # Absolute ref, not `./…`: this is a reusable workflow, so a relative
       # action path would resolve against the CONSUMER repo's workspace, which
       # has no copy of the SDK's actions.
-      - uses: atlanhq/application-sdk/.github/actions/install-pkl@main
+      - id: pkl
+        uses: atlanhq/application-sdk/.github/actions/install-pkl@main
         with:
           version: ${{ inputs.pkl-version }}
 
@@ -137,10 +143,20 @@ jobs:
               artifacts are stale or were hand-edited.
             - **Broken contract** — `contract/app.pkl` exists but `pkl eval` failed, so it
               does not regenerate at all (a toolkit bump likely merged without regenerating).
+            - **Version skew** — the contract uses syntax your local pkl accepts and this
+              one does not. pkl is a language, not just a renderer: backslash
+              line-continuations inside a multi-line string, for instance, are valid from
+              0.28 on and a hard `Invalid character escape sequence` before it. This job
+              rendered with **pkl `${{ steps.pkl.outputs.version }}`**.
 
             **To resolve, pick one:**
-            - Run `pkl eval -m . contract/app.pkl` (or `uv run poe generate`) locally, fix any
-              eval error, and push the refreshed output.
+            - Render with the version this gate uses, so a clean local run is actual
+              evidence — `python -m application_sdk.dev.pkl run -- eval --project-dir
+              contract -m . contract/app.pkl` downloads and caches that exact build.
+              `python -m application_sdk.dev.pkl check` just reports whether the pkl on
+              your `PATH` has drifted from it.
+            - Run `uv run poe generate` locally, fix any eval error, and push the refreshed
+              output.
             - If this app **intentionally** hand-maintains its generated config, opt out by
               setting `check-freshness: false` on the caller workflow.
 

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -157,9 +157,9 @@ jobs:
         with:
           version: "0.12.11"
 
-      # Version omitted deliberately: this job has no pkl pin of its own, so it
-      # tracks the action's fleet-wide default rather than reintroducing a
-      # fourth literal "0.27.2" that drifts silently.
+      # Version omitted deliberately — as it now is at every call site: the
+      # action resolves the single pin in application_sdk/pkl_version.py, so no
+      # workflow carries a literal of its own to drift silently (FND-1864).
       - uses: ./.github/actions/install-pkl
 
       # Renovate 43 requires Node >=24.11 — newer than the ubuntu-latest default,

--- a/.github/workflows/sdk-gate.yaml
+++ b/.github/workflows/sdk-gate.yaml
@@ -155,6 +155,18 @@ jobs:
               # in the sdk-refine step below instead.
             toolkit:
               - 'contract-toolkit/**'
+              # The pkl pin (FND-1864). A bump here changes the renderer every
+              # contract in the fleet is evaluated with, so it must run the
+              # toolkit suite — whose "Verify generated output" job regenerates
+              # every examples/ tree with the new pkl and fails on any diff.
+              # That is the only check that can prove a pin bump is
+              # output-neutral, and without this entry a bump would be a
+              # single-line Python change that matches no filter and merges
+              # unverified. Listed as its own file rather than folded into
+              # application_sdk/version.py precisely so this filter stays
+              # precise: an ordinary SDK release bump must not drag the toolkit
+              # suite along with it.
+              - 'application_sdk/pkl_version.py'
               - 'application_sdk/contracts/**'
               - 'application_sdk/credentials/**'
               - 'application_sdk/handler/**'

--- a/application_sdk/dev/_pkl_errors.py
+++ b/application_sdk/dev/_pkl_errors.py
@@ -1,0 +1,42 @@
+"""Typed error leaves for the pinned-pkl dev toolchain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from application_sdk.errors.leaves import InternalError
+
+
+@dataclass(kw_only=True)
+class UnsupportedPklPlatformError(InternalError):
+    """No published pkl asset for this os/arch pair.
+
+    pkl ships one native binary per platform; the combination reported by
+    ``platform`` has none, so there is nothing to download. Separate from
+    Dapr's ``UnsupportedArchitectureError`` because the *supported sets differ*
+    — pkl publishes no arm64 Windows build, for one — and a shared error would
+    have to describe both.
+    """
+
+    code: ClassVar[str] = "INTERNAL_PKL_UNSUPPORTED_PLATFORM"
+    message: str = "No published pkl release asset for this platform"
+    component: str | None = "pinned_pkl"
+    os_name: str | None = None
+    architecture: str | None = None
+
+
+@dataclass(kw_only=True)
+class PklDownloadError(InternalError):
+    """The pinned pkl binary could not be fetched.
+
+    pkl is a GitHub release asset, so this is a live dependency on the release
+    CDN — which returns 503s in bursts. Raised only after the retries in
+    ``application_sdk.dev.pkl`` are exhausted.
+    """
+
+    code: ClassVar[str] = "INTERNAL_PKL_DOWNLOAD_FAILED"
+    message: str = "Could not download the pinned pkl binary"
+    component: str | None = "pinned_pkl"
+    asset_url: str | None = None
+    attempts: int | None = None

--- a/application_sdk/dev/pkl.py
+++ b/application_sdk/dev/pkl.py
@@ -1,0 +1,307 @@
+"""The pinned Pkl toolchain, available to an app's own tooling (FND-1864).
+
+CI renders every contract with one exact pkl build — the pin in
+``application_sdk.pkl_version``. This module hands an app that same build, so a
+local ``uv run poe generate`` performs the *same computation* the
+``Generated Artifact Freshness`` gate performs rather than an approximation of
+it with whatever ``brew install pkl`` last produced.
+
+That distinction is the whole point. pkl is a language: syntax accepted by one
+release is rejected by another (backslash line-continuations inside a
+multi-line string are valid from 0.28 on and a hard ``Invalid character escape
+sequence`` on 0.27). Before this, a contract could render cleanly on a laptop
+and be structurally incapable of rendering in CI, and the gate reported it as
+stale artifacts.
+
+Public module, unlike its sibling ``_dapr``: apps invoke it directly.
+
+Use it from an app
+------------------
+In ``pyproject.toml``, run the generator through the pinned binary::
+
+    [tool.poe.tasks]
+    generate.shell = \"\"\"
+      PKL="$(python -m application_sdk.dev.pkl path)"
+      "$PKL" eval --project-dir contract -m . contract/app.pkl
+      uvx ruff check --fix --select F401 --quiet app/generated/*.py
+      uvx ruff format app/generated/*.py
+    \"\"\"
+
+Or, equivalently, without capturing the path::
+
+    python -m application_sdk.dev.pkl run -- \\
+      eval --project-dir contract -m . contract/app.pkl
+
+An app that would rather keep using the pkl on ``PATH`` can at least learn when
+it has drifted from CI::
+
+    python -m application_sdk.dev.pkl check          # exit 1 on mismatch
+    python -m application_sdk.dev.pkl check --warn    # advisory only
+
+Where the binary goes
+---------------------
+``~/.cache/atlan-sdk/pkl/<version>/pkl``, keyed by version so several pins can
+coexist and a bump is a fresh download rather than an overwrite. Same cache
+convention, download-on-first-use behaviour and no-checksum posture as the
+embedded daprd in ``application_sdk.dev._dapr`` — pkl publishes no per-asset
+digest, and this is the same HTTPS fetch of the same pinned release asset that
+the CI ``install-pkl`` action already performs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from application_sdk.dev._pkl_errors import (
+    PklDownloadError,
+    UnsupportedPklPlatformError,
+)
+from application_sdk.pkl_version import PKL_VERSION
+
+
+def _progress(message: str) -> None:
+    """Report download progress on **stderr**.
+
+    Deliberately not the SDK logger. That writes to stdout — correct for app
+    runtime, where the collector reads stdout for OTel — and wrong here: this
+    module's stdout is a machine-readable value that a generate task consumes
+    (``PKL="$(python -m application_sdk.dev.pkl path)"``), so a single log line
+    on stdout turns the captured path into three lines of garbage. Nothing
+    collects this process anyway; it runs on a laptop before the app exists.
+    """
+    print(message, file=sys.stderr)
+
+
+_RELEASE_ASSET_URL = "https://github.com/apple/pkl/releases/download/{version}/{asset}"
+
+# The pkl release assets, keyed by (platform.system().lower(), normalised arch).
+# Enumerated rather than templated because the naming is not uniform: Linux and
+# macOS spell 64-bit ARM `aarch64` while Dapr spells it `arm64`, and Windows
+# publishes an `.exe` for amd64 only. A missing key is a real gap, not a string
+# to guess at.
+_ASSETS: dict[tuple[str, str], str] = {
+    ("linux", "amd64"): "pkl-linux-amd64",
+    ("linux", "aarch64"): "pkl-linux-aarch64",
+    ("darwin", "amd64"): "pkl-macos-amd64",
+    ("darwin", "aarch64"): "pkl-macos-aarch64",
+    ("windows", "amd64"): "pkl-windows-amd64.exe",
+}
+
+_DOWNLOAD_MAX_ATTEMPTS = 3
+_DOWNLOAD_RETRY_SLEEP_S = 5.0
+
+# Accepts pkl's own `--version` banner ("Pkl 0.32.1 (macOS 26.4, native)") and a
+# bare version, and tolerates a pre-release suffix so an rc pin still parses.
+_VERSION_RE = re.compile(r"(?:Pkl\s+)?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)")
+
+
+def _cache_dir(version: str) -> Path:
+    return Path.home() / ".cache" / "atlan-sdk" / "pkl" / version
+
+
+def _binary_name() -> str:
+    return "pkl.exe" if platform.system().lower() == "windows" else "pkl"
+
+
+def platform_key() -> tuple[str, str]:
+    """Return ``(os, arch)`` normalised to the keys of :data:`_ASSETS`."""
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"):
+        arch = "amd64"
+    elif machine in ("arm64", "aarch64"):
+        arch = "aarch64"
+    else:
+        raise UnsupportedPklPlatformError(
+            os_name=platform.system(), architecture=platform.machine()
+        )
+    if (system, arch) not in _ASSETS:
+        raise UnsupportedPklPlatformError(
+            os_name=platform.system(), architecture=platform.machine()
+        )
+    return system, arch
+
+
+def asset_name() -> str:
+    """The pkl release asset published for the current platform."""
+    return _ASSETS[platform_key()]
+
+
+def asset_url(version: str = PKL_VERSION) -> str:
+    """The download URL for *version* on the current platform."""
+    return _RELEASE_ASSET_URL.format(version=version, asset=asset_name())
+
+
+def _download(url: str, target: Path) -> None:
+    """Fetch *url* to *target*, retrying the GitHub release CDN.
+
+    The CDN returns 503s in bursts lasting minutes — the reason CI's download
+    goes through ``with-retry.sh`` — so a single failed GET is not evidence the
+    pin is wrong. Downloads to a sibling temp file and renames, so an
+    interrupted fetch cannot leave a truncated binary in the cache for every
+    later run to execute.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_name = tempfile.mkstemp(dir=str(target.parent), suffix=".part")
+    os.close(tmp_fd)
+    tmp_path = Path(tmp_name)
+    last: Exception | None = None
+    try:
+        for attempt in range(1, _DOWNLOAD_MAX_ATTEMPTS + 1):
+            try:
+                urllib.request.urlretrieve(url, tmp_name)
+                break
+            except (urllib.error.URLError, OSError) as exc:
+                last = exc
+                if attempt == _DOWNLOAD_MAX_ATTEMPTS:
+                    raise PklDownloadError(
+                        asset_url=url, attempts=_DOWNLOAD_MAX_ATTEMPTS
+                    ) from exc
+                _progress(
+                    f"pkl download failed (attempt {attempt}/"
+                    f"{_DOWNLOAD_MAX_ATTEMPTS}): {exc} — retrying in "
+                    f"{_DOWNLOAD_RETRY_SLEEP_S:.0f}s"
+                )
+                time.sleep(_DOWNLOAD_RETRY_SLEEP_S)
+        else:  # pragma: no cover — the loop either breaks or raises
+            raise PklDownloadError(
+                asset_url=url, attempts=_DOWNLOAD_MAX_ATTEMPTS
+            ) from last
+        tmp_path.chmod(
+            tmp_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+        )
+        tmp_path.replace(target)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+    _progress(f"pkl {target.parent.name} cached at {target}")
+
+
+def ensure_pkl(version: str = PKL_VERSION) -> Path:
+    """Return the path to the pinned pkl binary, downloading it if absent."""
+    binary = _cache_dir(version) / _binary_name()
+    if not binary.exists():
+        os_name, arch = platform_key()
+        _progress(f"Downloading pkl {version} for {os_name}/{arch} …")
+        _download(asset_url(version), binary)
+    return binary
+
+
+def parse_version(text: str) -> str | None:
+    """Extract a version from a ``pkl --version`` banner, or ``None``."""
+    match = _VERSION_RE.search(text.strip())
+    return match.group(1) if match else None
+
+
+def runtime_version(binary: str | Path = "pkl") -> str | None:
+    """Version reported by *binary*, or ``None`` if it cannot be run or read."""
+    try:
+        result = subprocess.run(
+            [str(binary), "--version"], text=True, capture_output=True
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    return parse_version(result.stdout)
+
+
+def _cmd_print_version(_args: argparse.Namespace) -> int:
+    print(PKL_VERSION)
+    return 0
+
+
+def _cmd_path(_args: argparse.Namespace) -> int:
+    print(ensure_pkl())
+    return 0
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    binary = ensure_pkl()
+    return subprocess.run([str(binary), *args.pkl_args]).returncode
+
+
+def _cmd_check(args: argparse.Namespace) -> int:
+    """Compare the pkl on ``PATH`` against the pin.
+
+    Advisory with ``--warn``: an app that has not adopted the pinned binary
+    still wants to be told, and a hard failure there would break the very
+    ``poe generate`` the developer is running.
+    """
+    found = runtime_version(args.binary)
+    if found is None:
+        print(
+            f"pkl not found on PATH (or unreadable). CI renders contracts with "
+            f"pkl {PKL_VERSION}; install it, or render through "
+            f"'python -m application_sdk.dev.pkl run -- …'.",
+            file=sys.stderr,
+        )
+        return 0 if args.warn else 1
+    if found != PKL_VERSION:
+        print(
+            f"pkl version skew: '{args.binary}' is {found}, CI renders contracts "
+            f"with {PKL_VERSION}. pkl is a language, so the two can disagree on "
+            f"what your contract even means — a clean local render is not "
+            f"evidence the freshness gate will pass. Render through the pinned "
+            f"binary instead: python -m application_sdk.dev.pkl run -- "
+            f"eval --project-dir contract -m . contract/app.pkl",
+            file=sys.stderr,
+        )
+        return 0 if args.warn else 1
+    print(f"pkl {found} matches the SDK pin.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m application_sdk.dev.pkl", description=__doc__
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_version = sub.add_parser(
+        "print-version", help="print the pkl version CI renders contracts with"
+    )
+    p_version.set_defaults(func=_cmd_print_version)
+
+    p_path = sub.add_parser(
+        "path", help="print the cached pinned pkl binary, downloading if needed"
+    )
+    p_path.set_defaults(func=_cmd_path)
+
+    p_run = sub.add_parser("run", help="run the pinned pkl with the given arguments")
+    p_run.add_argument("pkl_args", nargs=argparse.REMAINDER, metavar="-- ARGS")
+    p_run.set_defaults(func=_cmd_run)
+
+    p_check = sub.add_parser(
+        "check", help="compare the pkl on PATH against the SDK pin"
+    )
+    p_check.add_argument(
+        "--binary", default="pkl", help="binary to interrogate (default: pkl)"
+    )
+    p_check.add_argument(
+        "--warn",
+        action="store_true",
+        help="report skew but exit 0, so a generate task is not broken by it",
+    )
+    p_check.set_defaults(func=_cmd_check)
+
+    args = parser.parse_args(argv)
+    # `run -- eval …` leaves the separator in REMAINDER; drop it so it is not
+    # passed to pkl as an argument.
+    if getattr(args, "pkl_args", None) and args.pkl_args[0] == "--":
+        args.pkl_args = args.pkl_args[1:]
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/application_sdk/pkl_version.py
+++ b/application_sdk/pkl_version.py
@@ -1,0 +1,67 @@
+"""Single source of truth for the Pkl toolchain pin (FND-1864).
+
+Every place that installs or runs ``pkl`` derives the version from the one
+literal below — the reusable CI workflows, the composite actions, and an app's
+own ``poe generate``. Nothing re-hardcodes it, and
+``.github/scripts/tests/test_pkl_version.py`` fails the build if anything does.
+
+Why a pin at all, and why it has to be *readable*
+-------------------------------------------------
+``pkl`` is a language, not just a renderer: syntax accepted by one release is
+rejected by another. Backslash line-continuations inside a multi-line string,
+for instance, are valid from 0.28 on and a hard ``Invalid character escape
+sequence`` on 0.27. So a contract can evaluate cleanly on a developer's machine
+and be structurally incapable of evaluating in CI.
+
+That skew is what FND-1864 was filed for. CI pinned 0.27.2 while developers had
+whatever ``brew install pkl`` gave them (0.32.x), the docs stated a *floor*
+(``pkl >= 0.25.1``) rather than a pin, and the version was buried inside the
+SDK's reusable workflow where no app could see it. The
+``Generated Artifact Freshness`` gate's whole value is that a local
+``uv run poe generate`` predicts it — with the skew, "it evals locally" was not
+evidence, and the failure surfaced only after push behind a message that blamed
+stale artifacts.
+
+Two consumers, one literal
+--------------------------
+* **CI**, without importing the SDK — the workflows and composite actions read
+  this file textually via ``.github/scripts/pkl_version.py``, so the pin is
+  available in jobs that never install the package (and in *consumer* repos,
+  where the action is checked out but the SDK is not necessarily installed).
+
+* **Apps**, by import — ``atlan-application-sdk`` is already a dependency of
+  every connector, so an app's tooling can reach the exact version CI uses::
+
+      python -m application_sdk.dev.pkl print-version   # 0.32.1
+      python -m application_sdk.dev.pkl path            # cached pinned binary
+
+  ``application_sdk.dev.pkl`` downloads and caches that exact build, so a local
+  render is the same computation CI performs rather than an approximation of it.
+
+Bumping it
+----------
+Edit the literal below; that is the whole change. Two things then happen on the
+PR, both deliberate:
+
+* ``sdk-gate.yaml`` lists this file in its ``toolkit`` path filter, so
+  ``contract-toolkit-reusable.yaml`` runs — which regenerates every
+  ``contract-toolkit/examples/`` tree with the new pkl and fails on any diff.
+  A pin bump that would change generated output therefore cannot merge quietly;
+  it must arrive with the regenerated artifacts. That is why the pin lives in
+  its own module rather than in ``application_sdk/version.py``: the path filter
+  stays precise, so an ordinary SDK release bump does not drag the toolkit suite
+  along with it.
+
+* Renovate opens the bump but never auto-merges it (see the ``apple/pkl``
+  custom manager in ``renovate.json``) — a pkl release reaches the whole fleet's
+  CI at once, so it is a reviewed change, not a lockfile refresh.
+
+Renovate rewrites the assignment below; keep it a plain double-quoted literal on
+one line, or the custom manager silently stops matching.
+"""
+
+from __future__ import annotations
+
+PKL_VERSION: str = "0.32.1"
+
+__all__ = ["PKL_VERSION"]

--- a/application_sdk/pkl_version.py
+++ b/application_sdk/pkl_version.py
@@ -63,5 +63,11 @@ one line, or the custom manager silently stops matching.
 from __future__ import annotations
 
 PKL_VERSION: str = "0.32.1"
+"""The pkl version CI renders every contract with.
+
+Read it from an app rather than assuming a floor:
+``python -m application_sdk.dev.pkl print-version``, or
+``python -m application_sdk.dev.pkl path`` for the cached binary itself.
+"""
 
 __all__ = ["PKL_VERSION"]

--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -693,7 +693,15 @@ Releases are **automatic** — no manual trigger required.
 
 ## Requirements
 
-- [PKL](https://pkl-lang.org/) >= 0.25.1 (`brew install pkl` on macOS)
+- [PKL](https://pkl-lang.org/) at the **pinned** version declared in
+  `application_sdk/pkl_version.py` — a floor is not enough. pkl is a language, so a
+  contract that renders under one release can be rejected outright by another
+  (backslash line-continuations inside a multi-line string are valid from 0.28 on and
+  an `Invalid character escape sequence` before it), which means a clean local render
+  on some other version is not evidence CI will agree (FND-1864). Get the exact build
+  the CI workflows use with `python -m application_sdk.dev.pkl path`, check the one on
+  your `PATH` with `python -m application_sdk.dev.pkl check`, or `brew install pkl` for
+  exploration only.
 - Python 3 for invariant checks and SDK import validation
 - `ruff` or `uvx` for formatting generated `_input.py` files during `./scripts/regenerate-all.sh`
 - Application SDK import dependencies for `python scripts/test-sdk-import.py`

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.33.1
-source-sha:    e1969b393147b3e27c3d148c489f9f3e694f1a4c
-source-date:   2026-09-08T00:15:38+01:00
+sdk-version:   3.33.2
+source-sha:    eb3f58581f82399f32e701c4743a5bca879b2a89
+source-date:   2026-09-09T14:22:00+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -31,6 +31,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.main` | Dev entry point — run_dev_combined() and AppConfig for local execution and container startup | 2 |
 | `application_sdk.observability` | Logging context — ExecutionContext, CorrelationContext, request/correlation helpers | 29 |
 | `application_sdk.outputs` | Output collectors and record models for Automation Engine | 4 |
+| `application_sdk.pkl_version` | The Pkl toolchain pin — the one version CI renders contracts with, readable by an app's own tooling so a local render predicts the freshness gate | 1 |
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 44 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 7 |
@@ -2831,6 +2832,19 @@ Output collectors and record models for Automation Engine
 - **Signature:** `get_outputs() -> OutputCollector`
 - **Summary:** Get the output collector for the current execution context.
 - **Defined in:** `application_sdk/outputs/__init__.py`
+
+## `application_sdk.pkl_version`
+
+The Pkl toolchain pin — the one version CI renders contracts with, readable by an app's own tooling so a local render predicts the freshness gate
+
+### Constants and Enums
+
+#### `PKL_VERSION`
+
+- **Import:** `from application_sdk.pkl_version import PKL_VERSION`
+- **Signature:** `PKL_VERSION: str`
+- **Summary:** The pkl version CI renders every contract with.
+- **Defined in:** `application_sdk/pkl_version.py`
 
 ## `application_sdk.server`
 

--- a/docs/guides/pkl-contracts.md
+++ b/docs/guides/pkl-contracts.md
@@ -27,10 +27,27 @@ No handler overrides needed. Just commit the generated files.
 
 ## Prerequisites
 
-Install `pkl`:
+Use the **pinned** `pkl` — the one CI renders contracts with — not whatever
+`brew` last shipped:
+
 ```bash
-brew install pkl
-pkl --version   # 0.27+ recommended
+python -m application_sdk.dev.pkl print-version   # the version CI uses
+PKL="$(python -m application_sdk.dev.pkl path)"   # download + cache that build
+"$PKL" --version
+```
+
+`pkl` is a language, not just a renderer, so versions disagree about what your
+contract *means*: backslash line-continuations inside a multi-line string are
+valid from 0.28 on and a hard `Invalid character escape sequence` before it. A
+clean render on a different version is therefore not evidence the
+`Generated Artifact Freshness` gate will pass — which is the whole reason that
+gate exists (FND-1864). The pin lives in one place,
+`application_sdk/pkl_version.py`.
+
+Already have a `pkl` you like? Keep it, but check it:
+
+```bash
+python -m application_sdk.dev.pkl check   # exit 1 if it has drifted from CI
 ```
 
 ## Project Structure

--- a/docs/standards/ci.md
+++ b/docs/standards/ci.md
@@ -509,6 +509,63 @@ call the private reusable it wired up, so it had never produced a check run at
 all — and the App offers no `lockfile-globs` equivalent to scope, only a `security`
 label bypass. The App's check run is a separate thing and was never affected.
 
+## A toolchain pin is declared once, in a file consumers can read
+
+**Rule:** a tool version that CI installs gets exactly **one** literal in the
+repo, in a file that is *also* reachable by whoever has to reproduce what CI
+did. Every workflow, action and script derives it from there; none restates it.
+Two pins exist today and both follow this:
+
+| Tool | Declared in | Read by CI via |
+|---|---|---|
+| Container Python | the golden base tag in `Dockerfile` | `.github/scripts/container_python_version.py` |
+| `pkl` | `PKL_VERSION` in `application_sdk/pkl_version.py` | `.github/scripts/pkl_version.py` |
+
+**Why one literal.** `pkl` was pinned in six places at once — `install-pkl`, the
+`regenerate-contract` action, the freshness gate, and three
+`contract-toolkit-*` workflows — with nothing keeping them in agreement. Six
+copies of a value is six chances to bump five.
+
+**Why *readable* matters more.** The freshness gate's whole value is that a
+local `uv run poe generate` predicts it. `pkl` is a language, so a contract can
+render cleanly on a developer's 0.32.x and be structurally incapable of
+rendering on CI's 0.27.2 (`Invalid character escape sequence` on a backslash
+line-continuation inside a multi-line string, valid from 0.28 on). With the pin
+buried in a reusable workflow, "it evals locally" was not evidence, the failure
+surfaced only after push, and the gate's message blamed stale artifacts —
+FND-1864. No app could even fix it; the version was not theirs to see.
+
+So the pin lives in the *shipped package*, which every connector already
+depends on, and the SDK hands out the exact build:
+
+```bash
+python -m application_sdk.dev.pkl print-version   # what CI renders with
+python -m application_sdk.dev.pkl path            # download + cache that build
+python -m application_sdk.dev.pkl check           # has my PATH pkl drifted?
+```
+
+**The mechanics, when you add the next pin.**
+
+1. Declare the literal in one file, on one line, plainly enough for a regex to
+   read (a Renovate custom manager rewrites it in place).
+2. Add a `.github/scripts/<tool>_version.py` with a `resolve --requested`
+   subcommand, and default every workflow/action input to `""` rather than to
+   the version. "Empty means the pin" is conditional logic, so it belongs in the
+   tested script, not the install shell — see the first section of this file.
+3. Resolve from the **action's own** checkout, not the caller's workspace: a
+   composite that runs in a consumer repo has no copy of this repo's source.
+   `${{ github.action_path }}/../../..` is this repo's root in both places.
+4. Put the declaring file in whichever `sdk-gate.yaml` path filter runs the job
+   that would *catch a bad bump*. For `pkl` that is the `toolkit` filter, whose
+   suite regenerates every `contract-toolkit/examples/` tree and fails on any
+   diff — the only check that can prove a pin bump is output-neutral. Skip this
+   and the bump is a one-line change that matches no filter and merges
+   unverified.
+5. Guard it: `.github/scripts/tests/test_pkl_version.py` fails the build if any
+   workflow, action or script spells a `pkl` version out, if a call site pins
+   one, if the textual and imported reads disagree, or if the declaring file
+   falls out of that path filter.
+
 ## Reusing scripts from a reusable workflow
 
 A `uses:` reusable workflow does **not** bring its own repo's files into the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -397,6 +397,12 @@ extend-select = [
 
 [tool.ruff.lint.per-file-ignores]
 "application_sdk/main.py" = ["T201"]
+# A developer-facing CLI (`python -m application_sdk.dev.pkl`): its stdout IS
+# the product — a generate task captures it — and its diagnostics go to stderr.
+# The SDK logger is deliberately not used; it writes to stdout for OTel
+# collection, which would corrupt the captured value. Same exemption as main.py
+# and application_sdk/tools/**.
+"application_sdk/dev/pkl.py" = ["T201"]
 ".github/**" = ["G004", "T201"]
 # tests and tools exempted from PLC0415: production runtime risk does
 # not apply, and tests sometimes use inline imports for fixture isolation.

--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,36 @@
       "/^\\.github/workflow-templates/.+\\.ya?ml$/"
     ]
   },
+  "customManagers": [
+    {
+      "description": "Pkl toolchain pin: track PKL_VERSION in application_sdk/pkl_version.py, the single place the version is declared (FND-1864). Repo-local rather than in the fleet preset because the file is SDK-only — connector repos consume the pin through the SDK package and the reusable workflows, and have nothing of their own to bump. github-tags rather than github-releases: apple/pkl tags each release as a bare version (`0.32.1`, no `v`), which `semver` versioning reads directly, and the tags datasource is the one the fleet's release-age handling is exercised against (see the app-contract-toolkit manager in the preset).",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^application_sdk/pkl_version\\.py$/"
+      ],
+      "matchStrings": [
+        "PKL_VERSION\\s*:\\s*str\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "pkl",
+      "packageNameTemplate": "apple/pkl",
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver"
+    }
+  ],
   "packageRules": [
+    {
+      "description": "Pkl toolchain bumps are reviewed, never auto-merged — deliberately unlike every other lane in the fleet preset. pkl is a language, not a pinned library: one line here changes the renderer that every contract in the fleet is evaluated with, and a release that alters generated output would drift 22 connector repos at once with no PR of their own to notice it on. The SDK's own CI does prove the bump is safe — application_sdk/pkl_version.py is in sdk-gate.yaml's `toolkit` filter, so contract-toolkit-reusable.yaml regenerates every examples/ tree with the new pkl and fails on any diff — but 'green' there means 'the toolkit examples are unchanged', which is evidence for a human to weigh against the real contracts, not a substitute for weighing it. Also excluded from the release-age cooldown's PyPI lane by construction (different datasource), so the review IS the hold.",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDepNames": [
+        "pkl"
+      ],
+      "automerge": false,
+      "platformAutomerge": false,
+      "semanticCommitType": "chore",
+      "commitMessageTopic": "the pinned pkl toolchain"
+    },
     {
       "description": "Action bumps inside the shipped conformance bootstrap templates are conformance-package source changes: the PR-title gate requires a fix(conformance) scope for anything under packages/conformance/ (except tests/ and lock files), and these bumps change the package's scaffolded output so they should version it. Give them their own group + semantic type/scope so the PR title is deterministic and never collides with plain .github/workflows or .github/workflow-templates action bumps (which stay chore(deps)). Repo-local packageRules are appended after the fleet preset, so this overrides both the preset's force-chore rule and its github-actions groupName — but only for deps whose file lives under the templates dir (matchFileNames).",
       "matchManagers": [

--- a/tests/unit/dev/test_pkl.py
+++ b/tests/unit/dev/test_pkl.py
@@ -6,6 +6,7 @@ Covers the platform→asset mapping, the caching/retry behaviour of the download
 
 from __future__ import annotations
 
+import os
 import stat
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -106,7 +107,11 @@ class TestEnsurePkl:
         monkeypatch.setattr(pkl_mod, "_download", fake_download)
         first = pkl_mod.ensure_pkl("0.32.1")
         second = pkl_mod.ensure_pkl("0.32.1")
-        assert first == second == tmp_path / "0.32.1" / "pkl"
+        # Derive the filename rather than hardcoding "pkl": on Windows the
+        # cached binary is `pkl.exe` (pkl publishes `pkl-windows-amd64.exe`),
+        # so a literal here passes on POSIX and reds every Windows leg.
+        expected = tmp_path / "0.32.1" / pkl_mod._binary_name()
+        assert first == second == expected
         assert len(calls) == 1
 
     def test_cache_is_keyed_by_version(
@@ -132,7 +137,7 @@ class TestEnsurePkl:
 
 
 class TestDownload:
-    def test_marks_the_binary_executable_and_renames_into_place(
+    def test_renames_into_place_leaving_no_partial(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         target = tmp_path / "cache" / "pkl"
@@ -143,10 +148,31 @@ class TestDownload:
         monkeypatch.setattr(pkl_mod.urllib.request, "urlretrieve", fake_urlretrieve)
         pkl_mod._download("https://example.invalid/pkl", target)
         assert target.read_text(encoding="utf-8") == "binary"
-        assert target.stat().st_mode & stat.S_IXUSR
         # No .part left behind: a truncated fetch must not survive as a
         # cached binary every later run would execute.
         assert not list(target.parent.glob("*.part"))
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason=(
+            "os.chmod on Windows honours only the read-only flag, so S_IXUSR is "
+            "never set there however _download chmods — Windows decides "
+            "executability by extension, which is why the cached binary is "
+            "pkl.exe. The bit is load-bearing on POSIX only, so assert it there "
+            "rather than weakening the assertion for every platform."
+        ),
+    )
+    def test_marks_the_binary_executable_on_posix(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / "cache" / "pkl"
+        monkeypatch.setattr(
+            pkl_mod.urllib.request,
+            "urlretrieve",
+            lambda url, filename: Path(filename).write_text("binary", encoding="utf-8"),
+        )
+        pkl_mod._download("https://example.invalid/pkl", target)
+        assert target.stat().st_mode & stat.S_IXUSR
 
     def test_retries_then_succeeds(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/dev/test_pkl.py
+++ b/tests/unit/dev/test_pkl.py
@@ -1,0 +1,327 @@
+"""Unit tests for ``application_sdk.dev.pkl``.
+
+Covers the platform→asset mapping, the caching/retry behaviour of the download
+(stubbed — no binary is ever fetched), version parsing, and each CLI subcommand.
+"""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from application_sdk.dev import pkl as pkl_mod
+from application_sdk.dev._pkl_errors import (
+    PklDownloadError,
+    UnsupportedPklPlatformError,
+)
+from application_sdk.pkl_version import PKL_VERSION
+
+
+class TestPlatformKey:
+    """The asset names are enumerated, not templated: Linux/macOS spell 64-bit
+    ARM ``aarch64`` (Dapr spells the same thing ``arm64``) and Windows publishes
+    amd64 only."""
+
+    @pytest.mark.parametrize(
+        ("sys_name", "machine", "expected_asset"),
+        [
+            ("Linux", "x86_64", "pkl-linux-amd64"),
+            ("Linux", "aarch64", "pkl-linux-aarch64"),
+            ("Darwin", "arm64", "pkl-macos-aarch64"),
+            ("Darwin", "x86_64", "pkl-macos-amd64"),
+            ("Windows", "AMD64", "pkl-windows-amd64.exe"),
+        ],
+    )
+    def test_supported_platforms(
+        self, sys_name: str, machine: str, expected_asset: str
+    ) -> None:
+        with (
+            patch("platform.system", return_value=sys_name),
+            patch("platform.machine", return_value=machine),
+        ):
+            assert pkl_mod.asset_name() == expected_asset
+
+    def test_unsupported_arch_raises(self) -> None:
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="riscv64"),
+            pytest.raises(UnsupportedPklPlatformError),
+        ):
+            pkl_mod.platform_key()
+
+    def test_unsupported_os_raises(self) -> None:
+        with (
+            patch("platform.system", return_value="FreeBSD"),
+            patch("platform.machine", return_value="x86_64"),
+            pytest.raises(UnsupportedPklPlatformError),
+        ):
+            pkl_mod.platform_key()
+
+    def test_arm64_windows_has_no_asset(self) -> None:
+        # pkl publishes no aarch64 Windows build. The arch normalises fine, so
+        # only the (os, arch) lookup catches it — a templated asset name would
+        # have produced a URL that 404s at download time instead.
+        with (
+            patch("platform.system", return_value="Windows"),
+            patch("platform.machine", return_value="ARM64"),
+            pytest.raises(UnsupportedPklPlatformError),
+        ):
+            pkl_mod.platform_key()
+
+
+class TestAssetUrl:
+    def test_url_names_the_pinned_version(self) -> None:
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+        ):
+            url = pkl_mod.asset_url()
+        assert url == (
+            f"https://github.com/apple/pkl/releases/download/{PKL_VERSION}/pkl-linux-amd64"
+        )
+
+    def test_explicit_version_overrides(self) -> None:
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+        ):
+            assert "0.28.2" in pkl_mod.asset_url("0.28.2")
+
+
+class TestEnsurePkl:
+    def test_downloads_once_then_reuses_the_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pkl_mod, "_cache_dir", lambda version: tmp_path / version)
+        calls: list[tuple[str, Path]] = []
+
+        def fake_download(url: str, target: Path) -> None:
+            calls.append((url, target))
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("#!/bin/sh\n", encoding="utf-8")
+
+        monkeypatch.setattr(pkl_mod, "_download", fake_download)
+        first = pkl_mod.ensure_pkl("0.32.1")
+        second = pkl_mod.ensure_pkl("0.32.1")
+        assert first == second == tmp_path / "0.32.1" / "pkl"
+        assert len(calls) == 1
+
+    def test_cache_is_keyed_by_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A bump must be a fresh download, not an overwrite — otherwise two
+        # pins cannot coexist and a stale binary answers for the new version.
+        monkeypatch.setattr(pkl_mod, "_cache_dir", lambda version: tmp_path / version)
+        monkeypatch.setattr(
+            pkl_mod,
+            "_download",
+            lambda url, target: (
+                target.parent.mkdir(parents=True, exist_ok=True),
+                target.write_text("x", encoding="utf-8"),
+            )
+            and None,
+        )
+        a = pkl_mod.ensure_pkl("0.27.2")
+        b = pkl_mod.ensure_pkl("0.32.1")
+        assert a != b
+        assert a.parent.name == "0.27.2"
+        assert b.parent.name == "0.32.1"
+
+
+class TestDownload:
+    def test_marks_the_binary_executable_and_renames_into_place(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / "cache" / "pkl"
+
+        def fake_urlretrieve(url: str, filename: str) -> None:
+            Path(filename).write_text("binary", encoding="utf-8")
+
+        monkeypatch.setattr(pkl_mod.urllib.request, "urlretrieve", fake_urlretrieve)
+        pkl_mod._download("https://example.invalid/pkl", target)
+        assert target.read_text(encoding="utf-8") == "binary"
+        assert target.stat().st_mode & stat.S_IXUSR
+        # No .part left behind: a truncated fetch must not survive as a
+        # cached binary every later run would execute.
+        assert not list(target.parent.glob("*.part"))
+
+    def test_retries_then_succeeds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pkl_mod.time, "sleep", lambda *_a: None)
+        attempts = {"n": 0}
+
+        def flaky(url: str, filename: str) -> None:
+            attempts["n"] += 1
+            if attempts["n"] < 3:
+                raise OSError("503 from the release CDN")
+            Path(filename).write_text("binary", encoding="utf-8")
+
+        monkeypatch.setattr(pkl_mod.urllib.request, "urlretrieve", flaky)
+        pkl_mod._download("https://example.invalid/pkl", tmp_path / "pkl")
+        assert attempts["n"] == 3
+
+    def test_raises_typed_error_when_retries_exhaust(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pkl_mod.time, "sleep", lambda *_a: None)
+        monkeypatch.setattr(
+            pkl_mod.urllib.request,
+            "urlretrieve",
+            MagicMock(side_effect=OSError("503")),
+        )
+        with pytest.raises(PklDownloadError) as exc:
+            pkl_mod._download("https://example.invalid/pkl", tmp_path / "pkl")
+        assert exc.value.attempts == pkl_mod._DOWNLOAD_MAX_ATTEMPTS
+        assert not (tmp_path / "pkl").exists()
+
+
+class TestVersionReading:
+    @pytest.mark.parametrize(
+        ("banner", "expected"),
+        [
+            ("Pkl 0.32.1 (macOS 26.4, native)", "0.32.1"),
+            ("Pkl 0.27.2 (Linux 6.8, native)", "0.27.2"),
+            ("0.32.1", "0.32.1"),
+            ("Pkl 0.33.0-rc.1 (Linux, native)", "0.33.0-rc.1"),
+        ],
+    )
+    def test_parse_version(self, banner: str, expected: str) -> None:
+        assert pkl_mod.parse_version(banner) == expected
+
+    def test_parse_version_returns_none_when_absent(self) -> None:
+        assert pkl_mod.parse_version("command not found") is None
+
+    def test_runtime_version_none_when_binary_missing(self) -> None:
+        with patch("subprocess.run", side_effect=OSError):
+            assert pkl_mod.runtime_version("pkl") is None
+
+    def test_runtime_version_none_on_nonzero_exit(self) -> None:
+        with patch(
+            "subprocess.run",
+            return_value=MagicMock(returncode=1, stdout=""),
+        ):
+            assert pkl_mod.runtime_version("pkl") is None
+
+    def test_runtime_version_reads_stdout(self) -> None:
+        with patch(
+            "subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="Pkl 0.32.1 (Linux, native)"),
+        ):
+            assert pkl_mod.runtime_version("pkl") == "0.32.1"
+
+
+class TestCli:
+    def test_print_version(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert pkl_mod.main(["print-version"]) == 0
+        assert capsys.readouterr().out.strip() == PKL_VERSION
+
+    def test_path_prints_the_cached_binary(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setattr(pkl_mod, "ensure_pkl", lambda: tmp_path / "pkl")
+        assert pkl_mod.main(["path"]) == 0
+        assert capsys.readouterr().out.strip() == str(tmp_path / "pkl")
+
+    def test_path_puts_nothing_but_the_path_on_stdout(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Download progress goes to stderr, never stdout.
+
+        The documented call shape captures stdout —
+        ``PKL="$(python -m application_sdk.dev.pkl path)"`` — so one progress
+        line on stdout makes the captured value a multi-line string and the
+        next command fails with a path that does not exist. The SDK logger
+        writes to stdout (right for app runtime, where the collector reads it
+        for OTel), which is why this module reports on stderr instead.
+        """
+        binary = tmp_path / "0.32.1" / "pkl"
+
+        def fake_ensure() -> Path:
+            pkl_mod._progress("Downloading pkl 0.32.1 for linux/amd64 …")
+            pkl_mod._progress(f"pkl 0.32.1 cached at {binary}")
+            return binary
+
+        monkeypatch.setattr(pkl_mod, "ensure_pkl", fake_ensure)
+        assert pkl_mod.main(["path"]) == 0
+        captured = capsys.readouterr()
+        assert captured.out == f"{binary}\n"
+        assert "Downloading pkl" in captured.err
+
+    def test_run_forwards_args_and_returns_the_exit_code(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        binary = tmp_path / "pkl"
+        monkeypatch.setattr(pkl_mod, "ensure_pkl", lambda: binary)
+        seen: list[list[str]] = []
+
+        def fake_run(cmd: list[str]) -> MagicMock:
+            seen.append(cmd)
+            return MagicMock(returncode=3)
+
+        monkeypatch.setattr(pkl_mod.subprocess, "run", fake_run)
+        code = pkl_mod.main(
+            ["run", "--", "eval", "--project-dir", "contract", "contract/app.pkl"]
+        )
+        assert code == 3
+        # The `--` separator is consumed, not handed to pkl as an argument.
+        assert seen == [
+            [str(binary), "eval", "--project-dir", "contract", "contract/app.pkl"]
+        ]
+
+    def test_run_without_the_separator_also_works(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        binary = tmp_path / "pkl"
+        monkeypatch.setattr(pkl_mod, "ensure_pkl", lambda: binary)
+        seen: list[list[str]] = []
+        monkeypatch.setattr(
+            pkl_mod.subprocess,
+            "run",
+            lambda cmd: (seen.append(cmd), MagicMock(returncode=0))[1],
+        )
+        assert pkl_mod.main(["run", "eval", "contract/app.pkl"]) == 0
+        assert seen == [[str(binary), "eval", "contract/app.pkl"]]
+
+    def test_check_passes_when_path_pkl_matches(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(pkl_mod, "runtime_version", lambda binary: PKL_VERSION)
+        assert pkl_mod.main(["check"]) == 0
+        assert "matches the SDK pin" in capsys.readouterr().out
+
+    def test_check_fails_on_skew(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(pkl_mod, "runtime_version", lambda binary: "0.27.2")
+        assert pkl_mod.main(["check"]) == 1
+        err = capsys.readouterr().err
+        assert "version skew" in err
+        assert "0.27.2" in err and PKL_VERSION in err
+
+    def test_check_warn_reports_skew_without_failing(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # --warn exists so wiring the check into an app's `poe generate` cannot
+        # break the very command the developer is running.
+        monkeypatch.setattr(pkl_mod, "runtime_version", lambda binary: "0.27.2")
+        assert pkl_mod.main(["check", "--warn"]) == 0
+        assert "version skew" in capsys.readouterr().err
+
+    def test_check_reports_absent_pkl_separately_from_skew(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(pkl_mod, "runtime_version", lambda binary: None)
+        assert pkl_mod.main(["check"]) == 1
+        err = capsys.readouterr().err
+        assert "not found on PATH" in err
+        assert "skew" not in err


### PR DESCRIPTION
Closes FND-1864.

## The problem

The `Generated Artifact Freshness` gate's whole value is that `uv run poe generate` predicts it. It did not.

`generated-freshness.yaml` installed pkl **0.27.2**; developers have **0.32.x** from `brew`. pkl is a language, not just a renderer — a backslash line-continuation inside a multi-line string is valid from 0.28 on and a hard `Invalid character escape sequence` before it. So a contract could render cleanly on a laptop and be *structurally incapable* of rendering in CI. Baselining `atlan-db2-app` (FND-1291) hit exactly that, and the gate reported:

```
##[error]the contract has an evaluable pkl root but 'pkl eval' failed — the
committed generated artifacts cannot be verified and are almost certainly stale
(a toolkit bump merged without regenerating).
```

Which was not the cause. And no app could fix it: the version lived inside the SDK's reusable workflow, where nothing downstream could see it. The docs stated a **floor** (`pkl >= 0.25.1`), which is how a floor came to be mistaken for a pin.

## The fix — one value, declared once, readable by both sides

**`application_sdk/pkl_version.py`** holds `PKL_VERSION`, the only pkl literal in the repo. Six copies are gone — `install-pkl`, `regenerate-contract`, the freshness gate and the three `contract-toolkit-*` workflows now pass no version at all.

It has to be readable by two very different consumers, so it is read two ways:

- **CI, without importing the SDK** — a new `.github/scripts/pkl_version.py` (`resolve --requested`, `check-runtime`, `print-version`) reads it textually. Necessary because the jobs that install pkl run before (or entirely without) a Python env holding `atlan-application-sdk`, and two of the composites run in *connector* workspaces that have no `application_sdk/` at all. Same shape and rationale as the existing `container_python_version.py`.
- **Apps, by import** — the SDK is already every connector's dependency, so option 2 of the ticket needs no new distribution channel:

  ```bash
  python -m application_sdk.dev.pkl print-version   # what CI renders with
  python -m application_sdk.dev.pkl path            # download + cache that exact build
  python -m application_sdk.dev.pkl run -- eval --project-dir contract -m . contract/app.pkl
  python -m application_sdk.dev.pkl check           # has my PATH pkl drifted?
  ```

  Caches under `~/.cache/atlan-sdk/pkl/<version>/`, mirroring the embedded daprd in `application_sdk/dev/_dapr.py` (same download-on-first-use, retry and cache conventions). This is what lets `poe generate` perform the **same computation** CI performs rather than an approximation of it — the check the ticket's verification note said no developer would do by hand.

`install-pkl` additionally asserts that the pkl on `PATH` **is** the version it resolved (a runner image or earlier step can shadow `/usr/local/bin`), and exposes it as a step output.

## Pin bumped 0.27.2 → 0.32.1, verified output-neutral first

A pin bump changes the renderer for every contract in the fleet at once, so it was measured before being made — rendering under both versions and diffing:

| Check | Result |
|---|---|
| `pkl test contract-toolkit/tests/*.pkl` under 0.32.1 | 420/420 tests, 948/948 asserts pass |
| `regenerate-all.sh` over all 14 toolkit examples | byte-identical, clean tree |
| `check-invariants.sh` | all pass |
| 22 local connector contracts rendered under 0.27.2 **and** 0.32.1 | 21 byte-identical; the 22nd (`atlan-model-caster-app`) fails under **both**, independently of the pin |
| `pkl project package` — the publish path, not just eval | identical artifacts **and** identical sha256s |

## Guards, so a seventh literal cannot appear

In `.github/scripts/tests/test_pkl_version.py`, which rides the always-running (never path-filtered) `CI script tests` workflow:

- no workflow, composite action or CI script may spell a pkl version out;
- no `install-pkl` call site may pin one (the input stays, for deliberate divergence — it just has to be a reviewed exception rather than the shape a copied step happens to have);
- the textual read and the imported constant must agree;
- **`application_sdk/pkl_version.py` must stay in `sdk-gate.yaml`'s `toolkit` path filter.** This is the load-bearing one: it makes a bump run `contract-toolkit-reusable.yaml`, whose "Verify generated output" job regenerates every examples tree and fails on any diff. Without it a pin bump is a one-line Python change that matches no filter and merges unverified. It is also why the pin lives in its own module rather than in `application_sdk/version.py` — so an ordinary SDK release bump does not drag the toolkit suite along with it.

## The misdirecting message

The `eval_failed` error asserted a single cause. It now names **version skew first**, states which pkl actually ran (`pkl --version`, read best-effort on the failure path only), and keeps the stale-contract cause second. The sticky comment gains a "Version skew" bullet quoting the exact version the job used and the command that reproduces it.

## Keeping it moving

Renovate tracks `apple/pkl` through a custom manager on that one line — `github-tags`, since apple/pkl tags bare versions — with **`automerge: false`**. Deliberately unlike every other lane in the fleet preset: green on this repo means "the toolkit examples are unchanged", which is evidence for a human to weigh against the real contracts, not a substitute for weighing it.

## Docs

The floor is replaced by the pin, plus how to obtain it: `contract-toolkit/README.md`, the `make-contract` skill (both copies), `docs/guides/pkl-contracts.md`, and a new **"A toolchain pin is declared once, in a file consumers can read"** section in `docs/standards/ci.md` — the mechanics generalised for whoever adds the next tool pin, alongside the container-Python one that already works this way.

## Not done, deliberately

Option 3 of the ticket (state the version in the connector `CLAUDE.md` template) is framed there as the "failing both" fallback, and options 1 and 2 both landed. The only SDK-managed block in a connector's `CLAUDE.md` is the connector-*review* kit, which is the wrong home for a toolchain note. Connector-side discoverability now comes from the docs above and from the gate's comment naming the version.

## Security-relevant changes for review

Per the org baseline's control-plane rule: this edits `.github/workflows/**` (the freshness gate — the file the ticket names — plus three `contract-toolkit-*` workflows, `sdk-gate.yaml` and `renovate.yaml`) and two composite actions, and adds a Renovate custom manager. No permissions, secrets or auth config were touched; the freshness gate's accepted fork/`pkl eval` posture is unchanged.

## Testing

- `.github/scripts/tests` — **4576 passed** (240 of them new, plus the existing freshness-driver suite)
- `tests/unit/dev/test_pkl.py` — **32 passed** (platform→asset mapping, cache keying, download retry/atomicity, CLI subcommands, and a regression test that `path` writes *only* the path to stdout, since a generate task captures it)
- `pre-commit` clean on every changed file, including `actionlint` and `renovate-config-validator`
- End-to-end: rendered `atlan-openapi-app` through `python -m application_sdk.dev.pkl run` and diffed the result against that repo's committed `manifest.json` — identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FuuStQCbop9EmVEjyJ2nBH
