### PR TITLE
feat(contract-toolkit): FND-1890 addonBefore passthrough on credential FieldSpec

### DIFF
--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -137,7 +137,12 @@ For frontend's credential file-reference input, use
 references, while typed reference values (for example secret-store keys or
 `objectstore://` paths) remain plain strings. The generated JSON emits the
 selected upload widget plus `ui.accept`, `ui.fileMetadata`, and opt-in
-`ui.removeBeforeUpload` when the widget is emitted. When
+`ui.removeBeforeUpload` when the widget is emitted. To badge a field with fixed,
+immutable text inside the input box — a `https://` scheme on a hostname, say —
+set `addonBefore` on the `FieldSpec`; it renders as `ui.addonBefore` and leaves
+the submitted value, the generated e2e credential model, and validation
+untouched (`AdvancedJDBCUrlGroup.urlAddonBefore` is the equivalent for that
+group's URL input). When
 `credentialAuthOptions` has a single entry, the auth-type radio is auto-hidden —
 the generated default is still emitted, so no form input is required.
 For `credentialUrlGroup` forms, the visible auth panes live inside

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -1323,6 +1323,7 @@ class FieldSpec {
   message: String?                       // Inline validation message below field
   validationRules: Listing<Dynamic>?     // Validation rules (e.g., required, min, max)
   byocDisabled: Boolean?                 // Emit BYOCdisabled for frontend credential UIs
+  addonBefore: String?                   // Immutable badge inside the input, before the typed value
   includeUiWidget: Boolean = true
   includeUiLabel: Boolean = true
   includeUiHidden: Boolean = true
@@ -1343,6 +1344,32 @@ The `rows` option is emitted under `ui.rows` when non-null. Use it with
 `fieldType = "textarea"` for compact multiline-capable fields, for example
 `rows = 1` for certificate or key inputs that should remain visually short while
 still accepting pasted newlines.
+
+`addonBefore` puts fixed, immutable text inside the input box ahead of what the
+user types — most often a scheme badge, so the form states the protocol rather
+than asking every user to type it:
+
+```pkl
+new FieldSpec {
+  name = "host"
+  displayName = "Library URL"
+  placeholder = "mstr.example.com/Library"
+  addonBefore = "https://"
+}
+```
+
+Unset by default, in which case no `addonBefore` key is emitted. It renders
+verbatim as `ui.addonBefore`, immediately before `ui.rules`. Three things it
+does *not* change: the badge is not part of the submitted value, so the
+credential is unchanged; the generated e2e credential model keeps the field at
+the same type; and validation is untouched — a field that must reject a
+typed-in `https://` still needs its own `validationRegex` / `validationRules`.
+
+`AdvancedJDBCUrlGroup.urlAddonBefore` is the equivalent for the URL input that
+group renders. Reach for `addonBefore` when the badge belongs on a plain
+`FieldSpec`; a `Widgets.TextInput` with `prepend` renders the same UI, but
+`NamedWidget` entries are invisible to the e2e credential-model generator, so
+the field would silently vanish from the typed model.
 
 The `includeUi*`, `uiClass`, `uiRequired`, and `includeRequiredWhenFalse`
 controls are exact-parity escape hatches for existing hand-authored

--- a/contract-toolkit/examples/full/app.pkl
+++ b/contract-toolkit/examples/full/app.pkl
@@ -153,6 +153,17 @@ credentialAuthOptions {
     fields {
       new FieldSpec { name = "token"; sensitive = true; displayName = "API Token"; width = 8 }
       new FieldSpec {
+        name = "console_url"
+        displayName = "Console URL"
+        placeholder = "console.example.com"
+        helpText = "REST console this token also authenticates against."
+        // Scheme badge on a plain FieldSpec — the counterpart to the URL
+        // group's `urlAddonBefore`, rendered as `ui.addonBefore`.
+        addonBefore = "https://"
+        required = false
+        width = 8
+      }
+      new FieldSpec {
         name = "ca_cert-file"
         displayName = "CA Certificate File"
         fieldType = "fileUpload"

--- a/contract-toolkit/examples/full/app/generated/_e2e_credential.py
+++ b/contract-toolkit/examples/full/app/generated/_e2e_credential.py
@@ -17,6 +17,7 @@ class FullFeaturedCredentialBody(CredentialBody):
     username: str = Field(default="", alias="username")
     password: str = Field(default="", alias="password")
     token: str = Field(default="", alias="token")
+    console_url: str = Field(default="", alias="console_url")
     ca_cert_file: str = Field(default="", alias="ca_cert-file")
     keytab_file: str = Field(default="", alias="keytab-file")
 

--- a/contract-toolkit/examples/full/app/generated/atlan-connectors-full-featured.json
+++ b/contract-toolkit/examples/full/app/generated/atlan-connectors-full-featured.json
@@ -464,6 +464,16 @@
                   "grid": 8
                 }
               },
+              "console_url": {
+                "type": "string",
+                "ui": {
+                  "label": "Console URL",
+                  "help": "REST console this token also authenticates against.",
+                  "placeholder": "console.example.com",
+                  "grid": 8,
+                  "addonBefore": "https://"
+                }
+              },
               "ca_cert-file": {
                 "type": "string",
                 "ui": {
@@ -616,6 +626,16 @@
               "widget": "password",
               "label": "API Token",
               "grid": 8
+            }
+          },
+          "console_url": {
+            "type": "string",
+            "ui": {
+              "label": "Console URL",
+              "help": "REST console this token also authenticates against.",
+              "placeholder": "console.example.com",
+              "grid": 8,
+              "addonBefore": "https://"
             }
           },
           "ca_cert-file": {

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -604,6 +604,23 @@ class FieldSpec {
   validationRules: Listing<Dynamic>?
 
   byocDisabled: Boolean?
+
+  /// Fixed, immutable text shown inside the input box before the value the user
+  /// types — a scheme badge such as `https://` on a hostname field, so the form
+  /// states the protocol instead of asking every user to type it.
+  ///
+  /// Unset by default, in which case no `addonBefore` key is emitted at all.
+  ///
+  /// Renders verbatim as `ui.addonBefore` on this field in the credential
+  /// config. It is a *display* affordance only: the badge is not part of the
+  /// submitted value, so the credential this field produces is unchanged and
+  /// the generated e2e credential model keeps the same type. Validation is
+  /// likewise untouched — a field that must reject a typed-in `https://` still
+  /// needs its own `validationRegex` / `validationRules`.
+  ///
+  /// `AdvancedJDBCUrlGroup.urlAddonBefore` is the equivalent for the URL input
+  /// that group renders; this property badges a plain `FieldSpec`.
+  addonBefore: String?
 }
 
 /// A credential field whose visibility/label/placeholder is driven by a compound boolean filter.
@@ -1923,6 +1940,10 @@ local function renderField(f: FieldSpec): Mapping<String, Any> = new Mapping {
       when (f.fieldType == "fileUpload" || f.fieldType == "credentialFileInput") { ["fileMetadata"] = f.fileMetadata }
       when ((f.fieldType == "fileUpload" || f.fieldType == "credentialFileInput") && f.removeBeforeUpload) { ["removeBeforeUpload"] = true }
     }
+    // Emitted last before `rules` deliberately: apps that carry this badge as a
+    // post-`pkl eval` patch today have it sitting between `grid` and `rules`, so
+    // this position lets them adopt the property with a no-op regeneration diff.
+    when (f.addonBefore != null) { ["addonBefore"] = f.addonBefore }
     when (f.validationRules != null) {
       ["rules"] = f.validationRules
     }

--- a/contract-toolkit/tests/credential_field_rendering_test.pkl
+++ b/contract-toolkit/tests/credential_field_rendering_test.pkl
@@ -16,6 +16,18 @@ local appCredentialRendering = (App) {
 
   credentialCommonFields {
     new App.FieldSpec {
+      name = "host"
+      displayName = "Host"
+      placeholder = "host.example.com"
+      addonBefore = "https://"
+      validationRules {
+        new Dynamic {
+          required = true
+          message = "Please enter a valid host name"
+        }
+      }
+    }
+    new App.FieldSpec {
       name = "enable_ssl"
       displayName = "Enable SSL"
       fieldType = "checkbox"
@@ -292,11 +304,16 @@ local appJdbcCredentialJson: String =
 local nativeJdbcCredentialJson: String =
   nativeJdbcCredentialRendering.output.files["atlan-connectors-native-jdbc-credential-rendering-test.json"].text
 
+local appE2eCredential: String =
+  appCredentialRendering.output.files["app/generated/_e2e_credential.py"].text
+
 local appCredential = new json.Parser { useMapping = true }.parse(appCredentialJson)
 local nativeCredential = new json.Parser { useMapping = true }.parse(nativeCredentialJson)
 local appJdbcCredential = new json.Parser { useMapping = true }.parse(appJdbcCredentialJson)
 local nativeJdbcCredential = new json.Parser { useMapping = true }.parse(nativeJdbcCredentialJson)
 
+local appHost = appCredential["config"]["properties"]["host"]
+local appHostUiKeys = appHost["ui"].keys.toList()
 local appEnableSsl = appCredential["config"]["properties"]["enable_ssl"]
 local nativeEnableSsl = nativeCredential["config"]["properties"]["enable_ssl"]
 local appCaCertFile = appCredential["config"]["properties"]["ca_cert-file"]
@@ -341,6 +358,32 @@ local widgetsFileUploaderWithRemove = new json.Parser { useMapping = true }.pars
 ))
 
 facts {
+  ["App.pkl renders FieldSpec.addonBefore verbatim as ui.addonBefore"] {
+    appHost["ui"]["addonBefore"] == "https://"
+  }
+
+  // Position matters, not just presence: apps that carry this badge as a
+  // post-`pkl eval` patch have it between `grid` and `rules`, so emitting it
+  // here lets them drop the patch with a no-op regeneration diff.
+  ["App.pkl emits ui.addonBefore immediately before ui.rules"] {
+    appHostUiKeys.indexOf("addonBefore") == appHostUiKeys.indexOf("rules") - 1
+    appHostUiKeys.indexOf("grid") < appHostUiKeys.indexOf("addonBefore")
+  }
+
+  ["App.pkl omits ui.addonBefore entirely when FieldSpec.addonBefore is unset"] {
+    !appEnableSsl["ui"].containsKey("addonBefore")
+    !appKeytabFile["ui"].containsKey("addonBefore")
+  }
+
+  // The badge is a display affordance: it must not reach the typed credential
+  // model as a value, but the field itself must still be present there. A
+  // NamedWidget carrying `prepend` renders the same UI and silently drops the
+  // field from this model — that is the trap this property exists to avoid.
+  ["App.pkl keeps an addonBefore-badged field in the generated e2e credential model"] {
+    appE2eCredential.contains("host: str = Field(alias=\"host\")")
+    !appE2eCredential.contains("https://")
+  }
+
   ["App.pkl renders checkbox FieldSpec as checkbox widget with boolean schema"] {
     appEnableSsl["type"] == "boolean"
     appEnableSsl["default"] == true


### PR DESCRIPTION
## Why

Direct answer to the review question on #3703:

> I'd like to better understand the scenarios where we have a post-processing step to see if we can instead get rid of them entirely — hence fix this complexity by simply removing it.

I took one app that ships a `contract/post-generate.sh` — `atlan-microstrategy-app`, the app that thread started on — and inventoried what its post-processing actually does. Two patches. One was pure cosmetics and is [already deleted app-side](https://github.com/atlanhq/atlan-microstrategy-app/pull/153). The other could not be removed, because of the gap this PR closes.

**With this property in place, that app deletes `contract/post-generate.sh` and `scripts/patch_generated.py` outright.** No post-processing left.

## The gap

An app wants a fixed `https://` badge inside its credential host input, so the form states the protocol instead of asking every user to type it. That renders as `ui.addonBefore`.

The toolkit already emits that key on two paths:

| Path | Author-facing property | Source |
|---|---|---|
| JDBC URL group | `urlAddonBefore` | `App.pkl:1967,1978` |
| Typed widget | `TextInput.prepend` | `Widgets.pkl:566` |
| **Plain `FieldSpec`** | **— none —** | |

So this is a missing passthrough on one path, not a new concept.

## Why not just use a widget

`credentialCommonFields` accepts a `NamedWidget`, and `Widgets.TextInput` has `prepend`. That renders a **byte-identical** credential configmap and needs no toolkit change — it looks like the obvious answer.

It is a trap. The e2e credential-model generator walks `FieldSpec` entries only (`when (f is FieldSpec)`), so moving a field to a widget silently drops it from the generated `<Name>CredentialBody`:

```diff
 class MicrostrategyCredentialBody(CredentialBody):
     name: str = Field(alias="name")
     auth_type: str = Field(default="basic", alias="authType")
-    host: str = Field(alias="host")
     port: int = Field(default=443, alias="port")
```

Measured, not reasoned about — the switch was made, evaluated, and reverted when the model came back a field short. No warning, no eval error; the form still renders correctly. That trap is filed separately (it is not fixed here, and the passthrough does not disarm it — it only removes the reason to reach for a widget). This PR gives the plain-`FieldSpec` case a first-class answer.

`NamedProperty` also renders identically, but means hand-writing the fully-rendered property in pkl (`label` not `displayName`, `grid` not `width`, the `rules` array spelled out) — the same defect in different clothes, and worse, since nothing flags it when the toolkit's rendering moves on.

## Placement is deliberate

`addonBefore` is emitted **immediately before `rules`**. Apps carrying this badge as a post-`pkl eval` patch today already have it sitting between `grid` and `rules`, so this position lets them drop the patch with a *no-op* regeneration diff rather than a reformatting churn through the freshness gate.

A test asserts the adjacency, so a later tidy-up of the renderer cannot quietly move it:

```pkl
appHostUiKeys.indexOf("addonBefore") == appHostUiKeys.indexOf("rules") - 1
```

## End-to-end verification

Beyond the toolkit's own suite, I ran the motivating app against this branch with its post-processing **deleted**:

1. pointed `contract/PklProject` at this branch's toolkit source;
2. declared `addonBefore = "https://"` on its host `FieldSpec`;
3. neutered `contract/post-generate.sh` entirely;
4. regenerated and applied the same `ruff check --fix` + `ruff format` CI applies.

Result: **zero diff** across the whole `app/generated/**` tree, credential configmap included. The property is sufficient to retire that app's post-processing with no artifact churn.

(Before the ruff step, two generated `.py` files differed by import grouping and one 90-char wrap — the app's `poe generate` does not run ruff while CI does. Unrelated to this change; it is the FND-1816 baseline-formatting issue, noted here only so the intermediate state isn't mistaken for a regression.)

## What this does not change

The badge is display-only:

- not part of the submitted value, so the credential is unchanged;
- the generated e2e credential model keeps the field at the same type — and gains it, which is the whole point versus the widget route;
- validation is untouched, so a field that must reject a typed-in `https://` still needs its own `validationRegex` / `validationRules`.

Unset by default; no `addonBefore` key is emitted at all. Regenerating every example produced a diff in exactly one — the one I deliberately extended.

`NativeApp.pkl` is deliberately untouched, per the repo's editing rules on frozen legacy modules.

## Checklist

```
./scripts/regenerate-all.sh      ✅  only examples/full changed
./scripts/check-invariants.sh    ✅  all invariant checks passed
pkl test tests/*.pkl             ✅  424 passed / 955 asserts
python scripts/test-sdk-import.py ✅  all 41 files imported
git diff --check                 ✅  clean
```

Docs updated in `README.md` and `docs/reference.md`; extended doc comment on the property; `examples/full` demonstrates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
