### PR TITLE
chore(security): allowlist CVE-2026-84445 (HIGH, SLA 30d)

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,11 +1,22 @@
 {
   "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Auto-maintained by the vuln-triage rover; CODEOWNERS: SDK/security team + @atlan-ci (auto-merge of allowlist-only PRs).",
   "_base_image": "app-runtime-base:3",
-  "_updated": "2026-09-07",
+  "_updated": "2026-09-10",
   "_renewal_note": "Expiry dates are the remediation SLA per severity, measured from first detection. CRITICAL: 7 days. HIGH: 30 days. MEDIUM/LOW are NOT allowlisted (tracked on Linear tickets only). The gate (check_allowlist.py) passes while an entry is unexpired and fails once it expires. Enforced by .github/scripts/validate_allowlist.py via _expiry_policy below.",
   "_expiry_policy": {
     "CRITICAL": 7,
     "HIGH": 30
   },
-  "_entry_schema": "Each non-underscore key is a CVE/advisory ID. Required: package, severity (CRITICAL|HIGH only), reason, expires, added_by, case (1-4), ticket. Optional: fix_pr. Keep entries minimal but descriptive."
+  "_entry_schema": "Each non-underscore key is a CVE/advisory ID. Required: package, severity (CRITICAL|HIGH only), reason, expires, added_by, case (1-4), ticket. Optional: fix_pr. Keep entries minimal but descriptive.",
+  "CVE-2026-84445": {
+    "package": "dapr-daprd-1.18",
+    "severity": "HIGH",
+    "reason": "Case 4: base-image CVE (Chainguard dapr-daprd-1.18 1.18.3-r8 apk in app-runtime-base:3, not a uv.lock dependency); clears on a base-image rebuild onto dapr-daprd-1.18 1.18.3-r9 or later.",
+    "expires": "2026-10-10",
+    "added_by": "@vaibhavatlan",
+    "case": 4,
+    "ticket": "BLDX-1647",
+    "re_evaluation_trigger": "fix_released",
+    "fix_available_date": "2026-09-10"
+  }
 }


### PR DESCRIPTION
Adds the SLA-bearing allowlist entry for the one new HIGH from the 2026-09-10 daily security scan.

| Field | Value |
| -- | -- |
| CVE | `CVE-2026-84445` (`GHSA-2v4p-qf9q-27wj`) |
| Severity | HIGH (trivy) |
| Package | `dapr-daprd-1.18` @ `1.18.3-r8` |
| Source | base image (`app-runtime-base:3`) — **not** a `uv.lock` dependency |
| Case | **4** — base-image rebuild |
| Fixed in | `dapr-daprd-1.18` `1.18.3-r9` |
| Expires (SLA) | `2026-10-10` (HIGH → 30d from first detection) |
| Ticket | [BLDX-1647](https://linear.app/atlan-epd/issue/BLDX-1647/securityhigh-1-new-vulnerability-2026-09-10) |
| Scan run | [logs](https://github.com/atlanhq/application-sdk/actions/runs/34425894291) |

### Why Case 4 and not a bump

Dapr ships in `app-runtime-base:3`, not in `uv.lock`. Per
`.mothership/vuln-triage/ORCHESTRATION.md`, a fixed Dapr CVE is Case 4 (rebuild + republish the
base image), never Case 1 (dependency bump) — "fix available" and "we bump `uv.lock`" are
orthogonal. So there is no bump PR to pair with this one; the remediation is a Chainguard rebuild
of `app-runtime-base:3` onto `1.18.3-r9` or later, and this entry holds the gate green until then.

The fix version was confirmed against the Chainguard security feed, which lists
`1.18.3-r9: CVE-2026-84445, GHSA-2v4p-qf9q-27wj` under the `dapr-1.18` origin package.
`fix_available_date` is set to the date the fix was first observed available (the 2026-09-10 scan);
the feed publishes fixed-in versions but not release dates.

This is the same shape as #3678, which allowlisted two `dapr-daprd-1.18` Case 4 HIGHs and whose
entries were then cleared by #3680 once the base image was rebuilt onto `r7`+.

### Validation

- `uv run python .github/scripts/validate_allowlist.py` → `✅ Allowlist valid: 1 entry, all within policy`
- `uv run pre-commit run --files .security/base-allowlist.json` → passed
- Touches only `.security/base-allowlist.json`, per the allowlist-PR path limit

### Not auto-merge labelled

`vuln_auto_merge_gate.py` only trusts `atlan-ci`, `atlan-app-fleet[bot]` and `mothership-ai[bot]`
as PR authors. This one is human-authored, so the `vuln-auto-merge` label would buy nothing —
leaving it off for a normal review + merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
