### PR TITLE
ci(tests): pull MinIO from quay.io, where it still exists

### DIFF
--- a/.github/workflows/sdk-tests-reusable.yaml
+++ b/.github/workflows/sdk-tests-reusable.yaml
@@ -141,14 +141,18 @@ jobs:
           # Pull images first with retry — image pulls are the main 504 surface.
           # Use ${GITHUB_WORKSPACE} (not a bare relative path) to match the style
           # used in composite actions and stay correct if CWD ever changes.
-          "${GITHUB_WORKSPACE}/.github/scripts/with-retry.sh" docker pull minio/minio:RELEASE.2025-09-07T16-13-09Z
+          # quay.io, not Docker Hub: MinIO no longer publishes community images
+          # there (hub.docker.com/v2/repositories/minio/minio lists zero tags
+          # and every pull returns 'pull access denied'). quay.io carries the
+          # same pinned release tag, and is MinIO's own registry.
+          "${GITHUB_WORKSPACE}/.github/scripts/with-retry.sh" docker pull quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
           "${GITHUB_WORKSPACE}/.github/scripts/with-retry.sh" docker pull mcr.microsoft.com/azure-storage/azurite:3.31.0
           "${GITHUB_WORKSPACE}/.github/scripts/with-retry.sh" docker pull gcr.io/cloud-devrel-public-resources/storage-testbench:v0.62.0
           "${GITHUB_WORKSPACE}/.github/scripts/with-retry.sh" docker pull nginx:1.27-alpine
           # S3 → MinIO
           docker run -d --name minio -p 9000:9000 \
             -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
-            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
+            quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
           # Azure → Azurite
           docker run -d --name azurite -p 10000:10000 \
             mcr.microsoft.com/azure-storage/azurite:3.31.0 \

--- a/tests/integration/storage/test_emulator_preflight.py
+++ b/tests/integration/storage/test_emulator_preflight.py
@@ -9,7 +9,7 @@ Local:
 
     docker run -d --rm -p 9000:9000 \\
         -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \\
-        minio/minio server /data
+        quay.io/minio/minio server /data
     AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin \\
         aws --endpoint-url http://localhost:9000 s3 mb s3://sdk-customer-objectstore
     AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin \\

--- a/tests/integration/storage/test_emulator_s3.py
+++ b/tests/integration/storage/test_emulator_s3.py
@@ -18,7 +18,7 @@ sidecar). Local:
 
     docker run -d --rm -p 9000:9000 \\
         -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \\
-        minio/minio server /data
+        quay.io/minio/minio server /data
     AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin \\
         aws --endpoint-url http://localhost:9000 s3 mb s3://sdk-emulator-test
     uv run pytest tests/integration/storage/test_emulator_s3.py -m storage_emulator -v

--- a/tests/integration/storage/test_emulator_s3_assume_role.py
+++ b/tests/integration/storage/test_emulator_s3_assume_role.py
@@ -25,7 +25,7 @@ sidecar). Local:
 
     docker run -d --rm -p 9000:9000 \\
         -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \\
-        minio/minio server /data
+        quay.io/minio/minio server /data
     AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin \\
         aws --endpoint-url http://localhost:9000 s3 mb s3://sdk-emulator-test
     AWS_ENDPOINT_URL=http://localhost:9000 uv run pytest \\

--- a/tests/integration/storage/test_emulator_sdr_atlan_upload.py
+++ b/tests/integration/storage/test_emulator_sdr_atlan_upload.py
@@ -19,7 +19,7 @@ sidecar). Local:
 
     docker run -d --rm -p 9000:9000 \\
         -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \\
-        minio/minio server /data
+        quay.io/minio/minio server /data
     AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin \\
         aws --endpoint-url http://localhost:9000 s3 mb s3://sdk-customer-objectstore
     AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin \\


### PR DESCRIPTION
### Changelog
- `Storage Emulator Tests` fails on **every** PR at the first image pull: `pull access denied for minio/minio, repository does not exist or may require 'docker login'`, five retries, all denied.
- Not a rate limit and not transient. Docker Hub's API reports the pinned tag as `object not found`, and lists **zero** tags for `minio/minio` at all — MinIO has stopped publishing community images there. The job passed on this repo on 9 Sep and `sdk-tests-reusable.yaml` has not changed since #3204, so nothing in the repo caused it.
- `quay.io` — MinIO's own registry — still carries the exact pinned release: `RELEASE.2025-09-07T16-13-09Z`, manifest `sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e`, published 2025-09-07. So the change is the registry prefix on the pull and the `docker run`, and nothing else — same tag, no version bump.
- The four `tests/integration/storage/test_emulator_*.py` docstrings document the same image for local runs; repointed so a developer following them doesn't hit the same wall.

### Additional context (e.g. screenshots, logs, links)
- Example failure: https://github.com/atlanhq/application-sdk/actions/runs/34655901767/job/103448158254
- Verified through the quay.io API only — there is no Docker daemon on the machine this was written on, so the pull itself is proven by this PR's own workflow run. **If `Storage Emulator Tests` goes green here, that is the proof.**
- Found while working on #3721, which this was blocking (along with every other PR that runs the job). Kept separate so the fix lands for everyone rather than behind one review.

### Checklist
- [ ] Additional tests added — N/A, this is a registry prefix
- [ ] All CI checks passed
- [ ] Relevant documentation updated — the four test docstrings are updated

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)? No.
- [ ] If yes, have you modified the code in the context of this project? N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSRkGrDxQDKfLjn2J6yMMf