### PR TITLE
fix(sdr): mirror metadata_template_key onto object_filter in sdr:fetch_metadata

### DIFF
--- a/application_sdk/execution/_temporal/sdr.py
+++ b/application_sdk/execution/_temporal/sdr.py
@@ -694,6 +694,11 @@ def build_sdr_activities(
     async def fetch_metadata(input: MetadataInput) -> MetadataOutput:
         if input.agent_json is not None and input.agent_json.is_populated():
             input.credentials = await _resolve_agent_credentials(input.agent_json)
+        # Mirror the widget routing key onto object_filter when that's empty, matching
+        # the HTTP /metadata route, so per-entrypoint hooks reading the legacy field
+        # keep working over SDR (e.g. the warehouse-vs-schema-tree metadata widget).
+        if not input.object_filter and input.metadata_template_key:
+            input.object_filter = input.metadata_template_key
         with bind_invocation_context(binding.app_name, input.credentials):
             return await binding.handler.fetch_metadata(input)
 

--- a/tests/unit/execution/test_sdr.py
+++ b/tests/unit/execution/test_sdr.py
@@ -396,6 +396,32 @@ class TestBuildSdrActivities:
         with pytest.raises(AppContextError):
             _ = handler.context
 
+    async def test_fetch_metadata_mirrors_template_key_onto_object_filter(self) -> None:
+        # Parity with the HTTP /metadata route: the widget routing key must reach
+        # handlers that read the legacy object_filter (e.g. the warehouse widget),
+        # otherwise SDR runs the default fetch and the dropdown renders nothing.
+        handler = _StubHandler()
+        activities = build_sdr_activities(handler, app_name="myapp")
+        by_name = {
+            getattr(a, "__temporal_activity_definition").name: a for a in activities
+        }
+        fetch_metadata = by_name[SDR_FETCH_METADATA_ACTIVITY]
+
+        await fetch_metadata(
+            MetadataInput(credentials=[], metadata_template_key="warehouse")
+        )
+        assert handler.metadata_input.object_filter == "warehouse"
+
+        # An explicit object_filter is authoritative and never overwritten.
+        await fetch_metadata(
+            MetadataInput(
+                credentials=[],
+                metadata_template_key="warehouse",
+                object_filter="schemata",
+            )
+        )
+        assert handler.metadata_input.object_filter == "schemata"
+
     async def test_context_app_name_and_credentials_are_populated(self) -> None:
         handler = _StubHandler()
         activities = build_sdr_activities(handler, app_name="myapp")


### PR DESCRIPTION
## Problem

Over SDR, metadata-widget dropdowns that select a source by routing key — e.g. a warehouse-vs-schema-tree widget — return the wrong data and render nothing, while the same `/metadata` request in direct mode works.

The HTTP `/metadata` route mirrors the widget routing key (`metadataTemplateKey` / `type`, which lands on `metadata_template_key` via its validation alias) onto the legacy `object_filter` when that's empty, so per-entrypoint handlers reading `object_filter` get the right source:

https://github.com/atlanhq/application-sdk/blob/main/application_sdk/handler/service.py#L3087-L3090

The `sdr:fetch_metadata` activity skipped that step. So over SDR `object_filter` stayed empty and the handler ran its **default** fetch (the schema/table tree) for every request — the source-selecting widget got catalog/schema rows and rendered nothing.

## Fix

Apply the same mirror in the `sdr:fetch_metadata` activity, right before the handler call, so the SDR metadata path is equivalent to the direct HTTP path. An explicit `object_filter` still wins.

This is one half of the end-to-end fix: heracles must also forward the request body to the worker so `metadata_template_key` actually arrives (dropped today, forwarded in atlanhq/heracles#6502 / #6503). With the body forwarded but this mirror absent, `object_filter` is still empty; both changes are required.

## Tests

`tests/unit/execution/test_sdr.py::TestSdrActivities::test_fetch_metadata_mirrors_template_key_onto_object_filter` — asserts the mirror populates `object_filter` from `metadata_template_key`, and that an explicit `object_filter` is not overwritten. Full SDR suite green (45 passed).