### PR TITLE
chore(security): allowlist CVE-2026-15736 — snowflake-sqlalchemy 1.8.2 in app-runtime-base:3

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,11 +1,20 @@
 {
   "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Auto-maintained by the vuln-triage rover; CODEOWNERS: SDK/security team + @atlan-ci (auto-merge of allowlist-only PRs).",
   "_base_image": "app-runtime-base:3",
-  "_updated": "2026-09-07",
+  "_updated": "2026-09-10",
   "_renewal_note": "Expiry dates are the remediation SLA per severity, measured from first detection. CRITICAL: 7 days. HIGH: 30 days. MEDIUM/LOW are NOT allowlisted (tracked on Linear tickets only). The gate (check_allowlist.py) passes while an entry is unexpired and fails once it expires. Enforced by .github/scripts/validate_allowlist.py via _expiry_policy below.",
   "_expiry_policy": {
     "CRITICAL": 7,
     "HIGH": 30
   },
-  "_entry_schema": "Each non-underscore key is a CVE/advisory ID. Required: package, severity (CRITICAL|HIGH only), reason, expires, added_by, case (1-4), ticket. Optional: fix_pr. Keep entries minimal but descriptive."
+  "_entry_schema": "Each non-underscore key is a CVE/advisory ID. Required: package, severity (CRITICAL|HIGH only), reason, expires, added_by, case (1-4), ticket. Optional: fix_pr. Keep entries minimal but descriptive.",
+  "CVE-2026-15736": {
+    "package": "snowflake-sqlalchemy@1.8.2",
+    "severity": "HIGH",
+    "reason": "Base-image layer, not app deps. atlan-fivetran-app#251 resolves snowflake-sqlalchemy 1.11.0 (verified by a from-scratch `uv sync --locked` with the image's exact extras), its Dockerfile is single-stage with one venv, and a fresh uncached build still scans 1.8.2 - so the vulnerable copy ships in app-runtime-base:3 layers that apps cannot remediate. Needs a base-image rebuild picking up >=1.11.0. First detected 2026-09-09 on atlan-fivetran-app PRs.",
+    "expires": "2026-10-09",
+    "added_by": "zaman-atlan",
+    "case": 4,
+    "ticket": "CONNECT-1483"
+  }
 }


### PR DESCRIPTION
## What

One allowlist entry: **CVE-2026-15736** (HIGH) — `snowflake-sqlalchemy@1.8.2` — **case 4, base image**. Touches only `.security/base-allowlist.json`, per the allowlist-PR hard limit. `validate_allowlist.py` passes locally (`1 entry, all within policy`).

Expiry **2026-10-09** = first detection (2026-09-09, atlan-fivetran-app scans) + the 30-day HIGH SLA.

## Why case 4 — evidence, all reproducible

The vulnerable copy is **not in app dependencies**. Verified on [atlan-fivetran-app#251](https://github.com/atlanhq/atlan-fivetran-app/pull/251):

1. The app's lock resolves **1.11.0**, and a from-scratch `uv sync --locked` with the Dockerfile's exact extras installs 1.11.0 (`snowflake-connector-python 4.7.2` alongside).
2. The app Dockerfile is **single-stage with a single venv** — no other app-owned install path exists.
3. A **fresh, uncached build** of that branch (`e06d71f`, pyproject/lock checksums changed → new dependency layer) still scans **1.8.2**. Only base layers remain.
4. Control: bump-only [atlan-fivetran-app#250](https://github.com/atlanhq/atlan-fivetran-app/pull/250) passed this gate on **2026-09-08** — the day *before* the CVE first appeared in scans. Every fivetran scan since is red **regardless of app-side pins**, and any repo on `app-runtime-base:3` will follow as its scans re-run.

## What this does NOT do

It does not fix the CVE. The durable fix is a **base-image rebuild** picking up `snowflake-sqlalchemy>=1.11.0` (fixed version available — [PyPI 1.11.0, 2026-07-08](https://pypi.org/project/snowflake-sqlalchemy/1.11.0/), past the release-age cooldown). The entry expires 2026-10-09 either way, per policy.

## Unblocks

- atlan-fivetran-app#251 (approved ×2; Security Gate is its only required red)
- atlan-fivetran-app#250, #249, and any other `app-runtime-base:3` repo as scans re-run

Ticket: CONNECT-1483

🤖 Generated with [Claude Code](https://claude.com/claude-code)