### PR TITLE
ci(vuln-triage): send an attributed AI Gateway key from the rover

### DIFF
--- a/.github/scripts/mothership_sandbox_dispatch.py
+++ b/.github/scripts/mothership_sandbox_dispatch.py
@@ -82,6 +82,16 @@ def build_payload(
         "repositories": ["atlanhq/application-sdk"],
         "base_branch": "main",
         "snapshot": "_base",
+        # Mothership refuses to fall back to a shared, un-attributed AI Gateway
+        # key: without this the sandbox dies with `code=internal ... No
+        # attributed AI Gateway key for this run (channel=None, snapshot=None)`
+        # before the rover runs a single step. `_base` carries no key of its
+        # own, so the alias has to come from the payload. Reusing the
+        # `sdk_review` alias rather than minting `vuln_triage` keeps this lane
+        # on a key that is already provisioned and mounted (same call as
+        # sdk_resolve_dispatch.py); the trade is that vuln-triage spend is
+        # attributed to the review lane.
+        "ai_gateway_key_name": "sdk_review",
         "prompt": build_prompt(ticket, severity, run_date, gha_run_url),
         "max_timeout_seconds": 7200,
         "idle_timeout_seconds": 1800,

--- a/.github/scripts/tests/test_mothership_sandbox_dispatch.py
+++ b/.github/scripts/tests/test_mothership_sandbox_dispatch.py
@@ -115,6 +115,15 @@ def test_payload_shape():
     assert "BLDX-1" in p["prompt"] and "CRITICAL" in p["prompt"]
 
 
+def test_payload_declares_an_attributed_gateway_key():
+    """Mothership rejects the run outright when no AI Gateway key is
+    attributed to it, so the alias must be in the payload — `_base` does not
+    carry one. Regression guard for the silent breakage that left the rover
+    dead from 2026-08-21."""
+    p = md.build_payload("BLDX-1", "HIGH", "2026-09-10", "http://run")
+    assert p["ai_gateway_key_name"] == "sdk_review"
+
+
 # ---------------------------------------------------------------------------
 # health check
 # ---------------------------------------------------------------------------

--- a/.github/workflows/vuln-triage-cron.yml
+++ b/.github/workflows/vuln-triage-cron.yml
@@ -16,11 +16,14 @@
 # (tested) rather than inlined here — see docs/standards/ci.md.
 #
 # Required configuration (shared with sdk-evolution-cron.yml):
-#   secrets.HARNESS_TOKEN           Bearer token for /api/sandbox/execute.
-#   secrets.GLOBALPROTECT_USERNAME  VPN auth.
-#   secrets.GLOBALPROTECT_PASSWORD  VPN auth.
-#   vars.GLOBALPROTECT_PORTAL_URL   VPN portal URL.
-#   vars.MOTHERSHIP_URL             e.g. https://mothership.atlan.dev
+#   secrets.HARNESS_TOKEN            Bearer token for /api/sandbox/execute.
+#   secrets.TWINGATE_SERVICE_KEY     Twingate service-account key. Primary
+#                                    path to mothership.atlan.dev, which is
+#                                    on the private network.
+#   secrets.GLOBALPROTECT_USERNAME   Fallback VPN auth, used only if the
+#   secrets.GLOBALPROTECT_PASSWORD   Twingate step fails. Remove both once
+#   vars.GLOBALPROTECT_PORTAL_URL    Twingate is proven here.
+#   vars.MOTHERSHIP_URL              e.g. https://mothership.atlan.dev
 
 name: Vuln Triage (Rover)
 
@@ -47,11 +50,30 @@ jobs:
     # dispatch script's stream timeout matches.
     timeout-minutes: 130
     steps:
-      - name: Checkout repo (for local globalprotect-connect action)
+      - name: Checkout repo (for the local VPN actions)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Twingate is the primary path, matching sdk-review.yml. GlobalProtect
+      # authenticates CI as a *human* against a /24 DHCP pool shared with every
+      # engineer on the VPN, so runs fail with `Assign private IP address
+      # failed` whenever the pool is full — unrelated to the triage itself.
+      #
+      # GlobalProtect stays below as an automatic fallback: if this step fails
+      # for any reason, vpn1-vpn3 run exactly as they do today and behaviour is
+      # unchanged. Once Twingate has proven itself here, delete vpn1-vpn3 and
+      # the GLOBALPROTECT_* secrets.
+      - name: Connect to Twingate
+        id: twingate
+        uses: ./.github/actions/twingate-connect
+        continue-on-error: true
+        timeout-minutes: 5
+        with:
+          service-key: ${{ secrets.TWINGATE_SERVICE_KEY }}
+          mothership-url: ${{ vars.MOTHERSHIP_URL }}
 
       - name: Connect to VPN (attempt 1/3)
         id: vpn1
+        if: steps.twingate.outcome == 'failure'
         uses: ./.github/actions/globalprotect-connect
         continue-on-error: true
         with:


### PR DESCRIPTION
The vuln-triage rover has been dead since **2026-08-21** and nothing alerted. It should have opened the allowlist PR for BLDX-1647 itself; #3740 had to be raised by hand.

## Root cause — not the VPN

The rover's dispatch log for BLDX-1647 ([run 34425952622](https://github.com/atlanhq/application-sdk/actions/runs/34425952622)):

```
Mothership reachable (attempt 1)          ← VPN was fine
[started]   session=api-1b5424c9c0964648 sandbox=
[complete]  status=error cost_usd=
##[error]Sandbox error: code=internal message=[sandbox-api/_execute_sync]
  No attributed AI Gateway key for this run (channel=None, snapshot=None).
  Refusing to fall back to a shared, un-attributed key.
```

Mothership stopped allowing a shared, un-attributed AI Gateway key. `snapshot: "_base"` carries no key of its own, so the alias has to come from the payload — and `mothership_sandbox_dispatch.py` never sent one. The sandbox dies before the rover executes a single step.

The two lanes that were updated when mothership tightened this:

| Lane | `ai_gateway_key_name` | Status |
| -- | -- | -- |
| `sdk_review_dispatch.py:444` | `sdk_review` (#2984) | ✅ working |
| `sdk_resolve_dispatch.py:409` | `sdk_review` (#3403) | ✅ working |
| `mothership_sandbox_dispatch.py` (vuln-triage) | **missing** | ❌ **this PR** |
| `sdk_evolution_dispatch.py` | **missing** | ⚠️ latent — see below |

Failure timeline lines up exactly: rover runs were green through 2026-08-20, then failed 08-21, 09-05 (×2) and 09-10.

## The fix

Reuses the **already-provisioned `sdk_review` alias** rather than minting `vuln_triage`. #3403 set that precedent for the sdk-resolve lane. A new alias would need the LiteLLM key provisioned and mounted as `LITELLM_KEY_*` on the mothership deployment first — which can't be done from this repo, and the rover would stay broken until it was. The trade is that vuln-triage spend is attributed to the review lane; worth revisiting once someone can provision a dedicated key.

Adds a regression test asserting the payload declares a key, so this can't silently regress again.

## Also: Twingate

Moves the rover onto `twingate-connect` as the primary VPN path, with the GlobalProtect ladder unchanged behind it as automatic fallback — mirroring `sdk-review.yml`.

**To be clear: this was not the cause.** The log shows GlobalProtect connected on the first attempt. This is just the migration the other mothership lanes already made, and `sdk-review.yml`'s own comment says to remove GlobalProtect once Twingate is proven. Needs `secrets.TWINGATE_SERVICE_KEY` to be present for this workflow — if it isn't, the step fails and GlobalProtect takes over exactly as today, so the change is safe either way.

## Out of scope

- **`sdk_evolution_dispatch.py`** is missing the key too. It hasn't run since 2026-07-20, so it hasn't hit the wall yet, but it will fail identically whenever it next fires. Left alone deliberately — worth its own PR.
- **No alerting on this failure class.** `dispatch_vuln_triage.py` raises on a failed *dispatch*, but this dispatch succeeded and the sandbox failed downstream, so `daily-security-scan.yml` stayed green through four dead rover runs. That gap is why this went unnoticed for three weeks.

## Validation

- `uv run pytest .github/scripts/tests/test_mothership_sandbox_dispatch.py` → 13 passed
- `uv run pre-commit run --files <the three changed files>` → passed, incl. actionlint on the workflow

Ticket: [BLDX-1647](https://linear.app/atlan-epd/issue/BLDX-1647/securityhigh-1-new-vulnerability-2026-09-10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
