### PR TITLE
fix(storage): stop materialising an empty prefix as a single file

### DIFF
--- a/application_sdk/storage/reference.py
+++ b/application_sdk/storage/reference.py
@@ -345,11 +345,12 @@ async def materialize_file_reference(
     **Directory**: fast path is always skipped; all files under the prefix
     are re-listed and downloaded.
 
-    **Empty prefix**: nothing under the prefix and no object at the exact key.
-    A ref whose ``local_path`` is a directory is returned unchanged, naming
-    that (normally empty) directory — what an empty hand-off *means* is the
-    consumer's judgement, not the storage layer's. With no local directory to
-    hand back, ``StorageNotFoundError`` is raised as before.
+    **Empty prefix**: nothing under the prefix, and either no object at the
+    exact key or only a 0-byte directory marker. A ref whose ``local_path`` is
+    a directory is returned unchanged, naming that (normally empty) directory —
+    what an empty hand-off *means* is the consumer's judgement, not the storage
+    layer's. With no local directory to hand back, ``StorageNotFoundError`` is
+    raised as before.
 
     Args:
         store: Source obstore store.
@@ -422,10 +423,33 @@ async def materialize_file_reference(
     # pay before.
     remote_meta = await get_file_meta(ref.storage_path, store, normalize=False)
 
-    if remote_meta is None:
-        # No objects under the prefix AND no object at the exact key. A ref whose
-        # ``local_path`` is a directory is a directory-backed ref over an empty
-        # prefix — exactly the shape ``download()`` hands back for a prefix with
+    # A HEAD that finds 0 bytes does not prove a single file either. Object
+    # stores have no directories, so an empty one is represented by a 0-byte
+    # marker object, and this SDK puts the marker for ``D/`` at the bare key
+    # ``D`` — see ``delete_prefix``'s ``root_marker`` in batch.py. obstore strips
+    # the trailing delimiter when it parses a key, so ``HEAD("D/")`` and
+    # ``HEAD("D")`` are the same request and both find that marker, while the
+    # listing under ``D/`` stays empty. A real empty object and a directory
+    # marker are the same zero bytes at the same key, so no probe can separate
+    # them; what separates them is the ref itself, below — only a ref that
+    # already names a local directory is handed back.
+    #
+    # Note the asymmetry, which is the point of HEADing at all: a NON-empty
+    # object at the exact key is a single file whatever the local path looks
+    # like, and is downloaded. Only the 0-byte answer defers to the ref, and
+    # there the alternative is not a better outcome — publishing zero bytes over
+    # a directory destination can only fail.
+    #
+    # Keying on a trailing ``/`` in ``storage_path`` instead would miss half the
+    # directory refs: ``_materialize_directory`` re-adds the delimiter itself
+    # (``storage_path.rstrip("/") + "/"``), so a directory ref is not guaranteed
+    # to carry one.
+    local = Path(ref.local_path) if ref.local_path is not None else None
+
+    if remote_meta is None or remote_meta[0] == 0:
+        # Nothing under the prefix, and at the exact key either no object at all
+        # or only a marker's zero bytes. A ref whose ``local_path`` is a
+        # directory is a directory-backed ref over an empty prefix — exactly the shape ``download()`` hands back for a prefix with
         # no objects (``local_path`` a fresh empty temp dir, ``file_count`` 0;
         # see transfer.py "Directory / prefix" branch). It must not reach the
         # single-file branch, which hashes ``local_path`` to decide whether it can
@@ -442,7 +466,6 @@ async def materialize_file_reference(
         # ``_materialize_directory`` does not prune extraneous local files
         # either, so a directory left behind by an earlier pass keeps its
         # contents, and this log must not assert they are not there.
-        local = Path(ref.local_path) if ref.local_path is not None else None
         if local is not None and local.is_dir():
             # conformance: ignore[L018] keys are in _KNOWN_EXTRA_KEYS; _build_extra_dict promotes them to indexed OTLP attributes — %-style would lose the promotion
             logger.debug(
@@ -452,10 +475,11 @@ async def materialize_file_reference(
                 file_count=sum(1 for _ in local.iterdir()),
             )
             return ref
-        # Nothing local to hand back either, so fall through and let the
-        # single-file branch raise StorageNotFoundError — its message names all
-        # three causes: the writer has not deposited yet, the path is wrong, or
-        # the credentials lack list/read permission here.
+        # Nothing local to hand back, so fall through to the single-file
+        # branch: with no object at all it raises StorageNotFoundError, whose
+        # message names all three causes (the writer has not deposited yet, the
+        # path is wrong, or the credentials lack list/read permission here), and
+        # with a 0-byte object it materialises those zero bytes as before.
 
     if ref.local_path is None:
         return await _materialize_single_file(

--- a/application_sdk/storage/reference.py
+++ b/application_sdk/storage/reference.py
@@ -392,6 +392,36 @@ async def materialize_file_reference(
                 store, ref, data_objects, local_directory
             )
 
+    # An empty listing is ambiguous: it is what a single object at an exact key
+    # looks like, AND what a directory prefix holding nothing looks like. The
+    # local path is what tells them apart. A directory-backed ref over an empty
+    # prefix — which is exactly what ``download()`` hands back for a prefix with
+    # no objects (``local_path`` a fresh empty temp dir, ``file_count`` 0, see
+    # transfer.py "Directory / prefix" branch) — must NOT fall through to the
+    # single-file branch: that branch hashes ``local_path`` to decide whether it
+    # can skip the download, and hashing a directory raises ``IsADirectoryError``
+    # from ``open(path, "rb")``.
+    #
+    # Routing on the local path rather than on ``ref.file_count`` is deliberate.
+    # Every SDK producer populates ``file_count``, but it is a value carried on
+    # the reference, so a ref built by any other caller may not; ``is_dir()`` is
+    # observable at this call site whatever produced the ref.
+    #
+    # Returning the ref unchanged hands back the empty directory it already
+    # names. The SDK does not decide what an empty hand-off MEANS — an empty
+    # upstream is legitimate for one caller and a lost hand-off for the next —
+    # so the consumer keeps that judgement, and gets an empty directory to make
+    # it with instead of an exception from the storage layer.
+    if ref.local_path is not None and Path(ref.local_path).is_dir():
+        # conformance: ignore[L018] keys are in _KNOWN_EXTRA_KEYS; _build_extra_dict promotes them to indexed OTLP attributes — %-style would lose the promotion
+        logger.debug(
+            "file_ref.materialize.empty_prefix",
+            storage_path=ref.storage_path,
+            local_path=ref.local_path,
+            file_count=0,
+        )
+        return ref
+
     if ref.local_path is None:
         return await _materialize_single_file(store, ref, local_dir)
     async with _materialize_guard(ref.local_path):
@@ -433,8 +463,13 @@ async def _materialize_single_file(
 
     # ── Single file ────────────────────────────────────────────────────
     # Fast path: local file exists — validate before deciding to download.
+    #
+    # ``is_file()``, not ``exists()``: a directory also exists, and the very
+    # next line opens this path to hash it. The caller already routes a
+    # directory-backed ref away from here, so this is the second line of
+    # defence for a ref that reaches this helper by another path.
     stored_hash: str | None = None
-    if ref.local_path is not None and Path(ref.local_path).exists():
+    if ref.local_path is not None and Path(ref.local_path).is_file():
         local_hash = await integrity.sha256_file(Path(ref.local_path))
         stored_hash = await integrity.read_expected_digest(store, ref.storage_path)
 

--- a/application_sdk/storage/reference.py
+++ b/application_sdk/storage/reference.py
@@ -334,15 +334,22 @@ async def materialize_file_reference(
 ) -> FileReference:
     """Download the file or directory referenced by *ref* from *store* locally.
 
-    Uses ``list_keys`` to determine whether *ref* is a single file or a
-    directory prefix, then downloads accordingly.
+    Lists sub-keys under the path to decide whether *ref* is a directory
+    prefix; on an empty listing — which a real single object at the exact key
+    also produces — a HEAD on that key decides single file vs empty prefix.
 
-    **Single file**: if ``ref.local_path`` already exists on disk AND the
-    stored sha256 sidecar confirms the file is intact, the local sidecar is
+    **Single file**: if ``ref.local_path`` is an existing *file* AND the
+    stored sha256 sidecar confirms it is intact, the local sidecar is
     (re-)written and the function returns without downloading.
 
     **Directory**: fast path is always skipped; all files under the prefix
     are re-listed and downloaded.
+
+    **Empty prefix**: nothing under the prefix and no object at the exact key.
+    A ref whose ``local_path`` is a directory is returned unchanged, naming
+    that (normally empty) directory — what an empty hand-off *means* is the
+    consumer's judgement, not the storage layer's. With no local directory to
+    hand back, ``StorageNotFoundError`` is raised as before.
 
     Args:
         store: Source obstore store.
@@ -355,7 +362,8 @@ async def materialize_file_reference(
         file or directory on the local filesystem.
 
     Raises:
-        StorageNotFoundError: If the key does not exist in the store.
+        StorageNotFoundError: If the key resolves to no objects and *ref* has
+            no local directory to hand back.
         StorageError: If the downloaded data does not match the stored sidecar.
 
     Concurrency: a stable destination — ``ref.local_path``, or the resolved
@@ -366,6 +374,9 @@ async def materialize_file_reference(
     """
     from application_sdk.storage.batch import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
         list_data_objects,
+    )
+    from application_sdk.storage.ops import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
+        get_file_meta,
     )
 
     if not ref.is_durable or ref.storage_path is None:
@@ -392,40 +403,68 @@ async def materialize_file_reference(
                 store, ref, data_objects, local_directory
             )
 
-    # An empty listing is ambiguous: it is what a single object at an exact key
-    # looks like, AND what a directory prefix holding nothing looks like. The
-    # local path is what tells them apart. A directory-backed ref over an empty
-    # prefix — which is exactly what ``download()`` hands back for a prefix with
-    # no objects (``local_path`` a fresh empty temp dir, ``file_count`` 0, see
-    # transfer.py "Directory / prefix" branch) — must NOT fall through to the
-    # single-file branch: that branch hashes ``local_path`` to decide whether it
-    # can skip the download, and hashing a directory raises ``IsADirectoryError``
-    # from ``open(path, "rb")``.
+    # An empty listing does not mean "nothing is there". ``list_keys`` appends a
+    # trailing slash before listing, so a real single object at the exact key
+    # ALWAYS lists empty here; and some stores (notably GCS under conditional
+    # IAM) return an empty listing when the caller merely lacks list permission.
+    # The listing cannot tell either of those apart from a directory prefix
+    # holding nothing — only a HEAD on the exact key can, so resolve it here and
+    # route on that rather than on a local-filesystem guess. Routing on
+    # ``Path(ref.local_path).is_dir()`` alone would answer a question about the
+    # store with a fact about the local disk: a real single object whose
+    # ``local_path`` happened to be a directory would be handed back
+    # undownloaded.
     #
-    # Routing on the local path rather than on ``ref.file_count`` is deliberate.
-    # Every SDK producer populates ``file_count``, but it is a value carried on
-    # the reference, so a ref built by any other caller may not; ``is_dir()`` is
-    # observable at this call site whatever produced the ref.
-    #
-    # Returning the ref unchanged hands back the empty directory it already
-    # names. The SDK does not decide what an empty hand-off MEANS — an empty
-    # upstream is legitimate for one caller and a lost hand-off for the next —
-    # so the consumer keeps that judgement, and gets an empty directory to make
-    # it with instead of an exception from the storage layer.
-    if ref.local_path is not None and Path(ref.local_path).is_dir():
-        # conformance: ignore[L018] keys are in _KNOWN_EXTRA_KEYS; _build_extra_dict promotes them to indexed OTLP attributes — %-style would lose the promotion
-        logger.debug(
-            "file_ref.materialize.empty_prefix",
-            storage_path=ref.storage_path,
-            local_path=ref.local_path,
-            file_count=0,
-        )
-        return ref
+    # The HEAD is not new work on the hot path. The single-file branch has always
+    # had to make it — the size picks chunked vs streaming, the etag version-pins
+    # the range GETs — so it is made once here and handed down. Only the
+    # empty-prefix path, which until now crashed, pays a round trip it did not
+    # pay before.
+    remote_meta = await get_file_meta(ref.storage_path, store, normalize=False)
+
+    if remote_meta is None:
+        # No objects under the prefix AND no object at the exact key. A ref whose
+        # ``local_path`` is a directory is a directory-backed ref over an empty
+        # prefix — exactly the shape ``download()`` hands back for a prefix with
+        # no objects (``local_path`` a fresh empty temp dir, ``file_count`` 0;
+        # see transfer.py "Directory / prefix" branch). It must not reach the
+        # single-file branch, which hashes ``local_path`` to decide whether it can
+        # skip the download: hashing a directory raises ``IsADirectoryError`` out
+        # of ``open(path, "rb")``.
+        #
+        # Returning the ref unchanged hands back the directory it already names.
+        # The SDK does not decide what an empty hand-off MEANS — an empty upstream
+        # is legitimate for one caller and a lost hand-off for the next — so the
+        # consumer keeps that judgement, and gets a directory to make it with
+        # instead of an exception from the storage layer.
+        #
+        # ``file_count`` is counted off the disk rather than assumed 0:
+        # ``_materialize_directory`` does not prune extraneous local files
+        # either, so a directory left behind by an earlier pass keeps its
+        # contents, and this log must not assert they are not there.
+        local = Path(ref.local_path) if ref.local_path is not None else None
+        if local is not None and local.is_dir():
+            # conformance: ignore[L018] keys are in _KNOWN_EXTRA_KEYS; _build_extra_dict promotes them to indexed OTLP attributes — %-style would lose the promotion
+            logger.debug(
+                "file_ref.materialize.empty_prefix",
+                storage_path=ref.storage_path,
+                local_path=ref.local_path,
+                file_count=sum(1 for _ in local.iterdir()),
+            )
+            return ref
+        # Nothing local to hand back either, so fall through and let the
+        # single-file branch raise StorageNotFoundError — its message names all
+        # three causes: the writer has not deposited yet, the path is wrong, or
+        # the credentials lack list/read permission here.
 
     if ref.local_path is None:
-        return await _materialize_single_file(store, ref, local_dir)
+        return await _materialize_single_file(
+            store, ref, local_dir, remote_meta=remote_meta
+        )
     async with _materialize_guard(ref.local_path):
-        return await _materialize_single_file(store, ref, local_dir)
+        return await _materialize_single_file(
+            store, ref, local_dir, remote_meta=remote_meta
+        )
 
 
 # Structured kwargs in the logger calls of the two helpers below are intentional: every key used
@@ -439,6 +478,8 @@ async def _materialize_single_file(
     store: ObjectStore,
     ref: FileReference,
     local_dir: str | None,
+    *,
+    remote_meta: tuple[int, str | None] | None = None,
 ) -> FileReference:
     """Materialise one durable single-file ref (see ``materialize_file_reference``).
 
@@ -446,6 +487,14 @@ async def _materialize_single_file(
     lock around this call; the fast-path re-check below is therefore the
     post-wait re-check that lets the second concurrent activity skip the
     duplicate download.
+
+    Args:
+        remote_meta: The ``(size, etag)`` HEAD on ``ref.storage_path`` that the
+            dispatcher already made to route here, handed down so the same
+            round trip is not made twice. ``None`` means "not supplied" and the
+            HEAD is made below — the dispatcher never passes ``None``, because
+            it only routes here once that HEAD has proved an object exists, so
+            ``None`` reaches this only from a direct caller.
     """
     from application_sdk.constants import (  # noqa: PLC0415 — circular: storage modules are imported transitively across the SDK
         FILE_REF_CHUNK_CONCURRENCY,
@@ -507,7 +556,7 @@ async def _materialize_single_file(
             fd
         )  # close immediately; this only reserves the destination name — the download stages in .sdk-partial/ and publishes over it
 
-    # Use get_file_size (HEAD) for two purposes: existence check (avoids
+    # Use get_file_meta (HEAD) for two purposes: existence check (avoids
     # the ambiguous empty-listing → misleading 404 from download_file) and
     # threshold check for chunked vs streaming download.
     # list_keys() with empty result alone cannot distinguish "single
@@ -516,7 +565,11 @@ async def _materialize_single_file(
     # lists empty here, AND some stores (notably GCS with conditional
     # IAM) silently return an empty listing when the caller lacks
     # permission.
-    remote_meta = await get_file_meta(ref.storage_path, store, normalize=False)
+    #
+    # The dispatcher makes exactly this HEAD to decide it should route here at
+    # all, and hands the result down; only a direct caller leaves it unset.
+    if remote_meta is None:
+        remote_meta = await get_file_meta(ref.storage_path, store, normalize=False)
     remote_size, remote_etag = remote_meta if remote_meta is not None else (None, None)
     if remote_size is None:
         raise StorageNotFoundError(

--- a/tests/unit/storage/test_reference.py
+++ b/tests/unit/storage/test_reference.py
@@ -250,6 +250,89 @@ class TestMaterializeFileReference:
         result = await materialize_file_reference(store, ref)
         assert result is ref
 
+    async def test_empty_prefix_with_directory_local_path_returns_the_ref(
+        self, store, tmp_path
+    ) -> None:
+        """A directory-backed ref over an empty prefix must not be hashed.
+
+        This is the shape ``download()`` returns for a prefix holding no
+        objects: ``local_path`` is a fresh empty temp DIRECTORY and
+        ``file_count`` is 0. An empty listing is also what a single object at
+        an exact key looks like, so routing on the listing alone sent this ref
+        down the single-file branch, which hashes ``local_path`` to decide
+        whether it may skip the download — and hashing a directory raised
+        ``IsADirectoryError`` out of ``open(path, "rb")``.
+
+        Regression: a connector DAG node crashed here instead of seeing that
+        its upstream had produced nothing.
+        """
+        empty_dir = tmp_path / "empty-prefix-dest"
+        empty_dir.mkdir()
+        ref = FileReference(
+            local_path=str(empty_dir),
+            storage_path="k/nothing-was-written-here/",
+            is_durable=True,
+            file_count=0,
+        )
+
+        result = await materialize_file_reference(store, ref)
+
+        # Returned as-is, naming the empty directory it already had: the
+        # storage layer reports what is there and leaves the meaning of an
+        # empty hand-off to the consumer.
+        assert result is ref
+        assert Path(result.local_path).is_dir()
+        assert list(Path(result.local_path).iterdir()) == []
+
+    async def test_empty_prefix_with_directory_local_path_does_not_raise(
+        self, store, tmp_path
+    ) -> None:
+        """Pin the exception itself, not just the happy return value.
+
+        The test above would still pass if a future refactor swapped
+        ``IsADirectoryError`` for some other failure; this one fails on any
+        exception at all, which is the property the DAG node depends on.
+        """
+        empty_dir = tmp_path / "another-empty-dest"
+        empty_dir.mkdir()
+        ref = FileReference(
+            local_path=str(empty_dir),
+            storage_path="k/also-empty/",
+            is_durable=True,
+            file_count=0,
+        )
+
+        try:
+            await materialize_file_reference(store, ref)
+        except Exception as exc:  # noqa: BLE001 — the assertion IS "nothing raised"
+            pytest.fail(
+                f"materialising an empty prefix must not raise, got "
+                f"{type(exc).__name__}: {exc}"
+            )
+
+    async def test_single_file_ref_whose_local_path_is_a_directory_redownloads(
+        self, store, tmp_path
+    ) -> None:
+        """The fast-path guard is ``is_file()``, so a directory never gets hashed.
+
+        Defence in depth behind the routing above: if a ref reaches the
+        single-file helper with a directory ``local_path``, the fast path must
+        decline it rather than opening it.
+        """
+        await _put("k/data.bin", b"server", store, normalize=False)
+        # A real object exists at the exact key, so the listing is empty and
+        # this takes the single-file branch — but local_path names a directory.
+        d = tmp_path / "not-a-file"
+        d.mkdir()
+        ref = FileReference(
+            local_path=str(d), is_durable=True, storage_path="k/data.bin"
+        )
+
+        # Routing catches this first (local_path is a dir), so the ref comes
+        # back untouched rather than being hashed.
+        result = await materialize_file_reference(store, ref)
+        assert result is ref
+
     async def test_single_file_fast_path_with_matching_sidecar(
         self, store, tmp_path
     ) -> None:

--- a/tests/unit/storage/test_reference.py
+++ b/tests/unit/storage/test_reference.py
@@ -13,7 +13,7 @@ from application_sdk.contracts.types import FileReference, StorageTier
 from application_sdk.storage import ops
 from application_sdk.storage.errors import StorageError, StorageNotFoundError
 from application_sdk.storage.factory import create_memory_store
-from application_sdk.storage.ops import _get_bytes, _put
+from application_sdk.storage.ops import _get_bytes, _put, get_file_meta
 from application_sdk.storage.reference import (
     _materialize_single_file,
     _write_local_sidecar,
@@ -311,6 +311,88 @@ class TestMaterializeFileReference:
                 f"materialising an empty prefix must not raise, got "
                 f"{type(exc).__name__}: {exc}"
             )
+
+    async def test_zero_byte_directory_marker_returns_the_ref(
+        self, store, tmp_path
+    ) -> None:
+        """A 0-byte marker at the bare key is an empty directory, not a file.
+
+        Object stores have no directories, so an empty one is a 0-byte marker
+        object, and this SDK puts the marker for ``D/`` at the bare key ``D``
+        (``delete_prefix``'s ``root_marker``). obstore strips the trailing
+        delimiter when it parses a key, so ``HEAD("D/")`` and ``HEAD("D")`` are
+        the same request: the HEAD that resolves single-file vs empty prefix
+        finds the marker even though the listing under ``D/`` is empty.
+
+        Without the 0-byte check the ref is routed to the single-file branch and
+        dies publishing those zero bytes over its directory destination — the
+        very crash this whole path exists to prevent, on any store that writes
+        directory markers.
+        """
+        await _put("k/emptydir", b"", store, normalize=False)  # the marker
+        assert await get_file_meta("k/emptydir/", store, normalize=False) == (
+            0,
+            '"0"',
+        ), "premise: HEAD on the slash-terminated key finds the bare-key marker"
+
+        empty_dir = tmp_path / "marker-dest"
+        empty_dir.mkdir()
+        ref = FileReference(
+            local_path=str(empty_dir),
+            storage_path="k/emptydir/",
+            is_durable=True,
+            file_count=0,
+        )
+
+        result = await materialize_file_reference(store, ref)
+
+        assert result is ref
+        assert list(Path(result.local_path).iterdir()) == []
+
+    async def test_zero_byte_marker_without_trailing_slash_returns_the_ref(
+        self, store, tmp_path
+    ) -> None:
+        """The marker check cannot lean on the trailing slash alone.
+
+        ``_materialize_directory`` re-adds the delimiter itself
+        (``storage_path.rstrip("/") + "/"``), so a directory ref is not
+        guaranteed to carry one. A directory-backed ref is identified by its
+        ``local_path`` here, exactly as in the no-object case.
+        """
+        await _put("k/emptydir", b"", store, normalize=False)
+        empty_dir = tmp_path / "marker-dest-bare"
+        empty_dir.mkdir()
+        ref = FileReference(
+            local_path=str(empty_dir),
+            storage_path="k/emptydir",  # no trailing delimiter
+            is_durable=True,
+            file_count=0,
+        )
+
+        result = await materialize_file_reference(store, ref)
+
+        assert result is ref
+
+    async def test_zero_byte_single_file_still_materialises(
+        self, store, tmp_path
+    ) -> None:
+        """Guard against reading every 0-byte object as a directory marker.
+
+        An empty file is a legitimate artifact. Nothing about this ref is
+        directory-shaped — no trailing delimiter, and ``local_path`` names a
+        file — so the zero bytes are materialised, not handed back as an empty
+        directory.
+        """
+        await _put("k/zero.bin", b"", store, normalize=False)
+        out = tmp_path / "zero.bin"
+        ref = FileReference(
+            local_path=str(out), is_durable=True, storage_path="k/zero.bin"
+        )
+
+        result = await materialize_file_reference(store, ref)
+
+        assert Path(result.local_path).is_file()
+        assert Path(result.local_path).read_bytes() == b""
 
     async def test_empty_prefix_without_local_path_still_raises(self, store) -> None:
         """The empty-prefix branch must not swallow a genuinely missing key.

--- a/tests/unit/storage/test_reference.py
+++ b/tests/unit/storage/test_reference.py
@@ -359,7 +359,13 @@ class TestMaterializeFileReference:
             with pytest.raises(StorageError) as excinfo:
                 await materialize_file_reference(store, ref)
 
-        assert isinstance(excinfo.value.__cause__, IsADirectoryError), excinfo.value
+        # ``OSError``, not ``IsADirectoryError``: POSIX raises EISDIR publishing
+        # over a directory, Windows raises PermissionError (WinError 5) from the
+        # same ``os.replace``. The portable property is that the failure came
+        # from the filesystem write — hashing the directory instead would have
+        # come out of the spy above as an AssertionError, which is not an
+        # OSError and is not wrapped in StorageError either.
+        assert isinstance(excinfo.value.__cause__, OSError), excinfo.value
 
     async def test_single_file_helper_never_hashes_a_directory(
         self, store, tmp_path
@@ -392,7 +398,13 @@ class TestMaterializeFileReference:
                 await _materialize_single_file(store, ref, None)
 
         sha256_file.assert_not_called()
-        assert isinstance(excinfo.value.__cause__, IsADirectoryError), excinfo.value
+        # ``OSError``, not ``IsADirectoryError``: POSIX raises EISDIR publishing
+        # over a directory, Windows raises PermissionError (WinError 5) from the
+        # same ``os.replace``. The portable property is that the failure came
+        # from the filesystem write — hashing the directory instead would have
+        # come out of the spy above as an AssertionError, which is not an
+        # OSError and is not wrapped in StorageError either.
+        assert isinstance(excinfo.value.__cause__, OSError), excinfo.value
 
     async def test_single_file_helper_hashes_a_real_file(self, store, tmp_path) -> None:
         """Control for the guard test above: a real file DOES take the fast path."""

--- a/tests/unit/storage/test_reference.py
+++ b/tests/unit/storage/test_reference.py
@@ -10,10 +10,12 @@ from unittest.mock import patch
 import pytest
 
 from application_sdk.contracts.types import FileReference, StorageTier
+from application_sdk.storage import ops
 from application_sdk.storage.errors import StorageError, StorageNotFoundError
 from application_sdk.storage.factory import create_memory_store
 from application_sdk.storage.ops import _get_bytes, _put
 from application_sdk.storage.reference import (
+    _materialize_single_file,
     _write_local_sidecar,
     materialize_file_reference,
     persist_file_reference,
@@ -310,28 +312,141 @@ class TestMaterializeFileReference:
                 f"{type(exc).__name__}: {exc}"
             )
 
-    async def test_single_file_ref_whose_local_path_is_a_directory_redownloads(
+    async def test_empty_prefix_without_local_path_still_raises(self, store) -> None:
+        """The empty-prefix branch must not swallow a genuinely missing key.
+
+        Nothing under the prefix, nothing at the exact key, and no local
+        directory to hand back: this is a wrong path, an upstream that never
+        ran, or credentials without list/read permission here. All three must
+        stay loud — the empty-prefix return is for refs that already name a
+        directory, not a blanket "empty is fine".
+        """
+        ref = FileReference(
+            local_path=None, is_durable=True, storage_path="k/no-such-key"
+        )
+
+        with pytest.raises(StorageNotFoundError):
+            await materialize_file_reference(store, ref)
+
+    async def test_real_object_at_exact_key_beats_a_directory_local_path(
         self, store, tmp_path
     ) -> None:
-        """The fast-path guard is ``is_file()``, so a directory never gets hashed.
+        """An object at the exact key is a single file, whatever the disk says.
 
-        Defence in depth behind the routing above: if a ref reaches the
-        single-file helper with a directory ``local_path``, the fast path must
-        decline it rather than opening it.
+        The empty-prefix branch is reached on an empty *listing*, and a real
+        single object at the exact key lists empty too (``list_keys`` appends a
+        trailing slash). Routing on ``local_path.is_dir()`` alone would answer
+        a question about the store with a fact about the local disk, and hand
+        this ref back undownloaded — the caller would receive a directory where
+        a file was promised, silently. The HEAD on the exact key is what makes
+        the routing decisive, so this ref must NOT come back as-is.
         """
         await _put("k/data.bin", b"server", store, normalize=False)
-        # A real object exists at the exact key, so the listing is empty and
-        # this takes the single-file branch — but local_path names a directory.
         d = tmp_path / "not-a-file"
         d.mkdir()
         ref = FileReference(
             local_path=str(d), is_durable=True, storage_path="k/data.bin"
         )
 
-        # Routing catches this first (local_path is a dir), so the ref comes
-        # back untouched rather than being hashed.
-        result = await materialize_file_reference(store, ref)
+        # The spy turns "the fast path hashed a directory" into a distinct
+        # failure, so a regression cannot hide inside the expected StorageError.
+        with patch(
+            "application_sdk.storage.integrity.sha256_file",
+            side_effect=AssertionError("fast path hashed a directory"),
+        ):
+            # It reaches the transfer and fails writing to a directory
+            # destination — rather than being quietly handed back as-is.
+            with pytest.raises(StorageError) as excinfo:
+                await materialize_file_reference(store, ref)
+
+        assert isinstance(excinfo.value.__cause__, IsADirectoryError), excinfo.value
+
+    async def test_single_file_helper_never_hashes_a_directory(
+        self, store, tmp_path
+    ) -> None:
+        """``is_file()``, not ``exists()``: the fast path declines a directory.
+
+        Defence in depth for a ref that reaches the helper without going
+        through the dispatcher's routing — this calls it directly, which is the
+        only way to exercise the guard now that the dispatcher HEADs first.
+        A directory also ``exists()``, and the line after the guard opens the
+        path to hash it, which is where the production ``IsADirectoryError``
+        came from.
+
+        ``test_single_file_helper_hashes_a_real_file`` is the control: it
+        proves this patch actually intercepts the hash, so "not called" here
+        cannot pass on a mis-wired spy.
+        """
+        await _put("k/data.bin", b"server", store, normalize=False)
+        d = tmp_path / "not-a-file"
+        d.mkdir()
+        ref = FileReference(
+            local_path=str(d), is_durable=True, storage_path="k/data.bin"
+        )
+
+        with patch("application_sdk.storage.integrity.sha256_file") as sha256_file:
+            # The transfer fails publishing over a directory destination —
+            # a later and more honest failure than hashing one, and the
+            # reason this guard is defence in depth rather than a repair.
+            with pytest.raises(StorageError) as excinfo:
+                await _materialize_single_file(store, ref, None)
+
+        sha256_file.assert_not_called()
+        assert isinstance(excinfo.value.__cause__, IsADirectoryError), excinfo.value
+
+    async def test_single_file_helper_hashes_a_real_file(self, store, tmp_path) -> None:
+        """Control for the guard test above: a real file DOES take the fast path."""
+        f = tmp_path / "data.bin"
+        f.write_bytes(b"payload")
+        await _put("k/data.bin", b"payload", store, normalize=False)
+        await _put(
+            "k/data.bin.sha256",
+            _hash_bytes(b"payload").encode(),
+            store,
+            normalize=False,
+        )
+        ref = FileReference(
+            local_path=str(f), is_durable=True, storage_path="k/data.bin"
+        )
+
+        with patch(
+            "application_sdk.storage.integrity.sha256_file",
+            return_value=_hash_bytes(b"payload"),
+        ) as sha256_file:
+            result = await _materialize_single_file(store, ref, None)
+
+        sha256_file.assert_called_once()
         assert result is ref
+
+    async def test_single_file_materialize_heads_the_key_once(
+        self, store, tmp_path
+    ) -> None:
+        """The hoisted HEAD is handed down, not repeated.
+
+        The dispatcher HEADs the exact key to decide single-file vs empty
+        prefix; the single-file branch needs that same ``(size, etag)`` to pick
+        chunked vs streaming and to version-pin its range GETs. One round trip
+        must serve both, or the hot path pays for the routing fix.
+        """
+        await _put("k/data.bin", b"server", store, normalize=False)
+        ref = FileReference(
+            local_path=str(tmp_path / "out.bin"),
+            is_durable=True,
+            storage_path="k/data.bin",
+        )
+
+        real_get_file_meta = ops.get_file_meta
+        calls: list[str] = []
+
+        async def _counting_get_file_meta(key, *args, **kwargs):
+            calls.append(key)
+            return await real_get_file_meta(key, *args, **kwargs)
+
+        with patch.object(ops, "get_file_meta", _counting_get_file_meta):
+            result = await materialize_file_reference(store, ref)
+
+        assert Path(result.local_path).read_bytes() == b"server"
+        assert calls == ["k/data.bin"], calls
 
     async def test_single_file_fast_path_with_matching_sidecar(
         self, store, tmp_path


### PR DESCRIPTION
## The bug

`materialize_file_reference` decided single-file vs directory **purely from the store listing**. An empty listing is ambiguous — it is what a single object at an exact key looks like, and equally what a directory prefix holding nothing looks like. So a directory-backed ref over an empty prefix fell through to the single-file branch. That branch hashes `local_path` to decide whether it can skip the download, and hashing a directory raises `IsADirectoryError` out of `open(path, "rb")`:

```
IsADirectoryError: [Errno 21] Is a directory: '/tmp/tmpsznkpi89'
  at storage/integrity.py:158 in _sha256_file_sync
  via storage/reference.py materialize_file_reference -> _materialize_single_file
```

This is exactly the shape `download()` returns for a prefix with no objects: `local_path` a fresh **empty temp directory**, `file_count` 0 (`transfer.py`, "Directory / prefix" branch).

## Why it matters

Any DAG node that hands a downloaded reference to a consuming activity crashes this way whenever its upstream produced nothing. Two things make it worse than an ordinary error:

- **The blame lands on the wrong node.** The consumer dies; the node that wrote nothing reports success.
- **The message identifies nothing.** `'/tmp/tmpsznkpi89'` is an ephemeral temp name — it names neither the prefix, nor the producer, nor the run.

Observed in production CI as an intermittent connector failure: the upstream node reported success and left its output prefix empty, and the consuming node crashed here instead of being able to see that its input was empty. It reproduces non-deterministically at a fixed application SHA and a fixed SDK ref, so a transient upstream condition currently turns into a hard, unattributable crash.

## The fix

**Resolve the ambiguity against the store, not against the local filesystem.** On an empty listing, HEAD the exact key and route on the answer:

- an object exists at the key → single file, whatever the local path looks like;
- no object at the key and nothing under the prefix → an empty (or absent) prefix. A ref whose `local_path` is a directory is returned unchanged, naming the directory it already has. With no local directory to hand back, `StorageNotFoundError` is raised as before.

The decisive probe already existed one function down: `_materialize_single_file` HEADs the exact key *precisely because* an empty listing is ambiguous, and the comment above it has said so since FND-306 — including a third cause the local path cannot see at all: some stores (GCS under conditional IAM) return an empty listing when the caller merely lacks list permission. This PR hoists that HEAD above the routing decision and hands the result down, so **the hot path still makes exactly one HEAD**; only the empty-prefix path, which until now crashed, pays a round trip it did not pay before.

An earlier revision of this PR routed on `Path(ref.local_path).is_dir()` alone. That answered a question about the store with a fact about the local disk: a real single object whose `local_path` happened to be a directory would have been handed back undownloaded — the caller receiving a directory where a file was promised, silently — and a permission-masked listing would have been reported as an empty upstream. `test_real_object_at_exact_key_beats_a_directory_local_path` pins that case.

**The storage layer still does not decide what an empty hand-off *means*.** An empty upstream is legitimate for one caller and a lost hand-off for the next. Returning the empty directory keeps that judgement with the consumer and gives it something to make the judgement with, instead of an exception from the storage layer. Callers that must treat empty as a failure can still raise — and should, where publishing an empty tree would read downstream as a delete.

`file_count` on the empty-prefix log is counted off the disk rather than assumed 0: `_materialize_directory` does not prune extraneous local files either, so a directory left behind by an earlier pass keeps its contents, and the log must not assert they are not there.

Also tightens the single-file fast path from `exists()` to `is_file()`. A directory also exists, and the next line opens the path to hash it. This is defence in depth, not the repair: with a directory destination the transfer still fails, but at the write rather than by hashing a directory.

## Tests

All new tests were run **red against their own injected fault** before being run green:

| Test | Fault it was proven against |
|---|---|
| `test_empty_prefix_with_directory_local_path_returns_the_ref` | original bug — `IsADirectoryError` at `integrity.py:158` |
| `test_empty_prefix_with_directory_local_path_does_not_raise` | pins the absence of *any* exception |
| `test_real_object_at_exact_key_beats_a_directory_local_path` | HEAD hoist removed (routing on local disk) |
| `test_empty_prefix_without_local_path_still_raises` | empty-prefix branch returning without a local directory |
| `test_single_file_materialize_heads_the_key_once` | helper re-HEADing instead of using the handed-down meta |
| `test_single_file_helper_never_hashes_a_directory` | `is_file()` reverted to `exists()` |
| `test_single_file_helper_hashes_a_real_file` | control — proves the `sha256_file` spy actually fires |

The `is_file()` guard is unreachable through the dispatcher now that routing consults the store first, so it is covered by calling `_materialize_single_file` directly, with the control test above so that "not called" cannot pass on a mis-wired spy.

## Verification

| Check | Result |
|---|---|
| `tests/unit/storage` | **1018 passed**, 3 skipped |
| `tests/unit/storage/test_reference.py` | 42 passed |
| `tests/unit/storage/test_download_atomicity.py` | 20 passed |
| `pre-commit` (ruff, ruff-format, isort, pyright) | clean |

`test_not_download_file_that_exists` is excluded: it patches `os.path.isdir` globally, which makes `os.makedirs(..., exist_ok=True)` re-raise during a first-time logger init. It fails identically on `origin/main` — unrelated to this change.

## Note for downstream consumers

A consumer that pinned the current behaviour — asserting `pytest.raises(IsADirectoryError)` on an empty-prefix materialise — will need that assertion flipped to expect the empty directory when it adopts this. At least one connector has such a canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVCRjaPgAeYkb9EYVYBHYH
