### PR TITLE
ci(pulse): measure gate arrival, not PR hygiene or context count

### DIFF
--- a/.github/scripts/gate_enforcement_scan.py
+++ b/.github/scripts/gate_enforcement_scan.py
@@ -942,6 +942,13 @@ def parse_contexts_page(contexts: Optional[dict], where: str) -> dict:
         "count": len(context_nodes),
         "hasNextPage": has_next,
         "cursor": cursor,
+        # Whether the commit itself could not be read, as opposed to being read
+        # and found to hold no further contexts. The two are the same *shape* —
+        # no names, nothing more to fetch — and collapsing them makes an
+        # unreadable commit indistinguishable from a fully walked one, i.e. a
+        # false conclusive miss. Set by `parse_contexts_response`; a page that
+        # genuinely parsed is never unresolvable.
+        "unresolvable": False,
     }
 
 
@@ -953,11 +960,25 @@ def parse_contexts_response(payload: dict) -> dict:
         data.get("repository"), "data.repository", required=True
     )
     # `object` is null for an oid GitHub can no longer resolve (a force-pushed
-    # or GC'd commit). That is a legitimate skip, not drift: the page comes back
-    # empty and exhausted, so paging stops and the sample stays `truncated`.
+    # or GC'd commit). That is a legitimate skip, not drift — but it must not be
+    # reported as an exhausted page. Both produce no names and nothing more to
+    # fetch, so returning the plain page shape would let `_resolve_truncated`
+    # read "walked the whole connection, the gate was not in it" out of "could
+    # not read this commit at all" — turning an unreadable head into a false
+    # `never-arriving`, and on a gated repo into a `gate-not-arriving` error.
+    # That is a false claim about the repo, the failure this scanner's
+    # fail-loud contract exists to prevent, so it is flagged explicitly.
     commit = _expect_object(repository.get("object"), "data.repository.object")
+    if commit is None:
+        return {
+            "names": set(),
+            "count": 0,
+            "hasNextPage": False,
+            "cursor": None,
+            "unresolvable": True,
+        }
     rollup = _expect_object(
-        commit.get("statusCheckRollup") if commit else None,
+        commit.get("statusCheckRollup"),
         "data.repository.object.statusCheckRollup",
     )
     where = "data.repository.object.statusCheckRollup.contexts"
@@ -994,10 +1015,31 @@ def fetch_arrival_samples(
         raise GhError(f"unexpected arrival payload for {repo}")
     if payload.get("errors"):
         raise GhError(f"GraphQL errors for {repo}: {payload['errors']}")
-    return [
-        _resolve_truncated(repo, owner, name, sample, required_context, run=run)
-        for sample in parse_arrival_nodes(payload, required_context)
-    ]
+    # Resolved one at a time, NOT in a comprehension. Paging is the only part of
+    # this probe that issues a request per sample, so it is the only part where
+    # one transient failure can take the others with it: a comprehension lets a
+    # single 502 propagate out of `fetch_arrival_samples`, which `scan_repo`
+    # catches as `samples = None` — and an already-parsed, already-conclusive
+    # sibling sample is then discarded along with it. The repo lands on
+    # `no-data` with an empty findings list, which is the precise silence the
+    # `gate-arrival-unreadable` finding exists to close, reintroduced one layer
+    # below it. A failed page leaves *its own* sample truncated and nothing
+    # else; if that empties the denominator the verdict is `unknown` (reported),
+    # never `no-data` (silent).
+    samples: list = []
+    for sample in parse_arrival_nodes(payload, required_context):
+        try:
+            samples.append(
+                _resolve_truncated(repo, owner, name, sample, required_context, run=run)
+            )
+        except GhError as exc:
+            print(
+                f"::warning::{repo}: PR #{sample.get('number')}: context paging "
+                f"failed: {exc}",
+                file=sys.stderr,
+            )
+            samples.append(_public_sample({**sample, "truncated": True}))
+    return samples
 
 
 def fetch_context_page(
@@ -1076,6 +1118,11 @@ def _resolve_truncated(
         page = fetch_context_page(repo, owner, name, oid, cursor, run=run)
         if required_context in page["names"]:
             return _public_sample({**sample, "found": True, "truncated": False})
+        if page["unresolvable"]:
+            # The commit could not be read, so nothing was ruled out. Checked
+            # before the exhaustion branch below, which would otherwise read
+            # this identical shape as "walked it all, the gate was not there".
+            return _public_sample(sample)
         if not page["hasNextPage"] or not page["cursor"]:
             # The connection is exhausted and the gate was not anywhere in it.
             # That is now a *conclusive* miss — the whole point of paging.

--- a/.github/scripts/gate_enforcement_scan.py
+++ b/.github/scripts/gate_enforcement_scan.py
@@ -165,6 +165,21 @@ FINDING_NOT_REQUIRED = "gate-not-required"
 FINDING_NOT_ARRIVING = "gate-not-arriving"
 FINDING_UNPRODUCIBLE = "gate-context-unproducible"
 FINDING_UNREADABLE = "gate-state-unreadable"
+# The arrival-facet sibling of `gate-state-unreadable`, and the reason the
+# FND-1947 paging fix does not simply move the silence somewhere else. Before
+# paging, a commit with >100 contexts left the denominator and nothing was
+# reported; if every sample did that the repo landed on arrival `unknown` with
+# an EMPTY findings list, so a probe that had stopped working looked exactly
+# like a probe with nothing to say. Paging removes the routine cause of that,
+# which also removes the only place a human would have noticed it — truncation
+# counts going to ~0 means the dashboard card stops mentioning truncation at
+# all. So the residual case is reported explicitly instead: this fires only when
+# the scanner could not read ANY sample, i.e. a real paging regression, an
+# unresolvable head, or a commit past the page cap. It should be absent
+# fleet-wide, and its appearance is a fact about the scanner, not about the repo
+# — which is why it is the only finding here emitted at `warning` rather than
+# `error`. See the severity note at the emit site.
+FINDING_ARRIVAL_UNREADABLE = "gate-arrival-unreadable"
 
 # The SDK's standard location for the workflow that produces the gate context.
 #
@@ -419,6 +434,24 @@ def evaluate_repo(
                     f"required but observed on only {with_context}/{sampled} recent "
                     "pull requests — a required context that never reports blocks "
                     "every PR and creates pressure to drop the requirement",
+                )
+            )
+        if arrival_status == ARRIVAL_UNKNOWN:
+            findings.append(
+                _finding(
+                    FINDING_ARRIVAL_UNREADABLE,
+                    # `warning`, not `error` — the one finding here that is not
+                    # a claim about the repo. connector-pulse renders an error
+                    # pill red and everything else amber, and ranks headline
+                    # severity across error > warning > info, so `error` would
+                    # make an unreadable probe pixel-identical to a gate that is
+                    # genuinely not arriving and would promote the repo's
+                    # headline to match. The distinction this finding exists to
+                    # draw is exactly the one the severity field carries.
+                    "warning",
+                    f"gate arrival could not be determined: all {truncated} "
+                    "sampled pull requests had unreadable status contexts — the "
+                    "arrival probe, not the repo, is what needs looking at",
                 )
             )
         if arrival_status == ARRIVAL_NEVER and has_tests_workflow_file is False:

--- a/.github/scripts/gate_enforcement_scan.py
+++ b/.github/scripts/gate_enforcement_scan.py
@@ -291,9 +291,12 @@ def classify_arrival(samples: list) -> tuple:
     *conclusions* are noise here and only *appearance* is signal. That also
     sidesteps the check-runs ordering trap entirely.
 
-    A truncated sample (>100 contexts on the commit, gate not among the first
-    100) proves nothing either way, so it is excluded from the denominator
-    rather than counted as a miss.
+    A truncated sample proves nothing either way, so it is excluded from the
+    denominator rather than counted as a miss. Since FND-1947 a commit carrying
+    more than 100 contexts is *paged* rather than declared truncated, so this
+    now fires only when paging could not resolve the commit at all — the rare
+    safety valve it was written to be, rather than the routine outcome it had
+    quietly become as fleet repos grew past 100 checks.
     """
     conclusive = [s for s in samples if s.get("found") or not s.get("truncated")]
     truncated = len(samples) - len(conclusive)
@@ -627,19 +630,30 @@ def fetch_has_tests_workflow_file(repo: str, run: RunFn = _run_gh) -> bool:
     return True
 
 
+# `states: [OPEN, MERGED]` is load-bearing (FND-1947). Without it a CLOSED-
+# without-merge pull request is sampled like any other, and an abandoned branch
+# almost always carries an incomplete check set — CI cancelled, or never started
+# for the final SHA — so it reads as a conclusive *miss*. Worse, the sort key is
+# `UPDATED_AT` and closing a pull request updates it: abandoning a stale branch
+# actively promotes it into the window and evicts a real sample. That made the
+# verdict a function of PR hygiene rather than of gate arrival, and made it flap
+# as the window moved. An abandoned branch is not evidence either way — the same
+# argument the truncation handling below already makes.
 _ARRIVAL_QUERY = """
 query($owner: String!, $name: String!, $base: String!, $first: Int!) {
   repository(owner: $owner, name: $name) {
     pullRequests(first: $first, orderBy: {field: UPDATED_AT, direction: DESC},
-                 baseRefName: $base) {
+                 baseRefName: $base, states: [OPEN, MERGED]) {
       nodes {
         number
         commits(last: 1) {
           nodes {
             commit {
+              oid
               statusCheckRollup {
                 contexts(first: 100) {
                   totalCount
+                  pageInfo { hasNextPage endCursor }
                   nodes {
                     __typename
                     ... on CheckRun { name }
@@ -655,6 +669,42 @@ query($owner: String!, $name: String!, $base: String!, $first: Int!) {
   }
 }
 """
+
+# Page two onwards of one commit's status contexts, addressed by oid. The bulk
+# query above cannot ask for more than 100 per commit, and fleet repos have
+# grown past that: at the time of writing both `atlan-application-sdk` bump PRs
+# on `atlan-metabase-app` — the highest-signal PRs in the repo — carried 136
+# contexts and were discarded as truncated. Left alone the denominator shrinks
+# toward zero as context counts keep growing, and the verdict degrades to
+# `unknown` fleet-wide with nothing red to point at.
+_ARRIVAL_CONTEXTS_QUERY = """
+query($owner: String!, $name: String!, $oid: GitObjectID!, $after: String!) {
+  repository(owner: $owner, name: $name) {
+    object(oid: $oid) {
+      ... on Commit {
+        statusCheckRollup {
+          contexts(first: 100, after: $after) {
+            totalCount
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              __typename
+              ... on CheckRun { name }
+              ... on StatusContext { context }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+# Paging is bounded so a pathological commit can never stall the fleet sweep.
+# 20 pages is 2000 contexts; the busiest fleet repo sits under 150. Hitting it
+# leaves the sample `truncated`, i.e. excluded from the denominator, which is
+# exactly the pre-paging behaviour — the cap degrades to the old safety valve
+# rather than to a false miss.
+MAX_CONTEXT_PAGES = 20
 
 
 def _expect_object(value, path: str, *, required: bool = False) -> Optional[dict]:
@@ -703,7 +753,9 @@ def parse_arrival_nodes(payload: dict, required_context: str) -> list:
 
     One query per repo rather than one per pull request: the fleet sweep is
     already O(repos) on the REST side, and fanning arrival out per PR would
-    multiply that by the sample size for no extra signal.
+    multiply that by the sample size for no extra signal. The follow-up paging
+    in ``_resolve_truncated`` is the one exception, and it only fires for a
+    commit whose contexts did not fit in one page.
 
     Every level is shape-checked on the way down, so "malformed" reaches the
     caller as a ``GhError`` — and therefore as arrival ``unknown`` for that one
@@ -752,64 +804,132 @@ def parse_arrival_nodes(payload: dict, required_context: str) -> list:
             continue
 
         contexts = _expect_object(rollup.get("contexts"), f"{where}.contexts")
-        context_nodes = _expect_list(
-            contexts.get("nodes") if contexts else None, f"{where}.contexts.nodes"
-        )
-        names = set()
-        for ctx_index, ctx_node in enumerate(context_nodes):
-            ctx = _expect_object(ctx_node, f"{where}.contexts.nodes[{ctx_index}]")
-            if ctx is None:
-                continue
-            # CheckRun exposes `name`, StatusContext exposes `context`. Select
-            # by *presence*, not truthiness: an `or`-chain would collapse a
-            # present-but-falsy leaf (`0`, `False`, `[]`, `{}`) to the fallback
-            # or to `None`, skipping it as "absent" — a wrong-typed leaf then
-            # silently reads as `found: False`, the false clean negative the
-            # fail-loud contract forbids.
-            name = ctx.get("name")
-            if name is None:
-                name = ctx.get("context")
-            if name is None:
-                continue
-            if not isinstance(name, str):
-                # The leaf analogue of the container guards above: a present-
-                # but-wrong-typed `name`/`context` is schema drift, and must
-                # reach the caller as GhError rather than aborting the sweep
-                # (an unhashable list/dict raises an uncaught TypeError in
-                # `names.add`, which `scan_repo` does not catch) or silently
-                # misclassifying (a hashable int/bool never matches the
-                # required-context string, reading as a false `found: False`).
-                raise GhError(
-                    f"malformed arrival payload: expected "
-                    f"{where}.contexts.nodes[{ctx_index}].name/context to be a "
-                    f"string, got {type(name).__name__}"
-                )
-            names.add(name)
+        page = parse_contexts_page(contexts, f"{where}.contexts")
 
-        total = (contexts or {}).get("totalCount")
-        if total is None:
-            total = 0
-        if not isinstance(total, int) or isinstance(total, bool):
+        oid = commit.get("oid") if commit else None
+        if oid is not None and not isinstance(oid, str):
             raise GhError(
-                f"malformed arrival payload: expected {where}.contexts.totalCount "
-                f"to be an integer, got {type(total).__name__}"
+                f"malformed arrival payload: expected {where}.commits.nodes[0]."
+                f"commit.oid to be a string, got {type(oid).__name__}"
             )
 
         samples.append(
             {
                 "number": pr.get("number"),
-                "found": required_context in names,
-                # Compare against the nodes actually returned, NOT the distinct
-                # names: a commit routinely carries the same context several
-                # times (a bot PR stacks 5-7 gate runs on one SHA, all but the
-                # newest cancelled), so the deduplicated set is smaller than
-                # totalCount even when nothing was truncated. Measuring against
-                # the set marked most busy repos truncated, which quietly
-                # converted real never-arriving evidence into `unknown`.
-                "truncated": total > len(context_nodes),
+                "found": required_context in page["names"],
+                "truncated": page["hasNextPage"],
+                # Paging handles, consumed by `fetch_arrival_samples` and
+                # stripped before the sample reaches `classify_arrival`.
+                "oid": oid,
+                "cursor": page["cursor"],
             }
         )
     return samples
+
+
+def parse_contexts_page(contexts: Optional[dict], where: str) -> dict:
+    """Read one page of a ``statusCheckRollup.contexts`` connection.
+
+    Returns ``{"names", "count", "hasNextPage", "cursor"}``. Shared by the bulk
+    arrival query and the per-commit paging query so both walk the leaves under
+    the same fail-loud rules, and so a schema drift is caught in one place.
+    """
+    context_nodes = _expect_list(
+        contexts.get("nodes") if contexts else None, f"{where}.nodes"
+    )
+    names = set()
+    for ctx_index, ctx_node in enumerate(context_nodes):
+        ctx = _expect_object(ctx_node, f"{where}.nodes[{ctx_index}]")
+        if ctx is None:
+            continue
+        # CheckRun exposes `name`, StatusContext exposes `context`. Select
+        # by *presence*, not truthiness: an `or`-chain would collapse a
+        # present-but-falsy leaf (`0`, `False`, `[]`, `{}`) to the fallback
+        # or to `None`, skipping it as "absent" — a wrong-typed leaf then
+        # silently reads as `found: False`, the false clean negative the
+        # fail-loud contract forbids.
+        name = ctx.get("name")
+        if name is None:
+            name = ctx.get("context")
+        if name is None:
+            continue
+        if not isinstance(name, str):
+            # The leaf analogue of the container guards above: a present-
+            # but-wrong-typed `name`/`context` is schema drift, and must
+            # reach the caller as GhError rather than aborting the sweep
+            # (an unhashable list/dict raises an uncaught TypeError in
+            # `names.add`, which `scan_repo` does not catch) or silently
+            # misclassifying (a hashable int/bool never matches the
+            # required-context string, reading as a false `found: False`).
+            raise GhError(
+                f"malformed arrival payload: expected "
+                f"{where}.nodes[{ctx_index}].name/context to be a "
+                f"string, got {type(name).__name__}"
+            )
+        names.add(name)
+
+    total = (contexts or {}).get("totalCount")
+    if total is None:
+        total = 0
+    if not isinstance(total, int) or isinstance(total, bool):
+        raise GhError(
+            f"malformed arrival payload: expected {where}.totalCount "
+            f"to be an integer, got {type(total).__name__}"
+        )
+
+    page_info = _expect_object(
+        contexts.get("pageInfo") if contexts else None, f"{where}.pageInfo"
+    )
+    has_next = (page_info or {}).get("hasNextPage")
+    if has_next is None:
+        # `pageInfo` is the authoritative answer, but fall back to the count
+        # comparison when it was not selected. Compare against the nodes
+        # actually returned, NOT the distinct names: a commit routinely carries
+        # the same context several times (a bot PR stacks 5-7 gate runs on one
+        # SHA, all but the newest cancelled), so the deduplicated set is smaller
+        # than totalCount even when nothing was truncated. Measuring against the
+        # set marked most busy repos truncated, which quietly converted real
+        # never-arriving evidence into `unknown`.
+        has_next = total > len(context_nodes)
+    if not isinstance(has_next, bool):
+        raise GhError(
+            f"malformed arrival payload: expected {where}.pageInfo.hasNextPage "
+            f"to be a boolean, got {type(has_next).__name__}"
+        )
+
+    cursor = (page_info or {}).get("endCursor")
+    if cursor is not None and not isinstance(cursor, str):
+        raise GhError(
+            f"malformed arrival payload: expected {where}.pageInfo.endCursor "
+            f"to be a string, got {type(cursor).__name__}"
+        )
+
+    return {
+        "names": names,
+        "count": len(context_nodes),
+        "hasNextPage": has_next,
+        "cursor": cursor,
+    }
+
+
+def parse_contexts_response(payload: dict) -> dict:
+    """Turn one ``_ARRIVAL_CONTEXTS_QUERY`` response into a context page."""
+    root = _expect_object(payload, "response", required=True)
+    data = _expect_object(root.get("data"), "data", required=True)
+    repository = _expect_object(
+        data.get("repository"), "data.repository", required=True
+    )
+    # `object` is null for an oid GitHub can no longer resolve (a force-pushed
+    # or GC'd commit). That is a legitimate skip, not drift: the page comes back
+    # empty and exhausted, so paging stops and the sample stays `truncated`.
+    commit = _expect_object(repository.get("object"), "data.repository.object")
+    rollup = _expect_object(
+        commit.get("statusCheckRollup") if commit else None,
+        "data.repository.object.statusCheckRollup",
+    )
+    where = "data.repository.object.statusCheckRollup.contexts"
+    contexts = _expect_object(rollup.get("contexts") if rollup else None, where)
+    return parse_contexts_page(contexts, where)
 
 
 def fetch_arrival_samples(
@@ -841,7 +961,100 @@ def fetch_arrival_samples(
         raise GhError(f"unexpected arrival payload for {repo}")
     if payload.get("errors"):
         raise GhError(f"GraphQL errors for {repo}: {payload['errors']}")
-    return parse_arrival_nodes(payload, required_context)
+    return [
+        _resolve_truncated(repo, owner, name, sample, required_context, run=run)
+        for sample in parse_arrival_nodes(payload, required_context)
+    ]
+
+
+def fetch_context_page(
+    repo: str,
+    owner: str,
+    name: str,
+    oid: str,
+    cursor: str,
+    run: RunFn = _run_gh,
+) -> dict:
+    """One page of a commit's status contexts, after ``cursor``."""
+    raw = run(
+        [
+            "api",
+            "graphql",
+            "-f",
+            f"query={_ARRIVAL_CONTEXTS_QUERY}",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"name={name}",
+            "-f",
+            f"oid={oid}",
+            "-f",
+            f"after={cursor}",
+        ]
+    )
+    payload = _load_json(raw)
+    if not isinstance(payload, dict):
+        raise GhError(f"unexpected context payload for {repo}")
+    if payload.get("errors"):
+        raise GhError(f"GraphQL errors for {repo}: {payload['errors']}")
+    return parse_contexts_response(payload)
+
+
+def _public_sample(sample: dict) -> dict:
+    """The sample as `classify_arrival` and the record see it — paging handles
+    dropped, so the shape reaching the rest of the scanner is unchanged."""
+    return {
+        "number": sample.get("number"),
+        "found": sample.get("found"),
+        "truncated": sample.get("truncated"),
+    }
+
+
+def _resolve_truncated(
+    repo: str,
+    owner: str,
+    name: str,
+    sample: dict,
+    required_context: str,
+    run: RunFn,
+) -> dict:
+    """Page a truncated commit's remaining contexts until the gate appears.
+
+    Truncation used to be terminal: the sample left the denominator and its
+    evidence was thrown away. That was tolerable while >100 contexts on a commit
+    was rare, and it no longer is — so a truncated sample is now *resolved*
+    rather than discarded, and only an unresolvable one keeps the old treatment.
+
+    Paging stops the moment the gate is seen, and never starts for a sample that
+    already found it on page one — the common case costs nothing extra.
+    """
+    if sample.get("found") or not sample.get("truncated"):
+        return _public_sample(sample)
+
+    oid = sample.get("oid")
+    cursor = sample.get("cursor")
+    if not oid or not cursor:
+        # No handle to page with (a null `endCursor`, or an oid GitHub did not
+        # return). Leave it truncated: excluded from the denominator, which is
+        # the pre-paging behaviour, and never a false miss.
+        return _public_sample(sample)
+
+    for _ in range(MAX_CONTEXT_PAGES):
+        page = fetch_context_page(repo, owner, name, oid, cursor, run=run)
+        if required_context in page["names"]:
+            return _public_sample({**sample, "found": True, "truncated": False})
+        if not page["hasNextPage"] or not page["cursor"]:
+            # The connection is exhausted and the gate was not anywhere in it.
+            # That is now a *conclusive* miss — the whole point of paging.
+            return _public_sample({**sample, "truncated": False})
+        cursor = page["cursor"]
+
+    print(
+        f"::warning::{repo}: PR #{sample.get('number')}: stopped paging status "
+        f"contexts after {MAX_CONTEXT_PAGES} pages; sample excluded",
+        file=sys.stderr,
+    )
+    return _public_sample(sample)
 
 
 def scan_repo(

--- a/.github/scripts/tests/test_gate_enforcement_scan.py
+++ b/.github/scripts/tests/test_gate_enforcement_scan.py
@@ -28,6 +28,7 @@ from gate_enforcement_scan import (  # noqa: E402
     ARRIVAL_UNKNOWN,
     DEFAULT_NAME_PATTERN,
     DEFAULT_REQUIRED_CONTEXT,
+    FINDING_ARRIVAL_UNREADABLE,
     FINDING_NOT_ARRIVING,
     FINDING_NOT_REQUIRED,
     FINDING_UNPRODUCIBLE,
@@ -996,6 +997,65 @@ def test_a_gate_found_on_the_first_page_is_never_paged():
     # A truncated sample that found the gate was always conclusive; paging does
     # not change that.
     assert classify_arrival(samples)[:3] == (ARRIVAL_REPORTING, 1, 1)
+
+
+def test_an_unreadable_arrival_probe_is_a_finding_not_an_empty_findings_list():
+    """The silence FND-1947 would otherwise have relocated rather than fixed.
+
+    Paging removes the routine cause of truncation — which also removes the only
+    place a human would have noticed truncation, since the dashboard card stops
+    mentioning it once the counter sits at zero. So an all-truncated sample now
+    reports itself. Without this, a scanner that had stopped working produced a
+    record indistinguishable from one with nothing to say: arrival `unknown`,
+    `findings: []`."""
+    record = _evaluate(
+        arrival_samples=[{"found": False, "truncated": True} for _ in range(3)]
+    )
+    assert record["arrival"]["status"] == ARRIVAL_UNKNOWN
+    assert record["arrival"]["prsSampled"] == 0
+    assert record["arrival"]["truncatedSamples"] == 3
+    assert FINDING_ARRIVAL_UNREADABLE in _finding_ids(record)
+    # It is a statement about the probe, never about the repo's CI — so it must
+    # not also claim the gate is not arriving.
+    assert FINDING_NOT_ARRIVING not in _finding_ids(record)
+
+
+def test_the_unreadable_probe_finding_is_a_warning_not_an_error():
+    """The severity field is what carries "the probe, not the repo", so this is
+    not cosmetic. connector-pulse renders an `error` pill red and everything
+    else amber (`pages/GateEnforcement.tsx`), and ranks a repo's headline across
+    `("error", "warning", "info")`. Emitting `error` here would make an
+    unreadable probe pixel-identical to a gate that genuinely never arrives, and
+    would promote the repo's headline severity to match — so no wording on
+    either side could recover the distinction."""
+    record = _evaluate(arrival_samples=[{"found": False, "truncated": True}])
+    finding = next(
+        f for f in record["findings"] if f["id"] == FINDING_ARRIVAL_UNREADABLE
+    )
+    assert finding["severity"] == "warning"
+    # Every finding that IS a claim about the repo stays `error`.
+    record = _evaluate(arrival_samples=[{"found": False, "truncated": False}])
+    assert [f["severity"] for f in record["findings"]] == ["error"]
+
+
+def test_no_arrival_data_at_all_is_not_reported_as_an_unreadable_probe():
+    """`no-data` (nothing sampled) and `unknown` (sampled but unreadable) are
+    different claims. A repo with no recent pull requests has not exposed a
+    scanner bug, and reporting one would fire on every quiet repo."""
+    record = _evaluate(arrival_samples=[])
+    assert record["arrival"]["status"] == ARRIVAL_NO_DATA
+    assert record["findings"] == []
+
+
+def test_the_unreadable_probe_finding_is_scoped_to_gated_repos():
+    """An ungated repo's arrival is moot — `gate-not-required` is the finding
+    that matters there, and stacking a probe complaint on top would double-count
+    it in the fleet rollup."""
+    record = _evaluate(
+        rulesets=[],
+        arrival_samples=[{"found": False, "truncated": True}],
+    )
+    assert _finding_ids(record) == {FINDING_NOT_REQUIRED}
 
 
 def test_paging_stops_when_the_commit_can_no_longer_be_resolved():

--- a/.github/scripts/tests/test_gate_enforcement_scan.py
+++ b/.github/scripts/tests/test_gate_enforcement_scan.py
@@ -32,6 +32,7 @@ from gate_enforcement_scan import (  # noqa: E402
     FINDING_NOT_REQUIRED,
     FINDING_UNPRODUCIBLE,
     FINDING_UNREADABLE,
+    MAX_CONTEXT_PAGES,
     STATUS_GATED,
     STATUS_NOT_GATED,
     STATUS_UNKNOWN,
@@ -39,8 +40,10 @@ from gate_enforcement_scan import (  # noqa: E402
     build_fleet,
     classify_arrival,
     evaluate_repo,
+    fetch_arrival_samples,
     list_fleet_repos,
     parse_arrival_nodes,
+    parse_contexts_response,
     required_contexts,
     scan_repo,
     write_outputs,
@@ -412,7 +415,15 @@ def test_parse_arrival_nodes_reads_both_context_shapes():
         }
     }
     assert parse_arrival_nodes(payload, GATE) == [
-        {"number": 1, "found": True, "truncated": False}
+        {
+            "number": 1,
+            "found": True,
+            "truncated": False,
+            # Paging handles: absent from this fixture, and stripped again by
+            # `fetch_arrival_samples` before the sample reaches the record.
+            "oid": None,
+            "cursor": None,
+        }
     ]
 
 
@@ -829,6 +840,231 @@ def test_scan_repo_reads_a_gated_repo_end_to_end():
     # this token and is not consulted at all. Probing it would spend an API call
     # per repo to learn nothing.
     assert not any(str(c).endswith("/protection") for c in calls)
+
+
+# --- FND-1947: sampled population + context paging -------------------------
+
+
+def _ctx(name: str) -> dict:
+    return {"__typename": "CheckRun", "name": name}
+
+
+def _contexts(names, *, total=None, has_next=False, cursor=None) -> dict:
+    nodes = [_ctx(n) for n in names]
+    return {
+        "totalCount": len(nodes) if total is None else total,
+        "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+        "nodes": nodes,
+    }
+
+
+def _arrival_with(contexts: dict, *, number=1, oid="c0ffee") -> dict:
+    return _arrival_payload(
+        {
+            "number": number,
+            "commits": {
+                "nodes": [
+                    {
+                        "commit": {
+                            "oid": oid,
+                            "statusCheckRollup": {"contexts": contexts},
+                        }
+                    }
+                ]
+            },
+        }
+    )
+
+
+def _page(contexts: dict) -> dict:
+    return {
+        "data": {
+            "repository": {"object": {"statusCheckRollup": {"contexts": contexts}}}
+        }
+    }
+
+
+def _is_page_query(args: list) -> bool:
+    """The paging query is the one that does not select `pullRequests`."""
+    return "pullRequests" not in args[3]
+
+
+def test_the_arrival_query_excludes_pull_requests_closed_without_merge():
+    """Bug 1. An abandoned branch almost always carries an incomplete check set
+    — CI cancelled, or never started for the final SHA — so it reads as a
+    conclusive *miss*. And because the sort key is UPDATED_AT and closing a PR
+    updates it, abandoning a stale branch actively promotes it into the window
+    and evicts a real sample: the verdict became a function of PR hygiene, and
+    flapped as the window moved.
+
+    The filter is applied server-side, so the observable surface is the query
+    this script sends. Asserting it here is what stops the `states:` clause
+    being dropped in a future edit."""
+    sent: list = []
+
+    def run(args: list) -> str:
+        sent.append(args[3])
+        return json.dumps(_arrival_with(_contexts([GATE])))
+
+    fetch_arrival_samples(REPO, "main", 5, GATE, run=run)
+    assert "states: [OPEN, MERGED]" in sent[0]
+
+
+def test_a_truncated_sample_is_resolved_by_paging_not_discarded():
+    """Bug 2. The gate sitting past context 100 used to discard the sample
+    outright. Both `atlan-application-sdk` bump PRs — the highest-signal PRs in
+    a connector repo — carry ~136 contexts, so the highest-signal evidence was
+    exactly the evidence being thrown away."""
+    calls: list = []
+
+    def run(args: list) -> str:
+        calls.append(args)
+        if _is_page_query(args):
+            return json.dumps(_page(_contexts([GATE, "suite / D001"])))
+        return json.dumps(
+            _arrival_with(
+                _contexts(
+                    [f"suite / D{i:03d}" for i in range(100)],
+                    total=136,
+                    has_next=True,
+                    cursor="Y3Vyc29yOjEwMA==",
+                )
+            )
+        )
+
+    samples = fetch_arrival_samples(REPO, "main", 5, GATE, run=run)
+    assert samples == [{"number": 1, "found": True, "truncated": False}]
+    assert sum(1 for a in calls if _is_page_query(a)) == 1
+
+
+def test_paging_to_exhaustion_turns_truncation_into_a_conclusive_miss():
+    """The other half of the same fix: once every page has been read and the
+    gate is in none of them, that is real evidence of non-arrival — not an
+    unreadable sample. Without this the denominator only ever shrinks."""
+
+    def run(args: list) -> str:
+        if _is_page_query(args):
+            return json.dumps(_page(_contexts(["suite / D101"], has_next=False)))
+        return json.dumps(
+            _arrival_with(
+                _contexts(["suite / D001"], total=101, has_next=True, cursor="cur")
+            )
+        )
+
+    samples = fetch_arrival_samples(REPO, "main", 5, GATE, run=run)
+    assert samples == [{"number": 1, "found": False, "truncated": False}]
+    # …and that miss now reaches the verdict, instead of leaving the denominator.
+    assert classify_arrival(samples)[:3] == (ARRIVAL_NEVER, 1, 0)
+
+
+def test_paging_is_bounded_and_an_unfinished_walk_stays_truncated():
+    """A connection that never reports exhaustion must not stall the fleet
+    sweep. Hitting the cap degrades to the pre-paging behaviour — the sample
+    leaves the denominator — rather than to a false miss."""
+    pages = 0
+
+    def run(args: list) -> str:
+        nonlocal pages
+        if _is_page_query(args):
+            pages += 1
+            return json.dumps(_page(_contexts(["x"], has_next=True, cursor="more")))
+        return json.dumps(
+            _arrival_with(_contexts(["y"], total=9999, has_next=True, cursor="cur"))
+        )
+
+    samples = fetch_arrival_samples(REPO, "main", 5, GATE, run=run)
+    assert pages == MAX_CONTEXT_PAGES
+    assert samples == [{"number": 1, "found": False, "truncated": True}]
+    assert classify_arrival(samples)[0] == ARRIVAL_UNKNOWN
+
+
+def test_a_gate_found_on_the_first_page_is_never_paged():
+    """Paging is a repair path, not a cost every repo pays. A commit whose first
+    page already contains the gate spends no extra API call even when the
+    connection is truncated."""
+    calls: list = []
+
+    def run(args: list) -> str:
+        calls.append(args)
+        return json.dumps(
+            _arrival_with(_contexts([GATE], total=136, has_next=True, cursor="cur"))
+        )
+
+    samples = fetch_arrival_samples(REPO, "main", 5, GATE, run=run)
+    assert samples == [{"number": 1, "found": True, "truncated": True}]
+    assert not any(_is_page_query(a) for a in calls)
+    # A truncated sample that found the gate was always conclusive; paging does
+    # not change that.
+    assert classify_arrival(samples)[:3] == (ARRIVAL_REPORTING, 1, 1)
+
+
+def test_paging_stops_when_the_commit_can_no_longer_be_resolved():
+    """A force-pushed or GC'd head returns `object: null`. That is a legitimate
+    skip — an empty, exhausted page — not schema drift, so it must not raise and
+    must not loop."""
+    assert parse_contexts_response({"data": {"repository": {"object": None}}}) == {
+        "names": set(),
+        "count": 0,
+        "hasNextPage": False,
+        "cursor": None,
+    }
+
+
+def test_a_missing_cursor_leaves_the_sample_truncated_rather_than_paging_blind():
+    """`hasNextPage` without an `endCursor` gives nothing to page with. The
+    sample keeps the old treatment — excluded, never a false miss."""
+
+    def run(args: list) -> str:
+        assert not _is_page_query(args), "must not page without a cursor"
+        return json.dumps(
+            _arrival_with(_contexts(["x"], total=136, has_next=True, cursor=None))
+        )
+
+    samples = fetch_arrival_samples(REPO, "main", 5, GATE, run=run)
+    assert samples == [{"number": 1, "found": False, "truncated": True}]
+
+
+def test_page_info_outranks_the_count_comparison_but_the_fallback_survives():
+    """`pageInfo.hasNextPage` is the authoritative answer; the totalCount
+    comparison remains for a payload that did not select it, so the repeated-
+    context reasoning above still holds."""
+    with_page_info = parse_arrival_nodes(
+        _arrival_with(_contexts([GATE] * 3, total=99, has_next=True, cursor="c")), GATE
+    )[0]
+    assert with_page_info["truncated"] is True  # despite 3 < 99 being unread
+
+    no_page_info = parse_arrival_nodes(
+        _arrival_with({"totalCount": 140, "nodes": [_ctx("x")]}), GATE
+    )[0]
+    assert no_page_info["truncated"] is True
+    assert no_page_info["cursor"] is None
+
+
+@pytest.mark.parametrize(
+    "bad,match",
+    [
+        pytest.param({"hasNextPage": "yes"}, "hasNextPage", id="hasNextPage"),
+        pytest.param(
+            {"hasNextPage": True, "endCursor": 7}, "endCursor", id="endCursor"
+        ),
+    ],
+)
+def test_a_wrong_typed_page_info_leaf_raises_rather_than_guessing(bad, match):
+    """Same fail-loud contract as the other leaves: a wrong-typed paging field
+    must reach `scan_repo` as a GhError (arrival `unknown`), never be coerced
+    into "nothing more to read" — which would read as a clean conclusive miss."""
+    payload = _arrival_with({"totalCount": 136, "pageInfo": bad, "nodes": [_ctx("x")]})
+    with pytest.raises(GhError, match=match):
+        parse_arrival_nodes(payload, GATE)
+
+
+def test_an_oid_that_is_not_a_string_raises_rather_than_paging_on_it():
+    payload = _arrival_with(_contexts(["x"], total=136, has_next=True, cursor="c"))
+    payload["data"]["repository"]["pullRequests"]["nodes"][0]["commits"]["nodes"][0][
+        "commit"
+    ]["oid"] = 12345
+    with pytest.raises(GhError, match="oid"):
+        parse_arrival_nodes(payload, GATE)
 
 
 # --- discovery + rollup ----------------------------------------------------

--- a/.github/scripts/tests/test_gate_enforcement_scan.py
+++ b/.github/scripts/tests/test_gate_enforcement_scan.py
@@ -885,6 +885,57 @@ def _page(contexts: dict) -> dict:
     }
 
 
+def _arrival_two_prs() -> str:
+    """Two samples: #1 conclusive on page one, #2 truncated and needing paging."""
+    return json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequests": {
+                        "nodes": [
+                            {
+                                "number": 1,
+                                "commits": {
+                                    "nodes": [
+                                        {
+                                            "commit": {
+                                                "oid": "aaa",
+                                                "statusCheckRollup": {
+                                                    "contexts": _contexts([GATE])
+                                                },
+                                            }
+                                        }
+                                    ]
+                                },
+                            },
+                            {
+                                "number": 2,
+                                "commits": {
+                                    "nodes": [
+                                        {
+                                            "commit": {
+                                                "oid": "bbb",
+                                                "statusCheckRollup": {
+                                                    "contexts": _contexts(
+                                                        ["x"],
+                                                        total=136,
+                                                        has_next=True,
+                                                        cursor="cur",
+                                                    )
+                                                },
+                                            }
+                                        }
+                                    ]
+                                },
+                            },
+                        ]
+                    }
+                }
+            }
+        }
+    )
+
+
 def _is_page_query(args: list) -> bool:
     """The paging query is the one that does not select `pullRequests`."""
     return "pullRequests" not in args[3]
@@ -1060,14 +1111,93 @@ def test_the_unreadable_probe_finding_is_scoped_to_gated_repos():
 
 def test_paging_stops_when_the_commit_can_no_longer_be_resolved():
     """A force-pushed or GC'd head returns `object: null`. That is a legitimate
-    skip — an empty, exhausted page — not schema drift, so it must not raise and
-    must not loop."""
+    skip, not schema drift, so it must not raise and must not loop — and it is
+    flagged `unresolvable` so it cannot be mistaken for an exhausted page."""
     assert parse_contexts_response({"data": {"repository": {"object": None}}}) == {
         "names": set(),
         "count": 0,
         "hasNextPage": False,
         "cursor": None,
+        "unresolvable": True,
     }
+
+
+def test_an_unresolvable_commit_is_not_recorded_as_a_conclusive_miss():
+    """An unreadable commit and a fully walked one have the same page shape —
+    no names, nothing more to fetch. Reading the second out of the first turns
+    a force-pushed head into `never-arriving`, and on a gated repo into a
+    `gate-not-arriving` error: a false claim about the repo, which is worse than
+    the silence this PR set out to fix.
+
+    Asserted through `fetch_arrival_samples` rather than on the page shape,
+    because the page-shape assertion above is exactly what let this through."""
+
+    def run(args: list) -> str:
+        if _is_page_query(args):
+            return json.dumps({"data": {"repository": {"object": None}}})
+        return json.dumps(
+            _arrival_with(_contexts(["x"], total=136, has_next=True, cursor="cur"))
+        )
+
+    samples = fetch_arrival_samples(REPO, "main", 5, GATE, run=run)
+    assert samples == [{"number": 1, "found": False, "truncated": True}]
+    assert classify_arrival(samples)[0] == ARRIVAL_UNKNOWN
+    record = _evaluate(arrival_samples=samples)
+    assert FINDING_NOT_ARRIVING not in _finding_ids(record)
+    assert FINDING_ARRIVAL_UNREADABLE in _finding_ids(record)
+
+
+def test_one_failed_page_does_not_discard_the_other_samples():
+    """Paging is the only per-sample request in this probe, so it is the only
+    place one transient failure can take the others with it. Letting a `GhError`
+    escape `fetch_arrival_samples` sends `scan_repo` to `samples = None`, and a
+    sibling that had already conclusively found the gate dies with it — the repo
+    lands on `no-data` with no findings, which is the same silence
+    `gate-arrival-unreadable` exists to close, one layer below it."""
+
+    def run(args: list) -> str:
+        if _is_page_query(args):
+            raise GhError("gh api failed: HTTP 502", status=502)
+        return _arrival_two_prs()
+
+    samples = fetch_arrival_samples(REPO, "main", 5, GATE, run=run)
+    assert samples == [
+        {"number": 1, "found": True, "truncated": False},
+        {"number": 2, "found": False, "truncated": True},
+    ]
+    # PR #1's evidence survives, so the repo still has a verdict.
+    assert classify_arrival(samples)[:3] == (ARRIVAL_REPORTING, 1, 1)
+
+
+def test_a_repo_whose_every_page_fails_is_unknown_and_reported_not_silent():
+    """The degenerate case of the above: nothing conclusive survives. That must
+    be `unknown` + a finding, never `no-data` + an empty findings list."""
+
+    def run(args: list) -> str:
+        if _is_page_query(args):
+            raise GhError("gh api failed: HTTP 502", status=502)
+        return json.dumps(
+            _arrival_with(_contexts(["x"], total=136, has_next=True, cursor="cur"))
+        )
+
+    samples = fetch_arrival_samples(REPO, "main", 5, GATE, run=run)
+    assert samples == [{"number": 1, "found": False, "truncated": True}]
+    record = _evaluate(arrival_samples=samples)
+    assert record["arrival"]["status"] == ARRIVAL_UNKNOWN
+    assert FINDING_ARRIVAL_UNREADABLE in _finding_ids(record)
+
+
+def test_a_malformed_arrival_body_still_fails_the_whole_probe():
+    """Per-sample isolation is scoped to *paging*, which is a network call per
+    sample. A malformed top-level body is schema drift and must still reach
+    `scan_repo` as a GhError, so the repo degrades to `unknown` rather than
+    being evaluated on whatever parsed."""
+
+    def run(args: list) -> str:
+        return json.dumps({"data": {"repository": None}})
+
+    with pytest.raises(GhError, match="malformed arrival payload"):
+        fetch_arrival_samples(REPO, "main", 5, GATE, run=run)
 
 
 def test_a_missing_cursor_leaves_the_sample_truncated_rather_than_paging_blind():


### PR DESCRIPTION
Closes FND-1947.

`ci-on-prs` on the Fleet Drift → Baseline dashboard was not measuring whether the Tests Gate runs on PRs. Two properties of the arrival probe made the verdict depend on PR hygiene and on how many checks a repo happens to emit; a third made the resulting degradation silent.

Found reproducing a real false negative: `atlan-metabase-app` read **NOT BASELINED / "runs on PRs"** while its `tests.yaml` trigger config was byte-identical to canonical and the gate had reported on every recent PR.

## 1. Closed PRs were sampled, and closing one promoted it into the window

`_ARRIVAL_QUERY` carried no `states:` filter, so a CLOSED-without-merge pull request was evidence like any other. An abandoned branch almost always has an incomplete check set — CI cancelled, or never started for the final SHA — so it read as a *conclusive miss*. And because the sort key is `UPDATED_AT` and closing a PR updates it, abandoning a stale branch actively promoted it into the 5-PR window and evicted a real sample.

On metabase that was one abandoned refactor closed the previous day: 3 found / 4 conclusive → `intermittent` → gap. The signal then self-healed as the window moved, which is the same defect seen from the other side — the metric flapped for reasons unrelated to CI.

Now filtered to `states: [OPEN, MERGED]`.

## 2. The 100-context cap had stopped being a rare safety valve

`classify_arrival` excludes a truncated sample from the denominator rather than counting it as a miss. That was right for a rare event, but repos have grown past 100 contexts and it had become routine. Both `atlan-application-sdk` bump PRs on metabase — the highest-signal PRs in the repo — carried 136 contexts and were discarded outright; four more sat at 104, one workflow away from the same fate. Left alone the denominator shrinks toward zero and the verdict degrades to `unknown` fleet-wide.

The contexts connection is now paged by commit oid until the gate is found or the connection is exhausted, so a gate past position 100 counts as found and a genuine absence across every page counts as a real miss.

Chose paging over the ticket's fallback suggestion (raise the cap, alert near it) because raising only moves the cliff, and the alert would fire loudest on exactly the repos we most want to measure.

Bounded at 20 pages (2000 contexts). Hitting the cap leaves the sample `truncated` — degrading to the previous behaviour rather than to a false miss — and paging never starts at all for a sample that already found the gate, so a healthy repo spends no extra API call.

## 3. An unreadable probe now reports itself

The paging fix removes the routine cause of truncation, which also removes the only place anyone would notice it: the dashboard card mentions truncation only when the counter is non-zero.

The underlying silence predates paging. `classify_arrival` already returned `unknown` when every sample was truncated, and `evaluate_repo` emitted no finding for that state — so a repo whose arrival probe had stopped working produced a record indistinguishable from one with nothing to say: arrival `unknown`, `findings: []`. Same shape of defect as the cap itself, one layer up: silent, and worse over time rather than better.

New finding `gate-arrival-unreadable`, the arrival-facet sibling of `gate-state-unreadable`. Fires only when no sample could be read at all — a real paging regression, an unresolvable head, or a commit past the page cap. Should be absent fleet-wide.

Emitted at `warning`, the only finding here that is not `error`, because it is the only one that is not a claim about the repo. This is not cosmetic: connector-pulse renders an `error` pill red and everything else amber (`frontend/src/pages/GateEnforcement.tsx:714`) and ranks a repo's headline across `SEVERITY_ORDER`. At `error` an unreadable probe would be pixel-identical to a gate that genuinely never arrives and would promote the repo's headline to match — a distinction no wording could then recover. `warning` is already first-class in that consumer end to end (contract docstring, `SEVERITY_ORDER`, the `GateFinding` TS union, and its tests), and the new id passes through because the consumer filters a denylist of redundant ids rather than admitting an allowlist.

## Consumer impact

**None required.** Same fields, same `schemaVersion` 3.0.

What changes is the *population* behind the counters. `truncatedSamples` should now sit at ~0 and means "this commit could not be resolved" rather than "this commit had more than 100 checks". A gate sitting past context 100 now lands in `prsWithContext`; a 136-context commit with genuinely no gate now lands in `prsSampled` as a real miss. Both were previously invisible.

One nuance for anyone rendering these: `truncatedSamples` is not "every sample with `truncated=True`" — `classify_arrival` treats a truncated-but-found sample as conclusive, so it counts only truncated-**and**-not-found.

`--sample-size` stays at 5. With closed PRs excluded and truncation largely eliminated the denominator should now be 5/5 on a healthy repo, which was the original intent; raising it before seeing post-fix numbers would be guessing.

## Testing

73 passing in `.github/scripts/tests/test_gate_enforcement_scan.py`; full `.github/scripts/tests/` suite 4625 passed; pre-commit clean.

All three fixes are pinned red-green — I injected each fault separately and confirmed its own tests red:

- reverting the `states:` clause reds the query assertion
- short-circuiting the paging branch reds the three paging tests
- disabling the new finding reds it with `assert 'gate-arrival-unreadable' in set()`, which is literally the empty-findings silence it exists to prevent

## Security

No new privilege. Both queries are reads on the same `repository` scope the probe already used; the paging query addresses a commit by oid via `repository.object`. No writes, no new token scope, no change to what the fleet App can reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VW3wV9X5vvVrEYBg5siSnT
