### PR TITLE
ci(scan): retry the scan image build once on a transient registry failure

### DIFF
--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -143,7 +143,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.ORG_PAT_GITHUB }}
 
+      # buildx resolves the Dockerfile's `# syntax=docker/dockerfile:1`
+      # frontend from Docker Hub ANONYMOUSLY on every build, before it looks at
+      # the base image, and `uv sync` reaches the package index from inside the
+      # build. Both are third-party endpoints that have moments:
+      # `auth.docker.io/token: 500` and a `401 Unauthorized` from the index are
+      # both observed, both clear on a re-run with no code change, and both fail
+      # the required check on a PR that never touched the image. So: absorb one.
+      #
+      # A blanket retry (rather than one gated on the error text, which the
+      # action does not expose as an output) is cheap here because the failures
+      # that are NOT transient — a stale `uv.lock` under `--locked`, an
+      # unsatisfiable resolution — fail one to three seconds into the step, and
+      # `cache-from: type=gha` means the second attempt replays every layer
+      # before the failing one. The cost of a wasted retry is the sleep, not a
+      # second build.
       - name: Build image
+        id: build-image
+        continue-on-error: true
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
@@ -172,6 +189,35 @@ jobs:
           # This job already logs into GHCR with the PAT above, so there's no
           # benefit to minting a separate App token just for this -- the PAT is
           # already in play.
+          secrets: |
+            git_token=${{ secrets.ORG_PAT_GITHUB }}
+
+      # Long enough for a registry or index having a moment to have passed, short
+      # enough that a genuinely broken build still reports inside the job's
+      # 15-minute budget.
+      - name: Wait before the build retry
+        if: steps.build-image.outcome == 'failure'
+        run: sleep 30
+
+      # Inputs restated verbatim, comments and all omitted — see the first attempt.
+      # A reusable workflow cannot `uses:` a composite action from its own
+      # repository without checking that repository out first, so the block is
+      # duplicated rather than factored out.
+      #
+      # NOT continue-on-error: if the image cannot be built twice there is nothing
+      # to scan, and the security gate reads a failed `build` as exactly that.
+      - name: Build image (retry)
+        if: steps.build-image.outcome == 'failure'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: ${{ steps.meta.outputs.dockerfile }}
+          push: false
+          tags: ${{ steps.meta.outputs.scan_image }}
+          outputs: type=docker,dest=/tmp/image.tar
+          cache-from: type=gha,scope=scan
+          cache-to: type=gha,mode=max,scope=scan,ignore-error=true
+          provenance: false
           secrets: |
             git_token=${{ secrets.ORG_PAT_GITHUB }}
 


### PR DESCRIPTION
Closes FND-1939.

## The problem

`scan / Build Image` fails on third-party endpoints having a moment. Because `Vulnerability Scan` is a **required** gate, every such hiccup blocks an otherwise auto-mergeable PR until a human opens the run and clicks *re-run failed jobs*. That defeats auto-merge on exactly the PRs that should never need a human — Renovate lock bumps and first-party dependency bumps.

Today's instance, on a PR that never touched the image, died 0.4s into the build:

```
#2 resolve image config for docker-image://docker.io/docker/dockerfile:1
#2 ERROR: failed to authorize: failed to fetch oauth token:
   unexpected status from POST https://auth.docker.io/token: 500 Internal Server Error
```

That is the `# syntax=docker/dockerfile:1` directive on line 1 of the app Dockerfile: buildx resolves the BuildKit **frontend** from Docker Hub *anonymously* on every build, before it ever looks at the base image (Harbor, and fine). `scan / Security Gate` then went red too — a correct cascade, it is `if: always()` and reported "nothing to gate on, `build` failed". One transient, two red required checks. Re-running went 4/4 green with no code change.

## Measured before changing anything

30 most recent `Vulnerability Scan` runs × 8 fleet repos = 240 runs. Only two steps ever fail:

| job :: step | count |
|---|---|
| `Security Gate :: Check against allowlist` | 47 |
| `Build Image :: Build image` | 29 |

`Run Trivy scan`, `Install Trivy` and every artifact upload/download have **zero** failures in the window — the retries already in this file are doing their job, and nothing else is hardened here. Roughly 29 of the 47 gate failures are cascades from a failed build; the remainder are genuine allowlist findings.

The 29 build failures by error signature:

| signature | count | transient? |
|---|---|---|
| `uv.lock needs to be updated, but --locked was provided` | 26 | **no** — deterministic |
| `401 Unauthorized` from the package index during `uv sync` | 2 | yes |
| resolution failed across Python versions | 2 | no |
| `auth.docker.io/token: 500` | 1 | yes |

## The change

Retry `Build image` once, mirroring the pattern this file already uses for checkout, artifact upload and artifact download: `continue-on-error` → `sleep 30` → an identical attempt that is **not** `continue-on-error`, so two failures still fail the gate and the gate still names the build as the cause.

Lands fleet-wide with no per-repo PR: every app's `.github/workflows/vulnerability-scan.yml` calls `atlanhq/application-sdk/.github/workflows/build-and-scan.yaml@main`.

**Why a blanket retry, not one gated on the error text.** `docker/build-push-action` does not expose buildx's stderr as a step output, so a signature-gated retry would mean re-plumbing the build through a raw `run:` step. It is not worth it: every non-transient failure in the table above dies one to three seconds into the step, and `cache-from: type=gha` replays every layer before the failing one — so a wasted retry costs the 30s sleep, not a second build. The job's `timeout-minutes: 15` is unchanged and still bounds the worst case.

The retry block restates the build inputs verbatim rather than factoring them into a composite action, because a reusable workflow cannot `uses:` a composite from its own repository without checking that repository out first.

## Security review note

This edits a CI workflow, and specifically the workflow that *is* the container-scan gate — so, explicitly:

- The security gate is untouched. No `continue-on-error` added to `security-gate`, no `|| true`, no `--exit-code` change, no allowlist change. A genuine CRITICAL/HIGH finding blocks exactly as before.
- The retry only re-attempts a build that already failed. It cannot turn a failed *scan* green.
- No new secret is consumed. The retry passes the same `git_token` BuildKit secret as the first attempt, still as a `--mount=type=secret` and never as a build arg.
- Considered and rejected: adding a Docker Hub login to the build job. It would raise the anonymous pull-rate limit but does nothing about a 500, and it would make a required fleet-wide gate depend on a secret that is not guaranteed present on every caller repo.

## Verification

- `uv run pre-commit run --files .github/workflows/build-and-scan.yaml` — passes, actionlint included.
- Step order and conditions parsed back out of the YAML:

```
Build image                   | continue-on-error=True | if=-
Wait before the build retry   |                        | if=steps.build-image.outcome == 'failure'
Build image (retry)           |                        | if=steps.build-image.outcome == 'failure'
```

## Follow-up, deliberately not in this PR

`atlan-openapi-app` has a stale `uv.lock` — 26 consecutive build failures on `--locked`. No amount of retrying fixes that one; it needs `uv lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Roodos6HVN5HjYEBnfZMoY
